### PR TITLE
Phase 0: exit-code contract, RunE migration, deprecation forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## Unreleased
 
+### Changed
+
+- **Differentiated exit codes** - the CLI now exits with a stable, documented
+  code instead of always `1`: `0` success, `1` API/runtime error, `2`
+  usage/flag error, `3` targeted resource not found, `4` confirmation
+  declined, `5` `--wait`/`--timeout` expiry, `6` authentication failure
+  (missing/expired/rejected credentials, 401/403). Scripts can now branch on
+  the failure class (re-authenticate on 6, treat 3 as idempotent success)
+  without parsing error text.
+- **Errors always reach stderr and set a non-zero exit code.** Every command
+  handler was converted from cobra's `Run` to `RunE`. This fixes a class of
+  bugs where failures printed an error to *stdout* and exited `0`, invisible
+  to scripts and CI: all of `charts` and `chat`, `cluster manifests list`,
+  `cluster select`/`clear`, credential list commands, and others. Error text
+  no longer pollutes stdout for `-o json|yaml` consumers; it is printed by
+  cobra to stderr as `Error: ...`.
+- **`ankra delete cluster`** - declining the confirmation prompt now exits `4`
+  (previously printed "Aborted." and exited `0`); deleting a cluster that does
+  not exist now exits `3` (previously exited `0`); the refusal hint for cloud
+  clusters now points at `ankra cluster deprovision` instead of the
+  provider-namespaced form deprecated in v0.4.0; and the underlying API error
+  is included in the failure message instead of being swallowed.
+
+### Added
+
+- **Deprecation forwarding machinery** (internal) - `deprecateAndForward`
+  registers a hidden forwarder at an old command path that re-dispatches to
+  the replacement with argument rewriting, emitting cobra's human-facing
+  notice plus a machine-readable `ANKRA_DEPRECATED=<old>=><new>
+  removal=<version>` stderr marker for scripts and agents. No forwarders are
+  wired yet; this lands the mechanism for upcoming command-tree work.
+
 ## v0.4.0 - 2026-06-30
 
 The stable v0.4.0 release consolidates the v0.4.0 release candidates into a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,17 @@
 
 - **Differentiated exit codes** - the CLI now exits with a stable, documented
   code instead of always `1`: `0` success, `1` API/runtime error, `2`
