### PR TITLE
feat: generic cluster ssh-keys command + global --cluster targeting (PLA-613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Ankra CLI Changelog
 
+## Unreleased
+
+### Added
+
+- **Global `--cluster <name|id>` on every `ankra cluster ...` subcommand** —
+  target a cluster per command without first running `ankra cluster select`.
+  The flag is inherited by all cluster subcommands (`stacks`, `operations`,
+  `addons`, `manifests`, `get`/`logs`/`resources`, `helm`, `agent`,
+  `reconcile`, `provision`, `deprovision`, `roll-to`, `info`, ...) and takes
+  precedence over the persisted selection; it also accepts either a cluster
+  name or ID. `ankra chat health` and `ankra openclaw skill | handoff` gained
+  the same `--cluster` override. Commands that already accepted a positional
+  cluster name still do — an explicit argument wins over `--cluster`, which in
+  turn wins over the saved selection.
+
+- **`ankra cluster ssh-keys get | set | resync <cluster_id>`** — cloud-agnostic
+  SSH key management that detects the provider (Hetzner, OVH, UpCloud)
+  automatically from the cluster. `get` lists attached and available SSH key
+  credentials, `set` replaces the attached set (use `--clear` to remove all user
+  keys; the Ankra-managed key is always retained) and applies the change to
+  running nodes, and `resync` repairs a stale provider-side SSH key reference
+  (for example when the key was deleted and re-created in the provider console)
+  that blocks new node creation, re-applying the authorised keys to running
+  nodes.
+
+### Fixed
+
+- **`ankra login` now completes reliably on dual-stack (IPv4/IPv6) machines.**
+  The browser callback server binds the IPv4 loopback (`127.0.0.1`) but the
+  redirect URI advertised to the backend used `localhost`, which resolves to
+  both `127.0.0.1` and `::1`. A browser that connected to the IPv6 address
+  reached nothing, so after authenticating (including MFA) the final
+  `http://localhost:<port>/callback` redirect failed and login never finished.
+  The redirect URI now uses the `127.0.0.1` literal (RFC 8252 §8.3), matching
+  the listener. The CLI also waits up to 10 minutes for the callback (was 5) to
+  align with the backend's login-state expiry, so a slow MFA round-trip no
+  longer tears the callback server down early.
+
+### Deprecated
+
+- **`ankra cluster ovh ssh-keys get | set <cluster_id>`** — replaced by the
+  cloud-agnostic `ankra cluster ssh-keys get | set <cluster_id>`. The provider is
+  detected automatically from the cluster.
+
 ## v0.4.0-rc2 — 2026-06-19
 
 Builds on v0.4.0-rc1 (all of its provider-parity work is included) and adds

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -16,6 +16,12 @@ version; running one prints a warning pointing at the replacement.
 
 ## Upcoming removals
 
+### v0.6.0
+
+| Deprecated | Deprecated in | Replacement | Notes |
+|---|---|---|---|
+| `ankra cluster ovh ssh-keys <get\|set> <cluster_id>` | v0.5.0 | `ankra cluster ssh-keys <get\|set> <cluster_id>` | The provider is detected automatically from the cluster. The generic group also adds `resync` and works for Hetzner and UpCloud. |
+
 ### v0.5.0
 
 | Deprecated | Deprecated in | Replacement | Notes |

--- a/README.md
+++ b/README.md
@@ -393,11 +393,28 @@ ankra cluster provision [name]        # Provision (start) a managed cluster
 ankra cluster deprovision [name]      # Deprovision (stop) a managed cluster
   [--auto-delete] [--force]
 ankra cluster roll-to --version <id>  # Roll to a specific resource version
-  [--cluster <cluster_id>]
+  [--cluster <name|id>]
 ankra cluster k3s-versions            # List Kubernetes (k3s) versions available for upgrades
 ankra cluster upgrade <id> <version>  # Upgrade the Kubernetes version of a cloud cluster
                                       #   (Hetzner/OVH/UpCloud detected automatically)
 ```
+
+`ankra cluster ...` subcommands act on the selected cluster, but every one of
+them also accepts a global `--cluster <name|id>` flag so you can target a
+cluster for a single command **instead of** running `ankra cluster select`
+first:
+```bash
+ankra cluster stacks list --cluster prod          # By name
+ankra cluster operations list --cluster 2222...    # By ID
+ankra cluster agent status --cluster staging
+```
+The flag takes precedence over the saved selection and accepts either a cluster
+name or ID. For commands that also take a positional cluster name (for example
+`ankra cluster info [name]` and `ankra cluster reconcile [name]`), an explicit
+argument wins over `--cluster`, which in turn wins over the saved selection.
+`ankra chat health` and `ankra openclaw skill | handoff` accept `--cluster` too.
+(`ankra cluster scale | node-group | upgrade` always take the cluster id as a
+required positional argument and do not use the selection.)
 
 #### Cluster Access
 ```bash

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -19,9 +19,9 @@ var clusterAgentStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Get agent status for the selected cluster",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			return errNoClusterSelected{}
+			return err
 		}
 
 		agent, err := apiClient.GetClusterAgent(cluster.ID)
