### PR TITLE
added ovh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,134 @@
 # Ankra CLI Changelog
 
+## v0.1.126
+
+### New Features
+
+#### OVH Cloud Cluster Management
+
+Full lifecycle management for OVH Cloud clusters, including provisioning, deprovisioning, scaling, and Kubernetes version upgrades.
+
+##### Create a Cluster
+
+```bash
+ankra cluster ovh create \
+  --name my-cluster \
+  --credential-id <ovh_credential_id> \
+  --ssh-key-credential-id <ssh_key_credential_id> \
+  --region GRA7 \
+  --control-plane-count 1 \
+  --control-plane-flavor-id b2-15 \
+  --worker-count 2 \
+  --worker-flavor-id b2-15
+```
+
+##### Deprovision a Cluster
+
+```bash
+ankra cluster ovh deprovision <cluster_id>
+```
+
+##### Check Worker Count
+
+```bash
+ankra cluster ovh workers <cluster_id>
+```
+
+Example output:
+
+```
+Worker Count: 2
+```
+
+##### Scale Workers
+
+```bash
+ankra cluster ovh scale <cluster_id> 4
+```
+
+Example output:
+
+```
+Scaling workers.
+  Previous count: 2
+  New count:      4
+```
+
+##### Check Kubernetes Version
+
+```bash
+ankra cluster ovh k8s-version <cluster_id>
+```
+
+Example output:
+
+```
+Kubernetes Version: v1.31.2+k3s1
+  Distribution: k3s
+```
+
+##### Upgrade Kubernetes Version
+
+```bash
+ankra cluster ovh upgrade <cluster_id> v1.35.1+k3s1
+```
+
+Example output:
+
+```
+Kubernetes version upgrade initiated.
+  Previous version: v1.31.2+k3s1
+  New version:      v1.35.1+k3s1
+  Nodes affected:   3
+```
+
+#### OVH API Credentials
+
+Manage OVH Cloud API credentials for cluster provisioning.
+
+##### List OVH Credentials
+
+```bash
+ankra credentials ovh list
+```
+
+##### Create an OVH Credential
+
+```bash
+ankra credentials ovh create --name my-ovh-cred --project-id <project_id>
+```
+
+Prompts securely for application key, application secret, and consumer key. Credentials are validated against the OVH API on creation.
+
+##### List SSH Key Credentials
+
+```bash
+ankra credentials ovh ssh-key list
+```
+
+##### Create an SSH Key Credential
+
+```bash
+ankra credentials ovh ssh-key create --name my-key --generate
+```
+
+Use `--generate` to create a new keypair, or omit it to provide your own public key.
+
+### API Endpoints
+
+- `POST /api/v1/clusters/ovh` — create an OVH cluster
+- `DELETE /api/v1/clusters/ovh/{id}` — deprovision a cluster
+- `GET /api/v1/clusters/ovh/{id}/worker-count` — get worker count
+- `POST /api/v1/clusters/ovh/{id}/scale-workers` — scale workers
+- `GET /api/v1/clusters/ovh/{id}/k8s-version` — get Kubernetes version
+- `POST /api/v1/clusters/ovh/{id}/upgrade-k8s-version` — upgrade Kubernetes version
+- `GET /api/v1/credentials/ovh` — list OVH credentials
+- `POST /api/v1/credentials/ovh` — create an OVH credential
+- `GET /api/v1/credentials/ovh/ssh-keys` — list SSH key credentials
+- `POST /api/v1/credentials/ovh/ssh-key` — create an SSH key credential
+
+---
+
 ## v0.1.125
 
 ### New Features