-  usage/flag error, `3` targeted resource not found, `4` confirmation
-  declined, `5` `--wait`/`--timeout` expiry, `6` authentication failure
-  (missing/expired/rejected credentials, 401/403). Scripts can now branch on
-  the failure class (re-authenticate on 6, treat 3 as idempotent success)
-  without parsing error text.
+  usage/flag error (unknown command/flag, bad arguments, missing required
+  flags), `3` targeted resource not found, `4` confirmation declined, `5`
+  `--wait`/`--timeout` expiry on asynchronous writes (internal request
+  deadlines still exit `1`), `6` authentication failure (missing/expired/
+  rejected credentials, 401/403). Scripts can now branch on the failure class
+  (re-authenticate on 6, treat 3 as idempotent success) without parsing error
+  text.
+- **Declined confirmations exit `4` everywhere** - including `helm registries
+  delete` and `helm credentials delete`, which previously printed
+  "Cancelled." to stdout and exited `0`, indistinguishable from a successful
+  delete.
 - **Errors always reach stderr and set a non-zero exit code.** Every command
   handler was converted from cobra's `Run` to `RunE`. This fixes a class of
   bugs where failures printed an error to *stdout* and exited `0`, invisible

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -19,7 +19,7 @@ var clusterApplyCmd = &cobra.Command{
 	Use:   "apply",
 	Short: "Apply an ImportCluster YAML to the Ankra API",
 	Args:  cobra.NoArgs,
-	Run:   runApply,
+	RunE:  runApply,
 }
 
 func init() {
@@ -28,46 +28,35 @@ func init() {
 	registerAsyncWriteFlags(clusterApplyCmd)
 	registerStructuredOutputFlags(clusterApplyCmd)
 	setDryRunOffline(clusterApplyCmd)
-	if err := clusterApplyCmd.MarkFlagRequired("file"); err != nil {
-		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
-		os.Exit(1)
-	}
+	_ = clusterApplyCmd.MarkFlagRequired("file")
 	clusterCmd.AddCommand(clusterApplyCmd)
 }
 
-func runApply(cmd *cobra.Command, _ []string) {
+func runApply(cmd *cobra.Command, _ []string) error {
 	filePath, err := cmd.Flags().GetString("file")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error reading --file: %s\n", err)
-		os.Exit(1)
+		return fmt.Errorf("reading --file: %w", err)
 	}
 	if filePath == "" {
-		fmt.Fprintln(os.Stderr, "--file is required")
-		if err := cmd.Usage(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error displaying usage: %s\n", err)
-		}
-		os.Exit(1)
+		return errors.New("--file is required")
 	}
 	dryRun, err := cmd.Flags().GetBool("dry-run")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error reading --dry-run: %s\n", err)
-		os.Exit(1)
+		return fmt.Errorf("reading --dry-run: %w", err)
 	}
 
 	importRequest, err := buildImportRequest(filePath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Invalid ImportCluster in %q:\n  %s\n", filePath, err)
-		os.Exit(1)
+		return fmt.Errorf("invalid ImportCluster in %q:\n  %w", filePath, err)
 	}
 
 	if err := validateResourceGraph(importRequest); err != nil {
-		fmt.Fprintf(os.Stderr, "Invalid ImportCluster in %q:\n  %s\n", filePath, err)
-		os.Exit(1)
+		return fmt.Errorf("invalid ImportCluster in %q:\n  %w", filePath, err)
 	}
 
 	if dryRun {
 		fmt.Printf("Validation succeeded for %q; no changes applied (--dry-run).\n", filePath)
-		return
+		return nil
 	}
 
 	wait := asyncWriteWaitFlag(cmd)
@@ -76,34 +65,36 @@ func runApply(cmd *cobra.Command, _ []string) {
 
 	importResponse, submitted, err := apiClient.ApplyCluster(requestContext, importRequest, wait)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error applying cluster: %s\n", err)
-		os.Exit(1)
+		return fmt.Errorf("applying cluster: %w", err)
 	}
 	if submitted {
-		if renderStructuredOrExit(cmd, newAsyncSubmittedResult("Cluster apply")) {
-			return
+		if rendered, err := renderStructured(cmd, newAsyncSubmittedResult("Cluster apply")); rendered || err != nil {
+			return err
 		}
 		printAsyncWriteSubmitted("Cluster apply")
 		fmt.Println("For a new cluster, the agent install command is only shown when you use --wait.")
-		return
+		return nil
 	}
 
 	if len(importResponse.Errors) > 0 {
-		if renderStructuredOrExit(cmd, importResponse) {
-			os.Exit(1)
+		rendered, renderErr := renderStructured(cmd, importResponse)
+		if renderErr != nil {
+			return renderErr
 		}
-		fmt.Fprintln(os.Stderr, "Import failed with the following issues:")
-		for _, resourceError := range importResponse.Errors {
-			fmt.Fprintf(os.Stderr, "- %s %q:\n", resourceError.Kind, resourceError.Name)
-			for _, detail := range resourceError.Errors {
-				fmt.Fprintf(os.Stderr, "    • %s: %s\n", detail.Key, detail.Message)
+		if !rendered {
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Import failed with the following issues:")
+			for _, resourceError := range importResponse.Errors {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "- %s %q:\n", resourceError.Kind, resourceError.Name)
+				for _, detail := range resourceError.Errors {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "    • %s: %s\n", detail.Key, detail.Message)
+				}
 			}
 		}
-		os.Exit(1)
+		return errors.New("import failed")
 	}
 
-	if renderStructuredOrExit(cmd, importResponse) {
-		return
+	if rendered, err := renderStructured(cmd, importResponse); rendered || err != nil {
+		return err
 	}
 
 	if importResponse.ImportCommand == "" {
@@ -118,6 +109,7 @@ func runApply(cmd *cobra.Command, _ []string) {
 
 	fmt.Printf("\nView it in the UI:\n  %s/organisation/clusters/cluster/imported/%s/overview\n",
 		strings.TrimRight(baseURL, "/"), importResponse.ClusterId)
+	return nil
 }
 
 func buildImportRequest(path string) (client.CreateImportClusterRequest, error) {

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -71,7 +71,7 @@ func runApply(cmd *cobra.Command, _ []string) error {
 
 	importResponse, submitted, err := apiClient.ApplyCluster(requestContext, importRequest, wait)
 	if err != nil {
-		return fmt.Errorf("applying cluster: %w", err)
+		return asyncWriteError("applying cluster", wait, err)
 	}
 	if submitted {
 		if rendered, err := renderStructured(cmd, newAsyncSubmittedResult("Cluster apply")); rendered || err != nil {

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -59,8 +59,14 @@ func runApply(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	wait := asyncWriteWaitFlag(cmd)
-	requestContext, cancelRequestContext := asyncWriteRequestContext(cmd)
+	wait, err := asyncWriteWaitFlag(cmd)
+	if err != nil {
+		return err
+	}
+	requestContext, cancelRequestContext, err := asyncWriteRequestContext(cmd)
+	if err != nil {
+		return err
+	}
 	defer cancelRequestContext()
 
 	importResponse, submitted, err := apiClient.ApplyCluster(requestContext, importRequest, wait)

--- a/cmd/async_write.go
+++ b/cmd/async_write.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -37,6 +38,17 @@ func asyncWriteRequestContext(command *cobra.Command) (context.Context, context.
 	}
 	requestContext, cancel := context.WithTimeout(context.Background(), timeout)
 	return requestContext, cancel, nil
+}
+
+// asyncWriteError wraps a failed asynchronous write, tagging it with
+// exitWaitTimeout when the --wait deadline expired so scripts can distinguish
+// "gave up waiting" (the write may still complete) from a rejected write.
+func asyncWriteError(operationLabel string, wait bool, err error) error {
+	wrapped := fmt.Errorf("%s: %w", operationLabel, err)
+	if wait && errors.Is(err, context.DeadlineExceeded) {
+		return withExitCode(exitWaitTimeout, wrapped)
+	}
+	return wrapped
 }
 
 func printAsyncWriteSubmitted(operationLabel string) {

--- a/cmd/async_write.go
+++ b/cmd/async_write.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -16,26 +15,28 @@ func registerAsyncWriteFlags(command *cobra.Command) {
 	command.Flags().Duration("timeout", defaultAsyncWriteTimeout, "Maximum time to wait when --wait is set")
 }
 
-func asyncWriteWaitFlag(command *cobra.Command) bool {
+func asyncWriteWaitFlag(command *cobra.Command) (bool, error) {
 	wait, err := command.Flags().GetBool("wait")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error reading --wait: %s\n", err)
-		os.Exit(1)
+		return false, fmt.Errorf("reading --wait: %w", err)
 	}
-	return wait
+	return wait, nil
 }
 
-func asyncWriteRequestContext(command *cobra.Command) (context.Context, context.CancelFunc) {
-	wait := asyncWriteWaitFlag(command)
+func asyncWriteRequestContext(command *cobra.Command) (context.Context, context.CancelFunc, error) {
+	wait, err := asyncWriteWaitFlag(command)
+	if err != nil {
+		return nil, nil, err
+	}
 	if !wait {
-		return context.Background(), func() {}
+		return context.Background(), func() {}, nil
 	}
 	timeout, err := command.Flags().GetDuration("timeout")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error reading --timeout: %s\n", err)
-		os.Exit(1)
+		return nil, nil, fmt.Errorf("reading --timeout: %w", err)
 	}
-	return context.WithTimeout(context.Background(), timeout)
+	requestContext, cancel := context.WithTimeout(context.Background(), timeout)
+	return requestContext, cancel, nil
 }
 
 func printAsyncWriteSubmitted(operationLabel string) {

--- a/cmd/charts.go
+++ b/cmd/charts.go
@@ -20,24 +20,23 @@ var chartsCmd = &cobra.Command{
 var chartsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List available Helm charts",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		page, _ := cmd.Flags().GetInt("page")
 		pageSize, _ := cmd.Flags().GetInt("page-size")
 		onlySubscribed, _ := cmd.Flags().GetBool("subscribed")
 
 		resp, err := apiClient.ListCharts(page, pageSize, onlySubscribed)
 		if err != nil {
-			fmt.Printf("Error listing charts: %v\n", err)
-			return
+			return fmt.Errorf("listing charts: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, resp) {
-			return
+		if rendered, err := renderStructured(cmd, resp); rendered || err != nil {
+			return err
 		}
 
 		if len(resp.Charts) == 0 {
 			fmt.Println("No charts found.")
-			return
+			return nil
 		}
 
 		t := table.NewWriter()
@@ -67,6 +66,7 @@ var chartsListCmd = &cobra.Command{
 
 		fmt.Printf("\nPage %d of %d (page size: %d)\n",
 			resp.Pagination.Page, resp.Pagination.TotalPages, resp.Pagination.PageSize)
+		return nil
 	},
 }
 
@@ -74,25 +74,24 @@ var chartsSearchCmd = &cobra.Command{
 	Use:   "search <query>",
 	Short: "Search for Helm charts",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		query := args[0]
 
 		charts, err := apiClient.SearchCharts(query)
 		if err != nil {
-			fmt.Printf("Error searching charts: %v\n", err)
-			return
+			return fmt.Errorf("searching charts: %w", err)
 		}
 
 		if charts == nil {
 			charts = []client.ChartItem{}
 		}
-		if renderStructuredOrExit(cmd, charts) {
-			return
+		if rendered, err := renderStructured(cmd, charts); rendered || err != nil {
+			return err
 		}
 
 		if len(charts) == 0 {
 			fmt.Printf("No charts found matching '%s'.\n", query)
-			return
+			return nil
 		}
 
 		fmt.Printf("Charts matching '%s':\n\n", query)
@@ -121,6 +120,7 @@ var chartsSearchCmd = &cobra.Command{
 			})
 		}
 		t.Render()
+		return nil
 	},
 }
 
@@ -131,7 +131,7 @@ var chartsInfoCmd = &cobra.Command{
 
 Requires either --repository flag or finding the chart in the catalog first.`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		chartName := args[0]
 		repositoryURL, _ := cmd.Flags().GetString("repository")
 
@@ -139,8 +139,7 @@ Requires either --repository flag or finding the chart in the catalog first.`,
 		if repositoryURL == "" {
 			charts, err := apiClient.SearchCharts(chartName)
 			if err != nil {
-				fmt.Printf("Error finding chart: %v\n", err)
-				return
+				return fmt.Errorf("finding chart: %w", err)
 			}
 
 			// Find exact match
@@ -152,19 +151,17 @@ Requires either --repository flag or finding the chart in the catalog first.`,
 			}
 
 			if repositoryURL == "" {
-				fmt.Printf("Chart '%s' not found. Please specify --repository flag.\n", chartName)
-				return
+				return withExitCode(exitNotFound, fmt.Errorf("chart '%s' not found. Please specify --repository flag", chartName))
 			}
 		}
 
 		details, err := apiClient.GetChartDetails(chartName, repositoryURL)
 		if err != nil {
-			fmt.Printf("Error getting chart details: %v\n", err)
-			return
+			return fmt.Errorf("getting chart details: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, details) {
-			return
+		if rendered, err := renderStructured(cmd, details); rendered || err != nil {
+			return err
 		}
 
 		fmt.Printf("Chart: %s\n\n", details.Name)
@@ -198,6 +195,7 @@ Requires either --repository flag or finding the chart in the catalog first.`,
 				fmt.Println()
 			}
 		}
+		return nil
 	},
 }
 

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -204,7 +204,7 @@ func runInteractiveChat(clusterID *string) error {
 var chatHistoryCmd = &cobra.Command{
 	Use:   "history",
 	Short: "List chat conversation history",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterName, _ := cmd.Flags().GetString("cluster")
 		limit, _ := cmd.Flags().GetInt("limit")
 
@@ -212,25 +212,25 @@ var chatHistoryCmd = &cobra.Command{
 		if clusterName != "" {
 			cluster, err := apiClient.GetCluster(clusterName)
 			if err != nil {
-				fmt.Printf("Error finding cluster %s: %v\n", clusterName, err)
-				return
+				return fmt.Errorf("finding cluster %s: %w", clusterName, err)
 			}
 			clusterID = &cluster.ID
 		}
 
 		resp, err := apiClient.ListChatHistory(clusterID, limit, 0)
 		if err != nil {
-			fmt.Printf("Error listing chat history: %v\n", err)
-			return
+			return fmt.Errorf("listing chat history: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, resp) {
-			return
+		if handled, err := renderStructured(cmd, resp); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		if len(resp.Conversations) == 0 {
 			fmt.Println("No chat conversations found.")
-			return
+			return nil
 		}
 
 		t := table.NewWriter()
@@ -260,6 +260,7 @@ var chatHistoryCmd = &cobra.Command{
 			})
 		}
 		t.Render()
+		return nil
 	},
 }
 
@@ -267,17 +268,18 @@ var chatShowCmd = &cobra.Command{
 	Use:   "show <conversation_id>",
 	Short: "Show a specific chat conversation",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		conversationID := args[0]
 
 		conv, err := apiClient.GetChatConversation(conversationID)
 		if err != nil {
-			fmt.Printf("Error getting conversation: %v\n", err)
-			return
+			return fmt.Errorf("getting conversation: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, conv) {
-			return
+		if handled, err := renderStructured(cmd, conv); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		if conv.Title != nil {
@@ -295,6 +297,7 @@ var chatShowCmd = &cobra.Command{
 				fmt.Printf("%s: %s\n\n", text.FgGreen.Sprint("Assistant"), msg.Content)
 			}
 		}
+		return nil
 	},
 }
 
@@ -302,41 +305,41 @@ var chatDeleteCmd = &cobra.Command{
 	Use:   "delete <conversation_id>",
 	Short: "Delete a chat conversation",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		conversationID := args[0]
 
 		result, err := apiClient.DeleteChatConversation(conversationID)
 		if err != nil {
-			fmt.Printf("Error deleting conversation: %v\n", err)
-			return
+			return fmt.Errorf("deleting conversation: %w", err)
 		}
 
 		if result.Success {
 			fmt.Println("Conversation deleted successfully!")
 		}
+		return nil
 	},
 }
 
 var chatHealthCmd = &cobra.Command{
 	Use:   "health",
 	Short: "Get AI-analyzed cluster health",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		includeAI, _ := cmd.Flags().GetBool("ai")
 
 		health, err := apiClient.GetClusterHealth(cluster.ID, includeAI)
 		if err != nil {
-			fmt.Printf("Error getting cluster health: %v\n", err)
-			return
+			return fmt.Errorf("getting cluster health: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, health) {
-			return
+		if handled, err := renderStructured(cmd, health); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		fmt.Printf("Cluster Health for '%s'\n", cluster.Name)
@@ -368,6 +371,7 @@ var chatHealthCmd = &cobra.Command{
 				fmt.Printf("    - %s\n", rec)
 			}
 		}
+		return nil
 	},
 }
 

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -110,7 +110,7 @@ func runClone(cmd *cobra.Command, args []string) error {
 		parsedURL, _ := url.Parse(existingFileOrURL)
 		// Keep the full path up to the cluster file, then remove just the filename
 		parsedURL.Path = strings.TrimSuffix(parsedURL.Path, filepath.Base(parsedURL.Path))
-		existingBaseDir = strings.TrimSuffix(parsedURL.String(), "/")  // Remove trailing slash
+		existingBaseDir = strings.TrimSuffix(parsedURL.String(), "/") // Remove trailing slash
 	} else {
 		// Read existing cluster from local file
 		existingData, err = os.ReadFile(existingFileOrURL)

--- a/cmd/clone_test.go
+++ b/cmd/clone_test.go
@@ -98,11 +98,11 @@ func TestGetStackNames(t *testing.T) {
 
 func TestCheckStackConflicts(t *testing.T) {
 	tests := []struct {
-		name               string
-		newStack           StackConfig
-		existingStacks     []StackConfig
-		expectManifests    int
-		expectAddons       int
+		name            string
+		newStack        StackConfig
+		existingStacks  []StackConfig
+		expectManifests int
+		expectAddons    int
 	}{
 		{
 			name: "no conflicts",

--- a/cmd/cluster_access.go
+++ b/cmd/cluster_access.go
@@ -43,27 +43,28 @@ Examples:
 var clusterAccessListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List access grants for a cluster",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID, err := resolveKubeTokenClusterID(accessClusterFlag)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 
 		grants, err := apiClient.ListClusterAccessGrants(context.Background(), clusterID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 
-		if renderStructuredOrExit(cmd, grants.Result) {
-			return
+		if handled, err := renderStructured(cmd, grants.Result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		if len(grants.Result) == 0 {
 			fmt.Println("No access grants found. Add one with: ankra cluster access grant <email> --role view")
-			return
+			return nil
 		}
 		renderGrantsTable(grants.Result)
+		return nil
 	},
 }
 
@@ -77,16 +78,14 @@ The grant is cluster-wide by default; pass --namespace to limit it to one
 namespace. Roles map to the standard Kubernetes ClusterRoles: view, edit,
 admin, cluster-admin.`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		email := args[0]
 		if err := validateAccessRole(accessRoleFlag); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 		clusterID, err := resolveKubeTokenClusterID(accessClusterFlag)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 
 		request := client.CreateClusterAccessGrantRequest{
@@ -102,18 +101,20 @@ admin, cluster-admin.`,
 
 		created, err := apiClient.CreateClusterAccessGrant(context.Background(), clusterID, request)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 
-		if renderStructuredOrExit(cmd, created.Grant) {
-			return
+		if handled, err := renderStructured(cmd, created.Grant); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		grant := created.Grant
 		fmt.Printf("Granted %s role %q (%s scope) on the cluster.\n", email, grant.Role, grant.Scope)
 		fmt.Printf("  Grant ID: %s\n", grant.ID)
 		fmt.Println("The grant is applied to the cluster by the RBAC reconciler; check status with: ankra cluster access list")
 		fmt.Printf("The member can now run: ankra cluster kubeconfig add --cluster %s --use\n", displayClusterReference())
+		return nil
 	},
 }
 
@@ -125,27 +126,25 @@ var clusterAccessRevokeCmd = &cobra.Command{
 Pass a grant ID (from 'ankra cluster access list') to revoke a single grant,
 or an email address to revoke every grant that member has on the cluster.`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		target := args[0]
 		clusterID, err := resolveKubeTokenClusterID(accessClusterFlag)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 
 		grantIDs, err := resolveGrantIDs(clusterID, target)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 
 		for _, grantID := range grantIDs {
 			if _, err := apiClient.DeleteClusterAccessGrant(context.Background(), clusterID, grantID); err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				os.Exit(1)
+				return err
 			}
 			fmt.Printf("Revoked grant %s\n", grantID)
 		}
+		return nil
 	},
 }
 
@@ -164,7 +163,7 @@ func resolveGrantIDs(clusterID string, target string) ([]string, error) {
 		}
 	}
 	if len(grantIDs) == 0 {
-		return nil, fmt.Errorf("no access grants found for %q on this cluster", target)
+		return nil, withExitCode(exitNotFound, fmt.Errorf("no access grants found for %q on this cluster", target))
 	}
 	return grantIDs, nil
 }

--- a/cmd/cluster_addon.go
+++ b/cmd/cluster_addon.go
@@ -17,7 +17,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-
 var clusterAddonsCmd = &cobra.Command{
 	Use:   "addons",
 	Short: "Manage addons for clusters",
@@ -28,29 +27,29 @@ var clusterAddonsListCmd = &cobra.Command{
 	Use:   "list [addon name]",
 	Short: "List addons for the active cluster; or show details for a single addon",
 	Args:  cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		addons, err := apiClient.ListClusterAddons(cluster.ID)
 		if err != nil {
-			fmt.Printf("Error listing addons: %v\n", err)
-			return
+			return fmt.Errorf("listing addons: %w", err)
 		}
 		if len(args) == 0 {
 			if addons == nil {
 				addons = []client.ClusterAddonListItem{}
 			}
-			if renderStructuredOrExit(cmd, addons) {
-				return
+			if handled, err := renderStructured(cmd, addons); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 		}
 		if len(addons) == 0 {
 			fmt.Println("No addons found for the active cluster.")
-			return
+			return nil
 		}
 
 		if len(args) == 1 {
@@ -63,11 +62,12 @@ var clusterAddonsListCmd = &cobra.Command{
 				}
 			}
 			if found == nil {
-				fmt.Printf("Addon %q not found on the active cluster.\n", name)
-				return
+				return withExitCode(exitNotFound, fmt.Errorf("addon %q not found on the active cluster", name))
 			}
-			if renderStructuredOrExit(cmd, found) {
-				return
+			if handled, err := renderStructured(cmd, found); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 
 			fmt.Println("Addon Details:")
@@ -86,7 +86,7 @@ var clusterAddonsListCmd = &cobra.Command{
 			}
 			fmt.Printf("  Created:         %s\n", formatTimeAgo(found.CreatedAt.Format(time.RFC3339)))
 			fmt.Printf("  Updated:         %s\n", formatTimeAgo(found.UpdatedAt.Format(time.RFC3339)))
-			return
+			return nil
 		}
 
 		t := table.NewWriter()
@@ -129,34 +129,35 @@ var clusterAddonsListCmd = &cobra.Command{
 			})
 		}
 		t.Render()
+		return nil
 	},
 }
 
 var clusterAddonsAvailableCmd = &cobra.Command{
 	Use:   "available",
 	Short: "List addons available for installation",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		addons, err := apiClient.ListAvailableAddons(cluster.ID)
 		if err != nil {
-			fmt.Printf("Error listing available addons: %v\n", err)
-			return
+			return fmt.Errorf("listing available addons: %w", err)
 		}
 		if addons == nil {
 			addons = []client.AvailableAddon{}
 		}
-		if renderStructuredOrExit(cmd, addons) {
-			return
+		if handled, err := renderStructured(cmd, addons); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		if len(addons) == 0 {
 			fmt.Println("No addons available for installation.")
-			return
+			return nil
 		}
 
 		t := table.NewWriter()
@@ -185,6 +186,7 @@ var clusterAddonsAvailableCmd = &cobra.Command{
 			})
 		}
 		t.Render()
+		return nil
 	},
 }
 
@@ -192,22 +194,22 @@ var clusterAddonsSettingsCmd = &cobra.Command{
 	Use:   "settings <addon_name>",
 	Short: "Get settings for an addon",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		addonName := args[0]
 
 		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		settings, err := apiClient.GetAddonSettings(cluster.ID, addonName)
 		if err != nil {
-			fmt.Printf("Error getting addon settings: %v\n", err)
-			return
+			return fmt.Errorf("getting addon settings: %w", err)
 		}
-		if renderStructuredOrExit(cmd, settings) {
-			return
+		if handled, err := renderStructured(cmd, settings); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		fmt.Printf("Settings for addon '%s':\n\n", settings.AddonName)
@@ -215,10 +217,10 @@ var clusterAddonsSettingsCmd = &cobra.Command{
 		// Pretty print as JSON
 		jsonData, err := json.MarshalIndent(settings.Settings, "", "  ")
 		if err != nil {
-			fmt.Printf("Error formatting settings: %v\n", err)
-			return
+			return fmt.Errorf("formatting settings: %w", err)
 		}
 		fmt.Println(string(jsonData))
+		return nil
 	},
 }
 
@@ -258,20 +260,18 @@ var clusterAddonsUninstallCmd = &cobra.Command{
 	Use:   "uninstall <addon_name>",
 	Short: "Uninstall an addon from the cluster",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		addonName := args[0]
 		deletePermanently, _ := cmd.Flags().GetBool("delete")
 
 		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		addon, err := apiClient.GetAddonByName(cluster.ID, addonName)
 		if err != nil {
-			fmt.Printf("Error finding addon: %v\n", err)
-			return
+			return fmt.Errorf("finding addon: %w", err)
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -279,8 +279,7 @@ var clusterAddonsUninstallCmd = &cobra.Command{
 
 		result, err := apiClient.UninstallAddon(ctx, cluster.ID, addon.ID, deletePermanently)
 		if err != nil {
-			fmt.Printf("Error uninstalling addon: %v\n", err)
-			return
+			return fmt.Errorf("uninstalling addon: %w", err)
 		}
 
 		if result.Success {
@@ -290,6 +289,7 @@ var clusterAddonsUninstallCmd = &cobra.Command{
 				fmt.Printf("Addon '%s' uninstalled successfully!\n", addonName)
 			}
 		}
+		return nil
 	},
 }
 
@@ -308,37 +308,34 @@ Example JSON file:
 Usage:
   ankra cluster addons update my-addon -f settings.json`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		addonName := args[0]
 		filePath, _ := cmd.Flags().GetString("file")
 
 		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		fileData, err := os.ReadFile(filePath)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error reading file %s: %v\n", filePath, err)
-			os.Exit(1)
+			return fmt.Errorf("reading file %s: %w", filePath, err)
 		}
 
 		var settings client.AddonSettings
 		if err := json.Unmarshal(fileData, &settings); err != nil {
-			fmt.Fprintf(os.Stderr, "Error parsing settings JSON: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("parsing settings JSON: %w", err)
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
 		if err := apiClient.UpdateAddonSettings(ctx, cluster.ID, addonName, settings); err != nil {
-			fmt.Fprintf(os.Stderr, "Error updating addon settings: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("updating addon settings: %w", err)
 		}
 
 		fmt.Printf("Settings for addon '%s' updated successfully!\n", addonName)
+		return nil
 	},
 }
 

--- a/cmd/cluster_draft.go
+++ b/cmd/cluster_draft.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -31,40 +32,33 @@ can only be attached to an existing cluster. Stacks that already match the
 cluster's desired state are reported as "no changes" rather than creating an
 empty draft.`,
 	Args: cobra.NoArgs,
-	Run:  runClusterDraft,
+	RunE: runClusterDraft,
 }
 
 func init() {
 	clusterDraftCmd.Flags().StringP("file", "f", "", "Path to the ImportCluster YAML file to stage as drafts")
 	registerStructuredOutputFlags(clusterDraftCmd)
-	if err := clusterDraftCmd.MarkFlagRequired("file"); err != nil {
-		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
-		os.Exit(1)
-	}
+	_ = clusterDraftCmd.MarkFlagRequired("file")
 	clusterCmd.AddCommand(clusterDraftCmd)
 }
 
-func runClusterDraft(cmd *cobra.Command, _ []string) {
+func runClusterDraft(cmd *cobra.Command, _ []string) error {
 	filePath, err := cmd.Flags().GetString("file")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error reading --file: %s\n", err)
-		os.Exit(1)
+		return fmt.Errorf("reading --file: %w", err)
 	}
 	format, err := structuredFormatFromFlags(cmd)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
-		os.Exit(1)
+		return err
 	}
 	structured := format != outputDefault
 
 	importRequest, err := buildImportRequest(filePath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Invalid ImportCluster in %q:\n  %s\n", filePath, err)
-		os.Exit(1)
+		return fmt.Errorf("invalid ImportCluster in %q:\n  %w", filePath, err)
 	}
 	if err := validateResourceGraph(importRequest); err != nil {
-		fmt.Fprintf(os.Stderr, "Invalid ImportCluster in %q:\n  %s\n", filePath, err)
-		os.Exit(1)
+		return fmt.Errorf("invalid ImportCluster in %q:\n  %w", filePath, err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -72,8 +66,7 @@ func runClusterDraft(cmd *cobra.Command, _ []string) {
 
 	clusterID, err := resolveClusterForDraft(ctx, importRequest)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
-		os.Exit(1)
+		return err
 	}
 
 	var created, unchanged int
@@ -82,7 +75,7 @@ func runClusterDraft(cmd *cobra.Command, _ []string) {
 	for _, stack := range importRequest.Spec.Stacks {
 		result, draftErr := apiClient.CreateStackDraft(ctx, clusterID, stack)
 		if draftErr != nil {
-			fmt.Fprintf(os.Stderr, "- stack %q: %s\n", stack.Name, draftErr)
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "- stack %q: %s\n", stack.Name, draftErr)
 			hasErrors = true
 			stackOutputs = append(stackOutputs, stackDraftOutput{StackName: stack.Name, Error: draftErr.Error()})
 			continue
@@ -90,11 +83,11 @@ func runClusterDraft(cmd *cobra.Command, _ []string) {
 		switch {
 		case len(result.Errors) > 0:
 			hasErrors = true
-			fmt.Fprintf(os.Stderr, "- stack %q:\n", stack.Name)
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "- stack %q:\n", stack.Name)
 			errorParts := make([]string, 0, len(result.Errors))
 			for _, resourceError := range result.Errors {
 				for _, detail := range resourceError.Errors {
-					fmt.Fprintf(os.Stderr, "    • %s %q: %s - %s\n", resourceError.Kind, resourceError.Name, detail.Key, detail.Message)
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "    • %s %q: %s - %s\n", resourceError.Kind, resourceError.Name, detail.Key, detail.Message)
 					errorParts = append(errorParts, fmt.Sprintf("%s %q: %s - %s", resourceError.Kind, resourceError.Name, detail.Key, detail.Message))
 				}
 			}
@@ -116,18 +109,16 @@ func runClusterDraft(cmd *cobra.Command, _ []string) {
 
 	if structured {
 		if err := encodeStructured(cmd.OutOrStdout(), format, stackOutputs); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %s\n", err)
-			os.Exit(1)
+			return err
 		}
 		if hasErrors {
-			os.Exit(1)
+			return errors.New("some stacks could not be staged as drafts")
 		}
-		return
+		return nil
 	}
 
 	if hasErrors {
-		fmt.Fprintf(os.Stderr, "\nSome stacks could not be staged as drafts.\n")
-		os.Exit(1)
+		return errors.New("some stacks could not be staged as drafts")
 	}
 
 	fmt.Printf("\nStaged %d draft(s), %d stack(s) already up to date. Nothing was deployed.\n", created, unchanged)
@@ -135,6 +126,7 @@ func runClusterDraft(cmd *cobra.Command, _ []string) {
 		fmt.Printf("Review and deploy the drafts in the UI:\n  %s/organisation/clusters/cluster/imported/%s/overview\n",
 			strings.TrimRight(baseURL, "/"), clusterID)
 	}
+	return nil
 }
 
 // resolveClusterForDraft returns the cluster ID to attach drafts to. If the

--- a/cmd/cluster_encrypt.go
+++ b/cmd/cluster_encrypt.go
@@ -26,11 +26,10 @@ var clusterSopsConfigCmd = &cobra.Command{
 	Use:   "sops-config",
 	Short: "Display SOPS configuration for the organisation",
 	Long:  "Show the SOPS encryption configuration including the public key used for encrypting secrets.",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		config, err := apiClient.GetSopsConfig()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error fetching SOPS config: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("fetching SOPS config: %w", err)
 		}
 
 		fmt.Printf("SOPS Configuration:\n")
@@ -41,6 +40,7 @@ var clusterSopsConfigCmd = &cobra.Command{
 		} else {
 			fmt.Printf("  Public Key:  not configured\n")
 		}
+		return nil
 	},
 }
 

--- a/cmd/cluster_helm.go
+++ b/cmd/cluster_helm.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
@@ -21,11 +22,10 @@ var clusterHelmCmd = &cobra.Command{
 var clusterHelmReleasesCmd = &cobra.Command{
 	Use:   "releases",
 	Short: "List Helm releases in the cluster",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		namespace, _ := cmd.Flags().GetString("namespace")
@@ -39,14 +39,13 @@ var clusterHelmReleasesCmd = &cobra.Command{
 
 		response, err := apiClient.ListHelmReleases(cluster.ID, opts)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 
 		if outputFormat == "json" {
 			jsonData, _ := json.MarshalIndent(response, "", "  ")
 			fmt.Println(string(jsonData))
-			return
+			return nil
 		}
 
 		allItems := []interface{}{}
@@ -56,7 +55,7 @@ var clusterHelmReleasesCmd = &cobra.Command{
 
 		if len(allItems) == 0 {
 			fmt.Println("No Helm releases found.")
-			return
+			return nil
 		}
 
 		t := table.NewWriter()
@@ -87,6 +86,7 @@ var clusterHelmReleasesCmd = &cobra.Command{
 			}
 		}
 		t.Render()
+		return nil
 	},
 }
 
@@ -94,31 +94,29 @@ var clusterHelmUninstallCmd = &cobra.Command{
 	Use:   "uninstall <release_name>",
 	Short: "Uninstall a Helm release from the cluster",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		releaseName := args[0]
 		namespace, _ := cmd.Flags().GetString("namespace")
 
 		if namespace == "" {
-			fmt.Fprintln(os.Stderr, "Error: --namespace (-n) is required for uninstall")
-			os.Exit(1)
+			return errors.New("--namespace (-n) is required for uninstall")
 		}
 
 		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		result, err := apiClient.UninstallHelmRelease(cluster.ID, releaseName, namespace)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 
 		fmt.Printf("Helm release '%s' uninstalled from namespace '%s'.\n", releaseName, namespace)
 		if result.Message != nil && *result.Message != "" {
 			fmt.Printf("  Message: %s\n", *result.Message)
 		}
+		return nil
 	},
 }
 

--- a/cmd/cluster_k3s_versions.go
+++ b/cmd/cluster_k3s_versions.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -11,23 +10,23 @@ var clusterK3sVersionsCmd = &cobra.Command{
 	Use:   "k3s-versions",
 	Short: "List available k3s (Kubernetes) versions for cluster upgrades",
 	Long:  "List the k3s versions the platform can provision or upgrade to. Use one of these values with `ankra cluster upgrade <cluster_id> <target_version>` (the provider is detected automatically).",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		result, err := apiClient.ListK3sVersions()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error listing k3s versions: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("listing k3s versions: %w", err)
 		}
 		if result.StableVersion != "" {
 			fmt.Printf("Stable: %s\n", result.StableVersion)
 		}
 		if len(result.Versions) == 0 {
 			fmt.Println("No k3s versions available.")
-			return
+			return nil
 		}
 		fmt.Println("Available versions:")
 		for _, v := range result.Versions {
 			fmt.Printf("  %-22s channel=%s\n", v.Version, v.Channel)
 		}
+		return nil
 	},
 }
 

--- a/cmd/cluster_k8s.go
+++ b/cmd/cluster_k8s.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -95,7 +96,7 @@ type kindConfig struct {
 var kindConfigs = []kindConfig{
 	{
 		commandName: "deployments", kind: "Deployment", group: "apps", version: "v1",
-		short: "List deployments in the cluster",
+		short:   "List deployments in the cluster",
 		headers: table.Row{"Name", "Namespace", "Ready", "Up-to-date", "Available", "Age"},
 		formatRow: func(obj map[string]interface{}) table.Row {
 			readyCount := getNestedString(obj, "status", "readyReplicas")
@@ -126,7 +127,7 @@ var kindConfigs = []kindConfig{
 	},
 	{
 		commandName: "services", kind: "Service", group: "", version: "v1",
-		short: "List services in the cluster",
+		short:   "List services in the cluster",
 		headers: table.Row{"Name", "Namespace", "Type", "Cluster-IP", "External-IP", "Ports", "Age"},
 		formatRow: func(obj map[string]interface{}) table.Row {
 			ports := ""
@@ -163,7 +164,7 @@ var kindConfigs = []kindConfig{
 	},
 	{
 		commandName: "nodes", kind: "Node", group: "", version: "v1", clusterScoped: true,
-		short: "List nodes in the cluster",
+		short:   "List nodes in the cluster",
 		headers: table.Row{"Name", "Status", "Roles", "Version", "Age"},
 		formatRow: func(obj map[string]interface{}) table.Row {
 			status := "Unknown"
@@ -211,7 +212,7 @@ var kindConfigs = []kindConfig{
 	},
 	{
 		commandName: "namespaces", kind: "Namespace", group: "", version: "v1", clusterScoped: true,
-		short: "List namespaces in the cluster",
+		short:   "List namespaces in the cluster",
 		headers: table.Row{"Name", "Status", "Age"},
 		formatRow: func(obj map[string]interface{}) table.Row {
 			return table.Row{
@@ -223,7 +224,7 @@ var kindConfigs = []kindConfig{
 	},
 	{
 		commandName: "ingresses", kind: "Ingress", group: "networking.k8s.io", version: "v1",
-		short: "List ingresses in the cluster",
+		short:   "List ingresses in the cluster",
 		headers: table.Row{"Name", "Namespace", "Hosts", "Address", "Ports", "Age"},
 		formatRow: func(obj map[string]interface{}) table.Row {
 			hosts := ""
@@ -252,7 +253,7 @@ var kindConfigs = []kindConfig{
 	},
 	{
 		commandName: "events", kind: "Event", group: "", version: "v1",
-		short: "List events in the cluster",
+		short:   "List events in the cluster",
 		headers: table.Row{"Last Seen", "Type", "Reason", "Object", "Message"},
 		formatRow: func(obj map[string]interface{}) table.Row {
 			lastSeen := getNestedString(obj, "lastTimestamp")
@@ -273,7 +274,7 @@ var kindConfigs = []kindConfig{
 	},
 	{
 		commandName: "configmaps", kind: "ConfigMap", group: "", version: "v1",
-		short: "List configmaps in the cluster",
+		short:   "List configmaps in the cluster",
 		headers: table.Row{"Name", "Namespace", "Data", "Age"},
 		formatRow: func(obj map[string]interface{}) table.Row {
 			dataCount := 0
@@ -292,7 +293,7 @@ var kindConfigs = []kindConfig{
 	},
 	{
 		commandName: "secrets", kind: "Secret", group: "", version: "v1",
-		short: "List secrets in the cluster",
+		short:   "List secrets in the cluster",
 		headers: table.Row{"Name", "Namespace", "Type", "Data", "Age"},
 		formatRow: func(obj map[string]interface{}) table.Row {
 			dataCount := 0
@@ -312,7 +313,7 @@ var kindConfigs = []kindConfig{
 	},
 	{
 		commandName: "statefulsets", kind: "StatefulSet", group: "apps", version: "v1",
-		short: "List statefulsets in the cluster",
+		short:   "List statefulsets in the cluster",
 		headers: table.Row{"Name", "Namespace", "Ready", "Age"},
 		formatRow: func(obj map[string]interface{}) table.Row {
 			readyCount := getNestedString(obj, "status", "readyReplicas")
@@ -334,7 +335,7 @@ var kindConfigs = []kindConfig{
 	},
 	{
 		commandName: "daemonsets", kind: "DaemonSet", group: "apps", version: "v1",
-		short: "List daemonsets in the cluster",
+		short:   "List daemonsets in the cluster",
 		headers: table.Row{"Name", "Namespace", "Desired", "Current", "Ready", "Age"},
 		formatRow: func(obj map[string]interface{}) table.Row {
 			return table.Row{
@@ -349,7 +350,7 @@ var kindConfigs = []kindConfig{
 	},
 	{
 		commandName: "k8s-jobs", kind: "Job", group: "batch", version: "v1",
-		short: "List Kubernetes jobs in the cluster",
+		short:   "List Kubernetes jobs in the cluster",
 		headers: table.Row{"Name", "Namespace", "Completions", "Duration", "Age"},
 		formatRow: func(obj map[string]interface{}) table.Row {
 			completions := fmt.Sprintf("%s/%s",
@@ -376,7 +377,7 @@ var kindConfigs = []kindConfig{
 	},
 	{
 		commandName: "cronjobs", kind: "CronJob", group: "batch", version: "v1",
-		short: "List cronjobs in the cluster",
+		short:   "List cronjobs in the cluster",
 		headers: table.Row{"Name", "Namespace", "Schedule", "Suspend", "Active", "Last Schedule"},
 		formatRow: func(obj map[string]interface{}) table.Row {
 			activeCount := 0
@@ -399,26 +400,25 @@ var kindConfigs = []kindConfig{
 	},
 }
 
-func renderSingleResource(item interface{}, outputFormat string) {
+func renderSingleResource(item interface{}, outputFormat string) error {
 	switch outputFormat {
 	case "json":
 		jsonData, err := json.MarshalIndent(item, "", "  ")
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error marshalling to JSON: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("marshalling to JSON: %w", err)
 		}
 		fmt.Println(string(jsonData))
 	default:
 		yamlData, err := yaml.Marshal(item)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error marshalling to YAML: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("marshalling to YAML: %w", err)
 		}
 		fmt.Print(string(yamlData))
 	}
+	return nil
 }
 
-func fetchAndRenderResources(clusterID, namespace, nameFilter, labelSelector, outputFormat string, cfg kindConfig) {
+func fetchAndRenderResources(clusterID, namespace, nameFilter, labelSelector, outputFormat string, cfg kindConfig) error {
 	reqItem := client.ResourceRequestItem{
 		Kind:    cfg.kind,
 		Version: cfg.version,
@@ -440,40 +440,36 @@ func fetchAndRenderResources(clusterID, namespace, nameFilter, labelSelector, ou
 		ResourceRequests: []client.ResourceRequestItem{reqItem},
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 
 	if len(response.ResourceResponses) == 0 || len(response.ResourceResponses[0].Items) == 0 {
 		fmt.Printf("No %s found.\n", cfg.commandName)
-		return
+		return nil
 	}
 
 	items := response.ResourceResponses[0].Items
 
 	isSingleResourceLookup := nameFilter != "" && len(items) == 1
 	if isSingleResourceLookup {
-		renderSingleResource(items[0], outputFormat)
-		return
+		return renderSingleResource(items[0], outputFormat)
 	}
 
 	if outputFormat == "json" {
 		jsonData, err := json.MarshalIndent(response, "", "  ")
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error marshalling to JSON: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("marshalling to JSON: %w", err)
 		}
 		fmt.Println(string(jsonData))
-		return
+		return nil
 	}
 	if outputFormat == "yaml" {
 		yamlData, err := yaml.Marshal(response)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error marshalling to YAML: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("marshalling to YAML: %w", err)
 		}
 		fmt.Print(string(yamlData))
-		return
+		return nil
 	}
 
 	t := table.NewWriter()
@@ -487,19 +483,19 @@ func fetchAndRenderResources(clusterID, namespace, nameFilter, labelSelector, ou
 		}
 	}
 	t.Render()
+	return nil
 }
 
 func registerKindCommand(cfg kindConfig) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   cfg.commandName + " [name]",
-		Short: cfg.short,
-		Args:  cobra.MaximumNArgs(1),
+		Use:         cfg.commandName + " [name]",
+		Short:       cfg.short,
+		Args:        cobra.MaximumNArgs(1),
 		Annotations: map[string]string{"group": "kubernetes"},
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cluster, err := resolveActiveCluster(cmd)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
 			namespace, _ := cmd.Flags().GetString("namespace")
 			allNamespaces, _ := cmd.Flags().GetBool("all-namespaces")
@@ -518,7 +514,7 @@ func registerKindCommand(cfg kindConfig) *cobra.Command {
 				namespace = ""
 			}
 
-			fetchAndRenderResources(cluster.ID, namespace, nameFilter, labelSelector, outputFormat, cfg)
+			return fetchAndRenderResources(cluster.ID, namespace, nameFilter, labelSelector, outputFormat, cfg)
 		},
 	}
 
@@ -534,15 +530,14 @@ func registerKindCommand(cfg kindConfig) *cobra.Command {
 }
 
 var clusterPodsCmd = &cobra.Command{
-	Use:   "pods [name]",
-	Short: "List pods or get a specific pod's manifest",
-	Args:  cobra.MaximumNArgs(1),
+	Use:         "pods [name]",
+	Short:       "List pods or get a specific pod's manifest",
+	Args:        cobra.MaximumNArgs(1),
 	Annotations: map[string]string{"group": "kubernetes"},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 		namespace, _ := cmd.Flags().GetString("namespace")
 		allNamespaces, _ := cmd.Flags().GetBool("all-namespaces")
@@ -560,8 +555,7 @@ var clusterPodsCmd = &cobra.Command{
 				kind:        "Pod",
 				version:     "v1",
 			}
-			fetchAndRenderResources(cluster.ID, namespace, podName, "", outputFormat, podCfg)
-			return
+			return fetchAndRenderResources(cluster.ID, namespace, podName, "", outputFormat, podCfg)
 		}
 
 		if allNamespaces {
@@ -581,8 +575,7 @@ var clusterPodsCmd = &cobra.Command{
 
 			response, err := apiClient.ListPods(cluster.ID, opts)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				os.Exit(1)
+				return err
 			}
 
 			allPods = append(allPods, response.Pods...)
@@ -590,7 +583,7 @@ var clusterPodsCmd = &cobra.Command{
 			if outputFormat == "json" && page == 1 && response.TotalPages <= 1 {
 				jsonData, _ := json.MarshalIndent(response, "", "  ")
 				fmt.Println(string(jsonData))
-				return
+				return nil
 			}
 
 			if page >= response.TotalPages {
@@ -602,25 +595,23 @@ var clusterPodsCmd = &cobra.Command{
 		if outputFormat == "json" {
 			jsonData, err := json.MarshalIndent(allPods, "", "  ")
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error marshalling to JSON: %v\n", err)
-				os.Exit(1)
+				return fmt.Errorf("marshalling to JSON: %w", err)
 			}
 			fmt.Println(string(jsonData))
-			return
+			return nil
 		}
 		if outputFormat == "yaml" {
 			yamlData, err := yaml.Marshal(allPods)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error marshalling to YAML: %v\n", err)
-				os.Exit(1)
+				return fmt.Errorf("marshalling to YAML: %w", err)
 			}
 			fmt.Print(string(yamlData))
-			return
+			return nil
 		}
 
 		if len(allPods) == 0 {
 			fmt.Println("No pods found.")
-			return
+			return nil
 		}
 
 		t := table.NewWriter()
@@ -655,6 +646,7 @@ var clusterPodsCmd = &cobra.Command{
 		t.Render()
 
 		fmt.Printf("\n%d pods total.\n", len(allPods))
+		return nil
 	},
 }
 
@@ -665,9 +657,9 @@ var clusterLogsCmd = &cobra.Command{
 
 Example:
   ankra cluster logs my-pod -n default -c my-container --tail 100`,
-	Args: cobra.ExactArgs(1),
+	Args:        cobra.ExactArgs(1),
 	Annotations: map[string]string{"group": "kubernetes"},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		podName := args[0]
 		namespace, _ := cmd.Flags().GetString("namespace")
 		container, _ := cmd.Flags().GetString("container")
@@ -675,13 +667,11 @@ Example:
 		sinceSeconds, _ := cmd.Flags().GetInt("since")
 
 		if namespace == "" {
-			fmt.Fprintln(os.Stderr, "Error: --namespace (-n) is required for logs")
-			os.Exit(1)
+			return errors.New("--namespace (-n) is required for logs")
 		}
 		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		opts := client.PodLogOptions{
@@ -697,11 +687,11 @@ Example:
 
 		if err := apiClient.StreamPodLogs(ctx, cluster.ID, opts, os.Stdout); err != nil {
 			if ctx.Err() != nil {
-				return
+				return nil
 			}
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
+		return nil
 	},
 }
 
@@ -713,14 +703,13 @@ var clusterGenericResourcesCmd = &cobra.Command{
 Example:
   ankra cluster resources PersistentVolumeClaim -n default
   ankra cluster resources NetworkPolicy --all-namespaces`,
-	Args: cobra.ExactArgs(1),
+	Args:        cobra.ExactArgs(1),
 	Annotations: map[string]string{"group": "kubernetes"},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		kind := args[0]
 		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 		namespace, _ := cmd.Flags().GetString("namespace")
 		allNamespaces, _ := cmd.Flags().GetBool("all-namespaces")
@@ -749,7 +738,7 @@ Example:
 			},
 		}
 
-		fetchAndRenderResources(cluster.ID, namespace, nameFilter, labelSelector, outputFormat, genericCfg)
+		return fetchAndRenderResources(cluster.ID, namespace, nameFilter, labelSelector, outputFormat, genericCfg)
 	},
 }
 

--- a/cmd/cluster_kube_token.go
+++ b/cmd/cluster_kube_token.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -40,18 +39,16 @@ for example in a kubeconfig:
 
 It prints JSON to stdout and never prompts; run 'ankra login' first.`,
 	Annotations: map[string]string{"group": "kubernetes"},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterFlag, _ := cmd.Flags().GetString("cluster")
 		clusterID, err := resolveKubeTokenClusterID(clusterFlag)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 
 		kubeToken, err := apiClient.GetClusterKubeToken(context.Background(), clusterID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 
 		credential := execCredential{
@@ -64,10 +61,10 @@ It prints JSON to stdout and never prompts; run 'ankra login' first.`,
 		}
 		output, err := json.Marshal(credential)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 		fmt.Println(string(output))
+		return nil
 	},
 }
 
@@ -80,7 +77,7 @@ func resolveKubeTokenClusterID(clusterFlag string) (string, error) {
 		if isLikelyClusterID(clusterFlag) {
 			return clusterFlag, nil
 		}
-		return "", fmt.Errorf("cluster %q not found; pass a cluster name or ID (not the kubeconfig context name)", clusterFlag)
+		return "", withExitCode(exitNotFound, fmt.Errorf("cluster %q not found; pass a cluster name or ID (not the kubeconfig context name)", clusterFlag))
 	}
 	cluster, err := loadSelectedCluster()
 	if err != nil {

--- a/cmd/cluster_kube_token.go
+++ b/cmd/cluster_kube_token.go
@@ -77,7 +77,7 @@ func resolveKubeTokenClusterID(clusterFlag string) (string, error) {
 		if isLikelyClusterID(clusterFlag) {
 			return clusterFlag, nil
 		}
-		return "", withExitCode(exitNotFound, fmt.Errorf("cluster %q not found; pass a cluster name or ID (not the kubeconfig context name)", clusterFlag))
+		return "", fmt.Errorf("cluster %q not found; pass a cluster name or ID (not the kubeconfig context name): %w", clusterFlag, err)
 	}
 	cluster, err := loadSelectedCluster()
 	if err != nil {

--- a/cmd/cluster_kubeconfig.go
+++ b/cmd/cluster_kubeconfig.go
@@ -331,7 +331,7 @@ func resolveKubeconfigTargets() ([]kubeTarget, error) {
 		if isLikelyClusterID(kubeconfigClusterFlag) {
 			return []kubeTarget{{id: kubeconfigClusterFlag, name: kubeconfigClusterFlag}}, nil
 		}
-		return nil, withExitCode(exitNotFound, fmt.Errorf("cluster %q not found; pass a cluster name or ID", kubeconfigClusterFlag))
+		return nil, fmt.Errorf("cluster %q not found; pass a cluster name or ID: %w", kubeconfigClusterFlag, err)
 	}
 	selected, err := loadSelectedCluster()
 	if err != nil || selected.ID == "" {

--- a/cmd/cluster_kubeconfig.go
+++ b/cmd/cluster_kubeconfig.go
@@ -59,33 +59,24 @@ Examples:
 var clusterKubeconfigAddCmd = &cobra.Command{
 	Use:   "add",
 	Short: "Add or update an Ankra context in your kubeconfig",
-	Run: func(cmd *cobra.Command, args []string) {
-		if err := kubeconfigAdd(os.Stdout); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return kubeconfigAdd(os.Stdout)
 	},
 }
 
 var clusterKubeconfigRemoveCmd = &cobra.Command{
 	Use:   "remove",
 	Short: "Remove Ankra contexts from your kubeconfig",
-	Run: func(cmd *cobra.Command, args []string) {
-		if err := kubeconfigRemove(os.Stdout); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return kubeconfigRemove(os.Stdout)
 	},
 }
 
 var clusterKubeconfigListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List Ankra-managed contexts in your kubeconfig",
-	Run: func(cmd *cobra.Command, args []string) {
-		if err := kubeconfigList(os.Stdout); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return kubeconfigList(os.Stdout)
 	},
 }
 
@@ -340,7 +331,7 @@ func resolveKubeconfigTargets() ([]kubeTarget, error) {
 		if isLikelyClusterID(kubeconfigClusterFlag) {
 			return []kubeTarget{{id: kubeconfigClusterFlag, name: kubeconfigClusterFlag}}, nil
 		}
-		return nil, fmt.Errorf("cluster %q not found; pass a cluster name or ID", kubeconfigClusterFlag)
+		return nil, withExitCode(exitNotFound, fmt.Errorf("cluster %q not found; pass a cluster name or ID", kubeconfigClusterFlag))
 	}
 	selected, err := loadSelectedCluster()
 	if err != nil || selected.ID == "" {

--- a/cmd/cluster_manifests.go
+++ b/cmd/cluster_manifests.go
@@ -119,29 +119,29 @@ var clusterManifestsListCmd = &cobra.Command{
 	Use:   "list [manifest name]",
 	Short: "List manifests for the active cluster; or show details for a single manifest",
 	Args:  cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		manifests, err := apiClient.ListClusterManifests(cluster.ID)
 		if err != nil {
-			fmt.Printf("Error listing manifests: %v\n", err)
-			return
+			return fmt.Errorf("listing manifests: %w", err)
 		}
 		if len(args) == 0 {
 			if manifests == nil {
 				manifests = []client.ClusterManifestListItem{}
 			}
-			if renderStructuredOrExit(cmd, manifests) {
-				return
+			if handled, err := renderStructured(cmd, manifests); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 		}
 		if len(manifests) == 0 {
 			fmt.Println("No manifests found for the active cluster.")
-			return
+			return nil
 		}
 
 		if len(args) == 1 {
@@ -154,11 +154,12 @@ var clusterManifestsListCmd = &cobra.Command{
 				}
 			}
 			if found == nil {
-				fmt.Printf("Manifest %q not found on the active cluster.\n", name)
-				return
+				return withExitCode(exitNotFound, fmt.Errorf("manifest %q not found on the active cluster", name))
 			}
-			if renderStructuredOrExit(cmd, found) {
-				return
+			if handled, err := renderStructured(cmd, found); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 
 			kind := extractKindFromBase64(found.ManifestBase64)
@@ -186,15 +187,14 @@ var clusterManifestsListCmd = &cobra.Command{
 				fmt.Println("\n  Manifest Content:")
 				decoded, err := base64.StdEncoding.DecodeString(found.ManifestBase64)
 				if err != nil {
-					fmt.Printf("    Error decoding manifest: %v\n", err)
-				} else {
-					lines := strings.Split(string(decoded), "\n")
-					for _, line := range lines {
-						fmt.Printf("    %s\n", line)
-					}
+					return fmt.Errorf("decoding manifest: %w", err)
+				}
+				lines := strings.Split(string(decoded), "\n")
+				for _, line := range lines {
+					fmt.Printf("    %s\n", line)
 				}
 			}
-			return
+			return nil
 		}
 
 		t := table.NewWriter()
@@ -245,6 +245,7 @@ var clusterManifestsListCmd = &cobra.Command{
 			})
 		}
 		t.Render()
+		return nil
 	},
 }
 

--- a/cmd/cluster_node_group.go
+++ b/cmd/cluster_node_group.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 
 	"ankra/internal/client"
@@ -20,23 +19,20 @@ type (
 )
 
 // resolveNodeGroupClusterKind looks up the cluster and confirms it is a
-// cloud-managed kind that supports node groups, exiting with a clear message
+// cloud-managed kind that supports node groups, returning a clear error
 // otherwise.
-func resolveNodeGroupClusterKind(clusterID string) string {
+func resolveNodeGroupClusterKind(clusterID string) (string, error) {
 	cluster, lookupError := apiClient.GetClusterByID(clusterID)
 	if lookupError != nil {
-		fmt.Fprintf(os.Stderr, "Error looking up cluster %q: %v\n", clusterID, lookupError)
-		os.Exit(1)
+		return "", fmt.Errorf("looking up cluster %q: %w", clusterID, lookupError)
 	}
 	switch cluster.Kind {
 	case "hetzner", "ovh", "upcloud":
-		return cluster.Kind
+		return cluster.Kind, nil
 	default:
-		fmt.Fprintf(os.Stderr,
-			"Cluster %q (kind %q) does not support node groups. Only Hetzner, OVH, and UpCloud clusters can use this command.\n",
+		return "", fmt.Errorf(
+			"cluster %q (kind %q) does not support node groups. Only Hetzner, OVH, and UpCloud clusters can use this command",
 			clusterID, cluster.Kind)
-		os.Exit(1)
-		return ""
 	}
 }
 
@@ -113,26 +109,31 @@ var clusterNodeGroupListCmd = &cobra.Command{
 	Use:   "list <cluster_id>",
 	Short: "List node groups",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
-		kind := resolveNodeGroupClusterKind(clusterID)
+		kind, kindError := resolveNodeGroupClusterKind(clusterID)
+		if kindError != nil {
+			return kindError
+		}
 
 		result, listError := nodeGroupListForKind(kind)(clusterID)
 		if listError != nil {
-			fmt.Fprintf(os.Stderr, "Error listing node groups: %v\n", listError)
-			os.Exit(1)
+			return fmt.Errorf("listing node groups: %w", listError)
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		if len(result.NodeGroups) == 0 {
 			fmt.Println("No node groups found.")
-			return
+			return nil
 		}
 		for _, nodeGroup := range result.NodeGroups {
 			fmt.Printf("%-20s  type=%-8s  count=%d  labels=%d  taints=%d\n",
 				nodeGroup.Name, nodeGroup.InstanceType, nodeGroup.Count, len(nodeGroup.Labels), len(nodeGroup.Taints))
 		}
+		return nil
 	},
 }
 
@@ -140,9 +141,12 @@ var clusterNodeGroupAddCmd = &cobra.Command{
 	Use:   "add <cluster_id>",
 	Short: "Add a node group",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
-		kind := resolveNodeGroupClusterKind(clusterID)
+		kind, kindError := resolveNodeGroupClusterKind(clusterID)
+		if kindError != nil {
+			return kindError
+		}
 		name, _ := cmd.Flags().GetString("name")
 		instanceType, _ := cmd.Flags().GetString("instance-type")
 		count, _ := cmd.Flags().GetInt("count")
@@ -158,19 +162,24 @@ var clusterNodeGroupAddCmd = &cobra.Command{
 
 		result, submitted, addError := nodeGroupAddForKind(kind)(requestContext, clusterID, req, wait)
 		if addError != nil {
-			handleNodeGroupSubmitError("adding node group", addError)
+			return fmt.Errorf("adding node group: %w", addError)
 		}
 		if submitted {
-			if renderStructuredOrExit(cmd, newAsyncSubmittedResult("Node group add")) {
-				return
+			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group add")); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 			printAsyncWriteSubmitted("Node group add")
-			return
+			return nil
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		fmt.Printf("Node group '%s' created with %d node(s).\n", result.GroupName, result.Count)
+		return nil
 	},
 }
 
@@ -178,34 +187,41 @@ var clusterNodeGroupScaleCmd = &cobra.Command{
 	Use:   "scale <cluster_id> <group_name> <count>",
 	Short: "Scale a node group",
 	Args:  cobra.ExactArgs(3),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		groupName := args[1]
 		count, convertError := strconv.Atoi(args[2])
 		if convertError != nil {
-			fmt.Fprintf(os.Stderr, "Invalid count: %v\n", convertError)
-			os.Exit(1)
+			return fmt.Errorf("invalid count: %w", convertError)
 		}
-		kind := resolveNodeGroupClusterKind(clusterID)
+		kind, kindError := resolveNodeGroupClusterKind(clusterID)
+		if kindError != nil {
+			return kindError
+		}
 
 		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
 		defer cancelRequestContext()
 
 		result, submitted, scaleError := nodeGroupScaleForKind(kind)(requestContext, clusterID, groupName, count, wait)
 		if scaleError != nil {
-			handleNodeGroupSubmitError("scaling node group", scaleError)
+			return fmt.Errorf("scaling node group: %w", scaleError)
 		}
 		if submitted {
-			if renderStructuredOrExit(cmd, newAsyncSubmittedResult("Node group scale")) {
-				return
+			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group scale")); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 			printAsyncWriteSubmitted("Node group scale")
-			return
+			return nil
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		fmt.Printf("Node group '%s' scaled from %d to %d.\n", result.GroupName, result.PreviousCount, result.NewCount)
+		return nil
 	},
 }
 
@@ -213,30 +229,38 @@ var clusterNodeGroupUpgradeCmd = &cobra.Command{
 	Use:   "upgrade <cluster_id> <group_name> <instance_type>",
 	Short: "Upgrade instance type for a node group (cannot be reversed)",
 	Args:  cobra.ExactArgs(3),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		groupName := args[1]
 		instanceType := args[2]
-		kind := resolveNodeGroupClusterKind(clusterID)
+		kind, kindError := resolveNodeGroupClusterKind(clusterID)
+		if kindError != nil {
+			return kindError
+		}
 
 		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
 		defer cancelRequestContext()
 
 		result, submitted, upgradeError := nodeGroupUpgradeForKind(kind)(requestContext, clusterID, groupName, instanceType, wait)
 		if upgradeError != nil {
-			handleNodeGroupSubmitError("upgrading node group", upgradeError)
+			return fmt.Errorf("upgrading node group: %w", upgradeError)
 		}
 		if submitted {
-			if renderStructuredOrExit(cmd, newAsyncSubmittedResult("Node group instance-type update")) {
-				return
+			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group instance-type update")); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 			printAsyncWriteSubmitted("Node group instance-type update")
-			return
+			return nil
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		fmt.Printf("Node group '%s' instance type upgraded. %d node(s) affected.\n", result.GroupName, result.Updated)
+		return nil
 	},
 }
 
@@ -244,29 +268,37 @@ var clusterNodeGroupDeleteCmd = &cobra.Command{
 	Use:   "delete <cluster_id> <group_name>",
 	Short: "Delete a node group and all its nodes",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		groupName := args[1]
-		kind := resolveNodeGroupClusterKind(clusterID)
+		kind, kindError := resolveNodeGroupClusterKind(clusterID)
+		if kindError != nil {
+			return kindError
+		}
 
 		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
 		defer cancelRequestContext()
 
 		result, submitted, deleteError := nodeGroupDeleteForKind(kind)(requestContext, clusterID, groupName, wait)
 		if deleteError != nil {
-			handleNodeGroupSubmitError("deleting node group", deleteError)
+			return fmt.Errorf("deleting node group: %w", deleteError)
 		}
 		if submitted {
-			if renderStructuredOrExit(cmd, newAsyncSubmittedResult("Node group delete")) {
-				return
+			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group delete")); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 			printAsyncWriteSubmitted("Node group delete")
-			return
+			return nil
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		fmt.Printf("Node group '%s' deleted. %d node(s) removed.\n", result.GroupName, result.Deleted)
+		return nil
 	},
 }
 

--- a/cmd/cluster_node_group.go
+++ b/cmd/cluster_node_group.go
@@ -157,7 +157,10 @@ var clusterNodeGroupAddCmd = &cobra.Command{
 			Count:        count,
 		}
 
-		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
+		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
+		if err != nil {
+			return err
+		}
 		defer cancelRequestContext()
 
 		result, submitted, addError := nodeGroupAddForKind(kind)(requestContext, clusterID, req, wait)
@@ -199,7 +202,10 @@ var clusterNodeGroupScaleCmd = &cobra.Command{
 			return kindError
 		}
 
-		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
+		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
+		if err != nil {
+			return err
+		}
 		defer cancelRequestContext()
 
 		result, submitted, scaleError := nodeGroupScaleForKind(kind)(requestContext, clusterID, groupName, count, wait)
@@ -238,7 +244,10 @@ var clusterNodeGroupUpgradeCmd = &cobra.Command{
 			return kindError
 		}
 
-		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
+		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
+		if err != nil {
+			return err
+		}
 		defer cancelRequestContext()
 
 		result, submitted, upgradeError := nodeGroupUpgradeForKind(kind)(requestContext, clusterID, groupName, instanceType, wait)
@@ -276,7 +285,10 @@ var clusterNodeGroupDeleteCmd = &cobra.Command{
 			return kindError
 		}
 
-		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
+		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
+		if err != nil {
+			return err
+		}
 		defer cancelRequestContext()
 
 		result, submitted, deleteError := nodeGroupDeleteForKind(kind)(requestContext, clusterID, groupName, wait)

--- a/cmd/cluster_node_group.go
+++ b/cmd/cluster_node_group.go
@@ -165,7 +165,7 @@ var clusterNodeGroupAddCmd = &cobra.Command{
 
 		result, submitted, addError := nodeGroupAddForKind(kind)(requestContext, clusterID, req, wait)
 		if addError != nil {
-			return fmt.Errorf("adding node group: %w", addError)
+			return asyncWriteError("adding node group", wait, addError)
 		}
 		if submitted {
 			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group add")); err != nil {
@@ -210,7 +210,7 @@ var clusterNodeGroupScaleCmd = &cobra.Command{
 
 		result, submitted, scaleError := nodeGroupScaleForKind(kind)(requestContext, clusterID, groupName, count, wait)
 		if scaleError != nil {
-			return fmt.Errorf("scaling node group: %w", scaleError)
+			return asyncWriteError("scaling node group", wait, scaleError)
 		}
 		if submitted {
 			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group scale")); err != nil {
@@ -252,7 +252,7 @@ var clusterNodeGroupUpgradeCmd = &cobra.Command{
 
 		result, submitted, upgradeError := nodeGroupUpgradeForKind(kind)(requestContext, clusterID, groupName, instanceType, wait)
 		if upgradeError != nil {
-			return fmt.Errorf("upgrading node group: %w", upgradeError)
+			return asyncWriteError("upgrading node group", wait, upgradeError)
 		}
 		if submitted {
 			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group instance-type update")); err != nil {
@@ -293,7 +293,7 @@ var clusterNodeGroupDeleteCmd = &cobra.Command{
 
 		result, submitted, deleteError := nodeGroupDeleteForKind(kind)(requestContext, clusterID, groupName, wait)
 		if deleteError != nil {
-			return fmt.Errorf("deleting node group: %w", deleteError)
+			return asyncWriteError("deleting node group", wait, deleteError)
 		}
 		if submitted {
 			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group delete")); err != nil {

--- a/cmd/cluster_nodes.go
+++ b/cmd/cluster_nodes.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"sort"
 
 	"github.com/spf13/cobra"
@@ -41,21 +40,22 @@ func upcloudNodesOps() clusterNodesOps {
 	}
 }
 
-func runNodesList(cmd *cobra.Command, opsFn func() clusterNodesOps, clusterID string) {
+func runNodesList(cmd *cobra.Command, opsFn func() clusterNodesOps, clusterID string) error {
 	ops := opsFn()
 	result, err := ops.list(clusterID)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 
-	if renderStructuredOrExit(cmd, result) {
-		return
+	if handled, err := renderStructured(cmd, result); err != nil {
+		return err
+	} else if handled {
+		return nil
 	}
 
 	if len(result.Nodes) == 0 {
 		fmt.Println("No nodes found.")
-		return
+		return nil
 	}
 
 	fmt.Printf("%-36s  %-22s  %-13s  %-14s  %-16s  %-12s  %-15s\n",
@@ -75,18 +75,20 @@ func runNodesList(cmd *cobra.Command, opsFn func() clusterNodesOps, clusterID st
 			truncate(stringValue(n.PrivateIP), 15),
 		)
 	}
+	return nil
 }
 
-func runNodesGet(cmd *cobra.Command, opsFn func() clusterNodesOps, clusterID, nodeID string) {
+func runNodesGet(cmd *cobra.Command, opsFn func() clusterNodesOps, clusterID, nodeID string) error {
 	ops := opsFn()
 	detail, err := ops.get(clusterID, nodeID)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 
-	if renderStructuredOrExit(cmd, detail) {
-		return
+	if handled, err := renderStructured(cmd, detail); err != nil {
+		return err
+	} else if handled {
+		return nil
 	}
 
 	fmt.Printf("Node: %s\n", detail.Name)
@@ -104,22 +106,29 @@ func runNodesGet(cmd *cobra.Command, opsFn func() clusterNodesOps, clusterID, no
 
 	fmt.Println()
 	fmt.Println("Definition:")
-	printJSONBlock(detail.Definition)
+	if err := printJSONBlock(detail.Definition); err != nil {
+		return err
+	}
 
 	if len(detail.Info) > 0 {
 		fmt.Println()
 		fmt.Println("Provider info (latest):")
-		printJSONBlock(detail.Info)
+		if err := printJSONBlock(detail.Info); err != nil {
+			return err
+		}
 	}
 	if len(detail.Data) > 0 {
 		fmt.Println()
 		fmt.Println("Reconciler data (latest):")
-		printJSONBlock(detail.Data)
+		if err := printJSONBlock(detail.Data); err != nil {
+			return err
+		}
 	}
 
 	printEdges("Dependencies", detail.Dependencies)
 	printEdges("Relationships", detail.Relationships)
 	printEdges("Groups", detail.Groups)
+	return nil
 }
 
 func stringValue(p *string) string {
@@ -139,13 +148,13 @@ func truncate(s string, max int) string {
 	return s[:max-1] + "…"
 }
 
-func printJSONBlock(v interface{}) {
+func printJSONBlock(v interface{}) error {
 	encoded, err := json.MarshalIndent(v, "  ", "  ")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error encoding JSON: %v\n", err)
-		return
+		return fmt.Errorf("encoding JSON: %w", err)
 	}
 	fmt.Printf("  %s\n", string(encoded))
+	return nil
 }
 
 func printEdges(title string, edges map[string][]string) {
@@ -182,8 +191,8 @@ included so the saved topology is visible before re-provisioning.`,
 		Use:   "list <cluster_id>",
 		Short: "List all nodes for the cluster",
 		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			runNodesList(cmd, opsFn, args[0])
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runNodesList(cmd, opsFn, args[0])
 		},
 	}
 
@@ -191,8 +200,8 @@ included so the saved topology is visible before re-provisioning.`,
 		Use:   "get <cluster_id> <node_id>",
 		Short: "Show full spec and metadata for a single node",
 		Args:  cobra.ExactArgs(2),
-		Run: func(cmd *cobra.Command, args []string) {
-			runNodesGet(cmd, opsFn, args[0], args[1])
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runNodesGet(cmd, opsFn, args[0], args[1])
 		},
 	}
 

--- a/cmd/cluster_partial.go
+++ b/cmd/cluster_partial.go
@@ -564,7 +564,7 @@ func confirmPrompt(in io.Reader, out io.Writer, message string, yes bool) error 
 	if line == "y" || line == "yes" {
 		return nil
 	}
-	return errors.New("cancelled")
+	return errCancelled
 }
 
 // writeDecodedDoc writes a decoded document (addon values or manifest YAML) to

--- a/cmd/cluster_partial.go
+++ b/cmd/cluster_partial.go
@@ -724,4 +724,3 @@ func resolveClusterForCmd(flagValue string) (id, name string, err error) {
 	}
 	return cluster.ID, cluster.Name, nil
 }
-

--- a/cmd/cluster_scale.go
+++ b/cmd/cluster_scale.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 
 	"ankra/internal/client"
@@ -41,36 +40,34 @@ a named node group instead, use 'ankra cluster node-group scale'.
 Example:
   ankra cluster scale 62f4559a-a44d-46d7-aab3-a57c9dd6b4c6 3`,
 	Args: cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		workerCount, convertError := strconv.Atoi(args[1])
 		if convertError != nil {
-			fmt.Fprintf(os.Stderr, "Invalid worker count: %v\n", convertError)
-			os.Exit(1)
+			return fmt.Errorf("invalid worker count: %w", convertError)
 		}
 
 		cluster, lookupError := apiClient.GetClusterByID(clusterID)
 		if lookupError != nil {
-			fmt.Fprintf(os.Stderr, "Error looking up cluster %q: %v\n", clusterID, lookupError)
-			os.Exit(1)
+			return fmt.Errorf("looking up cluster %q: %w", clusterID, lookupError)
 		}
 
 		scale, supported := scaleFunctionForKind(cluster.Kind)
 		if !supported {
-			fmt.Fprintf(os.Stderr,
-				"Cluster %q (kind %q) does not support worker scaling. Only Hetzner, OVH, and UpCloud clusters can be scaled with this command.\n",
+			return fmt.Errorf(
+				"cluster %q (kind %q) does not support worker scaling. Only Hetzner, OVH, and UpCloud clusters can be scaled with this command",
 				clusterID, cluster.Kind)
-			os.Exit(1)
 		}
 
 		result, scaleError := scale(clusterID, workerCount)
 		if scaleError != nil {
-			fmt.Fprintf(os.Stderr, "Error scaling workers: %v\n", scaleError)
-			os.Exit(1)
+			return fmt.Errorf("scaling workers: %w", scaleError)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		fmt.Printf("  Provider: %s\n", cluster.Kind)
@@ -83,6 +80,7 @@ Example:
 			fmt.Printf("Scaling %s from %d to %d workers.\n",
 				text.FgYellow.Sprint("down"), result.PreviousCount, result.NewCount)
 		}
+		return nil
 	},
 }
 

--- a/cmd/cluster_select.go
+++ b/cmd/cluster_select.go
@@ -32,31 +32,29 @@ Examples:
   ankra cluster select
   ankra cluster select my-cluster`,
 	Args: cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 1 {
-			selectClusterByName(args[0])
-			return
+			return selectClusterByName(args[0])
 		}
-		selectClusterInteractive()
+		return selectClusterInteractive()
 	},
 }
 
-func selectClusterByName(name string) {
+func selectClusterByName(name string) error {
 	cluster, err := apiClient.GetCluster(name)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error finding cluster '%s': %v\n", name, err)
-		os.Exit(1)
+		return fmt.Errorf("finding cluster '%s': %w", name, err)
 	}
 
 	if err := saveSelectedCluster(cluster); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to save selection: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to save selection: %w", err)
 	}
 
 	fmt.Printf("Selected cluster: %s is now active.\n", cluster.Name)
+	return nil
 }
 
-func selectClusterInteractive() {
+func selectClusterInteractive() error {
 	page := 1
 	fetchedClusters := []client.ClusterListItem{}
 	startCursorPosition := 0
@@ -64,50 +62,45 @@ func selectClusterInteractive() {
 	for {
 		response, err := apiClient.ListClusters(page, 25)
 		if err != nil {
-			fmt.Printf("Error listing clusters: %v\n", err)
-			break
+			return fmt.Errorf("listing clusters: %w", err)
 		}
 
 		if len(response.Result) == 0 {
 			fmt.Println("No clusters available.")
-			break
+			return nil
 		}
 
 		prompt, selectableItems, updatedFetchedClusters := createListPromptUi(response, fetchedClusters, startCursorPosition)
 		fetchedClusters = updatedFetchedClusters
 		i, _, err := prompt.Run()
 		if err != nil {
-			fmt.Printf("Prompt failed: %v\n", err)
-			break
+			return fmt.Errorf("prompt failed: %w", err)
 		}
 		selectedItem := selectableItems[i]
 		if selectedItem.IsLoadMore {
 			startCursorPosition = i
 			page++
 			continue
-		} else {
-			selectedCluster := *selectedItem.Cluster
-			if err := saveSelectedCluster(selectedCluster); err != nil {
-				fmt.Printf("Failed to save selection: %v\n", err)
-				return
-			} else {
-				fmt.Printf("Selected cluster: %s is now active.\n", selectedCluster.Name)
-				fmt.Println("Run 'ankra cluster --help' to see available commands for this cluster")
-				return
-			}
 		}
+		selectedCluster := *selectedItem.Cluster
+		if err := saveSelectedCluster(selectedCluster); err != nil {
+			return fmt.Errorf("failed to save selection: %w", err)
+		}
+		fmt.Printf("Selected cluster: %s is now active.\n", selectedCluster.Name)
+		fmt.Println("Run 'ankra cluster --help' to see available commands for this cluster")
+		return nil
 	}
 }
 
 var clusterClearCmd = &cobra.Command{
 	Use:   "clear",
 	Short: "Clear the active cluster selection",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := clearSelectedCluster(); err != nil {
-			fmt.Printf("Error clearing selection: %v\n", err)
-			return
+			return fmt.Errorf("clearing selection: %w", err)
 		}
 		fmt.Println("Active cluster selection cleared.")
+		return nil
 	},
 }
 

--- a/cmd/cluster_ssh_keys.go
+++ b/cmd/cluster_ssh_keys.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
-	"os"
 
 	"ankra/internal/client"
 
@@ -17,23 +17,20 @@ type (
 )
 
 // resolveSSHKeysClusterKind looks up the cluster and confirms it is a
-// cloud-managed kind that supports cluster SSH key management, exiting with a
-// clear message otherwise.
-func resolveSSHKeysClusterKind(clusterID string) string {
+// cloud-managed kind that supports cluster SSH key management, returning a
+// clear error otherwise.
+func resolveSSHKeysClusterKind(clusterID string) (string, error) {
 	cluster, lookupError := apiClient.GetClusterByID(clusterID)
 	if lookupError != nil {
-		fmt.Fprintf(os.Stderr, "Error looking up cluster %q: %v\n", clusterID, lookupError)
-		os.Exit(1)
+		return "", fmt.Errorf("looking up cluster %q: %w", clusterID, lookupError)
 	}
 	switch cluster.Kind {
 	case "hetzner", "ovh", "upcloud":
-		return cluster.Kind
+		return cluster.Kind, nil
 	default:
-		fmt.Fprintf(os.Stderr,
-			"Cluster %q (kind %q) does not support SSH key management. Only Hetzner, OVH, and UpCloud clusters can use this command.\n",
+		return "", fmt.Errorf(
+			"cluster %q (kind %q) does not support SSH key management; only Hetzner, OVH, and UpCloud clusters can use this command",
 			clusterID, cluster.Kind)
-		os.Exit(1)
-		return ""
 	}
 }
 
@@ -88,18 +85,22 @@ var clusterSSHKeysGetCmd = &cobra.Command{
 	Use:   "get <cluster_id>",
 	Short: "Show SSH keys attached to a cluster",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
-		kind := resolveSSHKeysClusterKind(clusterID)
+		kind, err := resolveSSHKeysClusterKind(clusterID)
+		if err != nil {
+			return err
+		}
 
 		result, getError := sshKeysGetForKind(kind)(clusterID)
 		if getError != nil {
-			fmt.Fprintf(os.Stderr, "Error fetching SSH keys: %v\n", getError)
-			os.Exit(1)
+			return fmt.Errorf("fetching SSH keys: %w", getError)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		if len(result.SSHKeyCredentialIDs) == 0 {
@@ -117,6 +118,7 @@ var clusterSSHKeysGetCmd = &cobra.Command{
 				fmt.Printf("  %-38s  %s\n", key.CredentialID, key.Name)
 			}
 		}
+		return nil
 	},
 }
 
@@ -128,7 +130,7 @@ the next reconciliation and are applied to running nodes.
 
 Pass --clear to remove all user SSH keys (the Ankra-managed key always remains).`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		clear, _ := cmd.Flags().GetBool("clear")
 		sshKeyCredentialIDs, _ := cmd.Flags().GetStringSlice("ssh-key-credential-ids")
@@ -136,31 +138,35 @@ Pass --clear to remove all user SSH keys (the Ankra-managed key always remains).
 		if clear {
 			sshKeyCredentialIDs = []string{}
 		} else if len(sshKeyCredentialIDs) == 0 {
-			fmt.Fprintln(os.Stderr, "Provide at least one --ssh-key-credential-ids value, or pass --clear to remove all user SSH keys")
-			os.Exit(1)
+			return errors.New("provide at least one --ssh-key-credential-ids value, or pass --clear to remove all user SSH keys")
 		}
 
-		kind := resolveSSHKeysClusterKind(clusterID)
+		kind, err := resolveSSHKeysClusterKind(clusterID)
+		if err != nil {
+			return err
+		}
 
 		result, setError := sshKeysSetForKind(kind)(clusterID, sshKeyCredentialIDs)
 		if setError != nil {
-			fmt.Fprintf(os.Stderr, "Error updating SSH keys: %v\n", setError)
-			os.Exit(1)
+			return fmt.Errorf("updating SSH keys: %w", setError)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		fmt.Println(text.FgGreen.Sprint("SSH keys updated. Changes apply on next reconciliation."))
 		if len(result.SSHKeyCredentialIDs) == 0 {
 			fmt.Println("Attached SSH keys: none (Ankra-managed key retained)")
-			return
+			return nil
 		}
 		fmt.Println("Attached SSH key credential IDs:")
 		for _, id := range result.SSHKeyCredentialIDs {
 			fmt.Printf("  %s\n", id)
 		}
+		return nil
 	},
 }
 
@@ -172,24 +178,29 @@ stale provider-side SSH key reference (for example when the key was deleted and
 re-created in the provider console) that blocks new node creation, and to
 re-apply the authorised keys to running nodes.`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
-		kind := resolveSSHKeysClusterKind(clusterID)
+		kind, err := resolveSSHKeysClusterKind(clusterID)
+		if err != nil {
+			return err
+		}
 
 		result, resyncError := sshKeysResyncForKind(kind)(clusterID)
 		if resyncError != nil {
-			fmt.Fprintf(os.Stderr, "Error re-syncing SSH keys: %v\n", resyncError)
-			os.Exit(1)
+			return fmt.Errorf("re-syncing SSH keys: %w", resyncError)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		fmt.Println(text.FgGreen.Sprint("SSH key re-sync triggered. Keys are repaired and re-applied on the next reconciliation."))
 		for _, id := range result.ResourceIDs {
 			fmt.Printf("  %s\n", id)
 		}
+		return nil
 	},
 }
 

--- a/cmd/cluster_stacks.go
+++ b/cmd/cluster_stacks.go
@@ -194,8 +194,8 @@ var clusterStacksListCmd = &cobra.Command{
 // with a 422.
 //
 // The supported workflow is:
-//   1. Write a cluster YAML containing the new stack
-//   2. Run `ankra cluster apply -f cluster.yaml`
+//  1. Write a cluster YAML containing the new stack
+//  2. Run `ankra cluster apply -f cluster.yaml`
 //
 // or use `ankra cluster clone` followed by `ankra cluster apply`.
 var clusterStacksCreateCmd = &cobra.Command{

--- a/cmd/cluster_upgrade.go
+++ b/cmd/cluster_upgrade.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"ankra/internal/client"
 
@@ -40,28 +39,25 @@ the available target versions with 'ankra cluster k3s-versions'.
 Example:
   ankra cluster upgrade 62f4559a-a44d-46d7-aab3-a57c9dd6b4c6 v1.36.1+k3s1`,
 	Args: cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		targetVersion := args[1]
 
 		cluster, err := apiClient.GetClusterByID(clusterID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error looking up cluster %q: %v\n", clusterID, err)
-			os.Exit(1)
+			return fmt.Errorf("looking up cluster %q: %w", clusterID, err)
 		}
 
 		upgrade, supported := upgradeFunctionForKind(cluster.Kind)
 		if !supported {
-			fmt.Fprintf(os.Stderr,
-				"Cluster %q (kind %q) does not support Kubernetes version upgrades. Only Hetzner, OVH, and UpCloud clusters can be upgraded with this command.\n",
+			return fmt.Errorf(
+				"cluster %q (kind %q) does not support Kubernetes version upgrades. Only Hetzner, OVH, and UpCloud clusters can be upgraded with this command",
 				clusterID, cluster.Kind)
-			os.Exit(1)
 		}
 
 		result, err := upgrade(clusterID, targetVersion)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error upgrading Kubernetes version: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("upgrading Kubernetes version: %w", err)
 		}
 
 		previousVersion := "none"
@@ -73,6 +69,7 @@ Example:
 		fmt.Printf("  Previous version: %s\n", previousVersion)
 		fmt.Printf("  New version:      %s\n", text.FgGreen.Sprint(result.NewVersion))
 		fmt.Printf("  Nodes affected:   %d\n", result.NodesAffected)
+		return nil
 	},
 }
 

--- a/cmd/cluster_validate.go
+++ b/cmd/cluster_validate.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -25,7 +24,7 @@ Nothing is applied. Use --cluster <id> to validate the spec against an
 existing cluster's deployed resources, and --strict-secrets to treat
 plaintext secrets as errors instead of warnings.`,
 	Args: cobra.NoArgs,
-	Run:  runClusterValidate,
+	RunE: runClusterValidate,
 }
 
 func init() {
@@ -33,30 +32,24 @@ func init() {
 	clusterValidateCmd.Flags().Bool("strict-secrets", false, "Treat plaintext secrets as errors instead of warnings")
 	clusterValidateCmd.Flags().String("cluster", "", "Validate against an existing cluster's resources (cluster ID)")
 	registerStructuredOutputFlags(clusterValidateCmd)
-	if err := clusterValidateCmd.MarkFlagRequired("file"); err != nil {
-		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
-		os.Exit(1)
-	}
+	_ = clusterValidateCmd.MarkFlagRequired("file")
 	clusterCmd.AddCommand(clusterValidateCmd)
 }
 
-func runClusterValidate(cmd *cobra.Command, _ []string) {
+func runClusterValidate(cmd *cobra.Command, _ []string) error {
 	filePath, err := cmd.Flags().GetString("file")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error reading --file: %s\n", err)
-		os.Exit(1)
+		return fmt.Errorf("reading --file: %w", err)
 	}
 	strictSecrets, _ := cmd.Flags().GetBool("strict-secrets")
 	clusterID, _ := cmd.Flags().GetString("cluster")
 
 	importRequest, err := buildImportRequest(filePath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Invalid ImportCluster in %q:\n  %s\n", filePath, err)
-		os.Exit(1)
+		return fmt.Errorf("invalid ImportCluster in %q:\n  %w", filePath, err)
 	}
 	if err := validateResourceGraph(importRequest); err != nil {
-		fmt.Fprintf(os.Stderr, "Invalid ImportCluster in %q:\n  %s\n", filePath, err)
-		os.Exit(1)
+		return fmt.Errorf("invalid ImportCluster in %q:\n  %w", filePath, err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -64,35 +57,39 @@ func runClusterValidate(cmd *cobra.Command, _ []string) {
 
 	result, err := apiClient.ValidateCluster(ctx, importRequest.Spec, strictSecrets, clusterID)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error validating cluster: %s\n", err)
-		os.Exit(1)
+		return fmt.Errorf("validating cluster: %w", err)
 	}
 
-	if renderStructuredOrExit(cmd, result) {
+	rendered, err := renderStructured(cmd, result)
+	if err != nil {
+		return err
+	}
+	if rendered {
 		if len(result.Errors) > 0 {
-			os.Exit(1)
+			return fmt.Errorf("validation failed for %q", filePath)
 		}
-		return
+		return nil
 	}
 
 	for _, warning := range result.Warnings {
-		fmt.Fprintf(os.Stderr, "Warning: %s %q (%s): %s\n", warning.Kind, warning.Name, warning.Category, warning.Message)
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %s %q (%s): %s\n", warning.Kind, warning.Name, warning.Category, warning.Message)
 	}
 
 	if len(result.Errors) > 0 {
-		fmt.Fprintf(os.Stderr, "Validation failed for %q:\n", filePath)
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Validation failed for %q:\n", filePath)
 		for _, resourceError := range result.Errors {
-			fmt.Fprintf(os.Stderr, "- %s %q:\n", resourceError.Kind, resourceError.Name)
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "- %s %q:\n", resourceError.Kind, resourceError.Name)
 			for _, detail := range resourceError.Errors {
-				fmt.Fprintf(os.Stderr, "    • %s: %s\n", detail.Key, detail.Message)
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "    • %s: %s\n", detail.Key, detail.Message)
 			}
 		}
-		os.Exit(1)
+		return fmt.Errorf("validation failed for %q", filePath)
 	}
 
 	if len(result.Warnings) > 0 {
 		fmt.Printf("Validation passed for %q with %d warning(s); no changes applied.\n", filePath, len(result.Warnings))
-		return
+		return nil
 	}
 	fmt.Printf("Validation passed for %q; no changes applied.\n", filePath)
+	return nil
 }

--- a/cmd/control_plane.go
+++ b/cmd/control_plane.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
-	"os"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -44,15 +44,16 @@ func upcloudControlPlaneOps() controlPlaneOps {
 	}
 }
 
-func runControlPlaneGet(cmd *cobra.Command, opsFn func() controlPlaneOps, clusterID string) {
+func runControlPlaneGet(cmd *cobra.Command, opsFn func() controlPlaneOps, clusterID string) error {
 	ops := opsFn()
 	info, err := ops.get(clusterID)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
-	if renderStructuredOrExit(cmd, info) {
-		return
+	if handled, err := renderStructured(cmd, info); err != nil {
+		return err
+	} else if handled {
+		return nil
 	}
 	fmt.Printf("Control plane (%s)\n", ops.provider)
 	fmt.Printf("  Count:            %d\n", info.Count)
@@ -64,34 +65,39 @@ func runControlPlaneGet(cmd *cobra.Command, opsFn func() controlPlaneOps, cluste
 	if info.Reason != nil && *info.Reason != "" {
 		fmt.Printf("  Note:             %s\n", *info.Reason)
 	}
+	return nil
 }
 
-func runControlPlaneSetCount(cmd *cobra.Command, opsFn func() controlPlaneOps, clusterID string, count int) {
+func runControlPlaneSetCount(cmd *cobra.Command, opsFn func() controlPlaneOps, clusterID string, count int) error {
 	ops := opsFn()
 	res, err := ops.setCount(clusterID, count)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
-	if renderStructuredOrExit(cmd, res) {
-		return
+	if handled, err := renderStructured(cmd, res); err != nil {
+		return err
+	} else if handled {
+		return nil
 	}
 	fmt.Printf("Control plane count changed from %d to %d. Start the cluster to apply.\n",
 		res.PreviousCount, res.NewCount)
+	return nil
 }
 
-func runControlPlaneSetInstanceType(cmd *cobra.Command, opsFn func() controlPlaneOps, clusterID, instanceType string) {
+func runControlPlaneSetInstanceType(cmd *cobra.Command, opsFn func() controlPlaneOps, clusterID, instanceType string) error {
 	ops := opsFn()
 	res, err := ops.setInstanceType(clusterID, instanceType)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
-	if renderStructuredOrExit(cmd, res) {
-		return
+	if handled, err := renderStructured(cmd, res); err != nil {
+		return err
+	} else if handled {
+		return nil
 	}
 	fmt.Printf("Controller instance type changed from '%s' to '%s'. %d controller(s) updated. Start the cluster to apply.\n",
 		res.PreviousInstanceType, res.NewInstanceType, res.Updated)
+	return nil
 }
 
 func newControlPlaneCmd(opsFn func() controlPlaneOps, provider string) *cobra.Command {
@@ -108,8 +114,8 @@ the next time the cluster is started.`,
 		Use:   "get <cluster_id>",
 		Short: "Show the current control plane configuration",
 		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			runControlPlaneGet(cmd, opsFn, args[0])
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runControlPlaneGet(cmd, opsFn, args[0])
 		},
 	}
 
@@ -117,17 +123,15 @@ the next time the cluster is started.`,
 		Use:   "set-count <cluster_id> <count>",
 		Short: "Change the controller count (1 or 3)",
 		Args:  cobra.ExactArgs(2),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			count, err := strconv.Atoi(args[1])
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Invalid count: %v\n", err)
-				os.Exit(1)
+				return fmt.Errorf("invalid count: %w", err)
 			}
 			if count != 1 && count != 3 {
-				fmt.Fprintf(os.Stderr, "Count must be 1 or 3 (etcd quorum).\n")
-				os.Exit(1)
+				return errors.New("count must be 1 or 3 (etcd quorum)")
 			}
-			runControlPlaneSetCount(cmd, opsFn, args[0], count)
+			return runControlPlaneSetCount(cmd, opsFn, args[0], count)
 		},
 	}
 
@@ -135,8 +139,8 @@ the next time the cluster is started.`,
 		Use:   "set-instance-type <cluster_id> <instance_type>",
 		Short: "Change the controller instance type",
 		Args:  cobra.ExactArgs(2),
-		Run: func(cmd *cobra.Command, args []string) {
-			runControlPlaneSetInstanceType(cmd, opsFn, args[0], args[1])
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runControlPlaneSetInstanceType(cmd, opsFn, args[0], args[1])
 		},
 	}
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"os"
@@ -32,17 +31,10 @@ var deleteClusterCmd = &cobra.Command{
 			return nil
 		}
 
-		if !forceDelete {
-			fmt.Printf("Are you sure you want to delete cluster %q? This action is irreversible! (y/N): ", name)
-			resp, err := bufio.NewReader(os.Stdin).ReadString('\n')
-			if err != nil {
-				return fmt.Errorf("reading confirmation: %w", err)
-			}
-			resp = strings.TrimSpace(strings.ToLower(resp))
-			if resp != "y" && resp != "yes" {
-				fmt.Println("Aborted.")
-				return nil
-			}
+		if err := confirmPrompt(os.Stdin, os.Stdout,
+			fmt.Sprintf("Are you sure you want to delete cluster %q? This action is irreversible! (y/N): ", name),
+			forceDelete); err != nil {
+			return err
 		}
 
 		clusterInfo, lookupErr := apiClient.GetCluster(name)
@@ -51,8 +43,8 @@ var deleteClusterCmd = &cobra.Command{
 			case "hetzner", "ovh", "upcloud":
 				fmt.Printf(
 					"Cluster %q is a %s cloud cluster and cannot be deleted with this command.\n"+
-						"Run 'ankra cluster %s deprovision %s' instead so the cloud resources are released.\n",
-					name, clusterInfo.Kind, clusterInfo.Kind, clusterInfo.ID,
+						"Run 'ankra cluster deprovision %s' instead so the cloud resources are released.\n",
+					name, clusterInfo.Kind, clusterInfo.ID,
 				)
 				return fmt.Errorf("refusing to delete cloud cluster %q via generic delete", name)
 			}
@@ -64,14 +56,13 @@ var deleteClusterCmd = &cobra.Command{
 		if err := apiClient.DeleteCluster(ctx, name); err != nil {
 			errorString := err.Error()
 			if strings.Contains(errorString, "status 422") || strings.Contains(errorString, "status 404") {
-
-				fmt.Printf("Cluster %s does not exist, either %s is wrong or it's already been deleted.\n", name, name)
-				return nil
+				return withExitCode(exitNotFound,
+					fmt.Errorf("cluster %q does not exist: the name is wrong or it has already been deleted", name))
 			}
 			if strings.Contains(errorString, "status 409") {
 				return fmt.Errorf("delete refused: %s", errorString)
 			}
-			return fmt.Errorf("could not delete cluster %q", name)
+			return fmt.Errorf("could not delete cluster %q: %w", name, err)
 		}
 
 		fmt.Printf("Cluster %q deleted successfully.\n", name)

--- a/cmd/deprecation.go
+++ b/cmd/deprecation.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -16,4 +17,47 @@ func markDeprecatedForGenericVerb(replacement string, cmds ...*cobra.Command) {
 	for _, command := range cmds {
 		command.Deprecated = notice
 	}
+}
+
+// deprecateAndForward registers, under parent, a hidden command at the old
+// spelling that forwards every invocation to newPath (a space-separated
+// command path below root, e.g. "cluster delete"). Unlike
+// markDeprecatedForGenericVerb, the old implementation is not kept: the
+// forwarder rewrites arguments (rewrite may be nil for passthrough — it must
+// handle flags interleaved with positionals, since flag parsing is disabled
+// on the forwarder) and re-dispatches through the root command, so the
+// target's flags, validation, and hooks all apply exactly once.
+//
+// Two deprecation signals are emitted before forwarding: cobra's standard
+// human-facing notice, and a machine-readable stderr line
+// `ANKRA_DEPRECATED=<old>=><new> removal=<version>` for scripts and agents
+// (stderr keeps `-o json` output parseable). Each forwarder must have a
+// matching entry in DEPRECATIONS.md.
+//
+// The forwarder inherits the parent's auth annotations. When the target's
+// auth requirement differs from the old location's, set it explicitly on the
+// returned command — a silent flip would change which invocations demand a
+// token (see commandRequiresAuth's parent walk).
+func deprecateAndForward(parent *cobra.Command, use, newPath, removalVersion string, rewrite func([]string) []string) *cobra.Command {
+	forwarder := &cobra.Command{
+		Use:                use,
+		Short:              fmt.Sprintf("Deprecated: use `ankra %s` instead", newPath),
+		Hidden:             true,
+		DisableFlagParsing: true,
+		SilenceUsage:       true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Command %q is deprecated and will be removed in %s, use `ankra %s` instead\n",
+				cmd.CommandPath(), removalVersion, newPath)
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "ANKRA_DEPRECATED=%s=>ankra %s removal=%s\n",
+				cmd.CommandPath(), newPath, removalVersion)
+			if rewrite != nil {
+				args = rewrite(args)
+			}
+			root := cmd.Root()
+			root.SetArgs(append(strings.Split(newPath, " "), args...))
+			return root.Execute()
+		},
+	}
+	parent.AddCommand(forwarder)
+	return forwarder
 }

--- a/cmd/deprecation.go
+++ b/cmd/deprecation.go
@@ -34,10 +34,12 @@ func markDeprecatedForGenericVerb(replacement string, cmds ...*cobra.Command) {
 // (stderr keeps `-o json` output parseable). Each forwarder must have a
 // matching entry in DEPRECATIONS.md.
 //
-// The forwarder inherits the parent's auth annotations. When the target's
-// auth requirement differs from the old location's, set it explicitly on the
-// returned command — a silent flip would change which invocations demand a
-// token (see commandRequiresAuth's parent walk).
+// The forwarder itself is auth-free: with DisableFlagParsing, the persistent
+// pre-run would otherwise resolve credentials before --token/--base-url are
+// parsed and wrongly reject `ankra <old-cmd> --token ...`. Authentication is
+// enforced on the target during re-dispatch, after its flags are parsed.
+// The nested dispatch runs with errors silenced so a failing target prints
+// its error exactly once (from the outer Execute).
 func deprecateAndForward(parent *cobra.Command, use, newPath, removalVersion string, rewrite func([]string) []string) *cobra.Command {
 	forwarder := &cobra.Command{
 		Use:                use,
@@ -55,9 +57,13 @@ func deprecateAndForward(parent *cobra.Command, use, newPath, removalVersion str
 			}
 			root := cmd.Root()
 			root.SetArgs(append(strings.Split(newPath, " "), args...))
+			previousSilenceErrors := root.SilenceErrors
+			root.SilenceErrors = true
+			defer func() { root.SilenceErrors = previousSilenceErrors }()
 			return root.Execute()
 		},
 	}
+	setRequiresAuth(forwarder, false)
 	parent.AddCommand(forwarder)
 	return forwarder
 }

--- a/cmd/deprecation_test.go
+++ b/cmd/deprecation_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"bytes"
+	"errors"
+	"io"
 	"strings"
 	"testing"
 
@@ -70,5 +73,100 @@ func TestOvhNodeGroupLabelsAndTaintsNotDeprecated(t *testing.T) {
 		if leaf.Deprecated != "" {
 			t.Errorf("ovh node-group %s has no generic equivalent and must not be deprecated, got Deprecated=%q", verb, leaf.Deprecated)
 		}
+	}
+}
+
+func TestDeprecateAndForwardDispatchesToTarget(t *testing.T) {
+	var gotArgs []string
+	var gotFlag string
+	root := &cobra.Command{Use: "ankra"}
+	group := &cobra.Command{Use: "cluster"}
+	target := &cobra.Command{
+		Use: "delete",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gotArgs = args
+			gotFlag, _ = cmd.Flags().GetString("note")
+			return nil
+		},
+	}
+	target.Flags().String("note", "", "")
+	group.AddCommand(target)
+	root.AddCommand(group)
+
+	forwarder := deprecateAndForward(root, "delete-cluster", "cluster delete", "v0.7.0", nil)
+	if !forwarder.Hidden {
+		t.Error("forwarder should be hidden from help")
+	}
+
+	var stderr bytes.Buffer
+	root.SetErr(&stderr)
+	root.SetOut(io.Discard)
+	root.SetArgs([]string{"delete-cluster", "prod", "--note", "bye"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("forwarded execution failed: %v", err)
+	}
+	if len(gotArgs) != 1 || gotArgs[0] != "prod" {
+		t.Errorf("target args = %v, want [prod]", gotArgs)
+	}
+	if gotFlag != "bye" {
+		t.Errorf("target flag = %q, want %q (flags must pass through the forwarder)", gotFlag, "bye")
+	}
+	warnings := stderr.String()
+	if !strings.Contains(warnings, "ANKRA_DEPRECATED=ankra delete-cluster=>ankra cluster delete removal=v0.7.0") {
+		t.Errorf("missing machine-readable marker, stderr: %q", warnings)
+	}
+	if !strings.Contains(warnings, "deprecated") {
+		t.Errorf("missing human-facing notice, stderr: %q", warnings)
+	}
+}
+
+func TestDeprecateAndForwardRewritesArgs(t *testing.T) {
+	var gotArgs []string
+	root := &cobra.Command{Use: "ankra"}
+	target := &cobra.Command{
+		Use:  "cancel",
+		RunE: func(cmd *cobra.Command, args []string) error { gotArgs = args; return nil },
+	}
+	target.Flags().String("step", "", "")
+	root.AddCommand(target)
+
+	deprecateAndForward(root, "cancel-step", "cancel", "v0.7.0", func(args []string) []string {
+		if len(args) == 2 {
+			return []string{args[0], "--step", args[1]}
+		}
+		return args
+	})
+
+	root.SetErr(io.Discard)
+	root.SetOut(io.Discard)
+	root.SetArgs([]string{"cancel-step", "exec-1", "step-2"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("forwarded execution failed: %v", err)
+	}
+	if len(gotArgs) != 1 || gotArgs[0] != "exec-1" {
+		t.Errorf("rewritten args = %v, want positional [exec-1] with step-2 moved to --step", gotArgs)
+	}
+}
+
+func TestDeprecateAndForwardPropagatesTargetError(t *testing.T) {
+	root := &cobra.Command{Use: "ankra"}
+	target := &cobra.Command{
+		Use:           "fail",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE:          func(*cobra.Command, []string) error { return withExitCode(exitNotFound, errors.New("boom")) },
+	}
+	root.AddCommand(target)
+	deprecateAndForward(root, "old-fail", "fail", "v0.7.0", nil)
+
+	root.SetErr(io.Discard)
+	root.SetOut(io.Discard)
+	root.SetArgs([]string{"old-fail"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("target error should propagate through the forwarder")
+	}
+	if got := exitCodeFor(err); got != exitNotFound {
+		t.Errorf("exit code should survive forwarding, got %d", got)
 	}
 }

--- a/cmd/deprecation_test.go
+++ b/cmd/deprecation_test.go
@@ -149,17 +149,19 @@ func TestDeprecateAndForwardRewritesArgs(t *testing.T) {
 }
 
 func TestDeprecateAndForwardPropagatesTargetError(t *testing.T) {
-	root := &cobra.Command{Use: "ankra"}
+	// Configured like the real rootCmd: SilenceUsage only, errors NOT silenced,
+	// so this also guards against the forwarded error printing twice (once from
+	// the nested Execute, once from the outer one).
+	root := &cobra.Command{Use: "ankra", SilenceUsage: true}
 	target := &cobra.Command{
-		Use:           "fail",
-		SilenceErrors: true,
-		SilenceUsage:  true,
-		RunE:          func(*cobra.Command, []string) error { return withExitCode(exitNotFound, errors.New("boom")) },
+		Use:  "fail",
+		RunE: func(*cobra.Command, []string) error { return withExitCode(exitNotFound, errors.New("boom")) },
 	}
 	root.AddCommand(target)
 	deprecateAndForward(root, "old-fail", "fail", "v0.7.0", nil)
 
-	root.SetErr(io.Discard)
+	var stderr bytes.Buffer
+	root.SetErr(&stderr)
 	root.SetOut(io.Discard)
 	root.SetArgs([]string{"old-fail"})
 	err := root.Execute()
@@ -168,5 +170,22 @@ func TestDeprecateAndForwardPropagatesTargetError(t *testing.T) {
 	}
 	if got := exitCodeFor(err); got != exitNotFound {
 		t.Errorf("exit code should survive forwarding, got %d", got)
+	}
+	if got := strings.Count(stderr.String(), "Error: boom"); got != 1 {
+		t.Errorf("forwarded failure should print exactly once, got %d prints in: %q", got, stderr.String())
+	}
+	if root.SilenceErrors {
+		t.Error("root.SilenceErrors must be restored after forwarding")
+	}
+}
+
+func TestDeprecateAndForwardIsAuthFree(t *testing.T) {
+	// With DisableFlagParsing the persistent pre-run would resolve credentials
+	// before --token is parsed, so the forwarder itself must skip auth; the
+	// target enforces it during re-dispatch with parsed flags.
+	root := &cobra.Command{Use: "ankra"}
+	forwarder := deprecateAndForward(root, "old", "new", "v0.7.0", nil)
+	if commandRequiresAuth(forwarder) {
+		t.Error("forwarder must be auth-free; auth is enforced on the target after flags are parsed")
 	}
 }

--- a/cmd/exitcodes.go
+++ b/cmd/exitcodes.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// Exit codes are part of the CLI's scripting contract. 0 and 1 match the
+// historical behavior; 2-6 let scripts and CI distinguish failures they can
+// act on (re-run usage errors after fixing the invocation, treat not-found
+// as idempotent success, re-authenticate on auth failures, retry on wait
+// expiry) without parsing error text.
+const (
+	exitOK          = 0
+	exitError       = 1 // API or runtime failure
+	exitUsage       = 2 // bad flags, arguments, or subcommand
+	exitNotFound    = 3 // the targeted resource does not exist
+	exitCancelled   = 4 // confirmation declined
+	exitWaitTimeout = 5 // --wait/--timeout expired before completion
+	exitAuth        = 6 // missing, expired, or rejected credentials
+)
+
+// codedError attaches an exit code to an error without changing its message.
+type codedError struct {
+	code int
+	err  error
+}
+
+func (e *codedError) Error() string { return e.err.Error() }
+func (e *codedError) Unwrap() error { return e.err }
+
+// withExitCode wraps err so Execute exits with code. A nil err stays nil, so
+// call sites can wrap unconditionally.
+func withExitCode(code int, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &codedError{code: code, err: err}
+}
+
+// errCancelled is the shared confirmation-declined error. It carries
+// exitCancelled so a declined [y/N] prompt is distinguishable from a real
+// failure in scripts.
+var errCancelled = withExitCode(exitCancelled, errors.New("cancelled"))
+
+// exitCodeFor classifies an error returned by ExecuteC into an exit code.
+// Explicit withExitCode wrapping wins; otherwise auth and not-found API
+// responses and --wait expiry map to their codes, and anything unclassified
+// is a generic failure.
+func exitCodeFor(err error) int {
+	if err == nil {
+		return exitOK
+	}
+	var coded *codedError
+	if errors.As(err, &coded) {
+		return coded.code
+	}
+	var unexpected *client.UnexpectedResponseError
+	if errors.As(err, &unexpected) {
+		switch unexpected.StatusCode {
+		case 401, 403:
+			return exitAuth
+		case 404:
+			return exitNotFound
+		}
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return exitWaitTimeout
+	}
+	// Cobra reports unknown subcommands as plain errors with a fixed prefix.
+	if strings.HasPrefix(err.Error(), "unknown command ") {
+		return exitUsage
+	}
+	return exitError
+}
+
+// wrapArgsValidators decorates every registered Args validator in the tree so
+// argument-count errors exit with exitUsage instead of the generic failure
+// code. Called once from Execute after all commands are registered.
+func wrapArgsValidators(cmd *cobra.Command) {
+	if validate := cmd.Args; validate != nil {
+		cmd.Args = func(c *cobra.Command, args []string) error {
+			return withExitCode(exitUsage, validate(c, args))
+		}
+	}
+	for _, sub := range cmd.Commands() {
+		wrapArgsValidators(sub)
+	}
+}

--- a/cmd/exitcodes.go
+++ b/cmd/exitcodes.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"strings"
 
@@ -50,8 +49,10 @@ var errCancelled = withExitCode(exitCancelled, errors.New("cancelled"))
 
 // exitCodeFor classifies an error returned by ExecuteC into an exit code.
 // Explicit withExitCode wrapping wins; otherwise auth and not-found API
-// responses and --wait expiry map to their codes, and anything unclassified
-// is a generic failure.
+// responses map to their codes, and anything unclassified is a generic
+// failure. exitWaitTimeout is never inferred here — internal fixed request
+// deadlines also surface as context.DeadlineExceeded, so only call sites
+// that know --wait was set tag it (see asyncWriteError).
 func exitCodeFor(err error) int {
 	if err == nil {
 		return exitOK
@@ -59,6 +60,9 @@ func exitCodeFor(err error) int {
 	var coded *codedError
 	if errors.As(err, &coded) {
 		return coded.code
+	}
+	if errors.Is(err, client.ErrUnauthorized) {
+		return exitAuth
 	}
 	var unexpected *client.UnexpectedResponseError
 	if errors.As(err, &unexpected) {
@@ -69,11 +73,13 @@ func exitCodeFor(err error) int {
 			return exitNotFound
 		}
 	}
-	if errors.Is(err, context.DeadlineExceeded) {
-		return exitWaitTimeout
-	}
-	// Cobra reports unknown subcommands as plain errors with a fixed prefix.
-	if strings.HasPrefix(err.Error(), "unknown command ") {
+	// Cobra reports unknown subcommands, required-flag violations, and
+	// flag-group violations as plain errors; they bypass both FlagErrorFunc
+	// (parse errors only) and Args validators, so match their fixed shapes.
+	message := err.Error()
+	if strings.HasPrefix(message, "unknown command ") ||
+		strings.HasPrefix(message, "required flag(s) ") ||
+		strings.Contains(message, "flags in the group [") {
 		return exitUsage
 	}
 	return exitError

--- a/cmd/exitcodes_test.go
+++ b/cmd/exitcodes_test.go
@@ -27,8 +27,11 @@ func TestExitCodeForClassification(t *testing.T) {
 		{"forbidden response", &client.UnexpectedResponseError{StatusCode: 403}, exitAuth},
 		{"not-found response", &client.UnexpectedResponseError{StatusCode: 404}, exitNotFound},
 		{"server error response", &client.UnexpectedResponseError{StatusCode: 500}, exitError},
-		{"wait deadline", fmt.Errorf("waiting: %w", context.DeadlineExceeded), exitWaitTimeout},
+		{"bare deadline stays generic (internal request timeouts are not --wait expiry)", fmt.Errorf("waiting: %w", context.DeadlineExceeded), exitError},
+		{"unauthorized sentinel", fmt.Errorf("listing clusters: %w", client.ErrUnauthorized), exitAuth},
 		{"unknown command", errors.New(`unknown command "clusterz" for "ankra"`), exitUsage},
+		{"required flag", errors.New(`required flag(s) "file" not set`), exitUsage},
+		{"flag group violation", errors.New(`if any flags in the group [file cluster] are set none of the others can be; [cluster file] were all set`), exitUsage},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -76,5 +79,19 @@ func TestWrapArgsValidatorsMarksUsageErrors(t *testing.T) {
 
 	if err := child.Args(child, []string{"one"}); err != nil {
 		t.Errorf("valid args should still pass, got %v", err)
+	}
+}
+
+func TestAsyncWriteErrorTagsWaitExpiryOnly(t *testing.T) {
+	deadline := fmt.Errorf("request failed: %w", context.DeadlineExceeded)
+
+	if got := exitCodeFor(asyncWriteError("applying cluster", true, deadline)); got != exitWaitTimeout {
+		t.Errorf("--wait deadline expiry should exit %d, got %d", exitWaitTimeout, got)
+	}
+	if got := exitCodeFor(asyncWriteError("applying cluster", false, deadline)); got != exitError {
+		t.Errorf("internal deadline without --wait should exit %d, got %d", exitError, got)
+	}
+	if got := exitCodeFor(asyncWriteError("applying cluster", true, errors.New("rejected"))); got != exitError {
+		t.Errorf("non-deadline failure with --wait should exit %d, got %d", exitError, got)
 	}
 }

--- a/cmd/exitcodes_test.go
+++ b/cmd/exitcodes_test.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+func TestExitCodeForClassification(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"nil is ok", nil, exitOK},
+		{"plain error", errors.New("boom"), exitError},
+		{"explicit code", withExitCode(exitNotFound, errors.New("gone")), exitNotFound},
+		{"explicit code wrapped deeper", fmt.Errorf("outer: %w", withExitCode(exitWaitTimeout, errors.New("slow"))), exitWaitTimeout},
+		{"cancelled sentinel", errCancelled, exitCancelled},
+		{"cancelled wrapped", fmt.Errorf("delete: %w", errCancelled), exitCancelled},
+		{"unauthorized response", &client.UnexpectedResponseError{StatusCode: 401}, exitAuth},
+		{"forbidden response", &client.UnexpectedResponseError{StatusCode: 403}, exitAuth},
+		{"not-found response", &client.UnexpectedResponseError{StatusCode: 404}, exitNotFound},
+		{"server error response", &client.UnexpectedResponseError{StatusCode: 500}, exitError},
+		{"wait deadline", fmt.Errorf("waiting: %w", context.DeadlineExceeded), exitWaitTimeout},
+		{"unknown command", errors.New(`unknown command "clusterz" for "ankra"`), exitUsage},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := exitCodeFor(tc.err); got != tc.want {
+				t.Errorf("exitCodeFor(%v) = %d, want %d", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWithExitCodeNilStaysNil(t *testing.T) {
+	if err := withExitCode(exitNotFound, nil); err != nil {
+		t.Errorf("withExitCode(_, nil) = %v, want nil", err)
+	}
+}
+
+func TestWithExitCodePreservesMessageAndUnwraps(t *testing.T) {
+	underlying := errors.New("cluster \"x\" not found")
+	err := withExitCode(exitNotFound, underlying)
+	if err.Error() != underlying.Error() {
+		t.Errorf("message changed: %q vs %q", err.Error(), underlying.Error())
+	}
+	if !errors.Is(err, underlying) {
+		t.Error("wrapped error should unwrap to the underlying error")
+	}
+}
+
+func TestWrapArgsValidatorsMarksUsageErrors(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	child := &cobra.Command{
+		Use:  "child",
+		Args: cobra.ExactArgs(1),
+		RunE: func(*cobra.Command, []string) error { return nil },
+	}
+	root.AddCommand(child)
+	wrapArgsValidators(root)
+
+	err := child.Args(child, []string{})
+	if err == nil {
+		t.Fatal("expected an args-validation error")
+	}
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("args error should classify as exitUsage, got %d", got)
+	}
+
+	if err := child.Args(child, []string{"one"}); err != nil {
+		t.Errorf("valid args should still pass, got %v", err)
+	}
+}

--- a/cmd/helm.go
+++ b/cmd/helm.go
@@ -155,8 +155,7 @@ var helmRegistriesDeleteCmd = &cobra.Command{
 				IsConfirm: true,
 			}
 			if _, err := prompt.Run(); err != nil {
-				fmt.Println("Cancelled.")
-				return nil
+				return errCancelled
 			}
 		}
 
@@ -419,8 +418,7 @@ var helmCredentialsDeleteCmd = &cobra.Command{
 				IsConfirm: true,
 			}
 			if _, err := prompt.Run(); err != nil {
-				fmt.Println("Cancelled.")
-				return nil
+				return errCancelled
 			}
 		}
 

--- a/cmd/hetzner_cluster.go
+++ b/cmd/hetzner_cluster.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -21,7 +20,7 @@ var hetznerCmd = &cobra.Command{
 var hetznerCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new Hetzner cluster",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		name, _ := cmd.Flags().GetString("name")
 		credentialID, _ := cmd.Flags().GetString("credential-id")
 		sshKeyCredentialID, _ := cmd.Flags().GetString("ssh-key-credential-id")
@@ -38,8 +37,7 @@ var hetznerCreateCmd = &cobra.Command{
 		kubeVersion, _ := cmd.Flags().GetString("kubernetes-version")
 		externalCloudProvider, includeNetworking, err := resolveCloudProviderNetworking(cmd)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 		gitopsCredentialName, _ := cmd.Flags().GetString("gitops-credential-name")
 		gitopsRepository, _ := cmd.Flags().GetString("gitops-repository")
@@ -80,18 +78,20 @@ var hetznerCreateCmd = &cobra.Command{
 
 		result, err := apiClient.CreateHetznerCluster(req)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating Hetzner cluster: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating Hetzner cluster: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		fmt.Printf("Hetzner cluster '%s' created successfully!\n", result.Name)
 		fmt.Printf("  Cluster ID: %s\n", result.ClusterID)
 		fmt.Printf("\nView it in the UI:\n  %s/organisation/clusters/cluster/imported/%s/overview\n",
 			strings.TrimRight(baseURL, "/"), result.ClusterID)
+		return nil
 	},
 }
 
@@ -102,18 +102,19 @@ var hetznerDeprovisionCmd = &cobra.Command{
 		"jobs that delete cloud resources (servers, networks, SSH keys). Cloud resources are not " +
 		"deleted by the time this command returns; track progress via operations or the UI.",
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		force, _ := cmd.Flags().GetBool("force")
 
 		result, err := apiClient.DeprovisionHetznerCluster(clusterID, force)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error deprovisioning cluster: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("deprovisioning cluster: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		if result.Success {
@@ -127,6 +128,7 @@ var hetznerDeprovisionCmd = &cobra.Command{
 		if result.OperationID != nil && *result.OperationID != "" {
 			fmt.Printf("  Operation ID: %s\n", *result.OperationID)
 		}
+		return nil
 	},
 }
 
@@ -134,22 +136,24 @@ var hetznerWorkersCmd = &cobra.Command{
 	Use:   "workers <cluster_id>",
 	Short: "Get current worker count for a Hetzner cluster",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 
 		result, err := apiClient.GetHetznerWorkerCount(clusterID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error fetching worker count: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("fetching worker count: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		fmt.Printf("Worker Count: %d\n", result.WorkerCount)
 		fmt.Printf("  Min: %d\n", result.Min)
 		fmt.Printf("  Max: %d\n", result.Max)
+		return nil
 	},
 }
 
@@ -158,22 +162,22 @@ var hetznerScaleCmd = &cobra.Command{
 	Short: "Scale workers for a Hetzner cluster",
 	Long:  "Scale the number of worker nodes up or down for a Hetzner cluster.",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		workerCount, err := strconv.Atoi(args[1])
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Invalid worker count: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("invalid worker count: %w", err)
 		}
 
 		result, err := apiClient.ScaleHetznerWorkers(clusterID, workerCount)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error scaling workers: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("scaling workers: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		if result.PreviousCount == result.NewCount {
@@ -185,6 +189,7 @@ var hetznerScaleCmd = &cobra.Command{
 			fmt.Printf("Scaling %s from %d to %d workers.\n",
 				text.FgYellow.Sprint("down"), result.PreviousCount, result.NewCount)
 		}
+		return nil
 	},
 }
 
@@ -192,17 +197,18 @@ var hetznerK8sVersionCmd = &cobra.Command{
 	Use:   "k8s-version <cluster_id>",
 	Short: "Get current Kubernetes version for a Hetzner cluster",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 
 		result, err := apiClient.GetHetznerK8sVersion(clusterID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error fetching Kubernetes version: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("fetching Kubernetes version: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		version := "not set (using latest stable)"
@@ -211,6 +217,7 @@ var hetznerK8sVersionCmd = &cobra.Command{
 		}
 		fmt.Printf("Kubernetes Version: %s\n", version)
 		fmt.Printf("  Distribution: %s\n", result.Distribution)
+		return nil
 	},
 }
 
@@ -220,18 +227,19 @@ var hetznerUpgradeCmd = &cobra.Command{
 	Long:       "Upgrade the Kubernetes (k3s) version on all nodes in a Hetzner cluster.",
 	Deprecated: "use `ankra cluster upgrade <cluster_id> <target_version>` instead; the cloud provider is detected automatically.",
 	Args:       cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		targetVersion := args[1]
 
 		result, err := apiClient.UpgradeHetznerK8sVersion(clusterID, targetVersion)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error upgrading Kubernetes version: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("upgrading Kubernetes version: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		prev := "none"
@@ -242,6 +250,7 @@ var hetznerUpgradeCmd = &cobra.Command{
 		fmt.Printf("  Previous version: %s\n", prev)
 		fmt.Printf("  New version:      %s\n", text.FgGreen.Sprint(result.NewVersion))
 		fmt.Printf("  Nodes affected:   %d\n", result.NodesAffected)
+		return nil
 	},
 }
 
@@ -255,24 +264,26 @@ var nodeGroupListCmd = &cobra.Command{
 	Use:   "list <cluster_id>",
 	Short: "List node groups",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		result, err := apiClient.ListHetznerNodeGroups(clusterID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error listing node groups: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("listing node groups: %w", err)
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		if len(result.NodeGroups) == 0 {
 			fmt.Println("No node groups found.")
-			return
+			return nil
 		}
 		for _, ng := range result.NodeGroups {
 			fmt.Printf("%-20s  type=%-8s  count=%d  labels=%d  taints=%d\n",
 				ng.Name, ng.InstanceType, ng.Count, len(ng.Labels), len(ng.Taints))
 		}
+		return nil
 	},
 }
 
@@ -280,7 +291,7 @@ var nodeGroupAddCmd = &cobra.Command{
 	Use:   "add <cluster_id>",
 	Short: "Add a node group",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		name, _ := cmd.Flags().GetString("name")
 		instanceType, _ := cmd.Flags().GetString("instance-type")
@@ -297,19 +308,24 @@ var nodeGroupAddCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.AddHetznerNodeGroup(requestContext, clusterID, req, wait)
 		if err != nil {
-			handleNodeGroupSubmitError("adding node group", err)
+			return fmt.Errorf("adding node group: %w", err)
 		}
 		if submitted {
-			if renderStructuredOrExit(cmd, newAsyncSubmittedResult("Node group add")) {
-				return
+			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group add")); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 			printAsyncWriteSubmitted("Node group add")
-			return
+			return nil
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		fmt.Printf("Node group '%s' created with %d node(s).\n", result.GroupName, result.Count)
+		return nil
 	},
 }
 
@@ -317,13 +333,12 @@ var nodeGroupScaleCmd = &cobra.Command{
 	Use:   "scale <cluster_id> <group_name> <count>",
 	Short: "Scale a node group",
 	Args:  cobra.ExactArgs(3),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		groupName := args[1]
 		count, err := strconv.Atoi(args[2])
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Invalid count: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("invalid count: %w", err)
 		}
 
 		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
@@ -331,19 +346,24 @@ var nodeGroupScaleCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.ScaleHetznerNodeGroup(requestContext, clusterID, groupName, count, wait)
 		if err != nil {
-			handleNodeGroupSubmitError("scaling node group", err)
+			return fmt.Errorf("scaling node group: %w", err)
 		}
 		if submitted {
-			if renderStructuredOrExit(cmd, newAsyncSubmittedResult("Node group scale")) {
-				return
+			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group scale")); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 			printAsyncWriteSubmitted("Node group scale")
-			return
+			return nil
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		fmt.Printf("Node group '%s' scaled from %d to %d.\n", result.GroupName, result.PreviousCount, result.NewCount)
+		return nil
 	},
 }
 
@@ -351,7 +371,7 @@ var nodeGroupUpgradeCmd = &cobra.Command{
 	Use:   "upgrade <cluster_id> <group_name> <instance_type>",
 	Short: "Upgrade instance type for a node group (cannot be reversed)",
 	Args:  cobra.ExactArgs(3),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		groupName := args[1]
 		instanceType := args[2]
@@ -361,19 +381,24 @@ var nodeGroupUpgradeCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.UpdateHetznerNodeGroupInstanceType(requestContext, clusterID, groupName, instanceType, wait)
 		if err != nil {
-			handleNodeGroupSubmitError("upgrading node group", err)
+			return fmt.Errorf("upgrading node group: %w", err)
 		}
 		if submitted {
-			if renderStructuredOrExit(cmd, newAsyncSubmittedResult("Node group instance-type update")) {
-				return
+			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group instance-type update")); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 			printAsyncWriteSubmitted("Node group instance-type update")
-			return
+			return nil
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		fmt.Printf("Node group '%s' instance type upgraded. %d node(s) affected.\n", result.GroupName, result.Updated)
+		return nil
 	},
 }
 
@@ -381,7 +406,7 @@ var nodeGroupDeleteCmd = &cobra.Command{
 	Use:   "delete <cluster_id> <group_name>",
 	Short: "Delete a node group and all its nodes",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		groupName := args[1]
 
@@ -390,19 +415,24 @@ var nodeGroupDeleteCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.DeleteHetznerNodeGroup(requestContext, clusterID, groupName, wait)
 		if err != nil {
-			handleNodeGroupSubmitError("deleting node group", err)
+			return fmt.Errorf("deleting node group: %w", err)
 		}
 		if submitted {
-			if renderStructuredOrExit(cmd, newAsyncSubmittedResult("Node group delete")) {
-				return
+			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group delete")); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 			printAsyncWriteSubmitted("Node group delete")
-			return
+			return nil
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		fmt.Printf("Node group '%s' deleted. %d node(s) removed.\n", result.GroupName, result.Deleted)
+		return nil
 	},
 }
 
@@ -410,22 +440,22 @@ var hetznerLocationsCmd = &cobra.Command{
 	Use:   "locations",
 	Short: "List Hetzner locations available to a credential",
 	Long:  "List the Hetzner Cloud locations the supplied credential can deploy in. Only these locations are valid for cluster creation.",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		credentialID, _ := cmd.Flags().GetString("credential-id")
 
 		locations, err := apiClient.ListHetznerLocations(credentialID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error listing locations: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("listing locations: %w", err)
 		}
 		if len(locations) == 0 {
 			fmt.Println("No locations available for this credential.")
-			return
+			return nil
 		}
 		fmt.Printf("Locations available to credential %s:\n", credentialID)
 		for _, loc := range locations {
 			fmt.Printf("  %-6s %s, %s (zone: %s)\n", loc.Name, loc.City, loc.Country, loc.NetworkZone)
 		}
+		return nil
 	},
 }
 
@@ -433,19 +463,18 @@ var hetznerServerTypesCmd = &cobra.Command{
 	Use:   "server-types",
 	Short: "List Hetzner server types and availability",
 	Long:  "List Hetzner Cloud server types. Pass --location to see which types are currently available for provisioning there, and --available-only to hide the rest.",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		credentialID, _ := cmd.Flags().GetString("credential-id")
 		location, _ := cmd.Flags().GetString("location")
 		availableOnly, _ := cmd.Flags().GetBool("available-only")
 
 		serverTypes, err := apiClient.ListHetznerServerTypes(credentialID, location)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error listing server types: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("listing server types: %w", err)
 		}
 		if len(serverTypes) == 0 {
 			fmt.Println("No server types available for this credential.")
-			return
+			return nil
 		}
 		header := "Server types"
 		if location != "" {
@@ -464,6 +493,7 @@ var hetznerServerTypesCmd = &cobra.Command{
 			fmt.Printf("  %-12s %-6d %-6.0fGB %-5dGB %-6s %-10.2f %s\n",
 				st.Name, st.Cores, st.Memory, st.Disk, st.Architecture, st.PriceMonthly, available)
 		}
+		return nil
 	},
 }
 

--- a/cmd/hetzner_cluster.go
+++ b/cmd/hetzner_cluster.go
@@ -303,7 +303,10 @@ var nodeGroupAddCmd = &cobra.Command{
 			Count:        count,
 		}
 
-		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
+		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
+		if err != nil {
+			return err
+		}
 		defer cancelRequestContext()
 
 		result, submitted, err := apiClient.AddHetznerNodeGroup(requestContext, clusterID, req, wait)
@@ -341,7 +344,10 @@ var nodeGroupScaleCmd = &cobra.Command{
 			return fmt.Errorf("invalid count: %w", err)
 		}
 
-		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
+		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
+		if err != nil {
+			return err
+		}
 		defer cancelRequestContext()
 
 		result, submitted, err := apiClient.ScaleHetznerNodeGroup(requestContext, clusterID, groupName, count, wait)
@@ -376,7 +382,10 @@ var nodeGroupUpgradeCmd = &cobra.Command{
 		groupName := args[1]
 		instanceType := args[2]
 
-		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
+		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
+		if err != nil {
+			return err
+		}
 		defer cancelRequestContext()
 
 		result, submitted, err := apiClient.UpdateHetznerNodeGroupInstanceType(requestContext, clusterID, groupName, instanceType, wait)
@@ -410,7 +419,10 @@ var nodeGroupDeleteCmd = &cobra.Command{
 		clusterID := args[0]
 		groupName := args[1]
 
-		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
+		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
+		if err != nil {
+			return err
+		}
 		defer cancelRequestContext()
 
 		result, submitted, err := apiClient.DeleteHetznerNodeGroup(requestContext, clusterID, groupName, wait)

--- a/cmd/hetzner_cluster.go
+++ b/cmd/hetzner_cluster.go
@@ -311,7 +311,7 @@ var nodeGroupAddCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.AddHetznerNodeGroup(requestContext, clusterID, req, wait)
 		if err != nil {
-			return fmt.Errorf("adding node group: %w", err)
+			return asyncWriteError("adding node group", wait, err)
 		}
 		if submitted {
 			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group add")); err != nil {
@@ -352,7 +352,7 @@ var nodeGroupScaleCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.ScaleHetznerNodeGroup(requestContext, clusterID, groupName, count, wait)
 		if err != nil {
-			return fmt.Errorf("scaling node group: %w", err)
+			return asyncWriteError("scaling node group", wait, err)
 		}
 		if submitted {
 			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group scale")); err != nil {
@@ -390,7 +390,7 @@ var nodeGroupUpgradeCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.UpdateHetznerNodeGroupInstanceType(requestContext, clusterID, groupName, instanceType, wait)
 		if err != nil {
-			return fmt.Errorf("upgrading node group: %w", err)
+			return asyncWriteError("upgrading node group", wait, err)
 		}
 		if submitted {
 			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group instance-type update")); err != nil {
@@ -427,7 +427,7 @@ var nodeGroupDeleteCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.DeleteHetznerNodeGroup(requestContext, clusterID, groupName, wait)
 		if err != nil {
-			return fmt.Errorf("deleting node group: %w", err)
+			return asyncWriteError("deleting node group", wait, err)
 		}
 		if submitted {
 			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group delete")); err != nil {

--- a/cmd/hetzner_credentials.go
+++ b/cmd/hetzner_credentials.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -23,23 +24,24 @@ var hetznerCredCmd = &cobra.Command{
 var hetznerCredListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List Hetzner API credentials",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		creds, err := apiClient.ListHetznerCredentials()
 		if err != nil {
-			fmt.Printf("Error listing Hetzner credentials: %v\n", err)
-			return
+			return fmt.Errorf("listing Hetzner credentials: %w", err)
 		}
 
 		if creds == nil {
 			creds = []client.HetznerCredentialListItem{}
 		}
-		if renderStructuredOrExit(cmd, creds) {
-			return
+		if handled, err := renderStructured(cmd, creds); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		if len(creds) == 0 {
 			fmt.Println("No Hetzner credentials found.")
-			return
+			return nil
 		}
 
 		t := table.NewWriter()
@@ -66,13 +68,14 @@ var hetznerCredListCmd = &cobra.Command{
 			})
 		}
 		t.Render()
+		return nil
 	},
 }
 
 var hetznerCredCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a Hetzner API credential",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		name, _ := cmd.Flags().GetString("name")
 
 		prompt := promptui.Prompt{
@@ -87,8 +90,7 @@ var hetznerCredCreateCmd = &cobra.Command{
 		}
 		apiTokenValue, err := prompt.Run()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Prompt cancelled.\n")
-			os.Exit(1)
+			return errors.New("prompt cancelled")
 		}
 
 		result, err := apiClient.CreateHetznerCredential(client.CreateHetznerCredentialRequest{
@@ -96,42 +98,43 @@ var hetznerCredCreateCmd = &cobra.Command{
 			APIToken: apiTokenValue,
 		})
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating Hetzner credential: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating Hetzner credential: %w", err)
 		}
 
 		if !result.Success {
-			fmt.Fprintln(os.Stderr, "Failed to create Hetzner credential:")
+			msg := "failed to create Hetzner credential:"
 			for _, e := range result.Errors {
-				fmt.Fprintf(os.Stderr, "  - %s: %s\n", e.Key, e.Message)
+				msg += fmt.Sprintf("\n  - %s: %s", e.Key, e.Message)
 			}
-			os.Exit(1)
+			return errors.New(msg)
 		}
 
 		fmt.Printf("Hetzner credential '%s' created successfully!\n", name)
+		return nil
 	},
 }
 
 var sshKeyListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List SSH key credentials",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		creds, err := apiClient.ListSSHKeyCredentials()
 		if err != nil {
-			fmt.Printf("Error listing SSH key credentials: %v\n", err)
-			return
+			return fmt.Errorf("listing SSH key credentials: %w", err)
 		}
 
 		if creds == nil {
 			creds = []client.HetznerCredentialListItem{}
 		}
-		if renderStructuredOrExit(cmd, creds) {
-			return
+		if handled, err := renderStructured(cmd, creds); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		if len(creds) == 0 {
 			fmt.Println("No SSH key credentials found.")
-			return
+			return nil
 		}
 
 		t := table.NewWriter()
@@ -158,6 +161,7 @@ var sshKeyListCmd = &cobra.Command{
 			})
 		}
 		t.Render()
+		return nil
 	},
 }
 
@@ -169,14 +173,13 @@ var sshKeyCreateCmd = &cobra.Command{
 Examples:
   ankra credentials hetzner ssh-key create --name my-key --generate
   ankra credentials hetzner ssh-key create --name my-key --public-key "ssh-ed25519 AAAA..."`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		name, _ := cmd.Flags().GetString("name")
 		publicKey, _ := cmd.Flags().GetString("public-key")
 		generate, _ := cmd.Flags().GetBool("generate")
 
 		if !generate && publicKey == "" {
-			fmt.Fprintln(os.Stderr, "Either --public-key or --generate must be provided.")
-			os.Exit(1)
+			return errors.New("either --public-key or --generate must be provided")
 		}
 
 		req := client.CreateSSHKeyCredentialRequest{
@@ -189,16 +192,15 @@ Examples:
 
 		result, err := apiClient.CreateSSHKeyCredential(req)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating SSH key credential: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating SSH key credential: %w", err)
 		}
 
 		if !result.Success {
-			fmt.Fprintln(os.Stderr, "Failed to create SSH key credential:")
+			msg := "failed to create SSH key credential:"
 			for _, e := range result.Errors {
-				fmt.Fprintf(os.Stderr, "  - %s: %s\n", e.Key, e.Message)
+				msg += fmt.Sprintf("\n  - %s: %s", e.Key, e.Message)
 			}
-			os.Exit(1)
+			return errors.New(msg)
 		}
 
 		fmt.Printf("SSH key credential '%s' created successfully!\n", name)
@@ -207,6 +209,7 @@ Examples:
 			fmt.Println("\nGenerated private key (save this, it will not be shown again):")
 			fmt.Println(*result.PrivateKey)
 		}
+		return nil
 	},
 }
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -62,11 +62,11 @@ This command will:
 3. You can then use all ankra CLI commands
 
 Your credentials will be saved to ~/.ankra.yaml`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := runLogin(); err != nil {
-			fmt.Fprintf(os.Stderr, "Login failed: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("login failed: %w", err)
 		}
+		return nil
 	},
 }
 
@@ -74,14 +74,14 @@ var logoutCmd = &cobra.Command{
 	Use:   "logout",
 	Short: "Remove saved credentials",
 	Long:  `Remove saved credentials from ~/.ankra.yaml`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		configPath := getConfigPath()
 
 		// Read existing config
 		viper.SetConfigFile(configPath)
 		if err := viper.ReadInConfig(); err != nil {
 			fmt.Println("No credentials found.")
-			return
+			return nil
 		}
 
 		// Remove token and base-url (reset to default)
@@ -92,12 +92,12 @@ var logoutCmd = &cobra.Command{
 		viper.Set("machine_id", "")
 
 		if err := viper.WriteConfig(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error clearing credentials: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("clearing credentials: %w", err)
 		}
 
 		fmt.Println("Logged out successfully.")
 		fmt.Println("Your credentials have been removed from", configPath)
+		return nil
 	},
 }
 

--- a/cmd/node_group_async.go
+++ b/cmd/node_group_async.go
@@ -2,19 +2,18 @@ package cmd
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
 
-func nodeGroupAsyncContext(command *cobra.Command) (context.Context, context.CancelFunc, bool) {
-	wait := asyncWriteWaitFlag(command)
-	requestContext, cancelRequestContext := asyncWriteRequestContext(command)
-	return requestContext, cancelRequestContext, wait
-}
-
-func handleNodeGroupSubmitError(operationLabel string, err error) {
-	fmt.Fprintf(os.Stderr, "Error %s: %v\n", operationLabel, err)
-	os.Exit(1)
+func nodeGroupAsyncContext(command *cobra.Command) (context.Context, context.CancelFunc, bool, error) {
+	wait, err := asyncWriteWaitFlag(command)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	requestContext, cancelRequestContext, err := asyncWriteRequestContext(command)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	return requestContext, cancelRequestContext, wait, nil
 }

--- a/cmd/openclaw.go
+++ b/cmd/openclaw.go
@@ -36,11 +36,10 @@ var openclawSkillCmd = &cobra.Command{
 agent, addons, and AI Agents. The default output path is
 $HOME/.openclaw/skills/ankra-<cluster>.md but can be overridden via
 --output.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 		out, _ := cmd.Flags().GetString("output")
 		if out == "" {
@@ -48,16 +47,15 @@ $HOME/.openclaw/skills/ankra-<cluster>.md but can be overridden via
 			out = filepath.Join(home, ".openclaw", "skills", fmt.Sprintf("ankra-%s.md", sanitiseSkillName(cluster.Name)))
 		}
 		if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
-			fmt.Printf("Error creating output directory: %v\n", err)
-			return
+			return fmt.Errorf("creating output directory: %w", err)
 		}
 		body := buildSkillMarkdown(cluster.Name, cluster.ID, baseURL)
 		if err := os.WriteFile(out, []byte(body), 0o644); err != nil {
-			fmt.Printf("Error writing skill file: %v\n", err)
-			return
+			return fmt.Errorf("writing skill file: %w", err)
 		}
 		fmt.Printf("Wrote OpenClaw skill for cluster '%s' to %s\n", cluster.Name, out)
 		fmt.Println("Reload OpenClaw or restart your editor to pick it up.")
+		return nil
 	},
 }
 
@@ -65,7 +63,7 @@ var openclawHandoffCmd = &cobra.Command{
 	Use:   "handoff <conversation-id>",
 	Short: "Hand off an OpenClaw conversation to the Ankra portal",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		convID := args[0]
 		cluster, _ := resolveActiveCluster(cmd)
 		clusterPart := ""
@@ -74,6 +72,7 @@ var openclawHandoffCmd = &cobra.Command{
 		}
 		url := fmt.Sprintf("%s/organisation/ai-agents?openclaw=%s%s", strings.TrimRight(baseURL, "/"), convID, clusterPart)
 		fmt.Printf("Open this URL in your browser to continue in the Ankra AI Agents UI:\n  %s\n", url)
+		return nil
 	},
 }
 
@@ -109,7 +108,7 @@ below with full audit, approval flow, and sandboxed execution.
 - Anything that mutates the cluster (create/update/delete) should be
   proposed via the Ankra plan-mode flow rather than executed locally.
 - Anything that needs cluster credentials should run as an Ankra
-  ` + "`run_sandbox_job`" + ` so it inherits the per-agent NetworkPolicy and
+  `+"`run_sandbox_job`"+` so it inherits the per-agent NetworkPolicy and
   hardened distroless runner.
 - For scheduled / recurring work, register an Ankra AI Agent rather
   than wiring a local cron.
@@ -124,9 +123,9 @@ This opens the AI Agents tab with the conversation pre-loaded.
 
 ## Useful endpoints (token auth)
 
-- ` + "`POST %s/api/v1/agents/{id}/run`" + ` -- trigger a manual run
-- ` + "`GET  %s/api/v1/agents/{id}/runs`" + ` -- list runs
-- ` + "`GET  %s/api/v1/runs/{run_id}/stream`" + ` -- SSE event stream
+- `+"`POST %s/api/v1/agents/{id}/run`"+` -- trigger a manual run
+- `+"`GET  %s/api/v1/agents/{id}/runs`"+` -- list runs
+- `+"`GET  %s/api/v1/runs/{run_id}/stream`"+` -- SSE event stream
 
 ## Cluster metadata
 

--- a/cmd/organisation.go
+++ b/cmd/organisation.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -33,23 +34,22 @@ var orgCmd = &cobra.Command{
 var orgListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all organisations you belong to",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		orgs, err := apiClient.ListOrganisations()
 		if err != nil {
-			fmt.Printf("Error listing organisations: %v\n", err)
-			return
+			return fmt.Errorf("listing organisations: %w", err)
 		}
 
 		if orgs == nil {
 			orgs = []client.OrganisationSummary{}
 		}
-		if renderStructuredOrExit(cmd, orgs) {
-			return
+		if rendered, err := renderStructured(cmd, orgs); rendered || err != nil {
+			return err
 		}
 
 		if len(orgs) == 0 {
 			fmt.Println("No organisations found.")
-			return
+			return nil
 		}
 
 		t := table.NewWriter()
@@ -97,6 +97,7 @@ var orgListCmd = &cobra.Command{
 			})
 		}
 		t.Render()
+		return nil
 	},
 }
 
@@ -104,25 +105,22 @@ var orgSwitchCmd = &cobra.Command{
 	Use:   "switch <organisation>",
 	Short: "Switch to a different organisation by slug, name, or ID",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		reference := args[0]
 
 		orgs, err := apiClient.ListOrganisations()
 		if err != nil {
-			fmt.Printf("Error listing organisations: %v\n", err)
-			return
+			return fmt.Errorf("listing organisations: %w", err)
 		}
 
 		targetOrg, err := resolveOrganisationReference(orgs, reference)
 		if err != nil {
-			fmt.Printf("%v\n", err)
-			return
+			return err
 		}
 
 		resp, err := apiClient.SwitchOrganisation(targetOrg.OrganisationID)
 		if err != nil {
-			fmt.Printf("Error switching organisation: %v\n", err)
-			return
+			return fmt.Errorf("switching organisation: %w", err)
 		}
 
 		// Save locally
@@ -144,6 +142,7 @@ var orgSwitchCmd = &cobra.Command{
 		if resp.Message != "" {
 			fmt.Printf("Message: %s\n", resp.Message)
 		}
+		return nil
 	},
 }
 
@@ -155,15 +154,14 @@ type currentOrganisationOutput struct {
 var orgCurrentCmd = &cobra.Command{
 	Use:   "current",
 	Short: "Show the currently selected organisation",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		org, source, err := resolveTargetOrganisation(cmd)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			return err
 		}
 
-		if renderStructuredOrExit(cmd, currentOrganisationOutput{Organisation: org, Source: source}) {
-			return
+		if rendered, err := renderStructured(cmd, currentOrganisationOutput{Organisation: org, Source: source}); rendered || err != nil {
+			return err
 		}
 
 		name := ""
@@ -185,6 +183,7 @@ var orgCurrentCmd = &cobra.Command{
 			fmt.Printf("  Slug: %s\n", slug)
 		}
 		fmt.Printf("  Role: %s\n", role)
+		return nil
 	},
 }
 
@@ -192,7 +191,7 @@ var orgCreateCmd = &cobra.Command{
 	Use:   "create <name>",
 	Short: "Create a new organisation",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 		country, _ := cmd.Flags().GetString("country")
 
@@ -203,12 +202,11 @@ var orgCreateCmd = &cobra.Command{
 
 		resp, err := apiClient.CreateOrganisation(name, countryPtr)
 		if err != nil {
-			fmt.Printf("Error creating organisation: %v\n", err)
-			return
+			return fmt.Errorf("creating organisation: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, resp) {
-			return
+		if rendered, err := renderStructured(cmd, resp); rendered || err != nil {
+			return err
 		}
 
 		fmt.Printf("Organisation created successfully!\n")
@@ -223,6 +221,7 @@ var orgCreateCmd = &cobra.Command{
 			switchReference = resp.Slug
 		}
 		fmt.Printf("  ankra org switch %s\n", switchReference)
+		return nil
 	},
 }
 
@@ -230,7 +229,7 @@ var orgMembersCmd = &cobra.Command{
 	Use:   "members [org_id]",
 	Short: "List members of an organisation",
 	Args:  cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		var orgID string
 
 		if len(args) > 0 {
@@ -238,25 +237,22 @@ var orgMembersCmd = &cobra.Command{
 		} else {
 			resolved, err := resolveTargetOrganisationID(cmd)
 			if err != nil {
-				fmt.Printf("Error: %v\n", err)
-				return
+				return err
 			}
 			orgID = resolved
 		}
 
 		if orgID == "" {
-			fmt.Println("No organisation specified. Use 'ankra org members <org_id>' or select an organisation first.")
-			return
+			return errors.New("no organisation specified. Use 'ankra org members <org_id>' or select an organisation first")
 		}
 
 		org, err := apiClient.GetOrganisation(orgID)
 		if err != nil {
-			fmt.Printf("Error fetching organisation: %v\n", err)
-			return
+			return fmt.Errorf("fetching organisation: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, org) {
-			return
+		if rendered, err := renderStructured(cmd, org); rendered || err != nil {
+			return err
 		}
 
 		name := ""
@@ -267,7 +263,7 @@ var orgMembersCmd = &cobra.Command{
 
 		if len(org.Members) == 0 {
 			fmt.Println("No members found.")
-			return
+			return nil
 		}
 
 		t := table.NewWriter()
@@ -294,6 +290,7 @@ var orgMembersCmd = &cobra.Command{
 			})
 		}
 		t.Render()
+		return nil
 	},
 }
 
@@ -500,15 +497,13 @@ Examples:
   ankra org invite user@example.com
   ankra org invite user@example.com --role admin`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		email := args[0]
 		role, _ := cmd.Flags().GetString("role")
 
 		orgID, err := resolveOrganisationID()
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			fmt.Println("Select an organisation first with 'ankra org switch <org_id>'")
-			return
+			return fmt.Errorf("%w\nSelect an organisation first with 'ankra org switch <org_id>'", err)
 		}
 
 		result, err := apiClient.InviteUserToOrganisation(client.InviteUserRequest{
@@ -517,8 +512,7 @@ Examples:
 			Role:           role,
 		})
 		if err != nil {
-			fmt.Printf("Error inviting user: %v\n", err)
-			return
+			return fmt.Errorf("inviting user: %w", err)
 		}
 
 		if result.Success {
@@ -527,6 +521,7 @@ Examples:
 		if result.Message != "" {
 			fmt.Printf("Message: %s\n", result.Message)
 		}
+		return nil
 	},
 }
 
@@ -534,15 +529,13 @@ var orgRemoveCmd = &cobra.Command{
 	Use:   "remove <user_id>",
 	Short: "Remove a user from the current organisation",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		userID := args[0]
 		force, _ := cmd.Flags().GetBool("force")
 
 		orgID, err := resolveOrganisationID()
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			fmt.Println("Select an organisation first with 'ankra org switch <org_id>'")
-			return
+			return fmt.Errorf("%w\nSelect an organisation first with 'ankra org switch <org_id>'", err)
 		}
 
 		if !force {
@@ -550,10 +543,8 @@ var orgRemoveCmd = &cobra.Command{
 				Label:     fmt.Sprintf("Remove user %s from the organisation", userID),
 				IsConfirm: true,
 			}
-			_, err := prompt.Run()
-			if err != nil {
-				fmt.Println("Cancelled.")
-				return
+			if _, err := prompt.Run(); err != nil {
+				return errCancelled
 			}
 		}
 
@@ -562,8 +553,7 @@ var orgRemoveCmd = &cobra.Command{
 			OrganisationID: orgID,
 		})
 		if err != nil {
-			fmt.Printf("Error removing user: %v\n", err)
-			return
+			return fmt.Errorf("removing user: %w", err)
 		}
 
 		if result.Success {
@@ -572,6 +562,7 @@ var orgRemoveCmd = &cobra.Command{
 		if result.Message != "" {
 			fmt.Printf("Message: %s\n", result.Message)
 		}
+		return nil
 	},
 }
 

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/spf13/cobra"
 )
 
@@ -39,17 +36,6 @@ func renderStructured(cmd *cobra.Command, value interface{}) (bool, error) {
 		return false, nil
 	}
 	return true, encodeStructured(cmd.OutOrStdout(), format, value)
-}
-
-// renderStructuredOrExit is renderStructured for legacy Run-style commands
-// that print errors to stderr and exit instead of returning an error.
-func renderStructuredOrExit(cmd *cobra.Command, value interface{}) bool {
-	rendered, err := renderStructured(cmd, value)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
-	return rendered
 }
 
 // asyncSubmittedResult is the structured shape emitted when an asynchronous

--- a/cmd/ovh_cluster.go
+++ b/cmd/ovh_cluster.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -21,7 +21,7 @@ var ovhCmd = &cobra.Command{
 var ovhCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new OVH cluster",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		name, _ := cmd.Flags().GetString("name")
 		credentialID, _ := cmd.Flags().GetString("credential-id")
 		sshKeyCredentialID, _ := cmd.Flags().GetString("ssh-key-credential-id")
@@ -39,8 +39,7 @@ var ovhCreateCmd = &cobra.Command{
 		kubeVersion, _ := cmd.Flags().GetString("kubernetes-version")
 		externalCloudProvider, includeNetworking, err := resolveCloudProviderNetworking(cmd)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 		gitopsCredentialName, _ := cmd.Flags().GetString("gitops-credential-name")
 		gitopsRepository, _ := cmd.Flags().GetString("gitops-repository")
@@ -79,18 +78,20 @@ var ovhCreateCmd = &cobra.Command{
 
 		result, err := apiClient.CreateOvhCluster(req)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating OVH cluster: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating OVH cluster: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		fmt.Printf("OVH cluster '%s' created successfully!\n", result.Name)
 		fmt.Printf("  Cluster ID: %s\n", result.ClusterID)
 		fmt.Printf("\nView it in the UI:\n  %s/organisation/clusters/cluster/imported/%s/overview\n",
 			strings.TrimRight(baseURL, "/"), result.ClusterID)
+		return nil
 	},
 }
 
@@ -98,17 +99,18 @@ var ovhDeprovisionCmd = &cobra.Command{
 	Use:   "deprovision <cluster_id>",
 	Short: "Deprovision an OVH cluster",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 
 		result, err := apiClient.DeprovisionOvhCluster(clusterID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error deprovisioning cluster: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("deprovisioning cluster: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		if result.Success {
@@ -133,6 +135,7 @@ var ovhDeprovisionCmd = &cobra.Command{
 				fmt.Printf("    - %s\n", e)
 			}
 		}
+		return nil
 	},
 }
 
@@ -140,22 +143,24 @@ var ovhWorkersCmd = &cobra.Command{
 	Use:   "workers <cluster_id>",
 	Short: "Get current worker count for an OVH cluster",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 
 		result, err := apiClient.GetOvhWorkerCount(clusterID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error fetching worker count: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("fetching worker count: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		fmt.Printf("Worker Count: %d\n", result.WorkerCount)
 		fmt.Printf("  Min: %d\n", result.Min)
 		fmt.Printf("  Max: %d\n", result.Max)
+		return nil
 	},
 }
 
@@ -164,22 +169,22 @@ var ovhScaleCmd = &cobra.Command{
 	Short: "Scale workers for an OVH cluster",
 	Long:  "Scale the number of worker nodes up or down for an OVH cluster.",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		workerCount, err := strconv.Atoi(args[1])
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Invalid worker count: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("invalid worker count: %w", err)
 		}
 
 		result, err := apiClient.ScaleOvhWorkers(clusterID, workerCount)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error scaling workers: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("scaling workers: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		if result.PreviousCount == result.NewCount {
@@ -191,6 +196,7 @@ var ovhScaleCmd = &cobra.Command{
 			fmt.Printf("Scaling %s from %d to %d workers.\n",
 				text.FgYellow.Sprint("down"), result.PreviousCount, result.NewCount)
 		}
+		return nil
 	},
 }
 
@@ -198,17 +204,18 @@ var ovhK8sVersionCmd = &cobra.Command{
 	Use:   "k8s-version <cluster_id>",
 	Short: "Get current Kubernetes version for an OVH cluster",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 
 		result, err := apiClient.GetOvhK8sVersion(clusterID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error fetching Kubernetes version: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("fetching Kubernetes version: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		version := "not set (using latest stable)"
@@ -217,6 +224,7 @@ var ovhK8sVersionCmd = &cobra.Command{
 		}
 		fmt.Printf("Kubernetes Version: %s\n", version)
 		fmt.Printf("  Distribution: %s\n", result.Distribution)
+		return nil
 	},
 }
 
@@ -226,18 +234,19 @@ var ovhUpgradeCmd = &cobra.Command{
 	Long:       "Upgrade the Kubernetes (k3s) version on all nodes in an OVH cluster.",
 	Deprecated: "use `ankra cluster upgrade <cluster_id> <target_version>` instead; the cloud provider is detected automatically.",
 	Args:       cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		targetVersion := args[1]
 
 		result, err := apiClient.UpgradeOvhK8sVersion(clusterID, targetVersion)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error upgrading Kubernetes version: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("upgrading Kubernetes version: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		prev := "none"
@@ -248,6 +257,7 @@ var ovhUpgradeCmd = &cobra.Command{
 		fmt.Printf("  Previous version: %s\n", prev)
 		fmt.Printf("  New version:      %s\n", text.FgGreen.Sprint(result.NewVersion))
 		fmt.Printf("  Nodes affected:   %d\n", result.NodesAffected)
+		return nil
 	},
 }
 
@@ -255,25 +265,27 @@ var ovhRegionsCmd = &cobra.Command{
 	Use:   "regions",
 	Short: "List OVH regions available to a credential",
 	Long:  "List the OVH Cloud regions the supplied credential's project can deploy in. Only these regions are valid for cluster creation.",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		credentialID, _ := cmd.Flags().GetString("credential-id")
 
 		result, err := apiClient.ListOvhRegions(credentialID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error listing regions: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("listing regions: %w", err)
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		if len(result.Regions) == 0 {
 			fmt.Println("No regions available for this credential.")
-			return
+			return nil
 		}
 		fmt.Printf("Regions available to credential %s:\n", credentialID)
 		for _, region := range result.Regions {
 			fmt.Printf("  %s\n", region)
 		}
+		return nil
 	},
 }
 
@@ -282,17 +294,18 @@ var ovhStopCmd = &cobra.Command{
 	Short: "Stop an OVH cluster",
 	Long:  "Stop an OVH cluster's compute while keeping its configuration so it can be started again later.",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 
 		result, err := apiClient.StopOvhCluster(clusterID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error stopping cluster: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("stopping cluster: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		if result.Success {
@@ -304,6 +317,7 @@ var ovhStopCmd = &cobra.Command{
 		if result.OperationID != nil {
 			fmt.Printf("  Operation ID: %s\n", *result.OperationID)
 		}
+		return nil
 	},
 }
 
@@ -312,22 +326,22 @@ var ovhStartCmd = &cobra.Command{
 	Short: "Start a stopped OVH cluster",
 	Long:  "Start (re-provision) a stopped OVH cluster. Use --scope control_plane to bring up only the control plane.",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		scope, _ := cmd.Flags().GetString("scope")
 		if scope != "all" && scope != "control_plane" {
-			fmt.Fprintf(os.Stderr, "Invalid --scope %q: must be 'all' or 'control_plane'\n", scope)
-			os.Exit(1)
+			return fmt.Errorf("invalid --scope %q: must be 'all' or 'control_plane'", scope)
 		}
 
 		result, err := apiClient.StartOvhCluster(clusterID, scope)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error starting cluster: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("starting cluster: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		fmt.Println(text.FgGreen.Sprint("OVH cluster start initiated."))
@@ -336,6 +350,7 @@ var ovhStartCmd = &cobra.Command{
 			fmt.Printf("  Marked to start at: %s\n", result.MarkedToStartAt)
 		}
 		fmt.Printf("  Created operations: %d\n", result.CreatedOperations)
+		return nil
 	},
 }
 
@@ -344,17 +359,18 @@ var ovhAccessInfoCmd = &cobra.Command{
 	Short: "Show SSH access details for an OVH cluster",
 	Long:  "Show the gateway (bastion) and control plane IPs plus ready-to-use SSH jump and Kubernetes API port-forward commands.",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 
 		result, err := apiClient.GetOvhAccessInfo(clusterID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error fetching access info: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("fetching access info: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		gatewayIP := ""
@@ -386,6 +402,7 @@ var ovhAccessInfoCmd = &cobra.Command{
 			fmt.Println("\nPort-forward the Kubernetes API:")
 			fmt.Printf("  ssh -L 6443:%s:6443 -N ubuntu@%s\n", controlPlaneIP, gatewayIP)
 		}
+		return nil
 	},
 }
 
@@ -400,17 +417,18 @@ var ovhSSHKeysGetCmd = &cobra.Command{
 	Use:   "get <cluster_id>",
 	Short: "Show SSH keys attached to an OVH cluster",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 
 		result, err := apiClient.GetOvhClusterSSHKeys(clusterID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error fetching SSH keys: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("fetching SSH keys: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		if len(result.SSHKeyCredentialIDs) == 0 {
@@ -428,6 +446,7 @@ var ovhSSHKeysGetCmd = &cobra.Command{
 				fmt.Printf("  %-38s  %s\n", key.CredentialID, key.Name)
 			}
 		}
+		return nil
 	},
 }
 
@@ -436,22 +455,22 @@ var ovhSSHKeysSetCmd = &cobra.Command{
 	Short: "Set the SSH keys attached to an OVH cluster",
 	Long:  "Replace the SSH key credentials attached to an OVH cluster. Changes take effect on the next reconciliation.",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		sshKeyCredentialIDs, _ := cmd.Flags().GetStringSlice("ssh-key-credential-ids")
 		if len(sshKeyCredentialIDs) == 0 {
-			fmt.Fprintln(os.Stderr, "At least one --ssh-key-credential-ids value is required")
-			os.Exit(1)
+			return errors.New("at least one --ssh-key-credential-ids value is required")
 		}
 
 		result, err := apiClient.UpdateOvhClusterSSHKeys(clusterID, sshKeyCredentialIDs)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error updating SSH keys: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("updating SSH keys: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		fmt.Println(text.FgGreen.Sprint("SSH keys updated. Changes apply on next reconciliation."))
@@ -459,6 +478,7 @@ var ovhSSHKeysSetCmd = &cobra.Command{
 		for _, id := range result.SSHKeyCredentialIDs {
 			fmt.Printf("  %s\n", id)
 		}
+		return nil
 	},
 }
 
@@ -473,15 +493,14 @@ var ovhNodeGroupLabelsCmd = &cobra.Command{
 	Short: "Set labels on all nodes in a node group",
 	Long:  "Replace the labels on every node in the group. Pass --labels as a comma-separated list of key=value pairs (empty clears all labels).",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		groupName := args[1]
 		labelsFlag, _ := cmd.Flags().GetString("labels")
 
 		labels, err := parseLabelsFlag(labelsFlag)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Invalid --labels: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("invalid --labels: %w", err)
 		}
 
 		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
@@ -489,19 +508,24 @@ var ovhNodeGroupLabelsCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.UpdateOvhNodeGroupLabels(requestContext, clusterID, groupName, labels, wait)
 		if err != nil {
-			handleNodeGroupSubmitError("updating node group labels", err)
+			return fmt.Errorf("updating node group labels: %w", err)
 		}
 		if submitted {
-			if renderStructuredOrExit(cmd, newAsyncSubmittedResult("Node group labels update")) {
-				return
+			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group labels update")); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 			printAsyncWriteSubmitted("Node group labels update")
-			return
+			return nil
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		fmt.Printf("Node group '%s' labels updated. %d node(s) affected.\n", result.GroupName, result.Updated)
+		return nil
 	},
 }
 
@@ -510,15 +534,14 @@ var ovhNodeGroupTaintsCmd = &cobra.Command{
 	Short: "Set taints on all nodes in a node group",
 	Long:  "Replace the taints on every node in the group. Pass --taints as a comma-separated list of key=value:Effect (value optional, effect defaults to NoSchedule; empty clears all taints).",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		groupName := args[1]
 		taintsFlag, _ := cmd.Flags().GetString("taints")
 
 		taints, err := parseTaintsFlag(taintsFlag)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Invalid --taints: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("invalid --taints: %w", err)
 		}
 
 		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
@@ -526,19 +549,24 @@ var ovhNodeGroupTaintsCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.UpdateOvhNodeGroupTaints(requestContext, clusterID, groupName, taints, wait)
 		if err != nil {
-			handleNodeGroupSubmitError("updating node group taints", err)
+			return fmt.Errorf("updating node group taints: %w", err)
 		}
 		if submitted {
-			if renderStructuredOrExit(cmd, newAsyncSubmittedResult("Node group taints update")) {
-				return
+			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group taints update")); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 			printAsyncWriteSubmitted("Node group taints update")
-			return
+			return nil
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		fmt.Printf("Node group '%s' taints updated. %d node(s) affected.\n", result.GroupName, result.Updated)
+		return nil
 	},
 }
 
@@ -546,24 +574,26 @@ var ovhNodeGroupListCmd = &cobra.Command{
 	Use:   "list <cluster_id>",
 	Short: "List node groups",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		result, err := apiClient.ListOvhNodeGroups(clusterID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error listing node groups: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("listing node groups: %w", err)
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		if len(result.NodeGroups) == 0 {
 			fmt.Println("No node groups found.")
-			return
+			return nil
 		}
 		for _, ng := range result.NodeGroups {
 			fmt.Printf("%-20s  type=%-8s  count=%d  labels=%d  taints=%d\n",
 				ng.Name, ng.InstanceType, ng.Count, len(ng.Labels), len(ng.Taints))
 		}
+		return nil
 	},
 }
 
@@ -571,7 +601,7 @@ var ovhNodeGroupAddCmd = &cobra.Command{
 	Use:   "add <cluster_id>",
 	Short: "Add a node group",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		name, _ := cmd.Flags().GetString("name")
 		instanceType, _ := cmd.Flags().GetString("instance-type")
@@ -581,13 +611,11 @@ var ovhNodeGroupAddCmd = &cobra.Command{
 
 		labels, err := parseLabelsFlag(labelsFlag)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Invalid --labels: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("invalid --labels: %w", err)
 		}
 		taints, err := parseTaintsFlag(taintsFlag)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Invalid --taints: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("invalid --taints: %w", err)
 		}
 
 		req := client.AddNodeGroupRequest{
@@ -603,19 +631,24 @@ var ovhNodeGroupAddCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.AddOvhNodeGroup(requestContext, clusterID, req, wait)
 		if err != nil {
-			handleNodeGroupSubmitError("adding node group", err)
+			return fmt.Errorf("adding node group: %w", err)
 		}
 		if submitted {
-			if renderStructuredOrExit(cmd, newAsyncSubmittedResult("Node group add")) {
-				return
+			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group add")); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 			printAsyncWriteSubmitted("Node group add")
-			return
+			return nil
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		fmt.Printf("Node group '%s' created with %d node(s).\n", result.GroupName, result.Count)
+		return nil
 	},
 }
 
@@ -623,13 +656,12 @@ var ovhNodeGroupScaleCmd = &cobra.Command{
 	Use:   "scale <cluster_id> <group_name> <count>",
 	Short: "Scale a node group",
 	Args:  cobra.ExactArgs(3),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		groupName := args[1]
 		count, err := strconv.Atoi(args[2])
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Invalid count: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("invalid count: %w", err)
 		}
 
 		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
@@ -637,19 +669,24 @@ var ovhNodeGroupScaleCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.ScaleOvhNodeGroup(requestContext, clusterID, groupName, count, wait)
 		if err != nil {
-			handleNodeGroupSubmitError("scaling node group", err)
+			return fmt.Errorf("scaling node group: %w", err)
 		}
 		if submitted {
-			if renderStructuredOrExit(cmd, newAsyncSubmittedResult("Node group scale")) {
-				return
+			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group scale")); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 			printAsyncWriteSubmitted("Node group scale")
-			return
+			return nil
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		fmt.Printf("Node group '%s' scaled from %d to %d.\n", result.GroupName, result.PreviousCount, result.NewCount)
+		return nil
 	},
 }
 
@@ -657,7 +694,7 @@ var ovhNodeGroupUpgradeCmd = &cobra.Command{
 	Use:   "upgrade <cluster_id> <group_name> <instance_type>",
 	Short: "Upgrade instance type for a node group (cannot be reversed)",
 	Args:  cobra.ExactArgs(3),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		groupName := args[1]
 		instanceType := args[2]
@@ -667,19 +704,24 @@ var ovhNodeGroupUpgradeCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.UpdateOvhNodeGroupInstanceType(requestContext, clusterID, groupName, instanceType, wait)
 		if err != nil {
-			handleNodeGroupSubmitError("upgrading node group", err)
+			return fmt.Errorf("upgrading node group: %w", err)
 		}
 		if submitted {
-			if renderStructuredOrExit(cmd, newAsyncSubmittedResult("Node group instance-type update")) {
-				return
+			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group instance-type update")); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 			printAsyncWriteSubmitted("Node group instance-type update")
-			return
+			return nil
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		fmt.Printf("Node group '%s' instance type upgraded. %d node(s) affected.\n", result.GroupName, result.Updated)
+		return nil
 	},
 }
 
@@ -687,7 +729,7 @@ var ovhNodeGroupDeleteCmd = &cobra.Command{
 	Use:   "delete <cluster_id> <group_name>",
 	Short: "Delete a node group and all its nodes",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		groupName := args[1]
 
@@ -696,19 +738,24 @@ var ovhNodeGroupDeleteCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.DeleteOvhNodeGroup(requestContext, clusterID, groupName, wait)
 		if err != nil {
-			handleNodeGroupSubmitError("deleting node group", err)
+			return fmt.Errorf("deleting node group: %w", err)
 		}
 		if submitted {
-			if renderStructuredOrExit(cmd, newAsyncSubmittedResult("Node group delete")) {
-				return
+			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group delete")); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 			printAsyncWriteSubmitted("Node group delete")
-			return
+			return nil
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		fmt.Printf("Node group '%s' deleted. %d node(s) removed.\n", result.GroupName, result.Deleted)
+		return nil
 	},
 }
 

--- a/cmd/ovh_cluster.go
+++ b/cmd/ovh_cluster.go
@@ -503,7 +503,10 @@ var ovhNodeGroupLabelsCmd = &cobra.Command{
 			return fmt.Errorf("invalid --labels: %w", err)
 		}
 
-		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
+		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
+		if err != nil {
+			return err
+		}
 		defer cancelRequestContext()
 
 		result, submitted, err := apiClient.UpdateOvhNodeGroupLabels(requestContext, clusterID, groupName, labels, wait)
@@ -544,7 +547,10 @@ var ovhNodeGroupTaintsCmd = &cobra.Command{
 			return fmt.Errorf("invalid --taints: %w", err)
 		}
 
-		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
+		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
+		if err != nil {
+			return err
+		}
 		defer cancelRequestContext()
 
 		result, submitted, err := apiClient.UpdateOvhNodeGroupTaints(requestContext, clusterID, groupName, taints, wait)
@@ -626,7 +632,10 @@ var ovhNodeGroupAddCmd = &cobra.Command{
 			Taints:       taints,
 		}
 
-		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
+		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
+		if err != nil {
+			return err
+		}
 		defer cancelRequestContext()
 
 		result, submitted, err := apiClient.AddOvhNodeGroup(requestContext, clusterID, req, wait)
@@ -664,7 +673,10 @@ var ovhNodeGroupScaleCmd = &cobra.Command{
 			return fmt.Errorf("invalid count: %w", err)
 		}
 
-		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
+		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
+		if err != nil {
+			return err
+		}
 		defer cancelRequestContext()
 
 		result, submitted, err := apiClient.ScaleOvhNodeGroup(requestContext, clusterID, groupName, count, wait)
@@ -699,7 +711,10 @@ var ovhNodeGroupUpgradeCmd = &cobra.Command{
 		groupName := args[1]
 		instanceType := args[2]
 
-		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
+		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
+		if err != nil {
+			return err
+		}
 		defer cancelRequestContext()
 
 		result, submitted, err := apiClient.UpdateOvhNodeGroupInstanceType(requestContext, clusterID, groupName, instanceType, wait)
@@ -733,7 +748,10 @@ var ovhNodeGroupDeleteCmd = &cobra.Command{
 		clusterID := args[0]
 		groupName := args[1]
 
-		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
+		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
+		if err != nil {
+			return err
+		}
 		defer cancelRequestContext()
 
 		result, submitted, err := apiClient.DeleteOvhNodeGroup(requestContext, clusterID, groupName, wait)

--- a/cmd/ovh_cluster.go
+++ b/cmd/ovh_cluster.go
@@ -640,7 +640,7 @@ var ovhNodeGroupAddCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.AddOvhNodeGroup(requestContext, clusterID, req, wait)
 		if err != nil {
-			return fmt.Errorf("adding node group: %w", err)
+			return asyncWriteError("adding node group", wait, err)
 		}
 		if submitted {
 			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group add")); err != nil {
@@ -681,7 +681,7 @@ var ovhNodeGroupScaleCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.ScaleOvhNodeGroup(requestContext, clusterID, groupName, count, wait)
 		if err != nil {
-			return fmt.Errorf("scaling node group: %w", err)
+			return asyncWriteError("scaling node group", wait, err)
 		}
 		if submitted {
 			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group scale")); err != nil {
@@ -719,7 +719,7 @@ var ovhNodeGroupUpgradeCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.UpdateOvhNodeGroupInstanceType(requestContext, clusterID, groupName, instanceType, wait)
 		if err != nil {
-			return fmt.Errorf("upgrading node group: %w", err)
+			return asyncWriteError("upgrading node group", wait, err)
 		}
 		if submitted {
 			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group instance-type update")); err != nil {
@@ -756,7 +756,7 @@ var ovhNodeGroupDeleteCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.DeleteOvhNodeGroup(requestContext, clusterID, groupName, wait)
 		if err != nil {
-			return fmt.Errorf("deleting node group: %w", err)
+			return asyncWriteError("deleting node group", wait, err)
 		}
 		if submitted {
 			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group delete")); err != nil {

--- a/cmd/ovh_credentials.go
+++ b/cmd/ovh_credentials.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -20,23 +21,24 @@ var ovhCredCmd = &cobra.Command{
 var ovhCredListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List OVH API credentials",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		creds, err := apiClient.ListOvhCredentials()
 		if err != nil {
-			fmt.Printf("Error listing OVH credentials: %v\n", err)
-			return
+			return fmt.Errorf("listing OVH credentials: %w", err)
 		}
 
 		if creds == nil {
 			creds = []client.OvhCredentialListItem{}
 		}
-		if renderStructuredOrExit(cmd, creds) {
-			return
+		if handled, err := renderStructured(cmd, creds); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		if len(creds) == 0 {
 			fmt.Println("No OVH credentials found.")
-			return
+			return nil
 		}
 
 		t := table.NewWriter()
@@ -63,6 +65,7 @@ var ovhCredListCmd = &cobra.Command{
 			})
 		}
 		t.Render()
+		return nil
 	},
 }
 
@@ -76,7 +79,7 @@ GET, POST, PUT, DELETE rights on /cloud/project/* and /cloud/project.
 
 Examples:
   ankra credentials ovh create --name my-ovh-cred --project-id <project-id>`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		name, _ := cmd.Flags().GetString("name")
 		projectID, _ := cmd.Flags().GetString("project-id")
 
@@ -91,8 +94,7 @@ Examples:
 		}
 		applicationKey, err := appKeyPrompt.Run()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Prompt cancelled.\n")
-			os.Exit(1)
+			return errors.New("prompt cancelled")
 		}
 
 		appSecretPrompt := promptui.Prompt{
@@ -107,8 +109,7 @@ Examples:
 		}
 		applicationSecret, err := appSecretPrompt.Run()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Prompt cancelled.\n")
-			os.Exit(1)
+			return errors.New("prompt cancelled")
 		}
 
 		consumerKeyPrompt := promptui.Prompt{
@@ -123,8 +124,7 @@ Examples:
 		}
 		consumerKey, err := consumerKeyPrompt.Run()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Prompt cancelled.\n")
-			os.Exit(1)
+			return errors.New("prompt cancelled")
 		}
 
 		result, err := apiClient.CreateOvhCredential(client.CreateOvhCredentialRequest{
@@ -135,42 +135,43 @@ Examples:
 			ProjectID:         projectID,
 		})
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating OVH credential: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating OVH credential: %w", err)
 		}
 
 		if !result.Success {
-			fmt.Fprintln(os.Stderr, "Failed to create OVH credential:")
+			msg := "failed to create OVH credential:"
 			for _, e := range result.Errors {
-				fmt.Fprintf(os.Stderr, "  - %s: %s\n", e.Key, e.Message)
+				msg += fmt.Sprintf("\n  - %s: %s", e.Key, e.Message)
 			}
-			os.Exit(1)
+			return errors.New(msg)
 		}
 
 		fmt.Printf("OVH credential '%s' created successfully!\n", name)
+		return nil
 	},
 }
 
 var ovhSSHKeyListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List SSH key credentials",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		creds, err := apiClient.ListOvhSSHKeyCredentials()
 		if err != nil {
-			fmt.Printf("Error listing SSH key credentials: %v\n", err)
-			return
+			return fmt.Errorf("listing SSH key credentials: %w", err)
 		}
 
 		if creds == nil {
 			creds = []client.OvhCredentialListItem{}
 		}
-		if renderStructuredOrExit(cmd, creds) {
-			return
+		if handled, err := renderStructured(cmd, creds); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		if len(creds) == 0 {
 			fmt.Println("No SSH key credentials found.")
-			return
+			return nil
 		}
 
 		t := table.NewWriter()
@@ -197,6 +198,7 @@ var ovhSSHKeyListCmd = &cobra.Command{
 			})
 		}
 		t.Render()
+		return nil
 	},
 }
 
@@ -208,14 +210,13 @@ var ovhSSHKeyCreateCmd = &cobra.Command{
 Examples:
   ankra credentials ovh ssh-key create --name my-key --generate
   ankra credentials ovh ssh-key create --name my-key --public-key "ssh-ed25519 AAAA..."`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		name, _ := cmd.Flags().GetString("name")
 		publicKey, _ := cmd.Flags().GetString("public-key")
 		generate, _ := cmd.Flags().GetBool("generate")
 
 		if !generate && publicKey == "" {
-			fmt.Fprintln(os.Stderr, "Either --public-key or --generate must be provided.")
-			os.Exit(1)
+			return errors.New("either --public-key or --generate must be provided")
 		}
 
 		req := client.CreateSSHKeyCredentialRequest{
@@ -228,16 +229,15 @@ Examples:
 
 		result, err := apiClient.CreateOvhSSHKeyCredential(req)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating SSH key credential: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating SSH key credential: %w", err)
 		}
 
 		if !result.Success {
-			fmt.Fprintln(os.Stderr, "Failed to create SSH key credential:")
+			msg := "failed to create SSH key credential:"
 			for _, e := range result.Errors {
-				fmt.Fprintf(os.Stderr, "  - %s: %s\n", e.Key, e.Message)
+				msg += fmt.Sprintf("\n  - %s: %s", e.Key, e.Message)
 			}
-			os.Exit(1)
+			return errors.New(msg)
 		}
 
 		fmt.Printf("SSH key credential '%s' created successfully!\n", name)
@@ -246,6 +246,7 @@ Examples:
 			fmt.Println("\nGenerated private key (save this, it will not be shown again):")
 			fmt.Println(*result.PrivateKey)
 		}
+		return nil
 	},
 }
 

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -31,7 +31,9 @@ var profileAuthStatusCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("get authentication status: %w", err)
 		}
-		if renderStructuredOrExit(cmd, status) {
+		if handled, err := renderStructured(cmd, status); err != nil {
+			return err
+		} else if handled {
 			return nil
 		}
 		renderMFAStatus(cmd.OutOrStdout(), status)
@@ -53,7 +55,9 @@ var profileAuthTotpStartCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("start authenticator setup: %w", err)
 		}
-		if renderStructuredOrExit(cmd, result) {
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
 			return nil
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Authenticator setup started.")
@@ -79,7 +83,9 @@ var profileAuthTotpConfirmCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("confirm authenticator setup: %w", err)
 		}
-		if renderStructuredOrExit(cmd, result) {
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
 			return nil
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Authenticator app enabled.")
@@ -100,7 +106,9 @@ var profileAuthTotpRemoveCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("remove authenticator: %w", err)
 		}
-		if renderStructuredOrExit(cmd, result) {
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
 			return nil
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Authenticator app removed.")
@@ -127,7 +135,9 @@ var profileAuthRecoveryCodesRegenerateCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("regenerate recovery codes: %w", err)
 		}
-		if renderStructuredOrExit(cmd, result) {
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
 			return nil
 		}
 		renderRecoveryCodes(cmd, result.RecoveryCodes)
@@ -149,7 +159,9 @@ var profileAuthPasskeysListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("list passkeys: %w", err)
 		}
-		if renderStructuredOrExit(cmd, status.Passkeys) {
+		if handled, err := renderStructured(cmd, status.Passkeys); err != nil {
+			return err
+		} else if handled {
 			return nil
 		}
 		renderPasskeys(cmd.OutOrStdout(), status.Passkeys)
@@ -170,7 +182,9 @@ var profileAuthPasskeysRemoveCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("remove passkey: %w", err)
 		}
-		if renderStructuredOrExit(cmd, result) {
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
 			return nil
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Passkey removed.")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,10 +70,11 @@ func SetVersion(v string) {
 
 func Execute() {
 	rootCmd.Version = version
+	wrapArgsValidators(rootCmd)
 	executedCommand, err := rootCmd.ExecuteC()
 	if err != nil {
 		printSupportHintForUnexpectedError(os.Stderr, executedCommand, err)
-		os.Exit(1)
+		os.Exit(exitCodeFor(err))
 	}
 }
 
@@ -124,6 +125,10 @@ func init() {
 	viper.SetDefault("base-url", defaultBaseURL)
 
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
+
+	rootCmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
+		return withExitCode(exitUsage, err)
+	})
 }
 
 // setRequiresAuth attaches the auth requirement annotation to a command.
@@ -387,8 +392,8 @@ func resolveCredentials(cmd *cobra.Command) (resolvedCredentials, error) {
 			rawBaseURL = defaultBaseURL
 		}
 	default:
-		return resolvedCredentials{}, errors.New(
-			"not logged in: run `ankra login`, or provide a token via --token or ANKRA_API_TOKEN")
+		return resolvedCredentials{}, withExitCode(exitAuth, errors.New(
+			"not logged in: run `ankra login`, or provide a token via --token or ANKRA_API_TOKEN"))
 	}
 
 	normalized, err := client.NormalizeBaseURL(rawBaseURL, allowInsecureHTTP)

--- a/cmd/setvalues.go
+++ b/cmd/setvalues.go
@@ -13,9 +13,9 @@ import (
 type setKind int
 
 const (
-	setKindCoerce  setKind = iota // --set:        auto-coerce true/false/null/int/float, else string
-	setKindString                 // --set-string: always string
-	setKindFile                   // --set-file:   value is a file path; its contents become the string value
+	setKindCoerce setKind = iota // --set:        auto-coerce true/false/null/int/float, else string
+	setKindString                // --set-string: always string
+	setKindFile                  // --set-file:   value is a file path; its contents become the string value
 )
 
 // pathSegment is one component of a dotted path.

--- a/cmd/tokens.go
+++ b/cmd/tokens.go
@@ -143,7 +143,7 @@ var tokensDeleteCmd = &cobra.Command{
 
 		result, err := apiClient.DeleteAPIToken(tokenID)
 		if err != nil {
-			return fmt.Errorf("deleting token: %w\nNote: Tokens must be revoked before they can be deleted.", err)
+			return fmt.Errorf("deleting token (tokens must be revoked before they can be deleted): %w", err)
 		}
 
 		if result.Success {

--- a/cmd/tokens.go
+++ b/cmd/tokens.go
@@ -21,23 +21,22 @@ var tokensCmd = &cobra.Command{
 var tokensListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all API tokens",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		tokens, err := apiClient.ListAPITokens()
 		if err != nil {
-			fmt.Printf("Error listing tokens: %v\n", err)
-			return
+			return fmt.Errorf("listing tokens: %w", err)
 		}
 
 		if tokens == nil {
 			tokens = []client.APIToken{}
 		}
-		if renderStructuredOrExit(cmd, tokens) {
-			return
+		if rendered, err := renderStructured(cmd, tokens); rendered || err != nil {
+			return err
 		}
 
 		if len(tokens) == 0 {
 			fmt.Println("No API tokens found.")
-			return
+			return nil
 		}
 
 		t := table.NewWriter()
@@ -74,6 +73,7 @@ var tokensListCmd = &cobra.Command{
 			})
 		}
 		t.Render()
+		return nil
 	},
 }
 
@@ -81,7 +81,7 @@ var tokensCreateCmd = &cobra.Command{
 	Use:   "create <name>",
 	Short: "Create a new API token",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 		expiresAt, _ := cmd.Flags().GetString("expires")
 
@@ -92,12 +92,11 @@ var tokensCreateCmd = &cobra.Command{
 
 		result, err := apiClient.CreateAPIToken(name, expiresAtPtr)
 		if err != nil {
-			fmt.Printf("Error creating token: %v\n", err)
-			return
+			return fmt.Errorf("creating token: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if rendered, err := renderStructured(cmd, result); rendered || err != nil {
+			return err
 		}
 
 		fmt.Println("API token created successfully!")
@@ -110,6 +109,7 @@ var tokensCreateCmd = &cobra.Command{
 		fmt.Println()
 		fmt.Println("To use this token, set it as ANKRA_API_TOKEN environment variable:")
 		fmt.Printf("  export ANKRA_API_TOKEN='%s'\n", result.Token)
+		return nil
 	},
 }
 
@@ -117,19 +117,19 @@ var tokensRevokeCmd = &cobra.Command{
 	Use:   "revoke <token_id>",
 	Short: "Revoke an API token (can be deleted after)",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		tokenID := args[0]
 
 		result, err := apiClient.RevokeAPIToken(tokenID)
 		if err != nil {
-			fmt.Printf("Error revoking token: %v\n", err)
-			return
+			return fmt.Errorf("revoking token: %w", err)
 		}
 
 		if result.Success {
 			fmt.Println("Token revoked successfully!")
 			fmt.Println("You can now delete it with: ankra tokens delete", tokenID)
 		}
+		return nil
 	},
 }
 
@@ -138,19 +138,18 @@ var tokensDeleteCmd = &cobra.Command{
 	Short: "Delete a revoked API token",
 	Long:  "Delete an API token. The token must be revoked first.",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		tokenID := args[0]
 
 		result, err := apiClient.DeleteAPIToken(tokenID)
 		if err != nil {
-			fmt.Printf("Error deleting token: %v\n", err)
-			fmt.Println("Note: Tokens must be revoked before they can be deleted.")
-			return
+			return fmt.Errorf("deleting token: %w\nNote: Tokens must be revoked before they can be deleted.", err)
 		}
 
 		if result.Success {
 			fmt.Println("Token deleted successfully!")
 		}
+		return nil
 	},
 }
 

--- a/cmd/upcloud_cluster.go
+++ b/cmd/upcloud_cluster.go
@@ -361,7 +361,7 @@ var upcloudNodeGroupAddCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.AddUpcloudNodeGroup(requestContext, clusterID, req, wait)
 		if err != nil {
-			return fmt.Errorf("adding node group: %w", err)
+			return asyncWriteError("adding node group", wait, err)
 		}
 		if submitted {
 			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group add")); err != nil {
@@ -402,7 +402,7 @@ var upcloudNodeGroupScaleCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.ScaleUpcloudNodeGroup(requestContext, clusterID, groupName, count, wait)
 		if err != nil {
-			return fmt.Errorf("scaling node group: %w", err)
+			return asyncWriteError("scaling node group", wait, err)
 		}
 		if submitted {
 			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group scale")); err != nil {
@@ -440,7 +440,7 @@ var upcloudNodeGroupUpgradeCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.UpdateUpcloudNodeGroupInstanceType(requestContext, clusterID, groupName, plan, wait)
 		if err != nil {
-			return fmt.Errorf("upgrading node group: %w", err)
+			return asyncWriteError("upgrading node group", wait, err)
 		}
 		if submitted {
 			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group plan update")); err != nil {
@@ -477,7 +477,7 @@ var upcloudNodeGroupDeleteCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.DeleteUpcloudNodeGroup(requestContext, clusterID, groupName, wait)
 		if err != nil {
-			return fmt.Errorf("deleting node group: %w", err)
+			return asyncWriteError("deleting node group", wait, err)
 		}
 		if submitted {
 			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group delete")); err != nil {

--- a/cmd/upcloud_cluster.go
+++ b/cmd/upcloud_cluster.go
@@ -353,7 +353,10 @@ var upcloudNodeGroupAddCmd = &cobra.Command{
 			Count:        count,
 		}
 
-		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
+		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
+		if err != nil {
+			return err
+		}
 		defer cancelRequestContext()
 
 		result, submitted, err := apiClient.AddUpcloudNodeGroup(requestContext, clusterID, req, wait)
@@ -391,7 +394,10 @@ var upcloudNodeGroupScaleCmd = &cobra.Command{
 			return fmt.Errorf("invalid count: %w", err)
 		}
 
-		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
+		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
+		if err != nil {
+			return err
+		}
 		defer cancelRequestContext()
 
 		result, submitted, err := apiClient.ScaleUpcloudNodeGroup(requestContext, clusterID, groupName, count, wait)
@@ -426,7 +432,10 @@ var upcloudNodeGroupUpgradeCmd = &cobra.Command{
 		groupName := args[1]
 		plan := args[2]
 
-		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
+		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
+		if err != nil {
+			return err
+		}
 		defer cancelRequestContext()
 
 		result, submitted, err := apiClient.UpdateUpcloudNodeGroupInstanceType(requestContext, clusterID, groupName, plan, wait)
@@ -460,7 +469,10 @@ var upcloudNodeGroupDeleteCmd = &cobra.Command{
 		clusterID := args[0]
 		groupName := args[1]
 
-		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
+		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
+		if err != nil {
+			return err
+		}
 		defer cancelRequestContext()
 
 		result, submitted, err := apiClient.DeleteUpcloudNodeGroup(requestContext, clusterID, groupName, wait)

--- a/cmd/upcloud_cluster.go
+++ b/cmd/upcloud_cluster.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -21,7 +20,7 @@ var upcloudCmd = &cobra.Command{
 var upcloudCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new UpCloud cluster",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		name, _ := cmd.Flags().GetString("name")
 		credentialID, _ := cmd.Flags().GetString("credential-id")
 		sshKeyCredentialID, _ := cmd.Flags().GetString("ssh-key-credential-id")
@@ -36,8 +35,7 @@ var upcloudCreateCmd = &cobra.Command{
 		kubeVersion, _ := cmd.Flags().GetString("kubernetes-version")
 		externalCloudProvider, includeNetworking, err := resolveCloudProviderNetworking(cmd)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 		gitopsCredentialName, _ := cmd.Flags().GetString("gitops-credential-name")
 		gitopsRepository, _ := cmd.Flags().GetString("gitops-repository")
@@ -73,18 +71,20 @@ var upcloudCreateCmd = &cobra.Command{
 
 		result, err := apiClient.CreateUpcloudCluster(req)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating UpCloud cluster: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating UpCloud cluster: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		fmt.Printf("UpCloud cluster '%s' created successfully!\n", result.Name)
 		fmt.Printf("  Cluster ID: %s\n", result.ClusterID)
 		fmt.Printf("\nView it in the UI:\n  %s/organisation/clusters/cluster/imported/%s/overview\n",
 			strings.TrimRight(baseURL, "/"), result.ClusterID)
+		return nil
 	},
 }
 
@@ -92,17 +92,18 @@ var upcloudDeprovisionCmd = &cobra.Command{
 	Use:   "deprovision <cluster_id>",
 	Short: "Deprovision an UpCloud cluster",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 
 		result, err := apiClient.DeprovisionUpcloudCluster(clusterID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error deprovisioning cluster: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("deprovisioning cluster: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		if result.Success {
@@ -124,6 +125,7 @@ var upcloudDeprovisionCmd = &cobra.Command{
 				fmt.Printf("    - %s\n", e)
 			}
 		}
+		return nil
 	},
 }
 
@@ -132,13 +134,12 @@ var upcloudStopCmd = &cobra.Command{
 	Short: "Stop an UpCloud cluster",
 	Long:  "Stop an UpCloud cluster's compute while keeping its configuration so it can be started again later.",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 
 		result, err := apiClient.StopUpcloudCluster(clusterID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error stopping cluster: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("stopping cluster: %w", err)
 		}
 
 		if result.Success {
@@ -150,6 +151,7 @@ var upcloudStopCmd = &cobra.Command{
 		if result.OperationID != nil {
 			fmt.Printf("  Operation ID: %s\n", *result.OperationID)
 		}
+		return nil
 	},
 }
 
@@ -158,18 +160,16 @@ var upcloudStartCmd = &cobra.Command{
 	Short: "Start a stopped UpCloud cluster",
 	Long:  "Start (re-provision) a stopped UpCloud cluster. Use --scope control_plane to bring up only the control plane.",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		scope, _ := cmd.Flags().GetString("scope")
 		if scope != "all" && scope != "control_plane" {
-			fmt.Fprintf(os.Stderr, "Invalid --scope %q: must be 'all' or 'control_plane'\n", scope)
-			os.Exit(1)
+			return fmt.Errorf("invalid --scope %q: must be 'all' or 'control_plane'", scope)
 		}
 
 		result, err := apiClient.StartUpcloudCluster(clusterID, scope)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error starting cluster: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("starting cluster: %w", err)
 		}
 
 		fmt.Println(text.FgGreen.Sprint("UpCloud cluster start initiated."))
@@ -178,6 +178,7 @@ var upcloudStartCmd = &cobra.Command{
 			fmt.Printf("  Marked to start at: %s\n", result.MarkedToStartAt)
 		}
 		fmt.Printf("  Created operations: %d\n", result.CreatedOperations)
+		return nil
 	},
 }
 
@@ -185,22 +186,24 @@ var upcloudWorkersCmd = &cobra.Command{
 	Use:   "workers <cluster_id>",
 	Short: "Get current worker count for an UpCloud cluster",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 
 		result, err := apiClient.GetUpcloudWorkerCount(clusterID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error fetching worker count: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("fetching worker count: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		fmt.Printf("Worker Count: %d\n", result.WorkerCount)
 		fmt.Printf("  Min: %d\n", result.Min)
 		fmt.Printf("  Max: %d\n", result.Max)
+		return nil
 	},
 }
 
@@ -209,22 +212,22 @@ var upcloudScaleCmd = &cobra.Command{
 	Short: "Scale workers for an UpCloud cluster",
 	Long:  "Scale the number of worker nodes up or down for an UpCloud cluster.",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		workerCount, err := strconv.Atoi(args[1])
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Invalid worker count: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("invalid worker count: %w", err)
 		}
 
 		result, err := apiClient.ScaleUpcloudWorkers(clusterID, workerCount)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error scaling workers: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("scaling workers: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		if result.PreviousCount == result.NewCount {
@@ -236,6 +239,7 @@ var upcloudScaleCmd = &cobra.Command{
 			fmt.Printf("Scaling %s from %d to %d workers.\n",
 				text.FgYellow.Sprint("down"), result.PreviousCount, result.NewCount)
 		}
+		return nil
 	},
 }
 
@@ -243,17 +247,18 @@ var upcloudK8sVersionCmd = &cobra.Command{
 	Use:   "k8s-version <cluster_id>",
 	Short: "Get current Kubernetes version for an UpCloud cluster",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 
 		result, err := apiClient.GetUpcloudK8sVersion(clusterID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error fetching Kubernetes version: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("fetching Kubernetes version: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		version := "not set (using latest stable)"
@@ -262,6 +267,7 @@ var upcloudK8sVersionCmd = &cobra.Command{
 		}
 		fmt.Printf("Kubernetes Version: %s\n", version)
 		fmt.Printf("  Distribution: %s\n", result.Distribution)
+		return nil
 	},
 }
 
@@ -271,18 +277,19 @@ var upcloudUpgradeCmd = &cobra.Command{
 	Long:       "Upgrade the Kubernetes (k3s) version on all nodes in an UpCloud cluster.",
 	Deprecated: "use `ankra cluster upgrade <cluster_id> <target_version>` instead; the cloud provider is detected automatically.",
 	Args:       cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		targetVersion := args[1]
 
 		result, err := apiClient.UpgradeUpcloudK8sVersion(clusterID, targetVersion)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error upgrading Kubernetes version: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("upgrading Kubernetes version: %w", err)
 		}
 
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		prev := "none"
@@ -293,6 +300,7 @@ var upcloudUpgradeCmd = &cobra.Command{
 		fmt.Printf("  Previous version: %s\n", prev)
 		fmt.Printf("  New version:      %s\n", text.FgGreen.Sprint(result.NewVersion))
 		fmt.Printf("  Nodes affected:   %d\n", result.NodesAffected)
+		return nil
 	},
 }
 
@@ -306,24 +314,26 @@ var upcloudNodeGroupListCmd = &cobra.Command{
 	Use:   "list <cluster_id>",
 	Short: "List node groups",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		result, err := apiClient.ListUpcloudNodeGroups(clusterID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error listing node groups: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("listing node groups: %w", err)
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		if len(result.NodeGroups) == 0 {
 			fmt.Println("No node groups found.")
-			return
+			return nil
 		}
 		for _, ng := range result.NodeGroups {
 			fmt.Printf("%-20s  type=%-12s  count=%d  labels=%d  taints=%d\n",
 				ng.Name, ng.InstanceType, ng.Count, len(ng.Labels), len(ng.Taints))
 		}
+		return nil
 	},
 }
 
@@ -331,7 +341,7 @@ var upcloudNodeGroupAddCmd = &cobra.Command{
 	Use:   "add <cluster_id>",
 	Short: "Add a node group",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		name, _ := cmd.Flags().GetString("name")
 		instanceType, _ := cmd.Flags().GetString("instance-type")
@@ -348,19 +358,24 @@ var upcloudNodeGroupAddCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.AddUpcloudNodeGroup(requestContext, clusterID, req, wait)
 		if err != nil {
-			handleNodeGroupSubmitError("adding node group", err)
+			return fmt.Errorf("adding node group: %w", err)
 		}
 		if submitted {
-			if renderStructuredOrExit(cmd, newAsyncSubmittedResult("Node group add")) {
-				return
+			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group add")); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 			printAsyncWriteSubmitted("Node group add")
-			return
+			return nil
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		fmt.Printf("Node group '%s' created with %d node(s).\n", result.GroupName, result.Count)
+		return nil
 	},
 }
 
@@ -368,13 +383,12 @@ var upcloudNodeGroupScaleCmd = &cobra.Command{
 	Use:   "scale <cluster_id> <group_name> <count>",
 	Short: "Scale a node group",
 	Args:  cobra.ExactArgs(3),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		groupName := args[1]
 		count, err := strconv.Atoi(args[2])
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Invalid count: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("invalid count: %w", err)
 		}
 
 		requestContext, cancelRequestContext, wait := nodeGroupAsyncContext(cmd)
@@ -382,19 +396,24 @@ var upcloudNodeGroupScaleCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.ScaleUpcloudNodeGroup(requestContext, clusterID, groupName, count, wait)
 		if err != nil {
-			handleNodeGroupSubmitError("scaling node group", err)
+			return fmt.Errorf("scaling node group: %w", err)
 		}
 		if submitted {
-			if renderStructuredOrExit(cmd, newAsyncSubmittedResult("Node group scale")) {
-				return
+			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group scale")); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 			printAsyncWriteSubmitted("Node group scale")
-			return
+			return nil
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		fmt.Printf("Node group '%s' scaled from %d to %d.\n", result.GroupName, result.PreviousCount, result.NewCount)
+		return nil
 	},
 }
 
@@ -402,7 +421,7 @@ var upcloudNodeGroupUpgradeCmd = &cobra.Command{
 	Use:   "upgrade <cluster_id> <group_name> <plan>",
 	Short: "Upgrade server plan for a node group",
 	Args:  cobra.ExactArgs(3),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		groupName := args[1]
 		plan := args[2]
@@ -412,19 +431,24 @@ var upcloudNodeGroupUpgradeCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.UpdateUpcloudNodeGroupInstanceType(requestContext, clusterID, groupName, plan, wait)
 		if err != nil {
-			handleNodeGroupSubmitError("upgrading node group", err)
+			return fmt.Errorf("upgrading node group: %w", err)
 		}
 		if submitted {
-			if renderStructuredOrExit(cmd, newAsyncSubmittedResult("Node group plan update")) {
-				return
+			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group plan update")); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 			printAsyncWriteSubmitted("Node group plan update")
-			return
+			return nil
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		fmt.Printf("Node group '%s' plan upgraded. %d node(s) affected.\n", result.GroupName, result.Updated)
+		return nil
 	},
 }
 
@@ -432,7 +456,7 @@ var upcloudNodeGroupDeleteCmd = &cobra.Command{
 	Use:   "delete <cluster_id> <group_name>",
 	Short: "Delete a node group and all its nodes",
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		groupName := args[1]
 
@@ -441,19 +465,24 @@ var upcloudNodeGroupDeleteCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.DeleteUpcloudNodeGroup(requestContext, clusterID, groupName, wait)
 		if err != nil {
-			handleNodeGroupSubmitError("deleting node group", err)
+			return fmt.Errorf("deleting node group: %w", err)
 		}
 		if submitted {
-			if renderStructuredOrExit(cmd, newAsyncSubmittedResult("Node group delete")) {
-				return
+			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group delete")); err != nil {
+				return err
+			} else if handled {
+				return nil
 			}
 			printAsyncWriteSubmitted("Node group delete")
-			return
+			return nil
 		}
-		if renderStructuredOrExit(cmd, result) {
-			return
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 		fmt.Printf("Node group '%s' deleted. %d node(s) removed.\n", result.GroupName, result.Deleted)
+		return nil
 	},
 }
 

--- a/cmd/upcloud_credentials.go
+++ b/cmd/upcloud_credentials.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -21,23 +22,24 @@ var upcloudCredCmd = &cobra.Command{
 var upcloudCredListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List UpCloud API credentials",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		creds, err := apiClient.ListUpcloudCredentials()
 		if err != nil {
-			fmt.Printf("Error listing UpCloud credentials: %v\n", err)
-			return
+			return fmt.Errorf("listing UpCloud credentials: %w", err)
 		}
 
 		if creds == nil {
 			creds = []client.UpcloudCredentialListItem{}
 		}
-		if renderStructuredOrExit(cmd, creds) {
-			return
+		if handled, err := renderStructured(cmd, creds); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		if len(creds) == 0 {
 			fmt.Println("No UpCloud credentials found.")
-			return
+			return nil
 		}
 
 		t := table.NewWriter()
@@ -64,13 +66,14 @@ var upcloudCredListCmd = &cobra.Command{
 			})
 		}
 		t.Render()
+		return nil
 	},
 }
 
 var upcloudCredCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create an UpCloud API credential",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		name, _ := cmd.Flags().GetString("name")
 
 		prompt := promptui.Prompt{
@@ -85,8 +88,7 @@ var upcloudCredCreateCmd = &cobra.Command{
 		}
 		apiTokenValue, err := prompt.Run()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Prompt cancelled.\n")
-			os.Exit(1)
+			return errors.New("prompt cancelled")
 		}
 
 		result, err := apiClient.CreateUpcloudCredential(client.CreateUpcloudCredentialRequest{
@@ -94,19 +96,19 @@ var upcloudCredCreateCmd = &cobra.Command{
 			APIToken: apiTokenValue,
 		})
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating UpCloud credential: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating UpCloud credential: %w", err)
 		}
 
 		if !result.Success {
-			fmt.Fprintln(os.Stderr, "Failed to create UpCloud credential:")
+			msg := "failed to create UpCloud credential:"
 			for _, e := range result.Errors {
-				fmt.Fprintf(os.Stderr, "  - %s: %s\n", e.Key, e.Message)
+				msg += fmt.Sprintf("\n  - %s: %s", e.Key, e.Message)
 			}
-			os.Exit(1)
+			return errors.New(msg)
 		}
 
 		fmt.Printf("UpCloud credential '%s' created successfully!\n", name)
+		return nil
 	},
 }
 
@@ -119,23 +121,24 @@ var upcloudSSHKeyCmd = &cobra.Command{
 var upcloudSSHKeyListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List SSH key credentials",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		creds, err := apiClient.ListUpcloudSSHKeyCredentials()
 		if err != nil {
-			fmt.Printf("Error listing SSH key credentials: %v\n", err)
-			return
+			return fmt.Errorf("listing SSH key credentials: %w", err)
 		}
 
 		if creds == nil {
 			creds = []client.UpcloudCredentialListItem{}
 		}
-		if renderStructuredOrExit(cmd, creds) {
-			return
+		if handled, err := renderStructured(cmd, creds); err != nil {
+			return err
+		} else if handled {
+			return nil
 		}
 
 		if len(creds) == 0 {
 			fmt.Println("No SSH key credentials found.")
-			return
+			return nil
 		}
 
 		t := table.NewWriter()
@@ -162,6 +165,7 @@ var upcloudSSHKeyListCmd = &cobra.Command{
 			})
 		}
 		t.Render()
+		return nil
 	},
 }
 
@@ -173,14 +177,13 @@ var upcloudSSHKeyCreateCmd = &cobra.Command{
 Examples:
   ankra credentials upcloud ssh-key create --name my-key --generate
   ankra credentials upcloud ssh-key create --name my-key --public-key "ssh-ed25519 AAAA..."`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		name, _ := cmd.Flags().GetString("name")
 		publicKey, _ := cmd.Flags().GetString("public-key")
 		generate, _ := cmd.Flags().GetBool("generate")
 
 		if !generate && publicKey == "" {
-			fmt.Fprintln(os.Stderr, "Either --public-key or --generate must be provided.")
-			os.Exit(1)
+			return errors.New("either --public-key or --generate must be provided")
 		}
 
 		req := client.CreateSSHKeyCredentialRequest{
@@ -193,16 +196,15 @@ Examples:
 
 		result, err := apiClient.CreateUpcloudSSHKeyCredential(req)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating SSH key credential: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("creating SSH key credential: %w", err)
 		}
 
 		if !result.Success {
-			fmt.Fprintln(os.Stderr, "Failed to create SSH key credential:")
+			msg := "failed to create SSH key credential:"
 			for _, e := range result.Errors {
-				fmt.Fprintf(os.Stderr, "  - %s: %s\n", e.Key, e.Message)
+				msg += fmt.Sprintf("\n  - %s: %s", e.Key, e.Message)
 			}
-			os.Exit(1)
+			return errors.New(msg)
 		}
 
 		fmt.Printf("SSH key credential '%s' created successfully!\n", name)
@@ -211,6 +213,7 @@ Examples:
 			fmt.Println("\nGenerated private key (save this, it will not be shown again):")
 			fmt.Println(*result.PrivateKey)
 		}
+		return nil
 	},
 }
 

--- a/cmd/upgrade_e2e_test.go
+++ b/cmd/upgrade_e2e_test.go
@@ -63,23 +63,23 @@ spec:
 
 type upgradeMock struct {
 	baseMock
-	iac                string
-	addonValues        string
-	manifestB64        string
-	capturedRequests   []capturedPatch
-	patchResult        *client.PatchStackResult
-	patchErr           error
-	getIaCErr          error
-	getAddonValuesErr  error
-	getManifestCfgErr  error
-	disconnectCalls    []disconnectCall
-	disconnectErr      error
+	iac               string
+	addonValues       string
+	manifestB64       string
+	capturedRequests  []capturedPatch
+	patchResult       *client.PatchStackResult
+	patchErr          error
+	getIaCErr         error
+	getAddonValuesErr error
+	getManifestCfgErr error
+	disconnectCalls   []disconnectCall
+	disconnectErr     error
 
-	encryptCalls       []encryptCall
-	encryptResult      string
-	encryptErr         error
-	decryptResult      string
-	decryptErr         error
+	encryptCalls  []encryptCall
+	encryptResult string
+	encryptErr    error
+	decryptResult string
+	decryptErr    error
 }
 
 type encryptCall struct {

--- a/cmd/variables_e2e_test.go
+++ b/cmd/variables_e2e_test.go
@@ -16,19 +16,19 @@ import (
 type varsMock struct {
 	baseMock
 
-	iac              string
-	orgVars          []client.OrganisationVariable
-	clusterVars      []client.ClusterVariable
-	createOrgCalls   []createVarCall
-	updateOrgCalls   []updateVarCall
-	deleteOrgCalls   []string
-	createOrgErr     error
-	updateOrgErr     error
-	deleteOrgErr     error
-	createClusterCalls   []createClusterVarCall
-	updateClusterCalls   []updateClusterVarCall
-	deleteClusterCalls   []deleteClusterVarCall
-	createClusterErr     error
+	iac                string
+	orgVars            []client.OrganisationVariable
+	clusterVars        []client.ClusterVariable
+	createOrgCalls     []createVarCall
+	updateOrgCalls     []updateVarCall
+	deleteOrgCalls     []string
+	createOrgErr       error
+	updateOrgErr       error
+	deleteOrgErr       error
+	createClusterCalls []createClusterVarCall
+	updateClusterCalls []updateClusterVarCall
+	deleteClusterCalls []deleteClusterVarCall
+	createClusterErr   error
 
 	patchCalls []capturedPatch
 	patchErr   error

--- a/internal/client/addons.go
+++ b/internal/client/addons.go
@@ -203,7 +203,7 @@ func (c *Client) GetClusterAddonValues(ctx context.Context, clusterID, addonName
 		return "", fmt.Errorf("read response: %w", err)
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
-		return "", fmt.Errorf("unauthorized. Run `ankra login` to re-authenticate")
+		return "", ErrUnauthorized
 	}
 	if resp.StatusCode != http.StatusOK {
 		return "", newUnexpectedResponseError("get addon configuration failed", resp.StatusCode, truncateForError(body, 500))

--- a/internal/client/executions.go
+++ b/internal/client/executions.go
@@ -203,7 +203,7 @@ func doExecutionPostJSON[T any](c *Client, ctx context.Context, endpoint string,
 	}
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, fmt.Errorf("unauthorized. Run `ankra login` to re-authenticate")
+		return nil, ErrUnauthorized
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		trimmed := strings.TrimSpace(string(body))

--- a/internal/client/helpers.go
+++ b/internal/client/helpers.go
@@ -61,7 +61,7 @@ func (c *Client) getJSON(url string, target interface{}) error {
 	}
 	defer closeBody(resp)
 	if resp.StatusCode == http.StatusUnauthorized {
-		return fmt.Errorf("unauthorized. Run `ankra login` to re-authenticate")
+		return ErrUnauthorized
 	}
 	if resp.StatusCode != http.StatusOK {
 		return newUnexpectedResponseErrorWithMessage(resp.StatusCode, fmt.Sprintf("unexpected status: %s", resp.Status))

--- a/internal/client/iac.go
+++ b/internal/client/iac.go
@@ -179,7 +179,7 @@ func (c *Client) GetClusterIaC(ctx context.Context, clusterID string) (string, e
 		return "", fmt.Errorf("get IaC failed: status 404, body: %s", truncateForError(body, 500))
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
-		return "", fmt.Errorf("unauthorized. Run `ankra login` to re-authenticate")
+		return "", ErrUnauthorized
 	}
 	if resp.StatusCode != http.StatusOK {
 		return "", newUnexpectedResponseErrorWithMessage(resp.StatusCode, fmt.Sprintf("get IaC failed: status %d, body: %s", resp.StatusCode, truncateForError(body, 500)))

--- a/internal/client/manifests.go
+++ b/internal/client/manifests.go
@@ -65,7 +65,7 @@ func (c *Client) GetClusterManifestConfiguration(ctx context.Context, clusterID,
 		return "", fmt.Errorf("read response: %w", err)
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
-		return "", fmt.Errorf("unauthorized. Run `ankra login` to re-authenticate")
+		return "", ErrUnauthorized
 	}
 	if resp.StatusCode != http.StatusOK {
 		return "", newUnexpectedResponseError("get manifest configuration failed", resp.StatusCode, truncateForError(body, 500))
@@ -108,7 +108,7 @@ func (c *Client) DisconnectManifest(ctx context.Context, clusterID, stackName, m
 		return nil, fmt.Errorf("read response: %w", err)
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, fmt.Errorf("unauthorized. Run `ankra login` to re-authenticate")
+		return nil, ErrUnauthorized
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, newUnexpectedResponseError("disconnect manifest failed", resp.StatusCode, truncateForError(body, 500))

--- a/internal/client/metrics.go
+++ b/internal/client/metrics.go
@@ -105,7 +105,7 @@ func (c *Client) postPrometheusQuery(endpoint string, payload []byte) (*Promethe
 		return nil, parseClusterError(body)
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, fmt.Errorf("unauthorized. Run `ankra login` to re-authenticate")
+		return nil, ErrUnauthorized
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, newUnexpectedResponseErrorWithMessage(resp.StatusCode, fmt.Sprintf("request failed: status %d: %s", resp.StatusCode, redactedBodyForError(body, 500)))

--- a/internal/client/support.go
+++ b/internal/client/support.go
@@ -290,7 +290,7 @@ func (c *Client) UploadSupportAttachment(ctx context.Context, ticketID, filePath
 		}
 		return &out, nil
 	case http.StatusUnauthorized:
-		return nil, fmt.Errorf("unauthorized. Run `ankra login` to re-authenticate")
+		return nil, ErrUnauthorized
 	case http.StatusNotFound:
 		return nil, ErrSupportTicketNotFound
 	default:
@@ -345,7 +345,7 @@ func (c *Client) doSupportRequest(ctx context.Context, method, url string, body 
 	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
 		return respBody, nil
 	case http.StatusUnauthorized:
-		return nil, fmt.Errorf("unauthorized. Run `ankra login` to re-authenticate")
+		return nil, ErrUnauthorized
 	case http.StatusNotFound:
 		return nil, ErrSupportTicketNotFound
 	case http.StatusConflict:

--- a/internal/client/unexpected_response.go
+++ b/internal/client/unexpected_response.go
@@ -1,6 +1,9 @@
 package client
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // UnexpectedResponseError marks an API response the CLI has no specific
 // handling for (the default branch of a status-code switch). cmd.Execute
@@ -32,3 +35,8 @@ func newUnexpectedResponseErrorWithMessage(statusCode int, message string) *Unex
 		message:    message,
 	}
 }
+
+// ErrUnauthorized is returned for 401 API responses so callers — and the
+// CLI's exit-code classification — can detect authentication failures with
+// errors.Is instead of matching message text.
+var ErrUnauthorized = errors.New("unauthorized. Run `ankra login` to re-authenticate")

--- a/internal/client/variables.go
+++ b/internal/client/variables.go
@@ -228,7 +228,7 @@ func (c *Client) doVariableRequest(ctx context.Context, method, url string, body
 	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
 		return respBody, nil
 	case http.StatusUnauthorized:
-		return nil, fmt.Errorf("unauthorized. Run `ankra login` to re-authenticate")
+		return nil, ErrUnauthorized
 	case http.StatusNotFound:
 		return nil, ErrVariableNotFound
 	case http.StatusConflict:


### PR DESCRIPTION
## What

Foundation phase of the CLI command restructure — no command surface changes (the completion-derived command tree is **byte-identical to master**), purely the behavioral contract underneath:

### Exit codes 0–6 (new scripting contract)

| Code | Meaning |
|---|---|
| 0 | success |
| 1 | API/runtime error |
| 2 | usage error (unknown command/flag, bad args, missing required flags, flag-group violations) |
| 3 | targeted resource not found |
| 4 | confirmation declined |
| 5 | `--wait`/`--timeout` expiry on async writes (internal request deadlines still exit 1) |
| 6 | auth failure (missing/expired/rejected credentials, 401/403) |

Classification is central (`cmd/exitcodes.go` + `Execute`): explicit `withExitCode` wins, then `client.ErrUnauthorized` / 401/403/404 `UnexpectedResponseError`, then cobra's fixed usage-error shapes. A new `client.ErrUnauthorized` sentinel replaces eight inline copies of the 401 message so `errors.Is` works everywhere.

### All 117 `Run:` handlers → `RunE`

Errors now always reach **stderr** and set a non-zero exit code. This fixes a class of silent failures where commands printed errors to *stdout* and exited 0 — all of `charts` and `chat`, `cluster manifests list`, `cluster select`/`clear`, credential lists, and more. `os.Exit` now exists in exactly one place (`Execute`'s exit-code mapping); the legacy `renderStructuredOrExit`/`handleNodeGroupSubmitError` helpers are gone.

### `deprecateAndForward` machinery (no forwarders wired yet)

Hidden forwarder that re-dispatches an old command path to its replacement with argv rewriting, emitting cobra's human notice plus a machine-readable `ANKRA_DEPRECATED=<old>=><new> removal=<version>` stderr marker. Lands the mechanism for the upcoming taxonomy phases. The forwarder is auth-free (auth is enforced on the target after flags are parsed — with `DisableFlagParsing`, checking earlier would reject `--token` invocations) and silences the nested dispatch so errors print exactly once.

### Behavior changes to note

- `delete cluster`: declining the prompt exits 4 (was: "Aborted.", exit 0); not-found exits 3 (was: exit 0); the cloud-cluster refusal hint now points at `ankra cluster deprovision` (was: the provider-namespaced form deprecated in v0.4.0); the underlying API error is no longer swallowed.
- `helm registries|credentials delete`: declining the prompt exits 4 (was: "Cancelled." on stdout, exit 0).
- Error text no longer pollutes stdout for `-o json|yaml` consumers.

## How it was built & verified

- Foundation written by hand; the mechanical RunE conversion fanned out to 9 parallel agents in isolated git worktrees (disjoint file batches, full suite run per batch, one commit each, cherry-picked).
- An adversarial 3-lens review (control-flow regressions / output-contract breaks / exit-classification audit) ran over the full diff with per-finding verification; 6 real defects found and fixed in the final commit — including the forwarder auth-ordering bug, required-flag violations exiting 1, 401s exiting 1 on most paths, and a blanket `DeadlineExceeded→5` mapping that misread internal request timeouts as `--wait` expiry.
- Verified: full test suite + golangci-lint green; command tree byte-identical to master; empirically on the built binary — unknown command/flag → 2, missing required flag → 2, not logged in → 6, success → 0.

Part of the CLI restructure plan (Phase 0 of the phased migration honoring DEPRECATIONS.md policy). Next phases: single cluster resolver, global `-o`, confirmation policy with `--yes`, then the v0.6.0 taxonomy moves via forwarders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)