@@ -75,9 +75,9 @@ var clusterAgentTokenCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		generate, _ := cmd.Flags().GetBool("generate")
 
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			return errNoClusterSelected{}
+			return err
 		}
 
 		if generate {
@@ -123,9 +123,9 @@ var clusterAgentUpgradeCmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "Upgrade the agent on the selected cluster",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			return errNoClusterSelected{}
+			return err
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -321,9 +321,9 @@ var chatHealthCmd = &cobra.Command{
 	Use:   "health",
 	Short: "Get AI-analyzed cluster health",
 	Run: func(cmd *cobra.Command, args []string) {
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println("No active cluster selected. Run 'ankra cluster select <name>' or 'ankra cluster select' to pick one.")
+			fmt.Println(err)
 			return
 		}
 
@@ -378,6 +378,7 @@ func init() {
 	chatHistoryCmd.Flags().Int("limit", 20, "Maximum number of conversations to show")
 
 	chatHealthCmd.Flags().Bool("ai", true, "Include AI analysis")
+	chatHealthCmd.Flags().String("cluster", "", "Target cluster name or ID (defaults to the selected cluster)")
 
 	registerStructuredOutputFlags(chatHistoryCmd, chatShowCmd, chatHealthCmd)
 

--- a/cmd/cluster_addon.go
+++ b/cmd/cluster_addon.go
@@ -29,9 +29,9 @@ var clusterAddonsListCmd = &cobra.Command{
 	Short: "List addons for the active cluster; or show details for a single addon",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println("No active cluster selected. Run 'ankra cluster select <name>' or 'ankra cluster select' to pick one.")
+			fmt.Println(err)
 			return
 		}
 
@@ -136,9 +136,9 @@ var clusterAddonsAvailableCmd = &cobra.Command{
 	Use:   "available",
 	Short: "List addons available for installation",
 	Run: func(cmd *cobra.Command, args []string) {
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println("No active cluster selected. Run 'ankra cluster select <name>' or 'ankra cluster select' to pick one.")
+			fmt.Println(err)
 			return
 		}
 
@@ -195,9 +195,9 @@ var clusterAddonsSettingsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		addonName := args[0]
 
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println("No active cluster selected. Run 'ankra cluster select <name>' or 'ankra cluster select' to pick one.")
+			fmt.Println(err)
 			return
 		}
 
@@ -262,9 +262,9 @@ var clusterAddonsUninstallCmd = &cobra.Command{
 		addonName := args[0]
 		deletePermanently, _ := cmd.Flags().GetBool("delete")
 
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println("No active cluster selected. Run 'ankra cluster select <name>' or 'ankra cluster select' to pick one.")
+			fmt.Println(err)
 			return
 		}
 
@@ -312,9 +312,9 @@ Usage:
 		addonName := args[0]
 		filePath, _ := cmd.Flags().GetString("file")
 
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println("No active cluster selected. Run 'ankra cluster select <name>' or 'ankra cluster select' to pick one.")
+			fmt.Println(err)
 			return
 		}
 

--- a/cmd/cluster_helm.go
+++ b/cmd/cluster_helm.go
@@ -22,9 +22,9 @@ var clusterHelmReleasesCmd = &cobra.Command{
 	Use:   "releases",
 	Short: "List Helm releases in the cluster",
 	Run: func(cmd *cobra.Command, args []string) {
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println("No active cluster selected. Run 'ankra cluster select <name>' or 'ankra cluster select' to pick one.")
+			fmt.Println(err)
 			return
 		}
 
@@ -103,9 +103,9 @@ var clusterHelmUninstallCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println("No active cluster selected. Run 'ankra cluster select <name>' or 'ankra cluster select' to pick one.")
+			fmt.Println(err)
 			return
 		}
 

--- a/cmd/cluster_k8s.go
+++ b/cmd/cluster_k8s.go
@@ -496,9 +496,9 @@ func registerKindCommand(cfg kindConfig) *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		Annotations: map[string]string{"group": "kubernetes"},
 		Run: func(cmd *cobra.Command, args []string) {
-			cluster, err := loadSelectedCluster()
+			cluster, err := resolveActiveCluster(cmd)
 			if err != nil {
-				fmt.Println("No active cluster selected. Run 'ankra cluster select <name>' or 'ankra cluster select' to pick one.")
+				fmt.Println(err)
 				return
 			}
 			namespace, _ := cmd.Flags().GetString("namespace")
@@ -539,9 +539,9 @@ var clusterPodsCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	Annotations: map[string]string{"group": "kubernetes"},
 	Run: func(cmd *cobra.Command, args []string) {
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println("No active cluster selected. Run 'ankra cluster select <name>' or 'ankra cluster select' to pick one.")
+			fmt.Println(err)
 			return
 		}
 		namespace, _ := cmd.Flags().GetString("namespace")
@@ -678,9 +678,9 @@ Example:
 			fmt.Fprintln(os.Stderr, "Error: --namespace (-n) is required for logs")
 			os.Exit(1)
 		}
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println("No active cluster selected. Run 'ankra cluster select <name>' or 'ankra cluster select' to pick one.")
+			fmt.Println(err)
 			return
 		}
 
@@ -717,9 +717,9 @@ Example:
 	Annotations: map[string]string{"group": "kubernetes"},
 	Run: func(cmd *cobra.Command, args []string) {
 		kind := args[0]
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println("No active cluster selected. Run 'ankra cluster select <name>' or 'ankra cluster select' to pick one.")
+			fmt.Println(err)
 			return
 		}
 		namespace, _ := cmd.Flags().GetString("namespace")

--- a/cmd/cluster_manifests.go
+++ b/cmd/cluster_manifests.go
@@ -120,9 +120,9 @@ var clusterManifestsListCmd = &cobra.Command{
 	Short: "List manifests for the active cluster; or show details for a single manifest",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println("No active cluster selected. Run 'ankra cluster select <name>' or 'ankra cluster select' to pick one.")
+			fmt.Println(err)
 			return
 		}
 

--- a/cmd/cluster_operation.go
+++ b/cmd/cluster_operation.go
@@ -71,9 +71,9 @@ var clusterOperationsListCmd = &cobra.Command{
 	Short:   "List executions for the active cluster; optionally, provide an ID for details",
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			return errNoClusterSelected{}
+			return err
 		}
 
 		statusFlag, _ := cmd.Flags().GetStringSlice("status")

--- a/cmd/cluster_select.go
+++ b/cmd/cluster_select.go
@@ -153,6 +153,54 @@ func saveSelectedCluster(cluster client.ClusterListItem) error {
 	return os.WriteFile(path, data, 0600)
 }
 
+// activeClusterFlagName is the persistent --cluster override registered on
+// clusterCmd. Every `ankra cluster ...` subcommand inherits it, so a single
+// command can target a cluster without first running `ankra cluster select`.
+const activeClusterFlagName = "cluster"
+
+// resolveActiveCluster returns the cluster a command should operate on. An
+// explicit --cluster <name|id> takes precedence over the cluster persisted by
+// `ankra cluster select`.
+func resolveActiveCluster(cmd *cobra.Command) (client.ClusterListItem, error) {
+	if override := clusterFlagOverride(cmd); override != "" {
+		return lookupClusterByNameOrID(override)
+	}
+	selected, err := loadSelectedCluster()
+	if err != nil {
+		return client.ClusterListItem{}, errNoClusterSelected{}
+	}
+	return selected, nil
+}
+
+// clusterFlagOverride returns the trimmed --cluster value when the command (or
+// an inherited persistent flag) defines it and a value was supplied.
+func clusterFlagOverride(cmd *cobra.Command) string {
+	if cmd == nil {
+		return ""
+	}
+	flag := cmd.Flags().Lookup(activeClusterFlagName)
+	if flag == nil {
+		return ""
+	}
+	return strings.TrimSpace(flag.Value.String())
+}
+
+// lookupClusterByNameOrID resolves a cluster name or UUID to its full list
+// item. A value shaped like a UUID is looked up by ID first, then falls back to
+// a name lookup so a name that merely resembles a UUID still resolves.
+func lookupClusterByNameOrID(nameOrID string) (client.ClusterListItem, error) {
+	if isLikelyClusterID(nameOrID) {
+		if cluster, err := apiClient.GetClusterByID(nameOrID); err == nil {
+			return cluster, nil
+		}
+	}
+	cluster, err := apiClient.GetCluster(nameOrID)
+	if err != nil {
+		return client.ClusterListItem{}, fmt.Errorf("cluster %q not found", nameOrID)
+	}
+	return cluster, nil
+}
+
 func loadSelectedCluster() (client.ClusterListItem, error) {
 	var cluster client.ClusterListItem
 	path, err := selectedClusterFile()
@@ -176,6 +224,7 @@ func clearSelectedCluster() error {
 }
 
 func init() {
+	clusterCmd.PersistentFlags().String(activeClusterFlagName, "", "Target cluster name or ID for this command, overriding `ankra cluster select`")
 	clusterCmd.AddCommand(clusterSelectCmd)
 	clusterCmd.AddCommand(clusterClearCmd)
 }

--- a/cmd/cluster_ssh_keys.go
+++ b/cmd/cluster_ssh_keys.go
@@ -1,0 +1,211 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+)
+
+type (
+	sshKeysGetFunc    func(clusterID string) (*client.ClusterSSHKeysResult, error)
+	sshKeysSetFunc    func(clusterID string, sshKeyCredentialIDs []string) (*client.UpdateClusterSSHKeysResult, error)
+	sshKeysResyncFunc func(clusterID string) (*client.ResyncSSHKeysResult, error)
+)
+
+// resolveSSHKeysClusterKind looks up the cluster and confirms it is a
+// cloud-managed kind that supports cluster SSH key management, exiting with a
+// clear message otherwise.
+func resolveSSHKeysClusterKind(clusterID string) string {
+	cluster, lookupError := apiClient.GetClusterByID(clusterID)
+	if lookupError != nil {
+		fmt.Fprintf(os.Stderr, "Error looking up cluster %q: %v\n", clusterID, lookupError)
+		os.Exit(1)
+	}
+	switch cluster.Kind {
+	case "hetzner", "ovh", "upcloud":
+		return cluster.Kind
+	default:
+		fmt.Fprintf(os.Stderr,
+			"Cluster %q (kind %q) does not support SSH key management. Only Hetzner, OVH, and UpCloud clusters can use this command.\n",
+			clusterID, cluster.Kind)
+		os.Exit(1)
+		return ""
+	}
+}
+
+func sshKeysGetForKind(kind string) sshKeysGetFunc {
+	switch kind {
+	case "hetzner":
+		return apiClient.GetHetznerClusterSSHKeys
+	case "ovh":
+		return apiClient.GetOvhClusterSSHKeys
+	case "upcloud":
+		return apiClient.GetUpcloudClusterSSHKeys
+	}
+	return nil
+}
+
+func sshKeysSetForKind(kind string) sshKeysSetFunc {
+	switch kind {
+	case "hetzner":
+		return apiClient.UpdateHetznerClusterSSHKeys
+	case "ovh":
+		return apiClient.UpdateOvhClusterSSHKeys
+	case "upcloud":
+		return apiClient.UpdateUpcloudClusterSSHKeys
+	}
+	return nil
+}
+
+func sshKeysResyncForKind(kind string) sshKeysResyncFunc {
+	switch kind {
+	case "hetzner":
+		return apiClient.ResyncHetznerClusterSSHKeys
+	case "ovh":
+		return apiClient.ResyncOvhClusterSSHKeys
+	case "upcloud":
+		return apiClient.ResyncUpcloudClusterSSHKeys
+	}
+	return nil
+}
+
+var clusterSSHKeysCmd = &cobra.Command{
+	Use:     "ssh-keys",
+	Aliases: []string{"ssh-key"},
+	Short:   "Manage SSH keys attached to a cloud cluster",
+	Long: `Get, set, and re-sync the SSH key credentials authorised to access a cloud
+cluster's nodes.
+
+The cloud provider (Hetzner, OVH, or UpCloud) is detected automatically from
+the cluster.`,
+}
+
+var clusterSSHKeysGetCmd = &cobra.Command{
+	Use:   "get <cluster_id>",
+	Short: "Show SSH keys attached to a cluster",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		clusterID := args[0]
+		kind := resolveSSHKeysClusterKind(clusterID)
+
+		result, getError := sshKeysGetForKind(kind)(clusterID)
+		if getError != nil {
+			fmt.Fprintf(os.Stderr, "Error fetching SSH keys: %v\n", getError)
+			os.Exit(1)
+		}
+
+		if renderStructuredOrExit(cmd, result) {
+			return
+		}
+
+		if len(result.SSHKeyCredentialIDs) == 0 {
+			fmt.Println("Attached SSH keys: none")
+		} else {
+			fmt.Println("Attached SSH key credential IDs:")
+			for _, id := range result.SSHKeyCredentialIDs {
+				fmt.Printf("  %s\n", id)
+			}
+		}
+
+		if len(result.AvailableSSHKeys) > 0 {
+			fmt.Println("\nAvailable SSH key credentials:")
+			for _, key := range result.AvailableSSHKeys {
+				fmt.Printf("  %-38s  %s\n", key.CredentialID, key.Name)
+			}
+		}
+	},
+}
+
+var clusterSSHKeysSetCmd = &cobra.Command{
+	Use:   "set <cluster_id>",
+	Short: "Set the SSH keys attached to a cluster",
+	Long: `Replace the SSH key credentials attached to a cluster. Changes take effect on
+the next reconciliation and are applied to running nodes.
+
+Pass --clear to remove all user SSH keys (the Ankra-managed key always remains).`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		clusterID := args[0]
+		clear, _ := cmd.Flags().GetBool("clear")
+		sshKeyCredentialIDs, _ := cmd.Flags().GetStringSlice("ssh-key-credential-ids")
+
+		if clear {
+			sshKeyCredentialIDs = []string{}
+		} else if len(sshKeyCredentialIDs) == 0 {
+			fmt.Fprintln(os.Stderr, "Provide at least one --ssh-key-credential-ids value, or pass --clear to remove all user SSH keys")
+			os.Exit(1)
+		}
+
+		kind := resolveSSHKeysClusterKind(clusterID)
+
+		result, setError := sshKeysSetForKind(kind)(clusterID, sshKeyCredentialIDs)
+		if setError != nil {
+			fmt.Fprintf(os.Stderr, "Error updating SSH keys: %v\n", setError)
+			os.Exit(1)
+		}
+
+		if renderStructuredOrExit(cmd, result) {
+			return
+		}
+
+		fmt.Println(text.FgGreen.Sprint("SSH keys updated. Changes apply on next reconciliation."))
+		if len(result.SSHKeyCredentialIDs) == 0 {
+			fmt.Println("Attached SSH keys: none (Ankra-managed key retained)")
+			return
+		}
+		fmt.Println("Attached SSH key credential IDs:")
+		for _, id := range result.SSHKeyCredentialIDs {
+			fmt.Printf("  %s\n", id)
+		}
+	},
+}
+
+var clusterSSHKeysResyncCmd = &cobra.Command{
+	Use:   "resync <cluster_id>",
+	Short: "Re-sync a cluster's SSH keys with the cloud provider",
+	Long: `Re-sync the cluster's SSH key with the cloud provider. Use this to repair a
+stale provider-side SSH key reference (for example when the key was deleted and
+re-created in the provider console) that blocks new node creation, and to
+re-apply the authorised keys to running nodes.`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		clusterID := args[0]
+		kind := resolveSSHKeysClusterKind(clusterID)
+
+		result, resyncError := sshKeysResyncForKind(kind)(clusterID)
+		if resyncError != nil {
+			fmt.Fprintf(os.Stderr, "Error re-syncing SSH keys: %v\n", resyncError)
+			os.Exit(1)
+		}
+
+		if renderStructuredOrExit(cmd, result) {
+			return
+		}
+
+		fmt.Println(text.FgGreen.Sprint("SSH key re-sync triggered. Keys are repaired and re-applied on the next reconciliation."))
+		for _, id := range result.ResourceIDs {
+			fmt.Printf("  %s\n", id)
+		}
+	},
+}
+
+func init() {
+	clusterSSHKeysSetCmd.Flags().StringSlice("ssh-key-credential-ids", nil, "SSH key credential IDs (comma-separated or repeated)")
+	clusterSSHKeysSetCmd.Flags().Bool("clear", false, "Remove all user SSH keys (the Ankra-managed key is retained)")
+
+	registerStructuredOutputFlags(
+		clusterSSHKeysGetCmd,
+		clusterSSHKeysSetCmd,
+		clusterSSHKeysResyncCmd,
+	)
+
+	clusterSSHKeysCmd.AddCommand(clusterSSHKeysGetCmd)
+	clusterSSHKeysCmd.AddCommand(clusterSSHKeysSetCmd)
+	clusterSSHKeysCmd.AddCommand(clusterSSHKeysResyncCmd)
+
+	clusterCmd.AddCommand(clusterSSHKeysCmd)
+}

