### PR TITLE
Native 2FA step-up during ankra login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 ## Unreleased
 
-## v0.4.0-rc4 — 2026-06-23
+### Changed
+
+- **`ankra login` now completes Ankra-native two-factor authentication.** Second
+  factors are managed by Ankra (not Auth0): when your account has a passkey,
+  security key, or authenticator app enrolled, the token exchange withholds the
+  API token and returns a one-time challenge URL. The CLI opens that URL in your
+  browser, you complete the second step (passkey, authenticator code, or recovery
+  code), and the CLI polls until the step-up succeeds and the token is released.
+  No flags change; accounts without a second factor log in exactly as before.
+
+## v0.4.0-rc4 - 2026-06-23
 
 ### Fixed
 
@@ -17,11 +27,11 @@
   is bounded by an overall 5-minute deadline, so a slow-but-progressing server
   completes the write instead of erroring out while still making progress.
 
-## v0.4.0-rc3 — 2026-06-23
+## v0.4.0-rc3 - 2026-06-23
 
 ### Added
 
-- **Global `--cluster <name|id>` on every `ankra cluster ...` subcommand** —
+- **Global `--cluster <name|id>` on every `ankra cluster ...` subcommand** -
   target a cluster per command without first running `ankra cluster select`.
   The flag is inherited by all cluster subcommands (`stacks`, `operations`,
   `addons`, `manifests`, `get`/`logs`/`resources`, `helm`, `agent`,
@@ -29,10 +39,10 @@
   precedence over the persisted selection; it also accepts either a cluster
   name or ID. `ankra chat health` and `ankra openclaw skill | handoff` gained
   the same `--cluster` override. Commands that already accepted a positional
-  cluster name still do — an explicit argument wins over `--cluster`, which in
+  cluster name still do - an explicit argument wins over `--cluster`, which in
   turn wins over the saved selection.
 
-- **`ankra cluster ssh-keys get | set | resync <cluster_id>`** — cloud-agnostic
+- **`ankra cluster ssh-keys get | set | resync <cluster_id>`** - cloud-agnostic
   SSH key management that detects the provider (Hetzner, OVH, UpCloud)
   automatically from the cluster. `get` lists attached and available SSH key
   credentials, `set` replaces the attached set (use `--clear` to remove all user
@@ -57,29 +67,29 @@
 
 ### Deprecated
 
-- **`ankra cluster ovh ssh-keys get | set <cluster_id>`** — replaced by the
+- **`ankra cluster ovh ssh-keys get | set <cluster_id>`** - replaced by the
   cloud-agnostic `ankra cluster ssh-keys get | set <cluster_id>`. The provider is
   detected automatically from the cluster.
 
-## v0.4.0-rc2 — 2026-06-19
+## v0.4.0-rc2 - 2026-06-19
 
 Builds on v0.4.0-rc1 (all of its provider-parity work is included) and adds
 stack-profile inspection and one-step apply, plus organisation slug resolution.
 
 ### Added
 
-- **`ankra stack-profiles get <profile-id>`** — show a stack profile's metadata,
+- **`ankra stack-profiles get <profile-id>`** - show a stack profile's metadata,
   its published versions, and the parameters a version exposes. Pick a specific
   version with `--version` (defaults to the profile's current version) and use
   `-o json|yaml` for structured output.
-- **`ankra stack-profiles apply <profile-id>`** — instantiate a stack profile
+- **`ankra stack-profiles apply <profile-id>`** - instantiate a stack profile
   onto a cluster. By default it creates a reviewable **draft** (nothing is
   deployed until you pass `--deploy` or deploy it from the dashboard); it targets
   the selected cluster unless `--cluster <name|id>` is given. Choose the profile
   `--version`, name the new stack with `--stack-name`, and bind parameters with
-  `--set name=value` — or, for secrets, `--set-file name=path` / `--set-env
+  `--set name=value` - or, for secrets, `--set-file name=path` / `--set-env
   name=ENV_VAR` so values never reach your shell history or process list.
-- **Organisation slugs** — the organisation `slug` is now shown in
+- **Organisation slugs** - the organisation `slug` is now shown in
   `ankra org list`, `ankra org current`, and `ankra org create`, and both
   `ankra org switch <organisation>` and the global `--org` flag resolve a
   reference by ID, slug, or name (case-insensitive), with actionable errors on
@@ -90,11 +100,11 @@ upgrade | scale | node-group` verbs, the cloud-provider/ingress parity across
 OVH, UpCloud and Hetzner, and the deprecation of the provider-specific
 `cluster {hetzner,ovh,upcloud}` commands.
 
-## v0.4.0-rc1 — 2026-06-18
+## v0.4.0-rc1 - 2026-06-18
 
 ### Added
 
-- **`ankra cluster access list | grant | revoke`** — manage who can reach a
+- **`ankra cluster access list | grant | revoke`** - manage who can reach a
   cluster's Kubernetes API through the Ankra kube gateway (the access used by
   `ankra cluster kubeconfig` and `ankra cluster kube-token`). A grant maps an
   organisation member (by email) to a Kubernetes role (`view`, `edit`, `admin`,
@@ -106,11 +116,11 @@ OVH, UpCloud and Hetzner, and the deprecation of the provider-specific
 
 - **`ankra cluster upgrade <cluster_id> <target_version>`**, **`ankra cluster
   scale <cluster_id> <worker_count>`**, and **`ankra cluster node-group
-  <list|add|scale|upgrade|delete>`** — cloud-agnostic verbs that detect the
+  <list|add|scale|upgrade|delete>`** - cloud-agnostic verbs that detect the
   provider (Hetzner, OVH, UpCloud) automatically from the cluster, so you no
   longer pick a provider namespace. They replace the provider-specific
   `ankra cluster {hetzner,ovh,upcloud} ...` forms (see Deprecated).
-- **`ankra cluster k3s-versions`** — list the k3s (Kubernetes) versions
+- **`ankra cluster k3s-versions`** - list the k3s (Kubernetes) versions
   available for `ankra cluster upgrade`, with the stable channel highlighted.
 - **`ankra cluster deprovision <cluster_id>`** now accepts a cluster ID or a
   name (previously name-only) and routes cloud clusters to the provider-specific
@@ -127,7 +137,7 @@ OVH, UpCloud and Hetzner, and the deprecation of the provider-specific
   `--include-networking=false` to keep the cloud provider without ingress.
 - **`ankra cluster upcloud create`** now matches OVH: **`--external-cloud-provider`**
   (UpCloud CCM + CSI) and the new **`--include-networking`** flag (Traefik +
-  cert-manager) both default to **on** and no longer require GitOps — the
+  cert-manager) both default to **on** and no longer require GitOps - the
   cloud-provider/networking stacks are reconciled directly, and are additionally
   committed to Git when **`--gitops-credential-name`** and **`--gitops-repository`**
   are set. `--include-networking` requires `--external-cloud-provider` (the ingress
@@ -144,14 +154,14 @@ OVH, UpCloud and Hetzner, and the deprecation of the provider-specific
   disables networking; pass `--include-networking=false` to keep the cloud provider
   without ingress.
 - **`ankra cluster ovh stop <cluster_id>`** and **`ankra cluster ovh start
-  <cluster_id> [--scope all|control_plane]`** — stop an OVH cluster's compute
+  <cluster_id> [--scope all|control_plane]`** - stop an OVH cluster's compute
   while keeping its configuration, then start it again later (optionally bringing
   up only the control plane first).
-- **`ankra cluster ovh access-info <cluster_id>`** — print the gateway (bastion)
+- **`ankra cluster ovh access-info <cluster_id>`** - print the gateway (bastion)
   and control plane IPs along with ready-to-use `ssh -J` jump and Kubernetes API
   port-forward commands.
 - **`ankra cluster ovh ssh-keys get <cluster_id>`** and **`ankra cluster ovh
-  ssh-keys set <cluster_id> --ssh-key-credential-ids <id>,...`** — view and
+  ssh-keys set <cluster_id> --ssh-key-credential-ids <id>,...`** - view and
   replace the SSH key credentials attached to an OVH cluster (changes apply on
   the next reconciliation).
 - **`ankra cluster ovh node-group add`** now accepts **`--labels k=v,...`** and
@@ -167,7 +177,7 @@ OVH, UpCloud and Hetzner, and the deprecation of the provider-specific
 
 - **`--config <file>` now fully isolates per-invocation state.** A config file
   with an unfamiliar or missing extension (for example `--config /run/ankra/worker1`)
-  is now parsed as YAML — the only format the CLI writes — instead of reading as
+  is now parsed as YAML - the only format the CLI writes - instead of reading as
   empty and silently dropping the saved token and base URL. The active-cluster
   selection (`ankra cluster select`) is also keyed to the explicit `--config`
   path (stored alongside it as `<config>.selected.json`) rather than `$HOME`, so
@@ -195,7 +205,7 @@ OVH, UpCloud and Hetzner, and the deprecation of the provider-specific
   runtime warning pointing at the replacement; they are scheduled for removal in
   v0.5.0. See `DEPRECATIONS.md`.
 
-## v0.3.0 — 2026-06-11
+## v0.3.0 - 2026-06-11
 
 First stable release of the v0.3.0 line. It consolidates everything shipped in
 the **v0.3.0-rc0 → rc3** release candidates and adds direct kubeconfig, metrics,
@@ -212,7 +222,7 @@ end-to-end from the terminal. Install it with the standard one-liner or
   secret value stayed plaintext base64, and `encrypted_paths` was still updated.
   A dotted `--key` is now normalised to its last segment (`data.password` →
   `password`) with a notice, and after every encryption the CLI verifies the
-  target key's value is real `ENC[...]` ciphertext — hard-failing before any
+  target key's value is real `ENC[...]` ciphertext - hard-failing before any
   file write or stack PATCH when SOPS encrypted nothing. The `--help` examples
   and the `ankra-sops-secrets` skill no longer steer users into the dotted-path
   form.
@@ -220,28 +230,28 @@ end-to-end from the terminal. Install it with the standard one-liner or
 ### Added
 
 - **`ankra cluster kubeconfig add | remove | list`** and **`ankra cluster
-  kube-token`** — wire `kubectl` straight to an Ankra cluster. `kube-token`
+  kube-token`** - wire `kubectl` straight to an Ankra cluster. `kube-token`
   prints a short-lived Kubernetes `ExecCredential` for use as a credential
   plugin, and `kubeconfig add` writes an `ankra-*` context (exec-based, or
   `--embed-token`) into your kubeconfig with atomic `0600` writes that preserve
   any foreign entries and use collision-safe context naming.
-- **`ankra cluster metrics query | query-range`** — proxy a PromQL query (instant
+- **`ankra cluster metrics query | query-range`** - proxy a PromQL query (instant
   or range) to the cluster's Prometheus metrics source, with `table | json |
   yaml` output for ad-hoc inspection and CI.
-- **`ankra support create | list | get | comment | attach | close`** — open and
+- **`ankra support create | list | get | comment | attach | close`** - open and
   track Ankra support requests from the CLI, including image/screenshot
   attachments. Each request goes through a mandatory AI review; use `--force` to
   submit a request the reviewer flags.
-- **`ankra stack-profiles list | export-iac | import`** — manage reusable,
+- **`ankra stack-profiles list | export-iac | import`** - manage reusable,
   organisation-level stack profiles as `ClusterInfrastructureAsCode` YAML
   (export a profile version, import one from a file).
-- **`ankra cluster draft`** — stage every stack in an `ImportCluster` as a
+- **`ankra cluster draft`** - stage every stack in an `ImportCluster` as a
   reviewable draft instead of applying it; nothing is deployed by the command
   itself.
-- **`ankra cluster validate`** — the offline `apply --dry-run` checks plus
+- **`ankra cluster validate`** - the offline `apply --dry-run` checks plus
   server-side chart-existence, plaintext-secret, and parent-reference
   validation; CI-friendly exit codes and `--strict-secrets`.
-- **Self-update & beta channel** — `ankra upgrade` downloads, SHA-256-verifies
+- **Self-update & beta channel** - `ankra upgrade` downloads, SHA-256-verifies
   and atomically swaps the binary, with `--version` pinning for upgrade,
   downgrade and rollback (`--allow-unverified` for releases that predate
   published checksums), and an `ankra config beta enable|disable|status`
@@ -255,14 +265,14 @@ end-to-end from the terminal. Install it with the standard one-liner or
 - **Shared `-o json|yaml` output across commands**, and unexpected platform
   errors now print a hint to file the bug with `ankra support create`.
 - **OVH command parity with the web UI**:
-  - `ovh regions --credential-id <id>` — list the OVH Cloud regions a
+  - `ovh regions --credential-id <id>` - list the OVH Cloud regions a
     credential's project can actually deploy in.
   - `ovh stop <cluster_id>` and `ovh start <cluster_id>
-    [--scope all|control_plane]` — stop a cluster's compute while keeping its
+    [--scope all|control_plane]` - stop a cluster's compute while keeping its
     configuration, then start it again later.
-  - `ovh access-info <cluster_id>` — gateway (bastion) and control plane IPs
+  - `ovh access-info <cluster_id>` - gateway (bastion) and control plane IPs
     with ready-to-use `ssh -J` jump and Kubernetes API port-forward commands.
-  - `ovh ssh-keys get|set` — view and replace the SSH key credentials attached
+  - `ovh ssh-keys get|set` - view and replace the SSH key credentials attached
     to a cluster (changes apply on the next reconciliation).
   - `ovh node-group add --labels k=v,... --taints k=v:Effect,...`, plus
     `node-group labels` / `node-group taints` to update existing groups (an
@@ -292,7 +302,7 @@ end-to-end from the terminal. Install it with the standard one-liner or
 
 #### Stage changes as drafts with `ankra cluster draft`
 
-`ankra cluster draft -f cluster.yaml` stages every stack in an ImportCluster YAML as a reviewable draft instead of applying it. The local checks run first (the same as `ankra cluster apply --dry-run`), then each stack is saved as a resource draft you can review, edit, and deploy from the Ankra stack builder — nothing is deployed by the command itself.
+`ankra cluster draft -f cluster.yaml` stages every stack in an ImportCluster YAML as a reviewable draft instead of applying it. The local checks run first (the same as `ankra cluster apply --dry-run`), then each stack is saved as a resource draft you can review, edit, and deploy from the Ankra stack builder - nothing is deployed by the command itself.
 
 If the cluster does not exist yet it is imported first (live), since drafts can only be attached to an existing cluster. Stacks that already match the cluster's desired state are reported as `no changes` rather than creating an empty draft. The command exits non-zero if any stack fails validation.
 
@@ -302,7 +312,7 @@ ankra cluster draft -f cluster.yaml
 
 #### Server-side validation with `ankra cluster validate`
 
-`ankra cluster validate -f cluster.yaml` runs the same offline checks as `ankra cluster apply --dry-run` (structure, referenced-file YAML, parent/dependency tree) and then sends the spec to the Ankra API for the checks that need server-side data — checks the offline path cannot perform:
+`ankra cluster validate -f cluster.yaml` runs the same offline checks as `ankra cluster apply --dry-run` (structure, referenced-file YAML, parent/dependency tree) and then sends the spec to the Ankra API for the checks that need server-side data - checks the offline path cannot perform:
 
 - **chart existence** in the Helm registries connected to your organisation,
 - **plaintext secret detection** for Kubernetes `Secret` manifests and addon values that are not SOPS-encrypted,
@@ -325,7 +335,7 @@ the running binary in place. It resolves the latest release tag from GitHub
 checksum, and atomically swaps the executable. The command needs no API token.
 
 Pin an exact release with `--version` (with or without the leading `v`) to
-upgrade *or* downgrade — a pinned version installs whether it is newer, older
+upgrade *or* downgrade - a pinned version installs whether it is newer, older
 or the same as the running binary, so it doubles as a rollback. Only an
 unpinned `ankra upgrade` keeps the "already up to date" / "installed version is
 newer" safety checks; pinning is treated as explicit intent and asks for a
@@ -426,7 +436,7 @@ ankra cluster operations list --watch --interval 10s
 ankra cluster operations steps <execution_id> -o json
 ```
 
-## v0.2.4 — May 2026
+## v0.2.4 - May 2026
 
 ### New Features
 
@@ -649,7 +659,7 @@ Available for all providers (`hetzner`, `ovh`, `upcloud`).
 
 #### Surgical Addon and Manifest Upgrades
 
-Two new subcommands for in-place updates against the existing partial-stack endpoint — no more hand-editing the full `ImportCluster.yaml`.
+Two new subcommands for in-place updates against the existing partial-stack endpoint - no more hand-editing the full `ImportCluster.yaml`.
 
 ##### Bump an addon's chart version
 
@@ -691,22 +701,22 @@ ankra cluster manifests upgrade demo-namespace \
 
 ##### Common options
 
-- `--cluster <name|id>` — defaults to the selected cluster.
-- `--stack <name>` — addons only, required when the same addon name exists in multiple stacks. Manifest names are globally unique on a cluster, so `manifests upgrade` has no `--stack` flag.
-- `--registry-name`, `--registry-url`, `--registry-credential-name` — atomically retag the addon's registry.
-- `--namespace` — destructive for addons (Helm reinstall); requires `--yes` or interactive confirmation.
-- `--dry-run` — print the before/after YAML; no API write.
-- `-o json|yaml` — machine-readable output for CI scripts.
+- `--cluster <name|id>` - defaults to the selected cluster.
+- `--stack <name>` - addons only, required when the same addon name exists in multiple stacks. Manifest names are globally unique on a cluster, so `manifests upgrade` has no `--stack` flag.
+- `--registry-name`, `--registry-url`, `--registry-credential-name` - atomically retag the addon's registry.
+- `--namespace` - destructive for addons (Helm reinstall); requires `--yes` or interactive confirmation.
+- `--dry-run` - print the before/after YAML; no API write.
+- `-o json|yaml` - machine-readable output for CI scripts.
 
 All upgrades go through the same partial-stack endpoint as the UI, so they are atomic, locked, and produce a single git commit per invocation when gitops is enabled.
 
 ### API Endpoints
 
-- `GET /api/v1/clusters/{provider}/{id}/control-plane` — read controller count, instance type and editability
-- `PUT /api/v1/clusters/{provider}/{id}/control-plane` — change controller count (1 or 3)
-- `PUT /api/v1/clusters/{provider}/{id}/control-plane/instance-type` — change controller instance type
-- `GET /api/v1/clusters/{provider}/{id}/nodes` — list all managed servers for the cluster
-- `GET /api/v1/clusters/{provider}/{id}/nodes/{node_id}` — full spec and metadata for a node
+- `GET /api/v1/clusters/{provider}/{id}/control-plane` - read controller count, instance type and editability
+- `PUT /api/v1/clusters/{provider}/{id}/control-plane` - change controller count (1 or 3)
+- `PUT /api/v1/clusters/{provider}/{id}/control-plane/instance-type` - change controller instance type
+- `GET /api/v1/clusters/{provider}/{id}/nodes` - list all managed servers for the cluster
+- `GET /api/v1/clusters/{provider}/{id}/nodes/{node_id}` - full spec and metadata for a node
 
 ### Deprecations
 
@@ -717,7 +727,7 @@ All upgrades go through the same partial-stack endpoint as the UI, so they are a
   When the warning prints, upgrade `ankra-cli` to the next release once a
   resumable session-based replacement has shipped on the platform.
 
-## v0.1.129 — April 2026
+## v0.1.129 - April 2026
 
 ### New Features
 
@@ -761,7 +771,7 @@ Node groups can be scaled to 0 (removes all servers but keeps the group definiti
 ankra cluster hetzner node-group upgrade <cluster_id> default cx43
 ```
 
-Instance type upgrades are irreversible — Hetzner disk enlargement cannot be undone. To use a smaller type, create a new node group and delete the old one.
+Instance type upgrades are irreversible - Hetzner disk enlargement cannot be undone. To use a smaller type, create a new node group and delete the old one.
 
 ##### Delete a Node Group
 
@@ -807,23 +817,23 @@ The `node_groups` field is now supported in the cluster create API for all provi
 - **Server naming**: Servers are now named `{cluster}-{group_name}-{index}` instead of `{cluster}-worker-{index}` for better identification.
 - **No online requirement**: Node group operations no longer require the cluster to be online.
 - **Safe instance type changes**: Servers are powered off, verified off, resized, then powered back on. If the resize fails, the server is powered back on automatically.
-- **Graceful K8s cleanup**: K8s uninstall during node deletion is now best-effort — unreachable nodes (powered off, deleted) no longer block the delete operation.
+- **Graceful K8s cleanup**: K8s uninstall during node deletion is now best-effort - unreachable nodes (powered off, deleted) no longer block the delete operation.
 
 ### API Endpoints
 
-- `GET /api/v1/clusters/hetzner/{id}/node-groups` — list node groups
-- `POST /api/v1/clusters/hetzner/{id}/node-groups` — add a node group
-- `PUT /api/v1/clusters/hetzner/{id}/node-groups/{name}/scale` — scale a node group
-- `PUT /api/v1/clusters/hetzner/{id}/node-groups/{name}/instance-type` — upgrade instance type
-- `PUT /api/v1/clusters/hetzner/{id}/node-groups/{name}/labels` — update labels
-- `PUT /api/v1/clusters/hetzner/{id}/node-groups/{name}/taints` — update taints
-- `DELETE /api/v1/clusters/hetzner/{id}/node-groups/{name}` — delete a node group
+- `GET /api/v1/clusters/hetzner/{id}/node-groups` - list node groups
+- `POST /api/v1/clusters/hetzner/{id}/node-groups` - add a node group
+- `PUT /api/v1/clusters/hetzner/{id}/node-groups/{name}/scale` - scale a node group
+- `PUT /api/v1/clusters/hetzner/{id}/node-groups/{name}/instance-type` - upgrade instance type
+- `PUT /api/v1/clusters/hetzner/{id}/node-groups/{name}/labels` - update labels
+- `PUT /api/v1/clusters/hetzner/{id}/node-groups/{name}/taints` - update taints
+- `DELETE /api/v1/clusters/hetzner/{id}/node-groups/{name}` - delete a node group
 
 Same endpoints available for OVH (`/clusters/ovh/...`) and UpCloud (`/clusters/upcloud/...`).
 
 ---
 
-## v0.1.128 — April 2026
+## v0.1.128 - April 2026
 
 ### New Features
 
@@ -939,16 +949,16 @@ ankra credentials upcloud ssh-key create --name my-key --public-key "ssh-ed25519
 
 ### API Endpoints
 
-- `POST /api/v1/clusters/upcloud` — create an UpCloud cluster
-- `DELETE /api/v1/clusters/upcloud/{id}` — deprovision a cluster (returns operation ID)
-- `GET /api/v1/clusters/upcloud/{id}/worker-count` — get worker count
-- `POST /api/v1/clusters/upcloud/{id}/scale-workers` — scale workers
-- `GET /api/v1/clusters/upcloud/{id}/k8s-version` — get Kubernetes version
-- `POST /api/v1/clusters/upcloud/{id}/upgrade-k8s-version` — upgrade Kubernetes version
-- `GET /api/v1/credentials/upcloud` — list UpCloud credentials
-- `POST /api/v1/credentials/upcloud` — create an UpCloud credential
-- `GET /api/v1/credentials/upcloud/ssh-keys` — list SSH key credentials
-- `POST /api/v1/credentials/upcloud/ssh-key` — create an SSH key credential
+- `POST /api/v1/clusters/upcloud` - create an UpCloud cluster
+- `DELETE /api/v1/clusters/upcloud/{id}` - deprovision a cluster (returns operation ID)
+- `GET /api/v1/clusters/upcloud/{id}/worker-count` - get worker count
+- `POST /api/v1/clusters/upcloud/{id}/scale-workers` - scale workers
+- `GET /api/v1/clusters/upcloud/{id}/k8s-version` - get Kubernetes version
+- `POST /api/v1/clusters/upcloud/{id}/upgrade-k8s-version` - upgrade Kubernetes version
+- `GET /api/v1/credentials/upcloud` - list UpCloud credentials
+- `POST /api/v1/credentials/upcloud` - create an UpCloud credential
+- `GET /api/v1/credentials/upcloud/ssh-keys` - list SSH key credentials
+- `POST /api/v1/credentials/upcloud/ssh-key` - create an SSH key credential
 
 ---
 
@@ -1068,16 +1078,16 @@ Use `--generate` to create a new keypair, or omit it to provide your own public 
 
 ### API Endpoints
 
-- `POST /api/v1/clusters/ovh` — create an OVH cluster
-- `DELETE /api/v1/clusters/ovh/{id}` — deprovision a cluster
-- `GET /api/v1/clusters/ovh/{id}/worker-count` — get worker count
-- `POST /api/v1/clusters/ovh/{id}/scale-workers` — scale workers
-- `GET /api/v1/clusters/ovh/{id}/k8s-version` — get Kubernetes version
-- `POST /api/v1/clusters/ovh/{id}/upgrade-k8s-version` — upgrade Kubernetes version
-- `GET /api/v1/credentials/ovh` — list OVH credentials
-- `POST /api/v1/credentials/ovh` — create an OVH credential
-- `GET /api/v1/credentials/ovh/ssh-keys` — list SSH key credentials
-- `POST /api/v1/credentials/ovh/ssh-key` — create an SSH key credential
+- `POST /api/v1/clusters/ovh` - create an OVH cluster
+- `DELETE /api/v1/clusters/ovh/{id}` - deprovision a cluster
+- `GET /api/v1/clusters/ovh/{id}/worker-count` - get worker count
+- `POST /api/v1/clusters/ovh/{id}/scale-workers` - scale workers
+- `GET /api/v1/clusters/ovh/{id}/k8s-version` - get Kubernetes version
+- `POST /api/v1/clusters/ovh/{id}/upgrade-k8s-version` - upgrade Kubernetes version
+- `GET /api/v1/credentials/ovh` - list OVH credentials
+- `POST /api/v1/credentials/ovh` - create an OVH credential
+- `GET /api/v1/credentials/ovh/ssh-keys` - list SSH key credentials
+- `POST /api/v1/credentials/ovh/ssh-key` - create an SSH key credential
 
 ---
 
@@ -1087,7 +1097,7 @@ Use `--generate` to create a new keypair, or omit it to provide your own public 
 
 #### Hetzner Worker Scaling
 
-Scale worker nodes on a Hetzner cluster up or down (1–10 nodes):
+Scale worker nodes on a Hetzner cluster up or down (1-10 nodes):
 
 ```bash
 ankra cluster hetzner scale <cluster_id> <count>
@@ -1132,9 +1142,9 @@ Kubernetes version upgrade initiated.
 
 ### API Endpoints
 
-- `POST /api/v1/clusters/hetzner/{id}/scale-workers` — scale workers
-- `GET /api/v1/clusters/hetzner/{id}/k8s-version` — fetch current k8s version
-- `POST /api/v1/clusters/hetzner/{id}/upgrade-k8s-version` — trigger k8s version upgrade
+- `POST /api/v1/clusters/hetzner/{id}/scale-workers` - scale workers
+- `GET /api/v1/clusters/hetzner/{id}/k8s-version` - fetch current k8s version
+- `POST /api/v1/clusters/hetzner/{id}/upgrade-k8s-version` - trigger k8s version upgrade
 
 ---
 
@@ -1182,8 +1192,8 @@ Kubernetes version upgrade initiated.
 
 ### API Endpoints
 
-- `GET /api/v1/clusters/hetzner/{id}/k8s-version` — fetch current k8s version
-- `POST /api/v1/clusters/hetzner/{id}/upgrade-k8s-version` — trigger k8s version upgrade
+- `GET /api/v1/clusters/hetzner/{id}/k8s-version` - fetch current k8s version
+- `POST /api/v1/clusters/hetzner/{id}/upgrade-k8s-version` - trigger k8s version upgrade
 
 ---
 
@@ -1387,7 +1397,7 @@ ankra cluster decrypt manifest trinity-database-secret -f cluster.yaml
 
 ---
 
-## v0.1.122 and earlier — initial releases
+## v0.1.122 and earlier - initial releases
 
 Originally published as "Ankra CLI v1.0.0"; the tags actually shipped for this
 initial line were `v0.1.115` through `v0.1.122`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ankra CLI
 
-A command-line interface for the [Ankra Platform](https://ankra.io) that allows you to manage Kubernetes clusters, operations, stacks, manifests, addons—and tap into platform-wide insights.
+A command-line interface for the [Ankra Platform](https://ankra.io) that allows you to manage Kubernetes clusters, operations, stacks, manifests, addons-and tap into platform-wide insights.
 
 ## Installation
 
@@ -59,7 +59,7 @@ date or running a newer build (use `--force` to override those).
 `ankra upgrade` downloads the matching `ankra-cli-<os>-<arch>` asset, verifies
 it against the published SHA-256 checksum, and atomically replaces the running
 binary. If a release publishes no checksum the upgrade aborts rather than
-installing an unverified binary — pass `--allow-unverified` to override for
+installing an unverified binary - pass `--allow-unverified` to override for
 older releases. If the binary lives in a directory you cannot write (such as
 `/usr/local/bin`), re-run with `sudo ankra upgrade`.
 
@@ -115,7 +115,7 @@ deprecated command also prints a warning at runtime.
   - CRUD for variables that get substituted into manifests and addon values
     at deploy time (`ankra org variables`, `ankra cluster variables`,
     `ankra cluster stacks variables`)
-  - Stack > cluster > org resolution order — a more specific scope shadows
+  - Stack > cluster > org resolution order - a more specific scope shadows
     less specific ones
   - Upsert semantics (`set` creates or updates), stdin value support,
     `-o json|yaml` for scripting
@@ -289,8 +289,8 @@ Every command that reads or returns data supports structured output via the
 shared `-o/--output` flag, so scripts and AI agents never have to parse
 tables or prose:
 
-- `-o json` — print the result as indented JSON
-- `-o yaml` — same data as YAML
+- `-o json` - print the result as indented JSON
+- `-o yaml` - same data as YAML
 - The kubectl-style commands default to `-o table` and accept `json`/`yaml`
   as alternatives (for example `ankra cluster get pods -o json`)
 
@@ -304,8 +304,8 @@ ankra cluster get pods -o json
 ```
 
 Write commands (reconcile, provision, deprovision, scaling, node groups,
-token creation, ...) also accept `-o json` and emit the API result — including
-operation IDs — so automation can poll `ankra cluster operations list <id> -o json`
+token creation, ...) also accept `-o json` and emit the API result - including
+operation IDs - so automation can poll `ankra cluster operations list <id> -o json`
 for completion. Asynchronous writes submitted without `--wait` emit
 `{"submitted": true, ...}`.
 
@@ -471,7 +471,7 @@ ankra stack-profiles import <file>              # Create a profile from an IaC Y
   [--name <name>] [--category <category>]
 ```
 
-By default `apply` creates a reviewable **draft** on the target cluster — nothing is deployed until you pass `--deploy` or deploy it from the dashboard. Run `ankra stack-profiles get <profile-id>` first to discover which parameters a profile expects. For **secret** parameters prefer `--set-file` or `--set-env` so values never land in your shell history or process list.
+By default `apply` creates a reviewable **draft** on the target cluster - nothing is deployed until you pass `--deploy` or deploy it from the dashboard. Run `ankra stack-profiles get <profile-id>` first to discover which parameters a profile expects. For **secret** parameters prefer `--set-file` or `--set-env` so values never land in your shell history or process list.
 
 #### Cluster Variables
 ```bash
@@ -481,7 +481,7 @@ ankra cluster variables set <name> <value> [--description <text>] [--cluster <na
 ankra cluster variables delete <name> [--cluster <name|id>] [--yes]
 ```
 
-Resolution at deploy time is **stack > cluster > organisation** — a more specific scope shadows less specific ones for the same variable name. Stack variables travel through the same partial-stack PATCH used by `manifests upgrade` / `addons upgrade`; org and cluster variables use dedicated bearer-token endpoints.
+Resolution at deploy time is **stack > cluster > organisation** - a more specific scope shadows less specific ones for the same variable name. Stack variables travel through the same partial-stack PATCH used by `manifests upgrade` / `addons upgrade`; org and cluster variables use dedicated bearer-token endpoints.
 
 #### Cluster Addons
 ```bash
@@ -644,7 +644,7 @@ ankra cluster encrypt addon --name <addon> --key <key> [--cluster <name|id>] [--
 ankra cluster decrypt manifest <name> [--cluster <name|id>]                # Print a decrypted manifest
 ankra cluster decrypt addon --name <addon> [--cluster <name|id>] [--stack <stack>]              # Print decrypted addon values
 
-# File mode (GitOps workflows — rewrites the local cluster.yaml in place)
+# File mode (GitOps workflows - rewrites the local cluster.yaml in place)
 ankra cluster encrypt manifest <name> --key <key> -f <file>
 ankra cluster encrypt addon --name <addon> --key <key> -f <file>
 ankra cluster decrypt manifest <name> -f <file>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,7 +47,7 @@ chmod +x "${ASSET}"
 sudo install -m 0755 "${ASSET}" /usr/local/bin/ankra
 ```
 
-On macOS you can additionally strip the quarantine attribute:
+On macOS you can strip the quarantine attribute:
 
 ```bash
 xattr -d com.apple.quarantine /usr/local/bin/ankra

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -262,7 +262,7 @@ func validateResourceGraph(request client.CreateImportClusterRequest) error {
 	declarationOrder := make([]resourceNode, 0)
 
 	// Parent references resolve by (kind, name) with no stack qualifier, so the
-	// same (kind, name) declared twice — even across stacks — is ambiguous and
+	// same (kind, name) declared twice - even across stacks - is ambiguous and
 	// the backend rejects it. Flag duplicates here rather than silently merging
 	// them into a single node.
 	addResource := func(kind, name, stackName string) error {

--- a/cmd/cluster_draft.go
+++ b/cmd/cluster_draft.go
@@ -94,8 +94,8 @@ func runClusterDraft(cmd *cobra.Command, _ []string) {
 			errorParts := make([]string, 0, len(result.Errors))
 			for _, resourceError := range result.Errors {
 				for _, detail := range resourceError.Errors {
-					fmt.Fprintf(os.Stderr, "    • %s %q: %s — %s\n", resourceError.Kind, resourceError.Name, detail.Key, detail.Message)
-					errorParts = append(errorParts, fmt.Sprintf("%s %q: %s — %s", resourceError.Kind, resourceError.Name, detail.Key, detail.Message))
+					fmt.Fprintf(os.Stderr, "    • %s %q: %s - %s\n", resourceError.Kind, resourceError.Name, detail.Key, detail.Message)
+					errorParts = append(errorParts, fmt.Sprintf("%s %q: %s - %s", resourceError.Kind, resourceError.Name, detail.Key, detail.Message))
 				}
 			}
 			stackOutputs = append(stackOutputs, stackDraftOutput{StackName: stack.Name, Error: strings.Join(errorParts, "; ")})

--- a/cmd/cluster_operation.go
+++ b/cmd/cluster_operation.go
@@ -123,7 +123,7 @@ var clusterOperationsListCmd = &cobra.Command{
 
 		for {
 			clearScreen()
-			fmt.Printf("Watching executions (every %s, press Ctrl+C to stop) — %s\n\n",
+			fmt.Printf("Watching executions (every %s, press Ctrl+C to stop) - %s\n\n",
 				interval, time.Now().Format("15:04:05"))
 			keepWatching, err := renderExecutionsOnce(options, executionID)
 			if err != nil {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -38,10 +38,17 @@ type tokenExchangeRequest struct {
 }
 
 type tokenExchangeResponse struct {
-	Token     string `json:"token"`
-	ExpiresAt string `json:"expires_at"`
-	TokenID   string `json:"token_id"`
-	TokenName string `json:"token_name"`
+	Token        string `json:"token"`
+	ExpiresAt    string `json:"expires_at"`
+	TokenID      string `json:"token_id"`
+	TokenName    string `json:"token_name"`
+	MfaRequired  bool   `json:"mfa_required"`
+	MfaTicket    string `json:"mfa_ticket"`
+	ChallengeURL string `json:"challenge_url"`
+}
+
+type mfaPollRequest struct {
+	Ticket string `json:"ticket"`
 }
 
 var loginCmd = &cobra.Command{
@@ -323,6 +330,18 @@ func runLogin() error {
 		return fmt.Errorf("parse token response: %w", err)
 	}
 
+	// When the account has a second factor, the backend withholds the token and
+	// hands back an MFA ticket plus a browser URL where the user completes the
+	// passkey / authenticator / recovery-code challenge. We open that URL and
+	// poll until the step-up succeeds and the token is released.
+	if tokenData.MfaRequired {
+		completed, err := completeMFAChallenge(loginURL, tokenData)
+		if err != nil {
+			return err
+		}
+		tokenData = completed
+	}
+
 	configPath := getConfigPath()
 
 	configDir := filepath.Dir(configPath)
@@ -377,6 +396,76 @@ func runLogin() error {
 	fmt.Println()
 
 	return nil
+}
+
+func completeMFAChallenge(loginURL string, pending tokenExchangeResponse) (tokenExchangeResponse, error) {
+	fmt.Println()
+	fmt.Println("Two-factor authentication required.")
+	fmt.Println("Complete the second step in your browser:")
+	fmt.Println()
+	fmt.Printf("  %s\n", pending.ChallengeURL)
+	fmt.Println()
+
+	if err := openBrowser(pending.ChallengeURL); err != nil {
+		fmt.Println("Could not open browser automatically. Please open the URL above manually.")
+	}
+
+	fmt.Println("Waiting for you to complete two-factor authentication...")
+	fmt.Println("(Press Ctrl+C to cancel)")
+	fmt.Println()
+
+	pollURL := fmt.Sprintf("%s/api/v1/cli/login/mfa/poll", strings.TrimRight(loginURL, "/"))
+	requestBody, _ := json.Marshal(mfaPollRequest{Ticket: pending.MfaTicket})
+
+	deadline := time.After(10 * time.Minute)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			return tokenExchangeResponse{}, fmt.Errorf("two-factor authentication timed out after 10 minutes")
+		case <-ticker.C:
+			polled, done, err := pollMFAToken(pollURL, requestBody)
+			if err != nil {
+				return tokenExchangeResponse{}, err
+			}
+			if done {
+				return polled, nil
+			}
+		}
+	}
+}
+
+func pollMFAToken(pollURL string, requestBody []byte) (tokenExchangeResponse, bool, error) {
+	resp, err := loginHTTPClient.Post(pollURL, "application/json", strings.NewReader(string(requestBody)))
+	if err != nil {
+		// Transient network error - keep polling.
+		return tokenExchangeResponse{}, false, nil
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", closeErr)
+		}
+	}()
+
+	if resp.StatusCode == http.StatusGone {
+		return tokenExchangeResponse{}, false, fmt.Errorf("login session expired; run 'ankra login' again")
+	}
+	if resp.StatusCode != http.StatusOK {
+		// Server hiccup - keep polling rather than failing the whole login.
+		return tokenExchangeResponse{}, false, nil
+	}
+
+	var polled tokenExchangeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&polled); err != nil {
+		return tokenExchangeResponse{}, false, nil
+	}
+	if polled.Token != "" {
+		return polled, true, nil
+	}
+	// Still awaiting the second factor.
+	return tokenExchangeResponse{}, false, nil
 }
 
 func generateCodeVerifier() (string, error) {

--- a/cmd/stack_profiles.go
+++ b/cmd/stack_profiles.go
@@ -212,7 +212,7 @@ var stackProfilesApplyCmd = &cobra.Command{
 	Short: "Apply a stack profile to a cluster as a draft (optionally deploy)",
 	Long: `Apply (instantiate) a stack profile onto a cluster.
 
-By default this creates a reviewable stack DRAFT on the target cluster — nothing is
+By default this creates a reviewable stack DRAFT on the target cluster - nothing is
 deployed until you review it in the Ankra dashboard or pass --deploy.
 
 Bind profile parameters with --set name=value. For secret parameters prefer

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -72,7 +72,7 @@ func (c *Client) OrganisationOverride() string {
 
 // httpClientForSlowWrite returns a client for synchronous writes that can
 // legitimately take longer than the shared client's 30s response-header
-// timeout to start responding — notably PATCH /stacks/{stack_name}, which
+// timeout to start responding - notably PATCH /stacks/{stack_name}, which
 // performs a synchronous git commit+push on the request path. It drops
 // ResponseHeaderTimeout so the call is bounded by the caller's context
 // instead of failing with "http2: timeout awaiting response headers" while

--- a/internal/client/clusters.go
+++ b/internal/client/clusters.go
@@ -410,7 +410,7 @@ type ValidateClusterResponse struct {
 }
 
 // ValidateCluster runs the server-side validation that the offline checks
-// cannot — chart existence in connected registries, plaintext-secret
+// cannot - chart existence in connected registries, plaintext-secret
 // detection, and parent references against live cluster state. A non-empty
 // clusterID validates the spec against that cluster's existing resources.
 func (c *Client) ValidateCluster(ctx context.Context, spec CreateResourceSpec, strictSecrets bool, clusterID string) (*ValidateClusterResponse, error) {

--- a/internal/skills/embedded/skills/ankra-alerts-webhooks/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-alerts-webhooks/SKILL.md
@@ -26,7 +26,7 @@ When an alert fires, Ankra can attach an AI analysis of the likely cause and aff
 
 ## Rules
 
-- **Secrets as credentials.** Webhook URLs and integration keys are secrets — store them in Ankra credentials / the secret store, never commit them.
+- **Secrets as credentials.** Webhook URLs and integration keys are secrets - store them in Ankra credentials / the secret store, never commit them.
 - **Scope and severity-route.** Don't fan every alert to every channel; map severity to destination (critical → on-call, warning → chat).
 - **Test delivery** before relying on a route in production.
 - **Avoid alert noise.** Tune thresholds so alerts are actionable; noisy alerts get ignored.

--- a/internal/skills/embedded/skills/ankra-cicd/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-cicd/SKILL.md
@@ -40,7 +40,7 @@ For full, copy-pasteable GitHub Actions and GitLab CI examples, see [reference.m
 
 ## Rules
 
-- **Immutable tags only** — commit SHA or semver, never `latest` or a moving tag.
+- **Immutable tags only** - commit SHA or semver, never `latest` or a moving tag.
 - **CI updates Git, Ankra deploys.** Do not run `kubectl apply` / `helm upgrade` against the cluster from CI.
 - **Least-privilege secrets.** CI needs registry push and GitOps-repo write; it does not need cluster admin.
 - **One image, many environments.** Promote by committing the same tag to the next environment's path, don't rebuild.

--- a/internal/skills/embedded/skills/ankra-cicd/reference.md
+++ b/internal/skills/embedded/skills/ankra-cicd/reference.md
@@ -1,4 +1,4 @@
-# Ankra CI/CD — pipeline examples
+# Ankra CI/CD - pipeline examples
 
 Both examples follow the same pattern: build, push an immutable tag, then commit the new tag into the GitOps repository so Ankra/ArgoCD syncs it. Neither talks to the cluster directly.
 

--- a/internal/skills/embedded/skills/ankra-cli/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-cli/SKILL.md
@@ -55,7 +55,7 @@ Most `ankra cluster ...` subcommands act on the selected cluster. Override per c
 
 ## Machine-readable output
 
-Every data command supports `-o json` (and `-o yaml`). **Always pass `-o json` when parsing output programmatically** — never scrape tables or prose:
+Every data command supports `-o json` (and `-o yaml`). **Always pass `-o json` when parsing output programmatically** - never scrape tables or prose:
 
 ```bash
 ankra cluster list -o json
@@ -93,7 +93,7 @@ ankra cluster access revoke user@example.com             # by email (all grants)
 
 ## Report bugs & get help (`ankra support`)
 
-Users **and agents** file bugs and support requests straight from the terminal. When any `ankra` command fails with an unexpected platform response, the CLI prints this exact suggestion — follow it:
+Users **and agents** file bugs and support requests straight from the terminal. When any `ankra` command fails with an unexpected platform response, the CLI prints this exact suggestion - follow it:
 
 ```bash
 ankra support create \
@@ -107,10 +107,10 @@ Expected: the apply to be accepted."
 ```
 
 - Include the **exact command, full error output, and what you expected** in `--description`. `--cluster` links the ticket to a cluster so the team sees its context.
-- Every ticket passes a **mandatory AI review**. If it is flagged (low detail, missing reproduction), the create returns guidance — improve the description, or re-submit with `--force` to file it anyway.
+- Every ticket passes a **mandatory AI review**. If it is flagged (low detail, missing reproduction), the create returns guidance - improve the description, or re-submit with `--force` to file it anyway.
 - Attach screenshots or images: `ankra support attach <ticket-id> <file>...`
 - Track it: `ankra support list`, `ankra support get <ticket-id>` (shows replies and whether the Ankra team is tracking it), `ankra support comment <ticket-id> -m "..."`, `ankra support close <ticket-id>`.
-- **Agents** filing on a user's behalf: pass `--source agent` and `-o json` for machine-readable output; never invent reproduction details — quote the real command and output.
+- **Agents** filing on a user's behalf: pass `--source agent` and `-o json` for machine-readable output; never invent reproduction details - quote the real command and output.
 - Categories: `technical` (default), `bug`, `account`, `billing`, `feature_request`, `other`. Severities: `low`, `medium`, `high`, `critical`.
 
 ## Authentication for automation
@@ -123,7 +123,7 @@ export ANKRA_ORG=<org>             # optional; or pass --org
 ankra cluster info --cluster prod
 ```
 
-Resolution order: explicit `--token` (paired with `--base-url`), then the saved login from `ankra login`, then `ANKRA_API_TOKEN` (+ optional `ANKRA_BASE_URL`). A saved login token takes precedence over `ANKRA_API_TOKEN` — run `ankra logout` first if you want the env var to win. Use least-privilege tokens and store them in the CI secret store, not in Git.
+Resolution order: explicit `--token` (paired with `--base-url`), then the saved login from `ankra login`, then `ANKRA_API_TOKEN` (+ optional `ANKRA_BASE_URL`). A saved login token takes precedence over `ANKRA_API_TOKEN` - run `ankra logout` first if you want the env var to win. Use least-privilege tokens and store them in the CI secret store, not in Git.
 
 ## Conventions to follow
 

--- a/internal/skills/embedded/skills/ankra-cloud-clusters/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-cloud-clusters/SKILL.md
@@ -9,7 +9,7 @@ Besides importing existing clusters, Ankra can provision managed K3s clusters on
 
 ## 1. Store provider credentials
 
-Provider credentials (and SSH keys) are scoped credentials held by Ankra. Create them first and note the returned credential ID — the create commands take the ID, not the name.
+Provider credentials (and SSH keys) are scoped credentials held by Ankra. Create them first and note the returned credential ID - the create commands take the ID, not the name.
 
 ```bash
 ankra credentials hetzner create --name hetzner-prod
@@ -36,7 +36,7 @@ ankra cluster ovh create \
 
 Hetzner/UpCloud `create` take equivalent flags (`--name`, `--credential-id`, location/region, control-plane and worker sizes/counts, `--ssh-key-credential-id[s]`, optional `--kubernetes-version`). Run `ankra cluster <provider> create --help` for the provider-specific server-type/location flags.
 
-> `ankra cluster provision` and `ankra cluster deprovision` **start and stop** an already-created managed cluster — they are not how you create one. Creation is always `ankra cluster <provider> create`.
+> `ankra cluster provision` and `ankra cluster deprovision` **start and stop** an already-created managed cluster - they are not how you create one. Creation is always `ankra cluster <provider> create`.
 
 ## 3. Manage the lifecycle
 
@@ -95,7 +95,7 @@ Confirm the target with `ankra cluster info` first; deprovisioning releases infr
 - **Confirm the target** before any `deprovision`, `delete`, scale-down, or version/instance upgrade. Node-group `upgrade` is irreversible.
 - **Use `--wait`** when a follow-up step depends on the result; otherwise treat creates and node-group mutations as in-flight and don't re-submit.
 - **Plan node groups** for workload isolation rather than one undifferentiated pool, and right-size them to avoid inflated cost.
-- **Upgrade deliberately** — review the target Kubernetes version and upgrade non-prod first.
+- **Upgrade deliberately** - review the target Kubernetes version and upgrade non-prod first.
 
 ## Related skills
 

--- a/internal/skills/embedded/skills/ankra-gitops/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-gitops/SKILL.md
@@ -50,14 +50,14 @@ gitops-repo/
 
 1. Branch from `main`, edit the relevant `stack.yaml` / manifests.
 2. Open a pull request; review the diff.
-3. Merge to the synced branch — Ankra/ArgoCD reconciles the change onto the cluster.
+3. Merge to the synced branch - Ankra/ArgoCD reconciles the change onto the cluster.
 4. Confirm with `ankra cluster operations list` and `ankra cluster info`.
 
 ## Rules
 
 - **Git is the source of truth.** Do not hand-edit cluster state out of band; change the repo and let it sync.
 - **Protect the synced branch.** Require PR review; treat merges as deploys.
-- **Encrypt secrets before commit.** Never commit plaintext Secrets — use SOPS (`ankra-sops-secrets`).
+- **Encrypt secrets before commit.** Never commit plaintext Secrets - use SOPS (`ankra-sops-secrets`).
 - **Pin versions.** Exact chart versions and immutable image tags so a commit fully determines what runs.
 - **Small, reviewable commits.** One logical change per PR; the diff should read as "what will deploy".
 

--- a/internal/skills/embedded/skills/ankra-helm-registries/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-helm-registries/SKILL.md
@@ -9,8 +9,8 @@ Addons pull charts from a `repository_url`. Public charts work as-is; private ch
 
 ## Registry types
 
-- **HTTP Helm repositories** — classic chart servers: ChartMuseum, Harbor, Nexus, JFrog Artifactory, an S3-backed index. `repository_url: https://charts.example.com`.
-- **OCI registries** — charts stored as OCI artifacts: GHCR, Amazon ECR, Google Artifact Registry, Azure Container Registry, Docker Hub. `repository_url: oci://registry.example.com/charts`.
+- **HTTP Helm repositories** - classic chart servers: ChartMuseum, Harbor, Nexus, JFrog Artifactory, an S3-backed index. `repository_url: https://charts.example.com`.
+- **OCI registries** - charts stored as OCI artifacts: GHCR, Amazon ECR, Google Artifact Registry, Azure Container Registry, Docker Hub. `repository_url: oci://registry.example.com/charts`.
 
 ## Connect and use
 
@@ -41,7 +41,7 @@ ankra charts info <chart>       # inspect a chart and its versions
 - **Least privilege.** Registry credentials should be read-only pull tokens, scoped to the needed repositories.
 - **Pin `chart_version`.** Always pin; never resolve `latest` from a registry in production.
 - **Prefer OCI** for new private registries where the backend supports it.
-- **Credentials live in Ankra**, referenced by name from addons — never inline secrets in stack YAML.
+- **Credentials live in Ankra**, referenced by name from addons - never inline secrets in stack YAML.
 - **Verify reachability** from the cluster's network before relying on a private registry in a deploy.
 
 ## Related skills

--- a/internal/skills/embedded/skills/ankra-import-cluster/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-import-cluster/SKILL.md
@@ -48,17 +48,17 @@ spec:
 
 ## Field reference
 
-- `spec.git_repository` — connect a Git repo so stacks are stored and synced from Git (see `ankra-gitops`). Omit for a non-GitOps import.
-- `spec.stacks[]` — each stack groups related `manifests` and `addons`.
-- `manifests[]` — raw Kubernetes YAML. Use `from_file: "path.yaml"` to reference a file, or `manifest: |-` for inline content.
-- `addons[]` — Helm releases. Required: `chart_name`, `chart_version`, `repository_url`, `namespace`. Configure via `configuration.values: |-` (inline) or `configuration.from_file:`.
-- `parents` — the dependency edges that control deployment order. A resource only deploys after its parents succeed. Reference a parent as `- manifest: <name>` or `- addon: <name>`.
+- `spec.git_repository` - connect a Git repo so stacks are stored and synced from Git (see `ankra-gitops`). Omit for a non-GitOps import.
+- `spec.stacks[]` - each stack groups related `manifests` and `addons`.
+- `manifests[]` - raw Kubernetes YAML. Use `from_file: "path.yaml"` to reference a file, or `manifest: |-` for inline content.
+- `addons[]` - Helm releases. Required: `chart_name`, `chart_version`, `repository_url`, `namespace`. Configure via `configuration.values: |-` (inline) or `configuration.from_file:`.
+- `parents` - the dependency edges that control deployment order. A resource only deploys after its parents succeed. Reference a parent as `- manifest: <name>` or `- addon: <name>`.
 
 ## Workflow
 
 1. Create namespaces as manifests first; make dependent addons/configmaps list that namespace manifest in `parents`.
 2. Pin every addon's `chart_version` to an exact version.
-3. Keep secret material out of plaintext — encrypt with SOPS and mark `encrypted_paths` (see `ankra-sops-secrets`).
+3. Keep secret material out of plaintext - encrypt with SOPS and mark `encrypted_paths` (see `ankra-sops-secrets`).
 4. Validate and apply:
 
 ```bash

--- a/internal/skills/embedded/skills/ankra-observability/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-observability/SKILL.md
@@ -54,7 +54,7 @@ Instead of (or in addition to) in-cluster Prometheus, connect a Prometheus-compa
 
 - **Namespace first**, then the stack via `parents`.
 - **Pin chart versions.**
-- **No plaintext credentials** (Grafana admin password, remote-write tokens) — use SOPS-encrypted values (`ankra-sops-secrets`).
+- **No plaintext credentials** (Grafana admin password, remote-write tokens) - use SOPS-encrypted values (`ankra-sops-secrets`).
 - **Read-only credentials** for external metrics sources.
 - **Right-size retention and resources** in values; avoid unbounded storage defaults in production.
 

--- a/internal/skills/embedded/skills/ankra-platform-principles/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-platform-principles/SKILL.md
@@ -46,7 +46,7 @@ Treat `delete`, `deprovision`, `roll-to`, and force operations as deliberate. Co
 
 ## 9. Review before deploy
 
-Protect synced branches, require pull-request review, and keep diffs small. A merge is a deploy — review it like one.
+Protect synced branches, require pull-request review, and keep diffs small. A merge is a deploy - review it like one.
 
 ## Related skills
 

--- a/internal/skills/embedded/skills/ankra-sops-secrets/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-sops-secrets/SKILL.md
@@ -11,11 +11,11 @@ Never commit plaintext Secrets. Ankra integrates SOPS (with AGE keys) so sensiti
 
 - **SOPS** encrypts the values of YAML keys, leaving structure readable so diffs stay reviewable.
 - **AGE** is the recommended key type (simple, modern). The public key encrypts; the private key (held by Ankra / the cluster) decrypts.
-- **`encrypted_paths`** — the list, on a manifest or addon, of YAML key names that are SOPS-encrypted, so Ankra knows what to decrypt.
+- **`encrypted_paths`** - the list, on a manifest or addon, of YAML key names that are SOPS-encrypted, so Ankra knows what to decrypt.
 
 ## Workflow with the CLI
 
-`encrypt` / `decrypt` take an `addon` or `manifest` subcommand and a `--key`. They run in two modes: **cluster mode** (default — fetch the resource from a live cluster, encrypt, and push the result back) and **file mode** (`-f cluster.yaml` — rewrite the referenced `from_file` on disk and add the key to `encrypted_paths`, for GitOps).
+`encrypt` / `decrypt` take an `addon` or `manifest` subcommand and a `--key`. They run in two modes: **cluster mode** (default - fetch the resource from a live cluster, encrypt, and push the result back) and **file mode** (`-f cluster.yaml` - rewrite the referenced `from_file` on disk and add the key to `encrypted_paths`, for GitOps).
 
 `--key` takes the **YAML key name**, not a dotted path: SOPS matches key names anywhere in the document, so the `password` under a Secret's `data:` is `--key password`. A dotted `--key` like `data.password` is normalised to its last segment, and the CLI verifies the value is real `ENC[...]` ciphertext after encrypting.
 
@@ -59,7 +59,7 @@ addons:
 ## Rules
 
 - **Plaintext secrets never reach Git.** Encrypt first, commit the encrypted file.
-- **Encrypt values, not whole files where possible** — keep keys/structure visible so reviews are meaningful.
+- **Encrypt values, not whole files where possible** - keep keys/structure visible so reviews are meaningful.
 - **Declare `encrypted_paths`** for every encrypted value so Ankra decrypts the right fields.
 - **Rotate keys** and re-encrypt when access changes; scope decryption to the clusters that need it.
 - **Do not log decrypted output** or paste it into chat, issues, or CI logs.

--- a/internal/skills/embedded/skills/ankra-stacks-addons/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-stacks-addons/SKILL.md
@@ -9,10 +9,10 @@ A Stack is Ankra's reusable unit of deployment: it bundles Helm addons, raw mani
 
 ## Building blocks
 
-- **Addon** — a Helm release: `chart_name`, `chart_version`, `repository_url`, `namespace`, and `configuration.values`.
-- **Manifest** — raw Kubernetes YAML (namespaces, ConfigMaps, CRDs, RBAC, anything Helm does not own).
-- **Variable** — a named value substituted into manifests/addon values, so the same stack works across environments.
-- **Parents** — dependency edges. A resource deploys only after every parent has succeeded.
+- **Addon** - a Helm release: `chart_name`, `chart_version`, `repository_url`, `namespace`, and `configuration.values`.
+- **Manifest** - raw Kubernetes YAML (namespaces, ConfigMaps, CRDs, RBAC, anything Helm does not own).
+- **Variable** - a named value substituted into manifests/addon values, so the same stack works across environments.
+- **Parents** - dependency edges. A resource deploys only after every parent has succeeded.
 
 ## Deployment order via `parents`
 
@@ -49,7 +49,7 @@ Promote anything environment-specific (domains, replica counts, storage classes,
 
 ## Design rules
 
-- **Small, focused stacks.** One concern per stack (logging, monitoring, ingress) beats a single mega-stack — easier to reason about, reorder, and clone.
+- **Small, focused stacks.** One concern per stack (logging, monitoring, ingress) beats a single mega-stack - easier to reason about, reorder, and clone.
 - **Namespace first.** The namespace manifest is a parent of everything deployed into it.
 - **Pin chart versions.** Exact `chart_version` everywhere; never floating in production.
 - **Test before prod.** Roll a stack out to dev/staging, then promote the same definition to production.

--- a/internal/skills/embedded/skills/ankra-terraform/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-terraform/SKILL.md
@@ -24,7 +24,7 @@ provider "ankra" {
 }
 ```
 
-Authenticate with a scoped API token created via `ankra tokens create`, supplied through `ANKRA_API_TOKEN` or a Terraform variable backed by the secret store — never a literal in committed HCL.
+Authenticate with a scoped API token created via `ankra tokens create`, supplied through `ANKRA_API_TOKEN` or a Terraform variable backed by the secret store - never a literal in committed HCL.
 
 ## Workflow
 

--- a/testing/validation/README.md
+++ b/testing/validation/README.md
@@ -39,7 +39,7 @@ addons are identified by name when present, otherwise by 1-based position
 | `manifest-no-source.yaml` | `stack "logging": manifest "namespace-fluent-bit": a manifest must set either 'manifest' (inline YAML) or 'from_file' (path to a YAML file)` |
 | `manifest-missing-file.yaml` | `stack "logging": manifest "namespace-fluent-bit": could not read the file referenced by 'from_file' ("..."): ... no such file or directory` |
 | `addon-missing-name.yaml` | `stack "logging": addon #1: every addon needs a 'name'` |
-| `stack-without-manifests-key.yaml` | Passes validation. A stack that omits the `manifests` key (and likewise `addons`) is handled gracefully — `cmd/apply.go` guards the map access, so no panic. |
+| `stack-without-manifests-key.yaml` | Passes validation. A stack that omits the `manifests` key (and likewise `addons`) is handled gracefully - `cmd/apply.go` guards the map access, so no panic. |
 
 `manifests/namespace.yaml` is the Kubernetes manifest referenced by
 `valid-cluster.yaml` via `from_file`.
@@ -51,12 +51,12 @@ After the structural checks above, `--dry-run` also validates the parent
 dependency errors the backend would otherwise only reject at apply time
 (HTTP 422). Three rules are enforced:
 
-1. **Parent kind** — each parent `kind` must be `manifest` or `addon`:
+1. **Parent kind** - each parent `kind` must be `manifest` or `addon`:
    `addon "cert-manager" in stack "apps": parent #1 has invalid kind "stack" (must be "manifest" or "addon")`
-2. **Parent existence** — each parent must name a manifest or addon declared
+2. **Parent existence** - each parent must name a manifest or addon declared
    anywhere in the same document (cross-stack references are allowed):
    `addon "cert-manager" in stack "apps": parent manifest "namespace" is not defined anywhere in this file`
-3. **Acyclic graph** — the parent edges must not form a cycle (a resource
+3. **Acyclic graph** - the parent edges must not form a cycle (a resource
    depending on itself counts):
    `dependency cycle detected: addon "a" -> addon "b" -> addon "a"`
 
@@ -67,11 +67,11 @@ These checks run for both `ankra cluster apply` and `ankra cluster apply --dry-r
 **Every file reference in the document is resolved and checked**, regardless of
 whether its content is ultimately used:
 
-- `manifest.from_file` and inline `manifest` — resolved and parsed as YAML
+- `manifest.from_file` and inline `manifest` - resolved and parsed as YAML
   (multi-document `---` files supported).
-- `addon.configuration.from_file` and inline `configuration.values` — resolved
+- `addon.configuration.from_file` and inline `configuration.values` - resolved
   and parsed as YAML.
-- `stack.description_from_file` — resolved and read (a plain-text description,
+- `stack.description_from_file` - resolved and read (a plain-text description,
   so existence/readability only). This is validated even when an inline
   `description` is also set and takes precedence for the value.
 


### PR DESCRIPTION
## Summary

`ankra login` now completes Ankra-native two-factor authentication. With 2FA moved off Auth0 Guardian, the CLI token exchange withholds the API token when the account has a second factor and returns a one-time ticket plus a browser challenge URL. The CLI opens that URL, the user completes passkey / authenticator / recovery in the browser, and the CLI polls `/api/v1/cli/login/mfa/poll` until the step-up succeeds and the token is released.

- `cmd/login.go`: detect `mfa_required` from the token exchange, open the challenge URL, poll until the token is issued (10-minute deadline, 2s interval).
- `CHANGELOG.md`: Unreleased entry describing the behaviour.
- No flags change; accounts without a second factor log in exactly as before.

Pairs with cluster MR !158 (backend `/api/v1/cli/login/mfa/{start,poll}` + step-up) and portal MR !662 (`/mfa/cli-complete`).

Bundles accumulated working-tree updates from the current session.

## Test plan

- [x] `go build ./...`
- [ ] Manual: `ankra login` with a passkey/TOTP-enrolled account completes via browser and finishes; an account without a factor logs in unchanged.

Made with [Cursor](https://cursor.com)