--- a/cmd/ovh_cluster.go
+++ b/cmd/ovh_cluster.go
@@ -1,0 +1,240 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+)
+
+var ovhCmd = &cobra.Command{
+	Use:   "ovh",
+	Short: "Manage OVH clusters",
+	Long:  "Commands to create, deprovision, and scale OVH Cloud clusters.",
+}
+
+var ovhCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new OVH cluster",
+	Run: func(cmd *cobra.Command, args []string) {
+		name, _ := cmd.Flags().GetString("name")
+		credentialID, _ := cmd.Flags().GetString("credential-id")
+		sshKeyCredentialID, _ := cmd.Flags().GetString("ssh-key-credential-id")
+		region, _ := cmd.Flags().GetString("region")
+		networkVlanID, _ := cmd.Flags().GetInt("network-vlan-id")
+		subnetCIDR, _ := cmd.Flags().GetString("subnet-cidr")
+		dhcpStart, _ := cmd.Flags().GetString("dhcp-start")
+		dhcpEnd, _ := cmd.Flags().GetString("dhcp-end")
+		gatewayFlavorID, _ := cmd.Flags().GetString("gateway-flavor-id")
+		cpCount, _ := cmd.Flags().GetInt("control-plane-count")
+		cpFlavorID, _ := cmd.Flags().GetString("control-plane-flavor-id")
+		workerCount, _ := cmd.Flags().GetInt("worker-count")
+		workerFlavorID, _ := cmd.Flags().GetString("worker-flavor-id")
+		distribution, _ := cmd.Flags().GetString("distribution")
+		kubeVersion, _ := cmd.Flags().GetString("kubernetes-version")
+
+		req := client.CreateOvhClusterRequest{
+			Name:                 name,
+			CredentialID:         credentialID,
+			SSHKeyCredentialID:   sshKeyCredentialID,
+			Region:               region,
+			NetworkVlanID:        networkVlanID,
+			SubnetCIDR:           subnetCIDR,
+			DHCPStart:            dhcpStart,
+			DHCPEnd:              dhcpEnd,
+			GatewayFlavorID:      gatewayFlavorID,
+			ControlPlaneCount:    cpCount,
+			ControlPlaneFlavorID: cpFlavorID,
+			WorkerCount:          workerCount,
+			WorkerFlavorID:       workerFlavorID,
+			Distribution:         distribution,
+		}
+		if kubeVersion != "" {
+			req.KubernetesVersion = &kubeVersion
+		}
+
+		result, err := client.CreateOvhCluster(apiToken, baseURL, req)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating OVH cluster: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("OVH cluster '%s' created successfully!\n", result.Name)
+		fmt.Printf("  Cluster ID: %s\n", result.ClusterID)
+		fmt.Printf("\nView it in the UI:\n  %s/organisation/clusters/cluster/imported/%s/overview\n",
+			strings.TrimRight(baseURL, "/"), result.ClusterID)
+	},
+}
+
+var ovhDeprovisionCmd = &cobra.Command{
+	Use:   "deprovision <cluster_id>",
+	Short: "Deprovision an OVH cluster",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		clusterID := args[0]
+
+		result, err := client.DeprovisionOvhCluster(apiToken, baseURL, clusterID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error deprovisioning cluster: %v\n", err)
+			os.Exit(1)
+		}
+
+		if result.Success {
+			fmt.Println(text.FgGreen.Sprint("OVH cluster deprovisioned successfully!"))
+		} else {
+			fmt.Println("Cluster deprovisioned with issues.")
+		}
+
+		fmt.Printf("  Cluster ID: %s\n", result.ClusterID)
+		if len(result.DeletedServers) > 0 {
+			fmt.Printf("  Deleted servers: %d\n", len(result.DeletedServers))
+		}
+		if len(result.DeletedNetworks) > 0 {
+			fmt.Printf("  Deleted networks: %d\n", len(result.DeletedNetworks))
+		}
+		if len(result.DeletedSSHKeys) > 0 {
+			fmt.Printf("  Deleted SSH keys: %d\n", len(result.DeletedSSHKeys))
+		}
+		if len(result.Errors) > 0 {
+			fmt.Println(text.FgYellow.Sprint("  Warnings:"))
+			for _, e := range result.Errors {
+				fmt.Printf("    - %s\n", e)
+			}
+		}
+	},
+}
+
+var ovhWorkersCmd = &cobra.Command{
+	Use:   "workers <cluster_id>",
+	Short: "Get current worker count for an OVH cluster",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		clusterID := args[0]
+
+		result, err := client.GetOvhWorkerCount(apiToken, baseURL, clusterID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error fetching worker count: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Worker Count: %d\n", result.WorkerCount)
+		fmt.Printf("  Min: %d\n", result.Min)
+		fmt.Printf("  Max: %d\n", result.Max)
+	},
+}
+
+var ovhScaleCmd = &cobra.Command{
+	Use:   "scale <cluster_id> <worker_count>",
+	Short: "Scale workers for an OVH cluster",
+	Long:  "Scale the number of worker nodes up or down for an OVH cluster.",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		clusterID := args[0]
+		workerCount, err := strconv.Atoi(args[1])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Invalid worker count: %v\n", err)
+			os.Exit(1)
+		}
+
+		result, err := client.ScaleOvhWorkers(apiToken, baseURL, clusterID, workerCount)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error scaling workers: %v\n", err)
+			os.Exit(1)
+		}
+
+		if result.PreviousCount == result.NewCount {
+			fmt.Printf("Worker count is already %d, no changes needed.\n", result.NewCount)
+		} else if result.NewCount > result.PreviousCount {
+			fmt.Printf("Scaling %s from %d to %d workers.\n",
+				text.FgGreen.Sprint("up"), result.PreviousCount, result.NewCount)
+		} else {
+			fmt.Printf("Scaling %s from %d to %d workers.\n",
+				text.FgYellow.Sprint("down"), result.PreviousCount, result.NewCount)
+		}
+	},
+}
+
+var ovhK8sVersionCmd = &cobra.Command{
+	Use:   "k8s-version <cluster_id>",
+	Short: "Get current Kubernetes version for an OVH cluster",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		clusterID := args[0]
+
+		result, err := client.GetOvhK8sVersion(apiToken, baseURL, clusterID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error fetching Kubernetes version: %v\n", err)
+			os.Exit(1)
+		}
+
+		version := "not set (using latest stable)"
+		if result.CurrentVersion != nil {
+			version = *result.CurrentVersion
+		}
+		fmt.Printf("Kubernetes Version: %s\n", version)
+		fmt.Printf("  Distribution: %s\n", result.Distribution)
+	},
+}
+
+var ovhUpgradeCmd = &cobra.Command{
+	Use:   "upgrade <cluster_id> <target_version>",
+	Short: "Upgrade Kubernetes version for an OVH cluster",
+	Long:  "Upgrade the Kubernetes (k3s) version on all nodes in an OVH cluster.",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		clusterID := args[0]
+		targetVersion := args[1]
+
+		result, err := client.UpgradeOvhK8sVersion(apiToken, baseURL, clusterID, targetVersion)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error upgrading Kubernetes version: %v\n", err)
+			os.Exit(1)
+		}
+
+		prev := "none"
+		if result.PreviousVersion != nil {
+			prev = *result.PreviousVersion
+		}
+		fmt.Printf("Kubernetes version upgrade initiated.\n")
+		fmt.Printf("  Previous version: %s\n", prev)
+		fmt.Printf("  New version:      %s\n", text.FgGreen.Sprint(result.NewVersion))
+		fmt.Printf("  Nodes affected:   %d\n", result.NodesAffected)
+	},
+}
+
+func init() {
+	ovhCreateCmd.Flags().String("name", "", "Cluster name (required)")
+	ovhCreateCmd.Flags().String("credential-id", "", "OVH API credential ID (required)")
+	ovhCreateCmd.Flags().String("ssh-key-credential-id", "", "SSH key credential ID (required)")
+	ovhCreateCmd.Flags().String("region", "", "OVH Cloud region (required)")
+	ovhCreateCmd.Flags().Int("network-vlan-id", 0, "Network VLAN ID")
+	ovhCreateCmd.Flags().String("subnet-cidr", "10.0.1.0/24", "Subnet CIDR")
+	ovhCreateCmd.Flags().String("dhcp-start", "10.0.1.100", "DHCP range start")
+	ovhCreateCmd.Flags().String("dhcp-end", "10.0.1.200", "DHCP range end")
+	ovhCreateCmd.Flags().String("gateway-flavor-id", "b2-7", "Gateway instance flavor")
+	ovhCreateCmd.Flags().Int("control-plane-count", 1, "Number of control plane nodes")
+	ovhCreateCmd.Flags().String("control-plane-flavor-id", "b2-15", "Control plane instance flavor")
+	ovhCreateCmd.Flags().Int("worker-count", 1, "Number of worker nodes")
+	ovhCreateCmd.Flags().String("worker-flavor-id", "b2-15", "Worker instance flavor")
+	ovhCreateCmd.Flags().String("distribution", "k3s", "Kubernetes distribution")
+	ovhCreateCmd.Flags().String("kubernetes-version", "", "Kubernetes version (optional)")
+
+	_ = ovhCreateCmd.MarkFlagRequired("name")
+	_ = ovhCreateCmd.MarkFlagRequired("credential-id")
+	_ = ovhCreateCmd.MarkFlagRequired("ssh-key-credential-id")
+	_ = ovhCreateCmd.MarkFlagRequired("region")
+
+	ovhCmd.AddCommand(ovhCreateCmd)
+	ovhCmd.AddCommand(ovhDeprovisionCmd)
+	ovhCmd.AddCommand(ovhWorkersCmd)
+	ovhCmd.AddCommand(ovhScaleCmd)
+	ovhCmd.AddCommand(ovhK8sVersionCmd)
+	ovhCmd.AddCommand(ovhUpgradeCmd)
+
+	clusterCmd.AddCommand(ovhCmd)
+}