--- a/cmd/cluster_ssh_keys_test.go
+++ b/cmd/cluster_ssh_keys_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type clusterSSHKeysMock struct {
+	baseMock
+	cluster client.ClusterListItem
+
+	hetznerResync []string
+	ovhResync     []string
+	upcloudResync []string
+}
+
+func (m *clusterSSHKeysMock) GetClusterByID(clusterID string) (client.ClusterListItem, error) {
+	return m.cluster, nil
+}
+
+func (m *clusterSSHKeysMock) resyncResult() *client.ResyncSSHKeysResult {
+	return &client.ResyncSSHKeysResult{ResourceIDs: []string{"resource-1"}}
+}
+
+func (m *clusterSSHKeysMock) ResyncHetznerClusterSSHKeys(clusterID string) (*client.ResyncSSHKeysResult, error) {
+	m.hetznerResync = append(m.hetznerResync, clusterID)
+	return m.resyncResult(), nil
+}
+
+func (m *clusterSSHKeysMock) ResyncOvhClusterSSHKeys(clusterID string) (*client.ResyncSSHKeysResult, error) {
+	m.ovhResync = append(m.ovhResync, clusterID)
+	return m.resyncResult(), nil
+}
+
+func (m *clusterSSHKeysMock) ResyncUpcloudClusterSSHKeys(clusterID string) (*client.ResyncSSHKeysResult, error) {
+	m.upcloudResync = append(m.upcloudResync, clusterID)
+	return m.resyncResult(), nil
+}
+
+func TestClusterSSHKeysResync_DispatchesByKind(t *testing.T) {
+	const clusterID = "62f4559a-a44d-46d7-aab3-a57c9dd6b4c6"
+
+	cases := []struct {
+		kind        string
+		wantHetzner int
+		wantOvh     int
+		wantUpcloud int
+	}{
+		{kind: "hetzner", wantHetzner: 1},
+		{kind: "ovh", wantOvh: 1},
+		{kind: "upcloud", wantUpcloud: 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			mock := &clusterSSHKeysMock{
+				cluster: client.ClusterListItem{ID: clusterID, Name: "demo", Kind: tc.kind},
+			}
+			setMockClient(t, mock)
+
+			out := captureStdout(t, func() {
+				rootCmd.SetArgs([]string{"cluster", "ssh-keys", "resync", clusterID})
+				if err := rootCmd.Execute(); err != nil {
+					t.Fatalf("execute failed: %v", err)
+				}
+			})
+
+			if len(mock.hetznerResync) != tc.wantHetzner {
+				t.Errorf("hetzner resync calls = %d, want %d", len(mock.hetznerResync), tc.wantHetzner)
+			}
+			if len(mock.ovhResync) != tc.wantOvh {
+				t.Errorf("ovh resync calls = %d, want %d", len(mock.ovhResync), tc.wantOvh)
+			}
+			if len(mock.upcloudResync) != tc.wantUpcloud {
+				t.Errorf("upcloud resync calls = %d, want %d", len(mock.upcloudResync), tc.wantUpcloud)
+			}
+			if !strings.Contains(out, "resource-1") {
+				t.Errorf("expected resource id in output, got:\n%s", out)
+			}
+		})
+	}
+}
+
+func TestSSHKeysSelectorsForKind(t *testing.T) {
+	mock := &clusterSSHKeysMock{}
+	setMockClient(t, mock)
+
+	for _, kind := range []string{"hetzner", "ovh", "upcloud"} {
+		if sshKeysGetForKind(kind) == nil ||
+			sshKeysSetForKind(kind) == nil ||
+			sshKeysResyncForKind(kind) == nil {
+			t.Errorf("kind %q should resolve all ssh-key operations", kind)
+		}
+	}
+	for _, kind := range []string{"imported", "ankra", ""} {
+		if sshKeysGetForKind(kind) != nil ||
+			sshKeysSetForKind(kind) != nil ||
+			sshKeysResyncForKind(kind) != nil {
+			t.Errorf("kind %q should not resolve ssh-key operations", kind)
+		}
+	}
+}

--- a/cmd/cluster_stacks.go
+++ b/cmd/cluster_stacks.go
@@ -25,9 +25,9 @@ var clusterStacksListCmd = &cobra.Command{
 	Short: "List stacks for the active cluster; or show details for a single stack",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			return errNoClusterSelected{}
+			return err
 		}
 
 		stacks, err := apiClient.ListClusterStacks(cluster.ID)
@@ -218,9 +218,9 @@ var clusterStacksDeleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		stackName := args[0]
 
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			return errNoClusterSelected{}
+			return err
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -247,9 +247,9 @@ var clusterStacksRenameCmd = &cobra.Command{
 		oldName := args[0]
 		newName := args[1]
 
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			return errNoClusterSelected{}
+			return err
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -275,9 +275,9 @@ var clusterStacksHistoryCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		stackName := args[0]
 
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			return errNoClusterSelected{}
+			return err
 		}
 
 		history, err := apiClient.GetStackHistory(cluster.ID, stackName)
@@ -350,9 +350,9 @@ and will need to be reconfigured in the target cluster.`,
 			return fmt.Errorf("--to flag is required: specify the target cluster name or ID")
 		}
 
-		sourceCluster, err := loadSelectedCluster()
+		sourceCluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			return errNoClusterSelected{}
+			return err
 		}
 
 		targetClusterID, err := resolveClusterID(targetCluster)

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -557,6 +557,34 @@ func (m baseMock) UpdateOvhClusterSSHKeys(clusterID string, sshKeyCredentialIDs 
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) ResyncOvhClusterSSHKeys(clusterID string) (*client.ResyncSSHKeysResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetHetznerClusterSSHKeys(clusterID string) (*client.ClusterSSHKeysResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) UpdateHetznerClusterSSHKeys(clusterID string, sshKeyCredentialIDs []string) (*client.UpdateClusterSSHKeysResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ResyncHetznerClusterSSHKeys(clusterID string) (*client.ResyncSSHKeysResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetUpcloudClusterSSHKeys(clusterID string) (*client.ClusterSSHKeysResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) UpdateUpcloudClusterSSHKeys(clusterID string, sshKeyCredentialIDs []string) (*client.UpdateClusterSSHKeysResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ResyncUpcloudClusterSSHKeys(clusterID string) (*client.ResyncSSHKeysResult, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) GetOvhAccessInfo(clusterID string) (*client.ClusterAccessInfo, error) {
 	return nil, errors.New("not implemented")
 }
@@ -1075,6 +1103,38 @@ func TestClusterAddonsListCommand(t *testing.T) {
 	}
 	if !strings.Contains(stdoutOutput, "ingress-nginx") {
 		t.Errorf("expected output to contain 'ingress-nginx', got: %s", stdoutOutput)
+	}
+}
+
+type clusterFlagOverrideMock struct {
+	baseMock
+	requestedClusterID string
+}
+
+func (m *clusterFlagOverrideMock) GetCluster(name string) (client.ClusterListItem, error) {
+	if name == "other-cluster" {
+		return client.ClusterListItem{ID: "other-cluster-id", Name: "other-cluster"}, nil
+	}
+	return client.ClusterListItem{}, errors.New("cluster not found")
+}
+
+func (m *clusterFlagOverrideMock) ListClusterAddons(clusterID string) ([]client.ClusterAddonListItem, error) {
+	m.requestedClusterID = clusterID
+	return []client.ClusterAddonListItem{}, nil
+}
+
+func TestClusterFlagOverridesSelectedCluster(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	mock := &clusterFlagOverrideMock{}
+	setMockClient(t, mock)
+	t.Cleanup(func() { _ = clusterCmd.PersistentFlags().Set(activeClusterFlagName, "") })
+
+	_ = captureStdout(t, func() {
+		_, _ = executeCommand("cluster", "addons", "list", "--cluster", "other-cluster")
+	})
+
+	if mock.requestedClusterID != "other-cluster-id" {
+		t.Errorf("expected --cluster to target other-cluster-id (overriding the selected cluster), got %q", mock.requestedClusterID)
 	}
 }
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -152,13 +152,18 @@ func runLogin() error {
 	}
 	codeChallenge := generateCodeChallenge(codeVerifier)
 
-	// Find an available port for the callback server
+	// Find an available port for the callback server. Bind to the IPv4
+	// loopback explicitly and advertise the same 127.0.0.1 literal in the
+	// redirect URI. Using "localhost" here is unsafe: on dual-stack hosts it
+	// resolves to both 127.0.0.1 and ::1, so a browser that picks the IPv6
+	// address reaches nothing (the server only listens on IPv4) and the login
+	// callback silently fails. RFC 8252 §8.3 recommends the loopback IP literal.
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return fmt.Errorf("start callback server: %w", err)
 	}
 	port := listener.Addr().(*net.TCPAddr).Port
-	callbackURL := fmt.Sprintf("http://localhost:%d/callback", port)
+	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/callback", port)
 
 	// Initialize login with the backend
 	loginURL := viper.GetString("base-url")
@@ -271,9 +276,9 @@ func runLogin() error {
 	case err := <-errChan:
 		_ = server.Close()
 		return fmt.Errorf("callback error: %w", err)
-	case <-time.After(5 * time.Minute):
+	case <-time.After(10 * time.Minute):
 		_ = server.Close()
-		return fmt.Errorf("login timed out after 5 minutes")
+		return fmt.Errorf("login timed out after 10 minutes")
 	}
 
 	_ = server.Close()

--- a/cmd/openclaw.go
+++ b/cmd/openclaw.go
@@ -37,9 +37,9 @@ agent, addons, and AI Agents. The default output path is
 $HOME/.openclaw/skills/ankra-<cluster>.md but can be overridden via
 --output.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		cluster, err := loadSelectedCluster()
+		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println("No active cluster selected. Run 'ankra cluster select' to pick one.")
+			fmt.Println(err)
 			return
 		}
 		out, _ := cmd.Flags().GetString("output")
@@ -67,9 +67,9 @@ var openclawHandoffCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		convID := args[0]
-		cluster, err := loadSelectedCluster()
+		cluster, _ := resolveActiveCluster(cmd)
 		clusterPart := ""
-		if err == nil && cluster.ID != "" {
+		if cluster.ID != "" {
 			clusterPart = fmt.Sprintf("&clusterId=%s", cluster.ID)
 		}
 		url := fmt.Sprintf("%s/organisation/ai-agents?openclaw=%s%s", strings.TrimRight(baseURL, "/"), convID, clusterPart)
@@ -150,6 +150,8 @@ This opens the AI Agents tab with the conversation pre-loaded.
 
 func init() {
 	openclawSkillCmd.Flags().StringP("output", "o", "", "Path to write SKILL.md to (default ~/.openclaw/skills/ankra-<cluster>.md)")
+	openclawSkillCmd.Flags().String("cluster", "", "Target cluster name or ID (defaults to the selected cluster)")
+	openclawHandoffCmd.Flags().String("cluster", "", "Target cluster name or ID (defaults to the selected cluster)")
 	openclawCmd.AddCommand(openclawSkillCmd)
 	openclawCmd.AddCommand(openclawHandoffCmd)
 	rootCmd.AddCommand(openclawCmd)

--- a/cmd/ovh_cluster.go
+++ b/cmd/ovh_cluster.go
@@ -843,6 +843,8 @@ func init() {
 		"ankra cluster node-group <list|add|scale|upgrade|delete>",
 		ovhNodeGroupListCmd, ovhNodeGroupAddCmd, ovhNodeGroupScaleCmd, ovhNodeGroupUpgradeCmd, ovhNodeGroupDeleteCmd,
 	)
+	markDeprecatedForGenericVerb("ankra cluster ssh-keys get <cluster_id>", ovhSSHKeysGetCmd)
+	markDeprecatedForGenericVerb("ankra cluster ssh-keys set <cluster_id> --ssh-key-credential-ids ...", ovhSSHKeysSetCmd)
 
 	ovhNodeGroupCmd.AddCommand(ovhNodeGroupListCmd)
 	ovhNodeGroupCmd.AddCommand(ovhNodeGroupAddCmd)

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -19,7 +19,7 @@ import (
 type errNoClusterSelected struct{}
 
 func (errNoClusterSelected) Error() string {
-	return "no cluster specified and none selected; run `ankra cluster select <name>` or `ankra cluster select` first"
+	return "no cluster specified and none selected; pass --cluster <name|id>, or run `ankra cluster select <name>` first"
 }
 
 // clusterCmd is the parent command for cluster operations
@@ -114,9 +114,9 @@ If no name is provided, shows details for the currently selected cluster.`,
 		if len(args) == 1 {
 			name = args[0]
 		} else {
-			selected, err := loadSelectedCluster()
+			selected, err := resolveActiveCluster(cmd)
 			if err != nil {
-				return errNoClusterSelected{}
+				return err
 			}
 			name = selected.Name
 		}