--- a/cmd/ovh_credentials.go
+++ b/cmd/ovh_credentials.go
@@ -1,0 +1,263 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/manifoldco/promptui"
+	"github.com/spf13/cobra"
+)
+
+var ovhCredCmd = &cobra.Command{
+	Use:   "ovh",
+	Short: "Manage OVH credentials",
+	Long:  "Commands to list and create OVH API credentials and SSH key credentials.",
+}
+
+var ovhCredListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List OVH API credentials",
+	Run: func(cmd *cobra.Command, args []string) {
+		creds, err := client.ListOvhCredentials(apiToken, baseURL)
+		if err != nil {
+			fmt.Printf("Error listing OVH credentials: %v\n", err)
+			return
+		}
+
+		if len(creds) == 0 {
+			fmt.Println("No OVH credentials found.")
+			return
+		}
+
+		t := table.NewWriter()
+		t.SetOutputMirror(os.Stdout)
+		t.SetStyle(table.StyleRounded)
+		t.AppendHeader(table.Row{"ID", "Name", "Available", "Created"})
+		t.SetColumnConfigs([]table.ColumnConfig{
+			{Number: 1, WidthMin: 36},
+			{Number: 2, WidthMin: 20},
+			{Number: 3, WidthMin: 10},
+			{Number: 4, WidthMin: 15},
+		})
+
+		for _, cred := range creds {
+			available := "yes"
+			if !cred.Available {
+				available = "no"
+			}
+			t.AppendRow(table.Row{
+				cred.ID,
+				cred.Name,
+				available,
+				formatTimeAgo(cred.CreatedAt),
+			})
+		}
+		t.Render()
+	},
+}
+
+var ovhCredCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create an OVH API credential",
+	Long: `Create an OVH API credential. You will be prompted for the required secrets.
+
+Generate your OVH API credentials at https://api.ovh.com/createToken/ with
+GET, POST, PUT, DELETE rights on /cloud/project/* and /cloud/project.
+
+Examples:
+  ankra credentials ovh create --name my-ovh-cred --project-id <project-id>`,
+	Run: func(cmd *cobra.Command, args []string) {
+		name, _ := cmd.Flags().GetString("name")
+		projectID, _ := cmd.Flags().GetString("project-id")
+
+		appKeyPrompt := promptui.Prompt{
+			Label: "OVH Application Key",
+			Validate: func(input string) error {
+				if len(input) == 0 {
+					return fmt.Errorf("application key cannot be empty")
+				}
+				return nil
+			},
+		}
+		applicationKey, err := appKeyPrompt.Run()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Prompt cancelled.\n")
+			os.Exit(1)
+		}
+
+		appSecretPrompt := promptui.Prompt{
+			Label: "OVH Application Secret",
+			Mask:  '*',
+			Validate: func(input string) error {
+				if len(input) == 0 {
+					return fmt.Errorf("application secret cannot be empty")
+				}
+				return nil
+			},
+		}
+		applicationSecret, err := appSecretPrompt.Run()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Prompt cancelled.\n")
+			os.Exit(1)
+		}
+
+		consumerKeyPrompt := promptui.Prompt{
+			Label: "OVH Consumer Key",
+			Mask:  '*',
+			Validate: func(input string) error {
+				if len(input) == 0 {
+					return fmt.Errorf("consumer key cannot be empty")
+				}
+				return nil
+			},
+		}
+		consumerKey, err := consumerKeyPrompt.Run()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Prompt cancelled.\n")
+			os.Exit(1)
+		}
+
+		result, err := client.CreateOvhCredential(apiToken, baseURL, client.CreateOvhCredentialRequest{
+			Name:              name,
+			ApplicationKey:    applicationKey,
+			ApplicationSecret: applicationSecret,
+			ConsumerKey:       consumerKey,
+			ProjectID:         projectID,
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating OVH credential: %v\n", err)
+			os.Exit(1)
+		}
+
+		if !result.Success {
+			fmt.Fprintln(os.Stderr, "Failed to create OVH credential:")
+			for _, e := range result.Errors {
+				fmt.Fprintf(os.Stderr, "  - %s: %s\n", e.Key, e.Message)
+			}
+			os.Exit(1)
+		}
+
+		fmt.Printf("OVH credential '%s' created successfully!\n", name)
+	},
+}
+
+var ovhSSHKeyListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List SSH key credentials",
+	Run: func(cmd *cobra.Command, args []string) {
+		creds, err := client.ListOvhSSHKeyCredentials(apiToken, baseURL)
+		if err != nil {
+			fmt.Printf("Error listing SSH key credentials: %v\n", err)
+			return
+		}
+
+		if len(creds) == 0 {
+			fmt.Println("No SSH key credentials found.")
+			return
+		}
+
+		t := table.NewWriter()
+		t.SetOutputMirror(os.Stdout)
+		t.SetStyle(table.StyleRounded)
+		t.AppendHeader(table.Row{"ID", "Name", "Available", "Created"})
+		t.SetColumnConfigs([]table.ColumnConfig{
+			{Number: 1, WidthMin: 36},
+			{Number: 2, WidthMin: 20},
+			{Number: 3, WidthMin: 10},
+			{Number: 4, WidthMin: 15},
+		})
+
+		for _, cred := range creds {
+			available := "yes"
+			if !cred.Available {
+				available = "no"
+			}
+			t.AppendRow(table.Row{
+				cred.ID,
+				cred.Name,
+				available,
+				formatTimeAgo(cred.CreatedAt),
+			})
+		}
+		t.Render()
+	},
+}
+
+var ovhSSHKeyCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create an SSH key credential for OVH",
+	Long: `Create an SSH key credential. Either provide a public key or generate a new keypair.
+
+Examples:
+  ankra credentials ovh ssh-key create --name my-key --generate
+  ankra credentials ovh ssh-key create --name my-key --public-key "ssh-ed25519 AAAA..."`,
+	Run: func(cmd *cobra.Command, args []string) {
+		name, _ := cmd.Flags().GetString("name")
+		publicKey, _ := cmd.Flags().GetString("public-key")
+		generate, _ := cmd.Flags().GetBool("generate")
+
+		if !generate && publicKey == "" {
+			fmt.Fprintln(os.Stderr, "Either --public-key or --generate must be provided.")
+			os.Exit(1)
+		}
+
+		req := client.CreateSSHKeyCredentialRequest{
+			Name:     name,
+			Generate: generate,
+		}
+		if publicKey != "" {
+			req.SSHPublicKey = &publicKey
+		}
+
+		result, err := client.CreateOvhSSHKeyCredential(apiToken, baseURL, req)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating SSH key credential: %v\n", err)
+			os.Exit(1)
+		}
+
+		if !result.Success {
+			fmt.Fprintln(os.Stderr, "Failed to create SSH key credential:")
+			for _, e := range result.Errors {
+				fmt.Fprintf(os.Stderr, "  - %s: %s\n", e.Key, e.Message)
+			}
+			os.Exit(1)
+		}
+
+		fmt.Printf("SSH key credential '%s' created successfully!\n", name)
+
+		if result.PrivateKey != nil {
+			fmt.Println("\nGenerated private key (save this, it will not be shown again):")
+			fmt.Println(*result.PrivateKey)
+		}
+	},
+}
+
+var ovhSSHKeyCmd = &cobra.Command{
+	Use:     "ssh-key",
+	Aliases: []string{"ssh-keys", "ssh"},
+	Short:   "Manage SSH key credentials for OVH",
+}
+
+func init() {
+	ovhCredCreateCmd.Flags().String("name", "", "Credential name (required)")
+	ovhCredCreateCmd.Flags().String("project-id", "", "OVH Cloud project ID (required)")
+	_ = ovhCredCreateCmd.MarkFlagRequired("name")
+	_ = ovhCredCreateCmd.MarkFlagRequired("project-id")
+
+	ovhSSHKeyCreateCmd.Flags().String("name", "", "Credential name (required)")
+	ovhSSHKeyCreateCmd.Flags().String("public-key", "", "SSH public key")
+	ovhSSHKeyCreateCmd.Flags().Bool("generate", false, "Generate a new SSH keypair")
+	_ = ovhSSHKeyCreateCmd.MarkFlagRequired("name")
+
+	ovhSSHKeyCmd.AddCommand(ovhSSHKeyListCmd)
+	ovhSSHKeyCmd.AddCommand(ovhSSHKeyCreateCmd)
+
+	ovhCredCmd.AddCommand(ovhCredListCmd)
+	ovhCredCmd.AddCommand(ovhCredCreateCmd)
+	ovhCredCmd.AddCommand(ovhSSHKeyCmd)
+
+	credentialsCmd.AddCommand(ovhCredCmd)
+}