@@ -154,7 +154,7 @@ If a cluster name is provided, reconciles that specific cluster.`,
 			return err
 		}
 
-		clusterID, clusterName, err := resolveClusterFromArgs(args)
+		clusterID, clusterName, err := resolveClusterFromArgs(cmd, args)
 		if err != nil {
 			return err
 		}
@@ -187,7 +187,7 @@ If a cluster name is provided, reconciles that specific cluster.`,
 	},
 }
 
-func resolveClusterFromArgs(args []string) (string, string, error) {
+func resolveClusterFromArgs(cmd *cobra.Command, args []string) (string, string, error) {
 	if len(args) > 0 {
 		clusterName := args[0]
 		cluster, err := apiClient.GetCluster(clusterName)
@@ -196,9 +196,9 @@ func resolveClusterFromArgs(args []string) (string, string, error) {
 		}
 		return cluster.ID, cluster.Name, nil
 	}
-	selected, err := loadSelectedCluster()
+	selected, err := resolveActiveCluster(cmd)
 	if err != nil {
-		return "", "", errNoClusterSelected{}
+		return "", "", err
 	}
 	return selected.ID, selected.Name, nil
 }
@@ -216,7 +216,7 @@ If no cluster name is provided, uses the currently selected cluster.`,
 			return err
 		}
 
-		clusterID, clusterName, err := resolveClusterFromArgs(args)
+		clusterID, clusterName, err := resolveClusterFromArgs(cmd, args)
 		if err != nil {
 			return err
 		}
@@ -276,7 +276,7 @@ deprovision endpoint so cloud resources are released.`,
 			return err
 		}
 
-		clusterID, clusterName, clusterKind, err := resolveClusterFromArgsWithKind(args)
+		clusterID, clusterName, clusterKind, err := resolveClusterFromArgsWithKind(cmd, args)
 		if err != nil {
 			return err
 		}
@@ -347,7 +347,7 @@ deprovision endpoint so cloud resources are released.`,
 	},
 }
 
-func resolveClusterFromArgsWithKind(args []string) (string, string, string, error) {
+func resolveClusterFromArgsWithKind(cmd *cobra.Command, args []string) (string, string, string, error) {
 	if len(args) > 0 {
 		identifier := args[0]
 		// Accept either a cluster ID (consistent with `cluster scale`,
@@ -361,16 +361,16 @@ func resolveClusterFromArgsWithKind(args []string) (string, string, string, erro
 		}
 		return cluster.ID, cluster.Name, cluster.Kind, nil
 	}
-	selected, err := loadSelectedCluster()
+	selected, err := resolveActiveCluster(cmd)
 	if err != nil {
-		return "", "", "", errNoClusterSelected{}
+		return "", "", "", err
 	}
 	cluster, lookupErr := apiClient.GetCluster(selected.Name)
 	if lookupErr != nil {
-		// We have a cached selection but the backend lookup failed. We
-		// intentionally return the cached id/name with no kind so the
-		// generic deprovision path is used (and the API will return a
-		// precise error if the cached selection is stale).
+		// We have a resolved selection but the backend lookup failed. We
+		// intentionally return the id/name with no kind so the generic
+		// deprovision path is used (and the API will return a precise error
+		// if the selection is stale).
 		return selected.ID, selected.Name, "", nil
 	}
 	return cluster.ID, cluster.Name, cluster.Kind, nil
@@ -387,18 +387,12 @@ Example:
   ankra cluster roll-to --version abc123`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		versionID, _ := cmd.Flags().GetString("version")