--- a/internal/client/ovh_clusters.go
+++ b/internal/client/ovh_clusters.go
@@ -1,0 +1,200 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+type CreateOvhClusterRequest struct {
+	Name                 string  `json:"name"`
+	Description          *string `json:"description,omitempty"`
+	CredentialID         string  `json:"credential_id"`
+	SSHKeyCredentialID   string  `json:"ssh_key_credential_id"`
+	Region               string  `json:"region"`
+	NetworkVlanID        int     `json:"network_vlan_id"`
+	SubnetCIDR           string  `json:"subnet_cidr"`
+	DHCPStart            string  `json:"dhcp_start"`
+	DHCPEnd              string  `json:"dhcp_end"`
+	GatewayFlavorID      string  `json:"gateway_flavor_id"`
+	ControlPlaneCount    int     `json:"control_plane_count"`
+	ControlPlaneFlavorID string  `json:"control_plane_flavor_id"`
+	WorkerCount          int     `json:"worker_count"`
+	WorkerFlavorID       string  `json:"worker_flavor_id"`
+	Distribution         string  `json:"distribution"`
+	KubernetesVersion    *string `json:"kubernetes_version,omitempty"`
+}
+
+type CreateOvhClusterResponse struct {
+	ClusterID string `json:"cluster_id"`
+	Name      string `json:"name"`
+}
+
+type DeprovisionOvhClusterResponse struct {
+	Success         bool     `json:"success"`
+	ClusterID       string   `json:"cluster_id"`
+	DeletedServers  []string `json:"deleted_servers"`
+	DeletedNetworks []string `json:"deleted_networks"`
+	DeletedSSHKeys  []string `json:"deleted_ssh_keys"`
+	Errors          []string `json:"errors"`
+}
+
+func CreateOvhCluster(token, baseURL string, req CreateOvhClusterRequest) (*CreateOvhClusterResponse, error) {
+	url := strings.TrimRight(baseURL, "/") + "/api/v1/clusters/ovh"
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", closeErr)
+		}
+	}()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("create failed: status %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	var result CreateOvhClusterResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &result, nil
+}
+
+func DeprovisionOvhCluster(token, baseURL, clusterID string) (*DeprovisionOvhClusterResponse, error) {
+	url := fmt.Sprintf("%s/api/v1/clusters/ovh/%s", strings.TrimRight(baseURL, "/"), clusterID)
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", closeErr)
+		}
+	}()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("deprovision failed: status %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	var result DeprovisionOvhClusterResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &result, nil
+}
+
+func GetOvhWorkerCount(token, baseURL, clusterID string) (*WorkerCountResult, error) {
+	url := fmt.Sprintf("%s/api/v1/clusters/ovh/%s/worker-count", strings.TrimRight(baseURL, "/"), clusterID)
+	var result WorkerCountResult
+	if err := getJSON(url, token, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func GetOvhK8sVersion(token, baseURL, clusterID string) (*K8sVersionInfo, error) {
+	url := fmt.Sprintf("%s/api/v1/clusters/ovh/%s/k8s-version", strings.TrimRight(baseURL, "/"), clusterID)
+	var result K8sVersionInfo
+	if err := getJSON(url, token, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func UpgradeOvhK8sVersion(token, baseURL, clusterID, targetVersion string) (*UpgradeK8sVersionResult, error) {
+	url := fmt.Sprintf("%s/api/v1/clusters/ovh/%s/upgrade-k8s-version", strings.TrimRight(baseURL, "/"), clusterID)
+	payload, err := json.Marshal(UpgradeK8sVersionRequest{TargetVersion: targetVersion})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", closeErr)
+		}
+	}()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("upgrade failed: status %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	var result UpgradeK8sVersionResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &result, nil
+}
+
+func ScaleOvhWorkers(token, baseURL, clusterID string, workerCount int) (*ScaleWorkersResult, error) {
+	url := fmt.Sprintf("%s/api/v1/clusters/ovh/%s/scale-workers", strings.TrimRight(baseURL, "/"), clusterID)
+	payload, err := json.Marshal(ScaleWorkersRequest{WorkerCount: workerCount})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", closeErr)
+		}
+	}()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("scale failed: status %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	var result ScaleWorkersResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &result, nil
+}

--- a/internal/client/ovh_credentials.go
+++ b/internal/client/ovh_credentials.go
@@ -1,0 +1,125 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+type OvhCredentialListItem struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	Provider       string `json:"provider"`
+	OrganisationID string `json:"organisation_id"`
+	System         bool   `json:"system"`
+	Available      bool   `json:"available"`
+	CreatedAt      string `json:"created_at"`
+	UpdatedAt      string `json:"updated_at"`
+}
+
+type CreateOvhCredentialRequest struct {
+	Name              string `json:"name"`
+	ApplicationKey    string `json:"application_key"`
+	ApplicationSecret string `json:"application_secret"`
+	ConsumerKey       string `json:"consumer_key"`
+	ProjectID         string `json:"project_id"`
+}
+
+type CreateOvhCredentialResponse struct {
+	Success bool            `json:"success"`
+	Errors  []ResourceError `json:"errors,omitempty"`
+}
+
+func ListOvhCredentials(token, baseURL string) ([]OvhCredentialListItem, error) {
+	url := strings.TrimRight(baseURL, "/") + "/api/v1/credentials/ovh"
+	var creds []OvhCredentialListItem
+	if err := getJSON(url, token, &creds); err != nil {
+		return nil, err
+	}
+	return creds, nil
+}
+
+func CreateOvhCredential(token, baseURL string, req CreateOvhCredentialRequest) (*CreateOvhCredentialResponse, error) {
+	url := strings.TrimRight(baseURL, "/") + "/api/v1/credentials/ovh"
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", closeErr)
+		}
+	}()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("create failed: status %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	var result CreateOvhCredentialResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &result, nil
+}
+
+func ListOvhSSHKeyCredentials(token, baseURL string) ([]OvhCredentialListItem, error) {
+	url := strings.TrimRight(baseURL, "/") + "/api/v1/credentials/ovh/ssh-keys"
+	var creds []OvhCredentialListItem
+	if err := getJSON(url, token, &creds); err != nil {
+		return nil, err
+	}
+	return creds, nil
+}
+
+func CreateOvhSSHKeyCredential(token, baseURL string, req CreateSSHKeyCredentialRequest) (*CreateSSHKeyCredentialResponse, error) {
+	url := strings.TrimRight(baseURL, "/") + "/api/v1/credentials/ovh/ssh-key"
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", closeErr)
+		}
+	}()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("create failed: status %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	var result CreateSSHKeyCredentialResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &result, nil
+}