-		clusterFlag, _ := cmd.Flags().GetString("cluster")
 
-		var clusterID string
-		if clusterFlag != "" {
-			clusterID = clusterFlag
-		} else {
-			selected, err := loadSelectedCluster()
-			if err != nil {
-				return fmt.Errorf("no cluster specified: run `ankra cluster select <name>` or use --cluster")
-			}
-			clusterID = selected.ID
+		selected, err := resolveActiveCluster(cmd)
+		if err != nil {
+			return err
 		}
+		clusterID := selected.ID
 
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
@@ -421,7 +415,6 @@ func init() {
 	clusterDeprovisionCmd.Flags().Bool("force", false, "Force deprovision even if cluster is in an unexpected state")
 
 	clusterRollToCmd.Flags().String("version", "", "Resource version ID to roll to (required)")
-	clusterRollToCmd.Flags().String("cluster", "", "Cluster ID (defaults to selected cluster)")
 	_ = clusterRollToCmd.MarkFlagRequired("version")
 
 	registerStructuredOutputFlags(

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -154,6 +154,9 @@ type APIClient interface {
 	ChangeHetznerControlPlaneInstanceType(clusterID, instanceType string) (*client.ChangeControlPlaneInstanceTypeResult, error)
 	ListHetznerClusterNodes(clusterID string) (*client.NodeListResult, error)
 	GetHetznerClusterNode(clusterID, nodeID string) (*client.NodeDetail, error)
+	GetHetznerClusterSSHKeys(clusterID string) (*client.ClusterSSHKeysResult, error)
+	UpdateHetznerClusterSSHKeys(clusterID string, sshKeyCredentialIDs []string) (*client.UpdateClusterSSHKeysResult, error)
+	ResyncHetznerClusterSSHKeys(clusterID string) (*client.ResyncSSHKeysResult, error)
 
 	ListHetznerCredentials() ([]client.HetznerCredentialListItem, error)
 	CreateHetznerCredential(req client.CreateHetznerCredentialRequest) (*client.CreateHetznerCredentialResponse, error)
@@ -166,6 +169,7 @@ type APIClient interface {
 	StartOvhCluster(clusterID, scope string) (*client.StartOvhClusterResult, error)
 	GetOvhClusterSSHKeys(clusterID string) (*client.ClusterSSHKeysResult, error)
 	UpdateOvhClusterSSHKeys(clusterID string, sshKeyCredentialIDs []string) (*client.UpdateClusterSSHKeysResult, error)
+	ResyncOvhClusterSSHKeys(clusterID string) (*client.ResyncSSHKeysResult, error)
 	GetOvhAccessInfo(clusterID string) (*client.ClusterAccessInfo, error)
 	GetOvhWorkerCount(clusterID string) (*client.WorkerCountResult, error)
 	ScaleOvhWorkers(clusterID string, workerCount int) (*client.ScaleWorkersResult, error)
@@ -211,6 +215,9 @@ type APIClient interface {
 	ChangeUpcloudControlPlaneInstanceType(clusterID, instanceType string) (*client.ChangeControlPlaneInstanceTypeResult, error)
 	ListUpcloudClusterNodes(clusterID string) (*client.NodeListResult, error)
 	GetUpcloudClusterNode(clusterID, nodeID string) (*client.NodeDetail, error)
+	GetUpcloudClusterSSHKeys(clusterID string) (*client.ClusterSSHKeysResult, error)
+	UpdateUpcloudClusterSSHKeys(clusterID string, sshKeyCredentialIDs []string) (*client.UpdateClusterSSHKeysResult, error)
+	ResyncUpcloudClusterSSHKeys(clusterID string) (*client.ResyncSSHKeysResult, error)
 
 	ListUpcloudCredentials() ([]client.UpcloudCredentialListItem, error)
 	CreateUpcloudCredential(req client.CreateUpcloudCredentialRequest) (*client.CreateUpcloudCredentialResponse, error)

--- a/internal/client/cluster_ssh_keys.go
+++ b/internal/client/cluster_ssh_keys.go
@@ -1,0 +1,117 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// ResyncSSHKeysResult is returned by the cluster ssh-keys resync endpoint.
+// It lists the SSH key resource ids that were flagged for re-sync.
+type ResyncSSHKeysResult struct {
+	ResourceIDs []string `json:"resource_ids"`
+}
+
+func (c *Client) getClusterSSHKeys(kind, clusterID string) (*ClusterSSHKeysResult, error) {
+	endpoint := fmt.Sprintf("%s/api/v1/clusters/%s/%s/ssh-keys", c.BaseURL, kind, url.PathEscape(clusterID))
+	var result ClusterSSHKeysResult
+	if err := c.getJSON(endpoint, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *Client) updateClusterSSHKeys(kind, clusterID string, sshKeyCredentialIDs []string) (*UpdateClusterSSHKeysResult, error) {
+	endpoint := fmt.Sprintf("%s/api/v1/clusters/%s/%s/ssh-keys", c.BaseURL, kind, url.PathEscape(clusterID))
+	payload, err := json.Marshal(UpdateClusterSSHKeysRequest{SSHKeyCredentialIDs: sshKeyCredentialIDs})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPut, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer closeBody(resp)
+
+	body, err := readResponseBody(resp)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, newUnexpectedResponseError("update ssh keys failed", resp.StatusCode, redactedBodyForError(body, 500))
+	}
+
+	var result UpdateClusterSSHKeysResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &result, nil
+}
+
+func (c *Client) resyncClusterSSHKeys(kind, clusterID string) (*ResyncSSHKeysResult, error) {
+	endpoint := fmt.Sprintf("%s/api/v1/clusters/%s/%s/ssh-keys/resync", c.BaseURL, kind, url.PathEscape(clusterID))
+
+	req, err := http.NewRequest(http.MethodPost, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer closeBody(resp)
+
+	body, err := readResponseBody(resp)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, newUnexpectedResponseError("resync ssh keys failed", resp.StatusCode, redactedBodyForError(body, 500))
+	}
+
+	var result ResyncSSHKeysResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &result, nil
+}
+
+func (c *Client) GetHetznerClusterSSHKeys(clusterID string) (*ClusterSSHKeysResult, error) {
+	return c.getClusterSSHKeys("hetzner", clusterID)
+}
+
+func (c *Client) UpdateHetznerClusterSSHKeys(clusterID string, sshKeyCredentialIDs []string) (*UpdateClusterSSHKeysResult, error) {
+	return c.updateClusterSSHKeys("hetzner", clusterID, sshKeyCredentialIDs)
+}
+
+func (c *Client) ResyncHetznerClusterSSHKeys(clusterID string) (*ResyncSSHKeysResult, error) {
+	return c.resyncClusterSSHKeys("hetzner", clusterID)
+}
+
+func (c *Client) ResyncOvhClusterSSHKeys(clusterID string) (*ResyncSSHKeysResult, error) {
+	return c.resyncClusterSSHKeys("ovh", clusterID)
+}
+
+func (c *Client) GetUpcloudClusterSSHKeys(clusterID string) (*ClusterSSHKeysResult, error) {
+	return c.getClusterSSHKeys("upcloud", clusterID)
+}
+
+func (c *Client) UpdateUpcloudClusterSSHKeys(clusterID string, sshKeyCredentialIDs []string) (*UpdateClusterSSHKeysResult, error) {
+	return c.updateClusterSSHKeys("upcloud", clusterID, sshKeyCredentialIDs)
+}
+
+func (c *Client) ResyncUpcloudClusterSSHKeys(clusterID string) (*ResyncSSHKeysResult, error) {
+	return c.resyncClusterSSHKeys("upcloud", clusterID)
+}


### PR DESCRIPTION
## Summary
- Add cloud-agnostic `ankra cluster ssh-keys get|set|resync <cluster_id>` that detects the provider (Hetzner/OVH/UpCloud) from the cluster, with matching client methods + the new `resync` endpoint; deprecate the OVH-only `cluster ovh ssh-keys get|set`.
- Add a global `--cluster <name|id>` flag on `ankra cluster ...` subcommands (`resolveActiveCluster`) so a cluster can be targeted per command without `ankra cluster select`.

Pairs with the backend MR in `cluster` (SSH-key self-heal + resync endpoints + reconcile-backlog fixes).

Linear: PLA-613 — https://linear.app/ankra/issue/PLA-613

## Test plan
- [x] `go build ./...`, `go vet`, `go test ./cmd/... ./internal/client/...`
- [x] Dispatch-by-kind unit test for `ssh-keys` (hetzner/ovh/upcloud)
- [x] Real `ankra-cli` -> charizard round-trip: `cluster ssh-keys get` returned org credentials; `cluster ssh-keys resync` flipped the resource to `updating`
- [ ] Reviewer: sanity-check the bundled `--cluster` targeting refactor