### PR DESCRIPTION
## v0.1.126

### New Features

#### OVH Cloud Cluster Management

Full lifecycle management for OVH Cloud clusters, including provisioning, deprovisioning, scaling, and Kubernetes version upgrades.

##### Create a Cluster

```bash
ankra cluster ovh create \
  --name my-cluster \
  --credential-id <ovh_credential_id> \
  --ssh-key-credential-id <ssh_key_credential_id> \
  --region GRA7 \
  --control-plane-count 1 \
  --control-plane-flavor-id b2-15 \
  --worker-count 2 \
  --worker-flavor-id b2-15
```

##### Deprovision a Cluster

```bash
ankra cluster ovh deprovision <cluster_id>
```

##### Check Worker Count

```bash
ankra cluster ovh workers <cluster_id>
```

Example output:

```
Worker Count: 2
```

##### Scale Workers

```bash
ankra cluster ovh scale <cluster_id> 4
```

Example output:

```
Scaling workers.
  Previous count: 2
  New count:      4
```

##### Check Kubernetes Version

```bash
ankra cluster ovh k8s-version <cluster_id>
```

Example output:

```
Kubernetes Version: v1.31.2+k3s1
  Distribution: k3s
```

##### Upgrade Kubernetes Version

```bash
ankra cluster ovh upgrade <cluster_id> v1.35.1+k3s1
```

Example output:

```
Kubernetes version upgrade initiated.
  Previous version: v1.31.2+k3s1
  New version:      v1.35.1+k3s1
  Nodes affected:   3
```

#### OVH API Credentials

Manage OVH Cloud API credentials for cluster provisioning.

##### List OVH Credentials

```bash
ankra credentials ovh list
```

##### Create an OVH Credential

```bash
ankra credentials ovh create --name my-ovh-cred --project-id <project_id>
```

Prompts securely for application key, application secret, and consumer key. Credentials are validated against the OVH API on creation.

##### List SSH Key Credentials

```bash
ankra credentials ovh ssh-key list
```

##### Create an SSH Key Credential

```bash
ankra credentials ovh ssh-key create --name my-key --generate
```

Use `--generate` to create a new keypair, or omit it to provide your own public key.

### API Endpoints

- `POST /api/v1/clusters/ovh` — create an OVH cluster
- `DELETE /api/v1/clusters/ovh/{id}` — deprovision a cluster
- `GET /api/v1/clusters/ovh/{id}/worker-count` — get worker count
- `POST /api/v1/clusters/ovh/{id}/scale-workers` — scale workers
- `GET /api/v1/clusters/ovh/{id}/k8s-version` — get Kubernetes version
- `POST /api/v1/clusters/ovh/{id}/upgrade-k8s-version` — upgrade Kubernetes version
- `GET /api/v1/credentials/ovh` — list OVH credentials
- `POST /api/v1/credentials/ovh` — create an OVH credential
- `GET /api/v1/credentials/ovh/ssh-keys` — list SSH key credentials
- `POST /api/v1/credentials/ovh/ssh-key` — create an SSH key credential

---