### PR TITLE
fix(cli): review hardening — exit codes, destructive-delete confirms, and correctness fixes

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -500,8 +500,14 @@ func buildAddon(am map[string]interface{}, baseDir string) (client.Addon, error)
 	if name == "" {
 		return client.Addon{}, errors.New("every addon needs a 'name'")
 	}
-	chart := fmt.Sprint(am["chart_name"])
-	ver := fmt.Sprint(am["chart_version"])
+	chart, err := requiredAddonString(am, name, "chart_name")
+	if err != nil {
+		return client.Addon{}, err
+	}
+	ver, err := requiredAddonString(am, name, "chart_version")
+	if err != nil {
+		return client.Addon{}, err
+	}
 	ns, _ := am["namespace"].(string)
 	parents := parseParentList(am["parents"])
 
@@ -524,6 +530,15 @@ func buildAddon(am map[string]interface{}, baseDir string) (client.Addon, error)
 
 	var cfg interface{}
 	if conf, ok := am["configuration"].(map[string]interface{}); ok {
+		var encryptedPaths []string
+		if rawPaths, ok := conf["encrypted_paths"].([]interface{}); ok {
+			for _, p := range rawPaths {
+				if s, ok := p.(string); ok {
+					encryptedPaths = append(encryptedPaths, s)
+				}
+			}
+		}
+
 		if pf, ok := conf["from_file"].(string); ok {
 			full, err := resolveSafePath(baseDir, pf)
 			if err != nil {
@@ -537,15 +552,19 @@ func buildAddon(am map[string]interface{}, baseDir string) (client.Addon, error)
 				return client.Addon{}, fmt.Errorf("the addon configuration file %q is not valid YAML: %w", full, err)
 			}
 			cfg = client.AddonStandaloneConfiguration{
-				ValuesBase64: base64.StdEncoding.EncodeToString(b),
+				ValuesBase64:   base64.StdEncoding.EncodeToString(b),
+				EncryptedPaths: encryptedPaths,
 			}
 		} else if inline, ok := conf["values"].(string); ok && inline != "" {
 			if err := validateYAMLDocuments([]byte(inline)); err != nil {
 				return client.Addon{}, fmt.Errorf("the inline addon 'configuration.values' is not valid YAML: %w", err)
 			}
 			cfg = client.AddonStandaloneConfiguration{
-				ValuesBase64: base64.StdEncoding.EncodeToString([]byte(inline)),
+				ValuesBase64:   base64.StdEncoding.EncodeToString([]byte(inline)),
+				EncryptedPaths: encryptedPaths,
 			}
+		} else if len(encryptedPaths) > 0 {
+			return client.Addon{}, errors.New("addon 'configuration.encrypted_paths' is set but there is nothing to decrypt (set 'from_file' or 'values')")
 		}
 	}
 
@@ -562,6 +581,25 @@ func buildAddon(am map[string]interface{}, baseDir string) (client.Addon, error)
 		RegistryCredentialName: registryCredentialName,
 		Settings:               settings,
 	}, nil
+}
+
+// requiredAddonString extracts a mandatory string field from an addon map.
+// A missing or empty value is an error; a non-string value (e.g. an unquoted
+// YAML number that parses as a float) is rejected with a hint to quote it,
+// since fmt.Sprint would otherwise mangle it (chart_version: 1.20 -> "1.2").
+func requiredAddonString(am map[string]interface{}, addonName, key string) (string, error) {
+	value, ok := am[key]
+	if !ok || value == nil {
+		return "", fmt.Errorf("addon %q: %s is required", addonName, key)
+	}
+	str, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("addon %q: %s must be a quoted string (got %v - quote it, as YAML reads unquoted numbers like 1.20 as numbers, not \"1.20\")", addonName, key, value)
+	}
+	if str == "" {
+		return "", fmt.Errorf("addon %q: %s is required", addonName, key)
+	}
+	return str, nil
 }
 
 func parseParentList(raw interface{}) []client.Parent {

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -350,6 +350,121 @@ func TestBuildAddon(t *testing.T) {
 			t.Errorf("expected error naming the file and YAML problem, got: %v", err)
 		}
 	})
+
+	t.Run("encrypted_paths round-trip from inline values", func(t *testing.T) {
+		am := map[string]interface{}{
+			"name":          "sealed",
+			"chart_name":    "test",
+			"chart_version": "1.0.0",
+			"configuration": map[string]interface{}{
+				"values":          "password: ENC[...]",
+				"encrypted_paths": []interface{}{"password", "apiKey"},
+			},
+		}
+		a, err := buildAddon(am, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		cfg, ok := a.Configuration.(client.AddonStandaloneConfiguration)
+		if !ok {
+			t.Fatalf("configuration type = %T, want AddonStandaloneConfiguration", a.Configuration)
+		}
+		if len(cfg.EncryptedPaths) != 2 || cfg.EncryptedPaths[0] != "password" || cfg.EncryptedPaths[1] != "apiKey" {
+			t.Errorf("encrypted_paths = %v, want [password apiKey]", cfg.EncryptedPaths)
+		}
+	})
+
+	t.Run("encrypted_paths round-trip from from_file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		valuesPath := filepath.Join(tmpDir, "values", "sealed.yaml")
+		if err := os.MkdirAll(filepath.Dir(valuesPath), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(valuesPath, []byte("password: ENC[...]"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		am := map[string]interface{}{
+			"name":          "sealed-file",
+			"chart_name":    "test",
+			"chart_version": "1.0.0",
+			"configuration": map[string]interface{}{
+				"from_file":       "values/sealed.yaml",
+				"encrypted_paths": []interface{}{"password"},
+			},
+		}
+		a, err := buildAddon(am, tmpDir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		cfg, ok := a.Configuration.(client.AddonStandaloneConfiguration)
+		if !ok {
+			t.Fatalf("configuration type = %T, want AddonStandaloneConfiguration", a.Configuration)
+		}
+		if len(cfg.EncryptedPaths) != 1 || cfg.EncryptedPaths[0] != "password" {
+			t.Errorf("encrypted_paths = %v, want [password]", cfg.EncryptedPaths)
+		}
+	})
+
+	t.Run("encrypted_paths with nothing to decrypt errors", func(t *testing.T) {
+		am := map[string]interface{}{
+			"name":          "sealed-empty",
+			"chart_name":    "test",
+			"chart_version": "1.0.0",
+			"configuration": map[string]interface{}{
+				"encrypted_paths": []interface{}{"password"},
+			},
+		}
+		_, err := buildAddon(am, "")
+		if err == nil {
+			t.Fatal("expected error for encrypted_paths with no configuration")
+		}
+		if !strings.Contains(err.Error(), "encrypted_paths") {
+			t.Errorf("expected encrypted_paths error, got: %v", err)
+		}
+	})
+
+	t.Run("missing chart_version errors", func(t *testing.T) {
+		am := map[string]interface{}{
+			"name":       "no-version",
+			"chart_name": "test",
+		}
+		_, err := buildAddon(am, "")
+		if err == nil {
+			t.Fatal("expected error for missing chart_version")
+		}
+		if !strings.Contains(err.Error(), "chart_version is required") {
+			t.Errorf("expected chart_version-required error, got: %v", err)
+		}
+	})
+
+	t.Run("missing chart_name errors", func(t *testing.T) {
+		am := map[string]interface{}{
+			"name":          "no-chart",
+			"chart_version": "1.0.0",
+		}
+		_, err := buildAddon(am, "")
+		if err == nil {
+			t.Fatal("expected error for missing chart_name")
+		}
+		if !strings.Contains(err.Error(), "chart_name is required") {
+			t.Errorf("expected chart_name-required error, got: %v", err)
+		}
+	})
+
+	t.Run("unquoted float chart_version errors with quote hint", func(t *testing.T) {
+		am := map[string]interface{}{
+			"name":          "float-version",
+			"chart_name":    "test",
+			"chart_version": 1.20, // YAML parses unquoted 1.20 as float64(1.2)
+		}
+		_, err := buildAddon(am, "")
+		if err == nil {
+			t.Fatal("expected error for unquoted float chart_version")
+		}
+		if !strings.Contains(err.Error(), "quoted string") {
+			t.Errorf("expected quote-hint error, got: %v", err)
+		}
+	})
 }
 
 func TestBuildStack(t *testing.T) {

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -307,6 +307,13 @@ var chatDeleteCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		conversationID := args[0]
+		yes, _ := cmd.Flags().GetBool("yes")
+
+		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Delete conversation %q? [y/N]: ", conversationID),
+			yes); err != nil {
+			return err
+		}
 
 		result, err := apiClient.DeleteChatConversation(conversationID)
 		if err != nil {
@@ -380,6 +387,8 @@ func init() {
 
 	chatHistoryCmd.Flags().String("cluster", "", "Filter by cluster")
 	chatHistoryCmd.Flags().Int("limit", 20, "Maximum number of conversations to show")
+
+	chatDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
 	chatHealthCmd.Flags().Bool("ai", true, "Include AI analysis")
 	chatHealthCmd.Flags().String("cluster", "", "Target cluster name or ID (defaults to the selected cluster)")

--- a/cmd/chat_test.go
+++ b/cmd/chat_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type chatDeleteMock struct {
+	baseMock
+	called            bool
+	gotConversationID string
+}
+
+func (m *chatDeleteMock) DeleteChatConversation(conversationID string) (*client.DeleteConversationResponse, error) {
+	m.called = true
+	m.gotConversationID = conversationID
+	return &client.DeleteConversationResponse{Success: true}, nil
+}
+
+func TestChatDelete_DeclineDoesNotCallAPI(t *testing.T) {
+	mock := &chatDeleteMock{}
+	resetConfirmFlag(t, chatDeleteCmd)
+	_, err := runWithInput(t, mock, "n\n", "chat", "delete", "conv-1")
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled on decline, got %v", err)
+	}
+	if mock.called {
+		t.Error("expected no delete call when declined")
+	}
+}
+
+func TestChatDelete_YesProceeds(t *testing.T) {
+	mock := &chatDeleteMock{}
+	resetConfirmFlag(t, chatDeleteCmd)
+	out, err := runWithInput(t, mock, "", "chat", "delete", "conv-1", "--yes")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if !mock.called {
+		t.Fatal("expected delete call with --yes")
+	}
+	if mock.gotConversationID != "conv-1" {
+		t.Errorf("conversation id = %q, want conv-1", mock.gotConversationID)
+	}
+}

--- a/cmd/cluster_addon.go
+++ b/cmd/cluster_addon.go
@@ -263,6 +263,7 @@ var clusterAddonsUninstallCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		addonName := args[0]
 		deletePermanently, _ := cmd.Flags().GetBool("delete")
+		yes, _ := cmd.Flags().GetBool("yes")
 
 		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
@@ -271,7 +272,20 @@ var clusterAddonsUninstallCmd = &cobra.Command{
 
 		addon, err := apiClient.GetAddonByName(cluster.ID, addonName)
 		if err != nil {
+			if errors.Is(err, client.ErrAddonNotFound) {
+				return withExitCode(exitNotFound, fmt.Errorf("finding addon: %w", err))
+			}
 			return fmt.Errorf("finding addon: %w", err)
+		}
+
+		var msg string
+		if deletePermanently {
+			msg = fmt.Sprintf("Uninstall and PERMANENTLY delete addon %q from cluster %q? [y/N]: ", addonName, cluster.Name)
+		} else {
+			msg = fmt.Sprintf("Uninstall addon %q from cluster %q? [y/N]: ", addonName, cluster.Name)
+		}
+		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(), msg, yes); err != nil {
+			return err
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -604,6 +618,7 @@ func collectSetAssignments(setEntries, setStrings, setFiles []string) ([]SetAssi
 
 func init() {
 	clusterAddonsUninstallCmd.Flags().Bool("delete", false, "Also delete the addon permanently")
+	clusterAddonsUninstallCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
 	clusterAddonsUpdateCmd.Flags().StringP("file", "f", "", "Path to JSON settings file (required)")
 	_ = clusterAddonsUpdateCmd.MarkFlagRequired("file")

--- a/cmd/cluster_addon_test.go
+++ b/cmd/cluster_addon_test.go
@@ -1,0 +1,179 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/pflag"
+)
+
+type clusterAddonUninstallMock struct {
+	baseMock
+	addons        []client.ClusterAddonListItem
+	uninstalls    []uninstallCall
+	uninstallErr  error
+	getClusterErr error
+}
+
+type uninstallCall struct {
+	ClusterID       string
+	AddonResourceID string
+	DeletePermanent bool
+}
+
+func (m *clusterAddonUninstallMock) GetCluster(name string) (client.ClusterListItem, error) {
+	if m.getClusterErr != nil {
+		return client.ClusterListItem{}, m.getClusterErr
+	}
+	return client.ClusterListItem{ID: "11111111-2222-3333-4444-555555555555", Name: name}, nil
+}
+
+func (m *clusterAddonUninstallMock) ListClusterAddons(clusterID string) ([]client.ClusterAddonListItem, error) {
+	return m.addons, nil
+}
+
+// GetAddonByName mirrors the real client: it returns ErrAddonNotFound (wrapped)
+// when the addon is absent so the handler can classify not-found.
+func (m *clusterAddonUninstallMock) GetAddonByName(clusterID, addonName string) (*client.ClusterAddonListItem, error) {
+	for i := range m.addons {
+		if m.addons[i].Name == addonName {
+			return &m.addons[i], nil
+		}
+	}
+	return nil, fmt.Errorf("addon %q: %w", addonName, client.ErrAddonNotFound)
+}
+
+func (m *clusterAddonUninstallMock) UninstallAddon(ctx context.Context, clusterID, addonResourceID string, deletePermanently bool) (*client.UninstallAddonResult, error) {
+	m.uninstalls = append(m.uninstalls, uninstallCall{
+		ClusterID:       clusterID,
+		AddonResourceID: addonResourceID,
+		DeletePermanent: deletePermanently,
+	})
+	if m.uninstallErr != nil {
+		return nil, m.uninstallErr
+	}
+	return &client.UninstallAddonResult{Success: true, Message: "Addon uninstalled"}, nil
+}
+
+func addonFixture(name, id string) client.ClusterAddonListItem {
+	return client.ClusterAddonListItem{ID: id, Name: name}
+}
+
+// executeAddonCommand runs the given args against rootCmd with stdin wired to
+// stdinContent (so the [y/N] prompt can be answered), returning the error.
+// It resets the uninstall command's flag state first: rootCmd is a process
+// global, so --delete/--yes from a prior test would otherwise leak in.
+func executeAddonCommand(t *testing.T, stdinContent string, args ...string) error {
+	t.Helper()
+	resetAddonUninstallFlags()
+	// rootCmd is a process global; reset the mutated flag state on the way out
+	// too so a leaked --cluster override does not bleed into unrelated tests.
+	t.Cleanup(func() {
+		rootCmd.SetIn(nil)
+		resetAddonUninstallFlags()
+	})
+	rootCmd.SetOut(new(strings.Builder))
+	rootCmd.SetErr(new(strings.Builder))
+	rootCmd.SetIn(strings.NewReader(stdinContent))
+	rootCmd.SetArgs(args)
+	return rootCmd.Execute()
+}
+
+func resetAddonUninstallFlags() {
+	reset := func(fs *pflag.FlagSet) {
+		fs.VisitAll(func(f *pflag.Flag) {
+			_ = f.Value.Set(f.DefValue)
+			f.Changed = false
+		})
+	}
+	reset(clusterAddonsUninstallCmd.Flags())
+	reset(clusterCmd.PersistentFlags())
+}
+
+func TestClusterAddonUninstall_MissingAddonExitsNotFound(t *testing.T) {
+	mock := &clusterAddonUninstallMock{
+		addons: []client.ClusterAddonListItem{addonFixture("present", "addon-1")},
+	}
+	setMockClient(t, mock)
+
+	err := executeAddonCommand(t, "y\n", "cluster", "addons", "uninstall", "absent", "--cluster", "my-cluster")
+	if err == nil {
+		t.Fatal("expected an error for a missing addon, got nil")
+	}
+	if got := exitCodeFor(err); got != exitNotFound {
+		t.Errorf("exitCodeFor(%v) = %d, want %d (exitNotFound)", err, got, exitNotFound)
+	}
+	if !errors.Is(err, client.ErrAddonNotFound) {
+		t.Errorf("expected error to wrap client.ErrAddonNotFound, got: %v", err)
+	}
+	if len(mock.uninstalls) != 0 {
+		t.Errorf("UninstallAddon must not be called for a missing addon, got %d calls", len(mock.uninstalls))
+	}
+}
+
+func TestClusterAddonUninstall_DeclinedPromptCancels(t *testing.T) {
+	mock := &clusterAddonUninstallMock{
+		addons: []client.ClusterAddonListItem{addonFixture("present", "addon-1")},
+	}
+	setMockClient(t, mock)
+
+	err := executeAddonCommand(t, "n\n", "cluster", "addons", "uninstall", "present", "--cluster", "my-cluster")
+	if err == nil {
+		t.Fatal("expected declined prompt to return an error, got nil")
+	}
+	if !errors.Is(err, errCancelled) {
+		t.Errorf("expected errCancelled, got: %v", err)
+	}
+	if got := exitCodeFor(err); got != exitCancelled {
+		t.Errorf("exitCodeFor(%v) = %d, want %d (exitCancelled)", err, got, exitCancelled)
+	}
+	if len(mock.uninstalls) != 0 {
+		t.Errorf("UninstallAddon must not be called after a declined prompt, got %d calls", len(mock.uninstalls))
+	}
+}
+
+func TestClusterAddonUninstall_ConfirmProceeds(t *testing.T) {
+	mock := &clusterAddonUninstallMock{
+		addons: []client.ClusterAddonListItem{addonFixture("present", "addon-1")},
+	}
+	setMockClient(t, mock)
+
+	err := executeAddonCommand(t, "y\n", "cluster", "addons", "uninstall", "present", "--cluster", "my-cluster")
+	if err != nil {
+		t.Fatalf("expected confirmed uninstall to succeed, got: %v", err)
+	}
+	if len(mock.uninstalls) != 1 {
+		t.Fatalf("expected exactly one UninstallAddon call, got %d", len(mock.uninstalls))
+	}
+	if mock.uninstalls[0].AddonResourceID != "addon-1" {
+		t.Errorf("uninstalled addon ID = %q, want %q", mock.uninstalls[0].AddonResourceID, "addon-1")
+	}
+	if mock.uninstalls[0].DeletePermanent {
+		t.Error("delete-permanently should be false without --delete")
+	}
+}
+
+func TestClusterAddonUninstall_YesSkipsPromptAndProceeds(t *testing.T) {
+	mock := &clusterAddonUninstallMock{
+		addons: []client.ClusterAddonListItem{addonFixture("present", "addon-1")},
+	}
+	setMockClient(t, mock)
+
+	// Empty stdin: if --yes did not skip the prompt, confirmPrompt would read
+	// EOF and cancel, so a successful uninstall proves the prompt was skipped.
+	err := executeAddonCommand(t, "", "cluster", "addons", "uninstall", "present", "--cluster", "my-cluster", "--yes", "--delete")
+	if err != nil {
+		t.Fatalf("expected --yes uninstall to succeed, got: %v", err)
+	}
+	if len(mock.uninstalls) != 1 {
+		t.Fatalf("expected exactly one UninstallAddon call, got %d", len(mock.uninstalls))
+	}
+	if !mock.uninstalls[0].DeletePermanent {
+		t.Error("delete-permanently should be true with --delete")
+	}
+}

--- a/cmd/cluster_draft.go
+++ b/cmd/cluster_draft.go
@@ -27,10 +27,11 @@ without deploying anything. The local checks run first (the same ones as
 'ankra cluster apply --dry-run'), then each stack in the file is saved as a
 resource draft you can review, edit, and deploy from the Ankra stack builder.
 
-If the cluster does not exist yet it is imported first (live), since drafts
-can only be attached to an existing cluster. Stacks that already match the
-cluster's desired state are reported as "no changes" rather than creating an
-empty draft.`,
+If the cluster does not exist yet it is imported first without its stacks,
+since drafts can only be attached to an existing cluster; every stack in the
+file is then staged as a draft. Stacks that already match the cluster's
+desired state are reported as "no changes" rather than creating an empty
+draft.`,
 	Args: cobra.NoArgs,
 	RunE: runClusterDraft,
 }
@@ -130,8 +131,9 @@ func runClusterDraft(cmd *cobra.Command, _ []string) error {
 }
 
 // resolveClusterForDraft returns the cluster ID to attach drafts to. If the
-// cluster does not exist yet it is imported (live) first, because drafts can
-// only be attached to an existing cluster.
+// cluster does not exist yet it is imported first without any stacks, because
+// drafts can only be attached to an existing cluster and importing the stacks
+// would deploy them.
 func resolveClusterForDraft(ctx context.Context, importRequest client.CreateImportClusterRequest) (string, error) {
 	existing, err := apiClient.GetCluster(importRequest.Name)
 	if err == nil && existing.ID != "" {
@@ -141,8 +143,12 @@ func resolveClusterForDraft(ctx context.Context, importRequest client.CreateImpo
 		return "", fmt.Errorf("looking up cluster %q: %w", importRequest.Name, err)
 	}
 
-	fmt.Fprintf(os.Stderr, "Cluster %q does not exist yet; importing it first...\n", importRequest.Name)
-	importResponse, _, importErr := apiClient.ApplyCluster(ctx, importRequest, true)
+	fmt.Fprintf(os.Stderr, "Cluster %q does not exist yet; importing it first (without stacks, so they can be staged as drafts)...\n", importRequest.Name)
+	// Bootstrap the cluster without stacks: importing the full request would
+	// deploy every stack as live desired state, leaving nothing to draft.
+	bootstrapRequest := importRequest
+	bootstrapRequest.Spec.Stacks = []client.Stack{}
+	importResponse, _, importErr := apiClient.ApplyCluster(ctx, bootstrapRequest, true)
 	if importErr != nil {
 		return "", fmt.Errorf("importing cluster %q: %w", importRequest.Name, importErr)
 	}

--- a/cmd/cluster_draft_test.go
+++ b/cmd/cluster_draft_test.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type draftBootstrapMock struct {
+	baseMock
+	existingCluster *client.ClusterListItem
+
+	applyCalls      int
+	applyStacks     []client.Stack
+	applyGitRepo    *client.GitRepository
+	applyName       string
+	draftClusterIDs []string
+	draftStackNames []string
+}
+
+func (m *draftBootstrapMock) GetCluster(name string) (client.ClusterListItem, error) {
+	if m.existingCluster != nil && m.existingCluster.Name == name {
+		return *m.existingCluster, nil
+	}
+	return client.ClusterListItem{}, fmt.Errorf("no cluster found for name %q", name)
+}
+
+func (m *draftBootstrapMock) ApplyCluster(ctx context.Context, clusterReq client.CreateImportClusterRequest, wait bool) (*client.ImportResponse, bool, error) {
+	m.applyCalls++
+	m.applyName = clusterReq.Name
+	m.applyGitRepo = clusterReq.Spec.GitRepository
+	m.applyStacks = append([]client.Stack(nil), clusterReq.Spec.Stacks...)
+	return &client.ImportResponse{Name: clusterReq.Name, ClusterId: "bootstrapped-cluster-id"}, false, nil
+}
+
+func (m *draftBootstrapMock) CreateStackDraft(ctx context.Context, clusterID string, stack client.Stack) (*client.StackDraftResult, error) {
+	m.draftClusterIDs = append(m.draftClusterIDs, clusterID)
+	m.draftStackNames = append(m.draftStackNames, stack.Name)
+	return &client.StackDraftResult{DraftID: "draft-" + stack.Name}, nil
+}
+
+func writeDraftImportClusterYAML(t *testing.T) string {
+	t.Helper()
+	yamlContent := `kind: ImportCluster
+metadata:
+  name: draft-cluster
+spec:
+  git_repository:
+    provider: github
+    credential_name: my-cred
+    branch: main
+    repository: org/repo
+  stacks:
+    - name: monitoring
+      manifests: []
+      addons: []
+    - name: apps
+      manifests: []
+      addons: []
+`
+	yamlPath := filepath.Join(t.TempDir(), "cluster.yaml")
+	if err := os.WriteFile(yamlPath, []byte(yamlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return yamlPath
+}
+
+func TestDraftBootstrapImportsClusterWithoutStacks(t *testing.T) {
+	mock := &draftBootstrapMock{}
+	setMockClient(t, mock)
+	yamlPath := writeDraftImportClusterYAML(t)
+
+	var output string
+	var err error
+	stdout := captureStdout(t, func() {
+		output, err = executeCommand("cluster", "draft", "-f", yamlPath)
+	})
+	if err != nil {
+		t.Fatalf("cluster draft failed: %v\noutput: %s", err, output)
+	}
+
+	if mock.applyCalls != 1 {
+		t.Fatalf("bootstrap ApplyCluster calls = %d, want 1", mock.applyCalls)
+	}
+	if len(mock.applyStacks) != 0 {
+		names := make([]string, 0, len(mock.applyStacks))
+		for _, stack := range mock.applyStacks {
+			names = append(names, stack.Name)
+		}
+		t.Errorf("bootstrap ApplyCluster received stacks %v, want none", names)
+	}
+	if mock.applyName != "draft-cluster" {
+		t.Errorf("bootstrap ApplyCluster name = %q, want %q", mock.applyName, "draft-cluster")
+	}
+	if mock.applyGitRepo == nil || mock.applyGitRepo.Repository != "org/repo" {
+		t.Errorf("bootstrap ApplyCluster git_repository = %+v, want repository %q kept", mock.applyGitRepo, "org/repo")
+	}
+
+	wantStacks := []string{"monitoring", "apps"}
+	if len(mock.draftStackNames) != len(wantStacks) {
+		t.Fatalf("CreateStackDraft calls = %v, want %v", mock.draftStackNames, wantStacks)
+	}
+	for i, want := range wantStacks {
+		if mock.draftStackNames[i] != want {
+			t.Errorf("CreateStackDraft call %d = %q, want %q", i, mock.draftStackNames[i], want)
+		}
+		if mock.draftClusterIDs[i] != "bootstrapped-cluster-id" {
+			t.Errorf("CreateStackDraft call %d cluster ID = %q, want %q", i, mock.draftClusterIDs[i], "bootstrapped-cluster-id")
+		}
+	}
+
+	for _, want := range []string{`stack "monitoring": draft created (draft-monitoring)`, `stack "apps": draft created (draft-apps)`} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("expected stdout to contain %q, got: %s", want, stdout)
+		}
+	}
+}
+
+func TestDraftExistingClusterSkipsImport(t *testing.T) {
+	mock := &draftBootstrapMock{
+		existingCluster: &client.ClusterListItem{ID: "existing-cluster-id", Name: "draft-cluster"},
+	}
+	setMockClient(t, mock)
+	yamlPath := writeDraftImportClusterYAML(t)
+
+	var output string
+	var err error
+	_ = captureStdout(t, func() {
+		output, err = executeCommand("cluster", "draft", "-f", yamlPath)
+	})
+	if err != nil {
+		t.Fatalf("cluster draft failed: %v\noutput: %s", err, output)
+	}
+
+	if mock.applyCalls != 0 {
+		t.Errorf("ApplyCluster calls = %d, want 0 for an existing cluster", mock.applyCalls)
+	}
+	if len(mock.draftStackNames) != 2 {
+		t.Errorf("CreateStackDraft calls = %v, want both stacks", mock.draftStackNames)
+	}
+	for i, clusterID := range mock.draftClusterIDs {
+		if clusterID != "existing-cluster-id" {
+			t.Errorf("CreateStackDraft call %d cluster ID = %q, want %q", i, clusterID, "existing-cluster-id")
+		}
+	}
+}

--- a/cmd/cluster_helm.go
+++ b/cmd/cluster_helm.go
@@ -107,6 +107,13 @@ var clusterHelmUninstallCmd = &cobra.Command{
 			return err
 		}
 
+		yes, _ := cmd.Flags().GetBool("yes")
+		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Uninstall Helm release %q (namespace %q) from cluster %q? [y/N]: ", releaseName, namespace, cluster.Name),
+			yes); err != nil {
+			return err
+		}
+
 		result, err := apiClient.UninstallHelmRelease(cluster.ID, releaseName, namespace)
 		if err != nil {
 			return err
@@ -126,6 +133,7 @@ func init() {
 	clusterHelmReleasesCmd.Flags().StringP("output", "o", "table", "Output format: table, json")
 
 	clusterHelmUninstallCmd.Flags().StringP("namespace", "n", "", "Kubernetes namespace (required)")
+	clusterHelmUninstallCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
 	clusterHelmCmd.AddCommand(clusterHelmReleasesCmd)
 	clusterHelmCmd.AddCommand(clusterHelmUninstallCmd)

--- a/cmd/cluster_helm_test.go
+++ b/cmd/cluster_helm_test.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type helmUninstallMock struct {
+	baseMock
+	called         bool
+	gotClusterID   string
+	gotReleaseName string
+	gotNamespace   string
+}
+
+func (m *helmUninstallMock) GetCluster(name string) (client.ClusterListItem, error) {
+	return client.ClusterListItem{ID: "cluster-abc", Name: name}, nil
+}
+
+func (m *helmUninstallMock) UninstallHelmRelease(clusterID, releaseName, namespace string) (*client.UninstallHelmReleaseResponse, error) {
+	m.called = true
+	m.gotClusterID = clusterID
+	m.gotReleaseName = releaseName
+	m.gotNamespace = namespace
+	return &client.UninstallHelmReleaseResponse{Status: "uninstalled"}, nil
+}
+
+func TestHelmUninstall_DeclineDoesNotCallAPI(t *testing.T) {
+	mock := &helmUninstallMock{}
+	resetConfirmFlag(t, clusterHelmUninstallCmd, clusterCmd)
+	_, err := runWithInput(t, mock, "n\n",
+		"cluster", "helm", "uninstall", "my-release", "--namespace", "prod", "--cluster", "prod-cluster")
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled on decline, got %v", err)
+	}
+	if mock.called {
+		t.Error("expected no uninstall call when declined")
+	}
+}
+
+func TestHelmUninstall_YesProceeds(t *testing.T) {
+	mock := &helmUninstallMock{}
+	resetConfirmFlag(t, clusterHelmUninstallCmd, clusterCmd)
+	out, err := runWithInput(t, mock, "",
+		"cluster", "helm", "uninstall", "my-release", "--namespace", "prod", "--cluster", "prod-cluster", "--yes")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if !mock.called {
+		t.Fatal("expected uninstall call with --yes")
+	}
+	if mock.gotClusterID != "cluster-abc" || mock.gotReleaseName != "my-release" || mock.gotNamespace != "prod" {
+		t.Errorf("got cluster=%q release=%q ns=%q, want cluster-abc/my-release/prod",
+			mock.gotClusterID, mock.gotReleaseName, mock.gotNamespace)
+	}
+}

--- a/cmd/cluster_k8s.go
+++ b/cmd/cluster_k8s.go
@@ -400,6 +400,19 @@ var kindConfigs = []kindConfig{
 	},
 }
 
+// validateK8sOutputFormat guards the kubernetes command family's -o flag, which
+// accepts table|json|yaml only. Unknown values (e.g. the kubectl habit of
+// "-o wide") are rejected up front with exitUsage so they never reach the table
+// renderer, whose named-resource path carries a nil formatRow and would panic.
+func validateK8sOutputFormat(outputFormat string) error {
+	switch outputFormat {
+	case "table", "json", "yaml":
+		return nil
+	default:
+		return withExitCode(exitUsage, fmt.Errorf("unsupported output format %q: use table, json or yaml", outputFormat))
+	}
+}
+
 func renderSingleResource(item interface{}, outputFormat string) error {
 	switch outputFormat {
 	case "json":
@@ -503,6 +516,10 @@ func registerKindCommand(cfg kindConfig) *cobra.Command {
 			labelSelector, _ := cmd.Flags().GetString("selector")
 			outputFormat, _ := cmd.Flags().GetString("output")
 
+			if err := validateK8sOutputFormat(outputFormat); err != nil {
+				return err
+			}
+
 			if len(args) == 1 {
 				nameFilter = args[0]
 				if outputFormat == "table" {
@@ -544,6 +561,10 @@ var clusterPodsCmd = &cobra.Command{
 		nodeName, _ := cmd.Flags().GetString("node")
 		nameContains, _ := cmd.Flags().GetString("name")
 		outputFormat, _ := cmd.Flags().GetString("output")
+
+		if err := validateK8sOutputFormat(outputFormat); err != nil {
+			return err
+		}
 
 		if len(args) == 1 {
 			podName := args[0]
@@ -667,7 +688,7 @@ Example:
 		sinceSeconds, _ := cmd.Flags().GetInt("since")
 
 		if namespace == "" {
-			return errors.New("--namespace (-n) is required for logs")
+			return withExitCode(exitUsage, errors.New("--namespace (-n) is required for logs"))
 		}
 		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
@@ -718,6 +739,10 @@ Example:
 		outputFormat, _ := cmd.Flags().GetString("output")
 		apiVersion, _ := cmd.Flags().GetString("api-version")
 		apiGroup, _ := cmd.Flags().GetString("group")
+
+		if err := validateK8sOutputFormat(outputFormat); err != nil {
+			return err
+		}
 
 		if allNamespaces {
 			namespace = ""

--- a/cmd/cluster_k8s_test.go
+++ b/cmd/cluster_k8s_test.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"testing"
+
+	"ankra/internal/client"
+)
+
+// k8sResourcesMock returns two same-named resources with no formatRow-friendly
+// shape. Under the old code, `-o wide` on a named lookup fell through to the
+// table renderer and panicked on the named-pod path's nil formatRow; the up-front
+// output-format validation must reject the value before any API call.
+type k8sResourcesMock struct {
+	baseMock
+	called bool
+}
+
+func (m *k8sResourcesMock) GetResources(clusterID string, req client.GetResourcesRequest) (*client.GetResourcesResponse, error) {
+	m.called = true
+	return &client.GetResourcesResponse{
+		ResourceResponses: []client.ResourceResponseItem{
+			{Status: "ok", Kind: "Pod", Version: "v1", Items: []interface{}{
+				map[string]interface{}{"metadata": map[string]interface{}{"name": "web-1"}},
+				map[string]interface{}{"metadata": map[string]interface{}{"name": "web-2"}},
+			}},
+		},
+	}, nil
+}
+
+func (m *k8sResourcesMock) ListPods(clusterID string, opts *client.ListPodsOptions) (*client.ListPodsResponse, error) {
+	m.called = true
+	return &client.ListPodsResponse{}, nil
+}
+
+func TestValidateK8sOutputFormat(t *testing.T) {
+	for _, ok := range []string{"table", "json", "yaml"} {
+		if err := validateK8sOutputFormat(ok); err != nil {
+			t.Errorf("validateK8sOutputFormat(%q) = %v, want nil", ok, err)
+		}
+	}
+	err := validateK8sOutputFormat("wide")
+	if err == nil {
+		t.Fatal("expected an error for -o wide")
+	}
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("-o wide should classify as exitUsage (%d), got %d", exitUsage, got)
+	}
+}
+
+// TestGetPodsNamedWideExitsUsageNoPanic drives `cluster get pods <name> -o wide`
+// end-to-end. It must exit usage (2) and must not panic; the mock records
+// whether the API was reached so we can confirm the value is rejected up front.
+func TestGetPodsNamedWideExitsUsageNoPanic(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	mock := &k8sResourcesMock{}
+	setMockClient(t, mock)
+
+	_, err := executeCommand("cluster", "get", "pods", "web", "-o", "wide")
+	if err == nil {
+		t.Fatal("expected a usage error for -o wide on a named pod")
+	}
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("-o wide on get pods <name> should exit %d, got %d", exitUsage, got)
+	}
+	if mock.called {
+		t.Error("invalid output format should be rejected before any API call")
+	}
+}
+
+// TestGetDeploymentsNamedWideExitsUsageNoPanic exercises the registerKindCommand
+// family (deployments) on the same panic-prone named-lookup path.
+func TestGetDeploymentsNamedWideExitsUsageNoPanic(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	mock := &k8sResourcesMock{}
+	setMockClient(t, mock)
+
+	_, err := executeCommand("cluster", "get", "deployments", "web", "-o", "wide")
+	if err == nil {
+		t.Fatal("expected a usage error for -o wide on a named deployment")
+	}
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("-o wide on get deployments <name> should exit %d, got %d", exitUsage, got)
+	}
+	if mock.called {
+		t.Error("invalid output format should be rejected before any API call")
+	}
+}
+
+// TestResourcesWideExitsUsage confirms the generic `cluster resources` command
+// rejects an unsupported -o value up front with exitUsage, matching the
+// get/pods family rather than silently rendering a table.
+func TestResourcesWideExitsUsage(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	mock := &k8sResourcesMock{}
+	setMockClient(t, mock)
+
+	_, err := executeCommand("cluster", "resources", "PersistentVolumeClaim", "-o", "wide")
+	if err == nil {
+		t.Fatal("expected a usage error for -o wide on cluster resources")
+	}
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("-o wide on cluster resources should exit %d, got %d", exitUsage, got)
+	}
+	if mock.called {
+		t.Error("invalid output format should be rejected before any API call")
+	}
+}

--- a/cmd/cluster_node_group.go
+++ b/cmd/cluster_node_group.go
@@ -280,9 +280,18 @@ var clusterNodeGroupDeleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		groupName := args[1]
+		yes, _ := cmd.Flags().GetBool("yes")
 		kind, kindError := resolveNodeGroupClusterKind(clusterID)
 		if kindError != nil {
 			return kindError
+		}
+
+		if err := confirmPrompt(
+			cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Delete node group %q from cluster %q? This deletes all its nodes! [y/N]: ", groupName, clusterID),
+			yes,
+		); err != nil {
+			return err
 		}
 
 		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
@@ -325,6 +334,8 @@ func init() {
 	registerAsyncWriteFlags(clusterNodeGroupScaleCmd)
 	registerAsyncWriteFlags(clusterNodeGroupUpgradeCmd)
 	registerAsyncWriteFlags(clusterNodeGroupDeleteCmd)
+
+	clusterNodeGroupDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
 	registerStructuredOutputFlags(
 		clusterNodeGroupListCmd,

--- a/cmd/cluster_partial.go
+++ b/cmd/cluster_partial.go
@@ -349,10 +349,16 @@ func mapPatchError(perr *client.PatchStackError) error {
 	case http.StatusBadRequest:
 		return fmt.Errorf("request rejected by API: %s", detail)
 	case http.StatusForbidden:
+		// 403 is a rejected credential/permission: classify as exitAuth while
+		// keeping the human-readable message identical.
 		if strings.Contains(strings.ToLower(string(perr.Body)), "sandbox") {
-			return errors.New("sandbox clusters cannot be patched via the CLI; promote the cluster first")
+			return withExitCode(exitAuth, errors.New("sandbox clusters cannot be patched via the CLI; promote the cluster first"))
 		}
-		return fmt.Errorf("forbidden: %s", detail)
+		return withExitCode(exitAuth, fmt.Errorf("forbidden: %s", detail))
+	case http.StatusNotFound:
+		// The stack or cluster does not exist: classify as exitNotFound while
+		// preserving the historical default-branch message shape.
+		return withExitCode(exitNotFound, fmt.Errorf("update stack failed: status %d, body: %s", perr.StatusCode, detail))
 	case http.StatusConflict:
 		return fmt.Errorf("cluster is not available — stack may be pending deletion or cluster is deprovisioned: %s", detail)
 	case http.StatusUnprocessableEntity:
@@ -363,9 +369,15 @@ func mapPatchError(perr *client.PatchStackError) error {
 		}
 		return fmt.Errorf("git push failed: %s", detail)
 	case http.StatusUnauthorized:
-		return errors.New("unauthorized. Run `ankra login` to re-authenticate")
+		// Wrap ErrUnauthorized (whose message is byte-for-byte identical to the
+		// historical text) so errors.Is matches and the exit code is exitAuth.
+		return client.ErrUnauthorized
 	}
-	return fmt.Errorf("update stack failed: status %d, body: %s", perr.StatusCode, detail)
+	// 5xx and any other unexpected status: wrap an *UnexpectedResponseError
+	// carrying the status code so the root-level support hint fires. The
+	// message text is unchanged from the historical default branch.
+	return client.NewUnexpectedResponseError(perr.StatusCode,
+		fmt.Sprintf("update stack failed: status %d, body: %s", perr.StatusCode, detail))
 }
 
 // extractDetail tries to surface the FastAPI `detail` field; falls back to

--- a/cmd/cluster_partial_test.go
+++ b/cmd/cluster_partial_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -424,6 +425,66 @@ func TestMapPatchError_StatusCodes(t *testing.T) {
 				t.Errorf("error %q does not contain %q", got.Error(), tc.wantSub)
 			}
 		})
+	}
+}
+
+func TestMapPatchError_ExitCodeClassification(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		wantExit   int
+	}{
+		{"401 unauthorized -> exitAuth", 401, exitAuth},
+		{"403 forbidden -> exitAuth", 403, exitAuth},
+		{"404 not found -> exitNotFound", 404, exitNotFound},
+		{"500 server error -> exitError", 500, exitError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			perr := &client.PatchStackError{StatusCode: tc.statusCode, Body: []byte(`{"detail":"boom"}`)}
+			err := mapPatchError(perr)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if got := exitCodeFor(err); got != tc.wantExit {
+				t.Errorf("exitCodeFor(mapPatchError(%d)) = %d, want %d", tc.statusCode, got, tc.wantExit)
+			}
+		})
+	}
+}
+
+func TestMapPatchError_ServerErrorTriggersSupportHint(t *testing.T) {
+	perr := &client.PatchStackError{StatusCode: 500, Body: []byte(`{"detail":"boom"}`)}
+	err := mapPatchError(perr)
+	var unexpected *client.UnexpectedResponseError
+	if !errors.As(err, &unexpected) {
+		t.Fatalf("5xx should wrap *client.UnexpectedResponseError so the support hint fires, got %T: %v", err, err)
+	}
+	if unexpected.StatusCode != 500 {
+		t.Errorf("wrapped status = %d, want 500", unexpected.StatusCode)
+	}
+	if got := err.Error(); !strings.Contains(got, "status 500") {
+		t.Errorf("message text changed: %q", got)
+	}
+}
+
+func TestMapPatchError_MessagesUnchanged(t *testing.T) {
+	cases := []struct {
+		statusCode int
+		body       string
+		want       string
+	}{
+		{401, ``, "unauthorized. Run `ankra login` to re-authenticate"},
+		{403, `{"detail":"nope"}`, "forbidden: nope"},
+		{403, `sandbox mode enabled`, "sandbox clusters cannot be patched via the CLI; promote the cluster first"},
+		{404, `{"detail":"missing"}`, "update stack failed: status 404, body: missing"},
+		{500, `{"detail":"boom"}`, "update stack failed: status 500, body: boom"},
+	}
+	for _, tc := range cases {
+		perr := &client.PatchStackError{StatusCode: tc.statusCode, Body: []byte(tc.body)}
+		if got := mapPatchError(perr).Error(); got != tc.want {
+			t.Errorf("status %d message = %q, want %q", tc.statusCode, got, tc.want)
+		}
 	}
 }
 

--- a/cmd/cluster_select.go
+++ b/cmd/cluster_select.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"os"
@@ -13,6 +14,15 @@ import (
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 )
+
+// isPromptCancellation reports whether a promptui error signals that the user
+// aborted the picker (Ctrl+C, ESC/abort, or EOF) rather than a real failure.
+// Callers map it to errCancelled so an aborted picker exits with exitCancelled.
+func isPromptCancellation(err error) bool {
+	return errors.Is(err, promptui.ErrInterrupt) ||
+		errors.Is(err, promptui.ErrAbort) ||
+		errors.Is(err, promptui.ErrEOF)
+}
 
 type SelectableItem struct {
 	IsLoadMore bool
@@ -74,6 +84,9 @@ func selectClusterInteractive() error {
 		fetchedClusters = updatedFetchedClusters
 		i, _, err := prompt.Run()
 		if err != nil {
+			if isPromptCancellation(err) {
+				return errCancelled
+			}
 			return fmt.Errorf("prompt failed: %w", err)
 		}
 		selectedItem := selectableItems[i]

--- a/cmd/cluster_select_test.go
+++ b/cmd/cluster_select_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/manifoldco/promptui"
+)
+
+// TestIsPromptCancellation asserts that promptui's abort signals (Ctrl+C, ESC,
+// EOF) are recognised as cancellations while real errors are not. The
+// interactive picker itself needs a TTY, so cover the mapping via this helper.
+func TestIsPromptCancellation(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"interrupt", promptui.ErrInterrupt, true},
+		{"abort", promptui.ErrAbort, true},
+		{"eof", promptui.ErrEOF, true},
+		{"wrapped interrupt", fmt.Errorf("prompt: %w", promptui.ErrInterrupt), true},
+		{"real error", errors.New("backend unreachable"), false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isPromptCancellation(tc.err); got != tc.want {
+				t.Errorf("isPromptCancellation(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPickerAbortMapsToCancelledExit asserts that when the picker abort is
+// mapped to errCancelled, it classifies as exitCancelled (exit 4) rather than
+// the generic failure code.
+func TestPickerAbortMapsToCancelledExit(t *testing.T) {
+	if !isPromptCancellation(promptui.ErrInterrupt) {
+		t.Fatal("interrupt should be treated as a cancellation")
+	}
+	// The handler returns errCancelled for a cancellation; confirm that
+	// sentinel still carries exitCancelled.
+	if got := exitCodeFor(errCancelled); got != exitCancelled {
+		t.Errorf("picker abort should exit %d, got %d", exitCancelled, got)
+	}
+}

--- a/cmd/cluster_stacks.go
+++ b/cmd/cluster_stacks.go
@@ -57,7 +57,7 @@ var clusterStacksListCmd = &cobra.Command{
 				}
 			}
 			if found == nil {
-				return fmt.Errorf("stack %q not found on the active cluster", name)
+				return withExitCode(exitNotFound, fmt.Errorf("stack %q not found on the active cluster", name))
 			}
 			if rendered, err := renderStructured(cmd, found); rendered || err != nil {
 				return err
@@ -217,9 +217,18 @@ var clusterStacksDeleteCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		stackName := args[0]
+		yes, _ := cmd.Flags().GetBool("yes")
 
 		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
+			return err
+		}
+
+		if err := confirmPrompt(
+			cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Delete stack %q from cluster %q? This removes every addon and manifest in the stack! [y/N]: ", stackName, cluster.Name),
+			yes,
+		); err != nil {
 			return err
 		}
 
@@ -443,6 +452,8 @@ func resolveClusterID(nameOrID string) (string, error) {
 
 func init() {
 	clusterStacksCreateCmd.Flags().String("description", "", "Description for the stack")
+
+	clusterStacksDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
 	// Clone command flags
 	clusterStacksCloneCmd.Flags().StringP("to", "t", "", "Target cluster name or ID (required)")

--- a/cmd/confirm_core_test.go
+++ b/cmd/confirm_core_test.go
@@ -1,0 +1,336 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// resetTreeFlags restores every flag on the given commands (and the shared
+// persistent --cluster override) to its default so the package-level rootCmd
+// does not leak state between confirm-prompt test cases.
+func resetTreeFlags(t *testing.T, cmds ...*cobra.Command) {
+	t.Helper()
+	cmds = append(cmds, clusterCmd)
+	for _, command := range cmds {
+		command.Flags().VisitAll(func(flag *pflag.Flag) {
+			_ = flag.Value.Set(flag.DefValue)
+			flag.Changed = false
+		})
+		command.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
+			_ = flag.Value.Set(flag.DefValue)
+			flag.Changed = false
+		})
+	}
+}
+
+// runConfirmCommand executes rootCmd end-to-end with the given stdin, capturing
+// combined output. It mirrors runSupportWithInput but is scoped to the
+// destructive-confirmation commands under test here.
+func runConfirmCommand(t *testing.T, mock APIClient, input string, resets []*cobra.Command, args ...string) (string, error) {
+	t.Helper()
+	withTempHome(t)
+	setMockClient(t, mock)
+	out := new(bytes.Buffer)
+	rootCmd.SetOut(out)
+	rootCmd.SetErr(out)
+	rootCmd.SetIn(strings.NewReader(input))
+	rootCmd.SetArgs(args)
+	t.Cleanup(func() { resetTreeFlags(t, resets...) })
+	err := rootCmd.Execute()
+	return out.String(), err
+}
+
+// --- cluster stacks delete ------------------------------------------------
+
+type stacksDeleteMock struct {
+	baseMock
+	cluster     client.ClusterListItem
+	deleteCalls int
+}
+
+func (m *stacksDeleteMock) GetCluster(name string) (client.ClusterListItem, error) {
+	if m.cluster.Name == name || m.cluster.ID == name {
+		return m.cluster, nil
+	}
+	return client.ClusterListItem{}, errors.New("not found")
+}
+
+func (m *stacksDeleteMock) DeleteStack(ctx context.Context, clusterID, stackName string) (*client.DeleteStackResult, error) {
+	m.deleteCalls++
+	return &client.DeleteStackResult{Success: true}, nil
+}
+
+func TestClusterStacksDelete_DeclineDoesNotDelete(t *testing.T) {
+	mock := &stacksDeleteMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo"}}
+	_, err := runConfirmCommand(t, mock, "n\n",
+		[]*cobra.Command{clusterStacksDeleteCmd},
+		"cluster", "stacks", "delete", "platform", "--cluster", "demo")
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled on decline, got %v", err)
+	}
+	if got := exitCodeFor(err); got != exitCancelled {
+		t.Errorf("expected exit code %d, got %d", exitCancelled, got)
+	}
+	if mock.deleteCalls != 0 {
+		t.Errorf("expected no delete call on decline, got %d", mock.deleteCalls)
+	}
+}
+
+func TestClusterStacksDelete_YesFlagProceeds(t *testing.T) {
+	mock := &stacksDeleteMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo"}}
+	_, err := runConfirmCommand(t, mock, "",
+		[]*cobra.Command{clusterStacksDeleteCmd},
+		"cluster", "stacks", "delete", "platform", "--cluster", "demo", "--yes")
+	if err != nil {
+		t.Fatalf("expected success with --yes, got %v", err)
+	}
+	if mock.deleteCalls != 1 {
+		t.Errorf("expected one delete call with --yes, got %d", mock.deleteCalls)
+	}
+}
+
+func TestClusterStacksDelete_PipedYesProceeds(t *testing.T) {
+	mock := &stacksDeleteMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo"}}
+	_, err := runConfirmCommand(t, mock, "y\n",
+		[]*cobra.Command{clusterStacksDeleteCmd},
+		"cluster", "stacks", "delete", "platform", "--cluster", "demo")
+	if err != nil {
+		t.Fatalf("expected success with piped y, got %v", err)
+	}
+	if mock.deleteCalls != 1 {
+		t.Errorf("expected one delete call with piped y, got %d", mock.deleteCalls)
+	}
+}
+
+// --- cluster stacks list <name> not found ---------------------------------
+
+type stacksListMock struct {
+	baseMock
+	cluster client.ClusterListItem
+	stacks  []client.ClusterStackListItem
+}
+
+func (m *stacksListMock) GetCluster(name string) (client.ClusterListItem, error) {
+	if m.cluster.Name == name || m.cluster.ID == name {
+		return m.cluster, nil
+	}
+	return client.ClusterListItem{}, errors.New("not found")
+}
+
+func (m *stacksListMock) ListClusterStacks(clusterID string) ([]client.ClusterStackListItem, error) {
+	return m.stacks, nil
+}
+
+func TestClusterStacksList_NotFoundUsesExitNotFound(t *testing.T) {
+	mock := &stacksListMock{
+		cluster: client.ClusterListItem{ID: "c-1", Name: "demo"},
+		stacks:  []client.ClusterStackListItem{{Name: "other"}},
+	}
+	_, err := runConfirmCommand(t, mock, "",
+		[]*cobra.Command{clusterStacksListCmd},
+		"cluster", "stacks", "list", "missing", "--cluster", "demo")
+	if err == nil {
+		t.Fatal("expected an error for a missing stack")
+	}
+	if got := exitCodeFor(err); got != exitNotFound {
+		t.Errorf("expected exit code %d for missing stack, got %d", exitNotFound, got)
+	}
+}
+
+// --- cluster deprovision --------------------------------------------------
+
+type deprovisionMock struct {
+	baseMock
+	cluster     client.ClusterListItem
+	deleteCalls int
+}
+
+func (m *deprovisionMock) GetClusterByID(clusterID string) (client.ClusterListItem, error) {
+	if m.cluster.ID == clusterID {
+		return m.cluster, nil
+	}
+	return client.ClusterListItem{}, errors.New("not found")
+}
+
+func (m *deprovisionMock) GetCluster(name string) (client.ClusterListItem, error) {
+	if m.cluster.Name == name || m.cluster.ID == name {
+		return m.cluster, nil
+	}
+	return client.ClusterListItem{}, errors.New("not found")
+}
+
+func (m *deprovisionMock) DeprovisionCluster(ctx context.Context, clusterID string, autoDelete, force bool) (*client.DeprovisionClusterResult, error) {
+	m.deleteCalls++
+	return &client.DeprovisionClusterResult{}, nil
+}
+
+func TestClusterDeprovision_DeclineDoesNotDeprovision(t *testing.T) {
+	// Kind is intentionally empty so the generic deprovision path is used.
+	mock := &deprovisionMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo"}}
+	_, err := runConfirmCommand(t, mock, "n\n",
+		[]*cobra.Command{clusterDeprovisionCmd},
+		"cluster", "deprovision", "demo")
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled on decline, got %v", err)
+	}
+	if got := exitCodeFor(err); got != exitCancelled {
+		t.Errorf("expected exit code %d, got %d", exitCancelled, got)
+	}
+	if mock.deleteCalls != 0 {
+		t.Errorf("expected no deprovision call on decline, got %d", mock.deleteCalls)
+	}
+}
+
+func TestClusterDeprovision_YesFlagProceeds(t *testing.T) {
+	mock := &deprovisionMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo"}}
+	_, err := runConfirmCommand(t, mock, "",
+		[]*cobra.Command{clusterDeprovisionCmd},
+		"cluster", "deprovision", "demo", "--yes")
+	if err != nil {
+		t.Fatalf("expected success with --yes, got %v", err)
+	}
+	if mock.deleteCalls != 1 {
+		t.Errorf("expected one deprovision call with --yes, got %d", mock.deleteCalls)
+	}
+}
+
+func TestClusterDeprovision_PipedYesProceeds(t *testing.T) {
+	mock := &deprovisionMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo"}}
+	_, err := runConfirmCommand(t, mock, "y\n",
+		[]*cobra.Command{clusterDeprovisionCmd},
+		"cluster", "deprovision", "demo")
+	if err != nil {
+		t.Fatalf("expected success with piped y, got %v", err)
+	}
+	if mock.deleteCalls != 1 {
+		t.Errorf("expected one deprovision call with piped y, got %d", mock.deleteCalls)
+	}
+}
+
+// --- cluster node-group delete --------------------------------------------
+
+type nodeGroupDeleteMock struct {
+	baseMock
+	cluster     client.ClusterListItem
+	deleteCalls int
+}
+
+func (m *nodeGroupDeleteMock) GetClusterByID(clusterID string) (client.ClusterListItem, error) {
+	if m.cluster.ID == clusterID {
+		return m.cluster, nil
+	}
+	return client.ClusterListItem{}, errors.New("not found")
+}
+
+func (m *nodeGroupDeleteMock) DeleteHetznerNodeGroup(ctx context.Context, clusterID, groupName string, wait bool) (*client.DeleteNodeGroupResult, bool, error) {
+	m.deleteCalls++
+	return &client.DeleteNodeGroupResult{GroupName: groupName, Deleted: 1}, false, nil
+}
+
+func TestClusterNodeGroupDelete_DeclineDoesNotDelete(t *testing.T) {
+	mock := &nodeGroupDeleteMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo", Kind: "hetzner"}}
+	_, err := runConfirmCommand(t, mock, "n\n",
+		[]*cobra.Command{clusterNodeGroupDeleteCmd},
+		"cluster", "node-group", "delete", "c-1", "workers")
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled on decline, got %v", err)
+	}
+	if got := exitCodeFor(err); got != exitCancelled {
+		t.Errorf("expected exit code %d, got %d", exitCancelled, got)
+	}
+	if mock.deleteCalls != 0 {
+		t.Errorf("expected no delete call on decline, got %d", mock.deleteCalls)
+	}
+}
+
+func TestClusterNodeGroupDelete_YesFlagProceeds(t *testing.T) {
+	mock := &nodeGroupDeleteMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo", Kind: "hetzner"}}
+	_, err := runConfirmCommand(t, mock, "",
+		[]*cobra.Command{clusterNodeGroupDeleteCmd},
+		"cluster", "node-group", "delete", "c-1", "workers", "--yes")
+	if err != nil {
+		t.Fatalf("expected success with --yes, got %v", err)
+	}
+	if mock.deleteCalls != 1 {
+		t.Errorf("expected one delete call with --yes, got %d", mock.deleteCalls)
+	}
+}
+
+func TestClusterNodeGroupDelete_PipedYesProceeds(t *testing.T) {
+	mock := &nodeGroupDeleteMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo", Kind: "hetzner"}}
+	_, err := runConfirmCommand(t, mock, "y\n",
+		[]*cobra.Command{clusterNodeGroupDeleteCmd},
+		"cluster", "node-group", "delete", "c-1", "workers")
+	if err != nil {
+		t.Fatalf("expected success with piped y, got %v", err)
+	}
+	if mock.deleteCalls != 1 {
+		t.Errorf("expected one delete call with piped y, got %d", mock.deleteCalls)
+	}
+}
+
+// --- credentials delete ----------------------------------------------------
+
+type credentialsDeleteMock struct {
+	baseMock
+	deleteCalls int
+}
+
+func (m *credentialsDeleteMock) ListOrganisations() ([]client.OrganisationSummary, error) {
+	return []client.OrganisationSummary{{OrganisationID: "org-1", UserCurrent: true}}, nil
+}
+
+func (m *credentialsDeleteMock) DeleteCredential(ctx context.Context, credentialID, organisationID string) (*client.DeleteCredentialResult, error) {
+	m.deleteCalls++
+	return &client.DeleteCredentialResult{Success: true}, nil
+}
+
+func TestCredentialsDelete_DeclineDoesNotDelete(t *testing.T) {
+	mock := &credentialsDeleteMock{}
+	_, err := runConfirmCommand(t, mock, "n\n",
+		[]*cobra.Command{credentialsDeleteCmd},
+		"credentials", "delete", "cred-1")
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled on decline, got %v", err)
+	}
+	if got := exitCodeFor(err); got != exitCancelled {
+		t.Errorf("expected exit code %d, got %d", exitCancelled, got)
+	}
+	if mock.deleteCalls != 0 {
+		t.Errorf("expected no delete call on decline, got %d", mock.deleteCalls)
+	}
+}
+
+func TestCredentialsDelete_YesFlagProceeds(t *testing.T) {
+	mock := &credentialsDeleteMock{}
+	_, err := runConfirmCommand(t, mock, "",
+		[]*cobra.Command{credentialsDeleteCmd},
+		"credentials", "delete", "cred-1", "--yes")
+	if err != nil {
+		t.Fatalf("expected success with --yes, got %v", err)
+	}
+	if mock.deleteCalls != 1 {
+		t.Errorf("expected one delete call with --yes, got %d", mock.deleteCalls)
+	}
+}
+
+func TestCredentialsDelete_PipedYesProceeds(t *testing.T) {
+	mock := &credentialsDeleteMock{}
+	_, err := runConfirmCommand(t, mock, "y\n",
+		[]*cobra.Command{credentialsDeleteCmd},
+		"credentials", "delete", "cred-1")
+	if err != nil {
+		t.Fatalf("expected success with piped y, got %v", err)
+	}
+	if mock.deleteCalls != 1 {
+		t.Errorf("expected one delete call with piped y, got %d", mock.deleteCalls)
+	}
+}

--- a/cmd/credentials.go
+++ b/cmd/credentials.go
@@ -120,6 +120,15 @@ var credentialsDeleteCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		credentialID := args[0]
+		yes, _ := cmd.Flags().GetBool("yes")
+
+		if err := confirmPrompt(
+			cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Delete credential %q? Clusters using it will fail to reconcile! [y/N]: ", credentialID),
+			yes,
+		); err != nil {
+			return err
+		}
 
 		var orgID string
 		local, err := loadSelectedOrganisation()
@@ -254,6 +263,7 @@ func looksLikeUUID(s string) bool {
 
 func init() {
 	credentialsListCmd.Flags().String("provider", "", "Filter by provider (e.g., github)")
+	credentialsDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
 	registerStructuredOutputFlags(credentialsListCmd, credentialsGetCmd)
 

--- a/cmd/hetzner_cluster.go
+++ b/cmd/hetzner_cluster.go
@@ -105,6 +105,13 @@ var hetznerDeprovisionCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		force, _ := cmd.Flags().GetBool("force")
+		yes, _ := cmd.Flags().GetBool("yes")
+
+		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Deprovision Hetzner cluster %q? This deletes all its servers, networks and SSH keys! [y/N]: ", clusterID),
+			yes); err != nil {
+			return err
+		}
 
 		result, err := apiClient.DeprovisionHetznerCluster(clusterID, force)
 		if err != nil {
@@ -418,6 +425,13 @@ var nodeGroupDeleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		groupName := args[1]
+		yes, _ := cmd.Flags().GetBool("yes")
+
+		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Delete node group %q from cluster %q? This deletes all its nodes! [y/N]: ", groupName, clusterID),
+			yes); err != nil {
+			return err
+		}
 
 		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
 		if err != nil {
@@ -535,6 +549,8 @@ func init() {
 	_ = hetznerCreateCmd.MarkFlagRequired("location")
 
 	hetznerDeprovisionCmd.Flags().Bool("force", false, "Force deprovision without waiting for the cluster agent (use only when the cluster agent is permanently offline; cloud resources may leak)")
+	hetznerDeprovisionCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
+	nodeGroupDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
 	hetznerLocationsCmd.Flags().String("credential-id", "", "Hetzner API credential ID (required)")
 	_ = hetznerLocationsCmd.MarkFlagRequired("credential-id")

--- a/cmd/hetzner_cluster_test.go
+++ b/cmd/hetzner_cluster_test.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type hetznerDeprovisionMock struct {
+	baseMock
+	called       bool
+	gotClusterID string
+	gotForce     bool
+}
+
+func (m *hetznerDeprovisionMock) DeprovisionHetznerCluster(clusterID string, force bool) (*client.DeprovisionHetznerClusterResponse, error) {
+	m.called = true
+	m.gotClusterID = clusterID
+	m.gotForce = force
+	return &client.DeprovisionHetznerClusterResponse{Success: true, ClusterID: clusterID}, nil
+}
+
+type hetznerNodeGroupDeleteMock struct {
+	baseMock
+	called       bool
+	gotClusterID string
+	gotGroupName string
+}
+
+func (m *hetznerNodeGroupDeleteMock) DeleteHetznerNodeGroup(ctx context.Context, clusterID, groupName string, wait bool) (*client.DeleteNodeGroupResult, bool, error) {
+	m.called = true
+	m.gotClusterID = clusterID
+	m.gotGroupName = groupName
+	return &client.DeleteNodeGroupResult{GroupName: groupName, Deleted: 1}, false, nil
+}
+
+// resetConfirmFlag clears the flags on the given commands to their defaults
+// before and after the test. The reset runs on cleanup as well so a persistent
+// flag set here (e.g. --cluster on clusterCmd) does not leak into later tests.
+func resetConfirmFlag(t *testing.T, commands ...*cobra.Command) {
+	t.Helper()
+	reset := func() {
+		for _, command := range commands {
+			command.Flags().VisitAll(func(flag *pflag.Flag) {
+				_ = flag.Value.Set(flag.DefValue)
+				flag.Changed = false
+			})
+		}
+	}
+	reset()
+	t.Cleanup(reset)
+}
+
+func runWithInput(t *testing.T, mock APIClient, input string, args ...string) (string, error) {
+	t.Helper()
+	setMockClient(t, mock)
+	out := &strings.Builder{}
+	rootCmd.SetOut(out)
+	rootCmd.SetErr(out)
+	rootCmd.SetIn(strings.NewReader(input))
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	return out.String(), err
+}
+
+func TestHetznerDeprovision_DeclineDoesNotCallAPI(t *testing.T) {
+	mock := &hetznerDeprovisionMock{}
+	resetConfirmFlag(t, hetznerDeprovisionCmd)
+	_, err := runWithInput(t, mock, "n\n", "cluster", "hetzner", "deprovision", "hz-123")
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled on decline, got %v", err)
+	}
+	if mock.called {
+		t.Error("expected no deprovision call when declined")
+	}
+}
+
+func TestHetznerDeprovision_YesProceeds(t *testing.T) {
+	mock := &hetznerDeprovisionMock{}
+	resetConfirmFlag(t, hetznerDeprovisionCmd)
+	out, err := runWithInput(t, mock, "", "cluster", "hetzner", "deprovision", "hz-123", "--yes")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if !mock.called {
+		t.Fatal("expected deprovision call with --yes")
+	}
+	if mock.gotClusterID != "hz-123" {
+		t.Errorf("cluster id = %q, want hz-123", mock.gotClusterID)
+	}
+}
+
+func TestHetznerDeprovision_YesPreservesForce(t *testing.T) {
+	mock := &hetznerDeprovisionMock{}
+	resetConfirmFlag(t, hetznerDeprovisionCmd)
+	_, err := runWithInput(t, mock, "", "cluster", "hetzner", "deprovision", "hz-123", "--yes", "--force")
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if !mock.gotForce {
+		t.Error("expected --force to still reach the API alongside --yes")
+	}
+}
+
+func TestHetznerNodeGroupDelete_DeclineDoesNotCallAPI(t *testing.T) {
+	mock := &hetznerNodeGroupDeleteMock{}
+	resetConfirmFlag(t, nodeGroupDeleteCmd)
+	_, err := runWithInput(t, mock, "n\n", "cluster", "hetzner", "node-group", "delete", "hz-123", "workers")
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled on decline, got %v", err)
+	}
+	if mock.called {
+		t.Error("expected no delete call when declined")
+	}
+}
+
+func TestHetznerNodeGroupDelete_YesProceeds(t *testing.T) {
+	mock := &hetznerNodeGroupDeleteMock{}
+	resetConfirmFlag(t, nodeGroupDeleteCmd)
+	out, err := runWithInput(t, mock, "", "cluster", "hetzner", "node-group", "delete", "hz-123", "workers", "--yes")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if !mock.called {
+		t.Fatal("expected delete call with --yes")
+	}
+	if mock.gotClusterID != "hz-123" || mock.gotGroupName != "workers" {
+		t.Errorf("got cluster=%q group=%q, want hz-123/workers", mock.gotClusterID, mock.gotGroupName)
+	}
+}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -365,12 +365,18 @@ func runLogin() error {
 
 	viper.Set("token", tokenData.Token)
 	viper.Set("base-url", loginURL)
+	viper.Set("machine_id", machineID)
 	if tokenData.TokenID != "" {
 		viper.Set("token_id", tokenData.TokenID)
 	}
 	if tokenData.TokenName != "" {
 		viper.Set("token_name", tokenData.TokenName)
 	}
+
+	// Second belt: if viper has to create the file (SafeWriteConfig path),
+	// have it do so with 0600 rather than its default so the token never
+	// briefly lands in a world-readable file.
+	viper.SetConfigPermissions(0o600)
 
 	if err := viper.WriteConfig(); err != nil {
 		if safeErr := viper.SafeWriteConfig(); safeErr != nil {
@@ -519,6 +525,14 @@ func formatExpiry(expiresAt string) string {
 	return t.Format("January 2, 2006")
 }
 
+// getOrCreateMachineID returns the machine ID for this host. It is read-only:
+// when a machine_id is already saved it is returned as-is, otherwise the ID is
+// derived in memory and returned WITHOUT writing anything to disk. Persisting
+// it is the caller's job (see the save block in runLogin), which only happens
+// after ensureSecureConfigFile has created the config file with 0600
+// permissions. Writing here previously created ~/.ankra.yaml world-readable
+// with the ANKRA_API_TOKEN env value bound into the global viper, leaking the
+// token if login then failed or was cancelled.
 func getOrCreateMachineID() string {
 	configPath := getConfigPath()
 	viper.SetConfigFile(configPath)
@@ -544,9 +558,6 @@ func getOrCreateMachineID() string {
 	rawID := fmt.Sprintf("%s-%s", sanitizeIdentifier(hostname), sanitizeIdentifier(username))
 	hash := sha256.Sum256([]byte(rawID))
 	machineID = hex.EncodeToString(hash[:16])
-
-	viper.Set("machine_id", machineID)
-	_ = viper.WriteConfig()
 
 	return machineID
 }

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -7,8 +7,11 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/spf13/viper"
 )
 
 func TestEnsureSecureConfigFileCreatesWithRestrictedPerms(t *testing.T) {
@@ -133,5 +136,111 @@ func TestPollMFATokenExpired(t *testing.T) {
 	_, _, err := pollMFAToken(server.URL, []byte(`{"ticket":"gone"}`))
 	if err == nil {
 		t.Fatal("expected expired MFA ticket error")
+	}
+}
+
+// TestGetOrCreateMachineIDDoesNotWriteConfig guards the credential-leak fix:
+// getOrCreateMachineID must be read-only. With ANKRA_API_TOKEN bound into the
+// global viper and no existing ~/.ankra.yaml, the old write-on-miss behavior
+// created the config file 0644 containing the env token, which persisted if
+// login then failed or was cancelled. The function must now derive the ID in
+// memory and touch nothing on disk.
+func TestGetOrCreateMachineIDDoesNotWriteConfig(t *testing.T) {
+	withFreshViperAndEnv(t)
+	home := withTempHome(t)
+	t.Setenv("ANKRA_API_TOKEN", "secret-env-token")
+
+	// Bind the env token into the global viper exactly as initConfig does, so
+	// a stray WriteConfig would serialize it into the file.
+	viper.AutomaticEnv()
+	if err := viper.BindEnv("token", envAnkraAPIToken); err != nil {
+		t.Fatalf("bind token env: %v", err)
+	}
+
+	configPath := filepath.Join(home, ".ankra.yaml")
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("precondition: config file already exists (err=%v)", err)
+	}
+
+	machineID := getOrCreateMachineID()
+	if machineID == "" {
+		t.Fatal("expected a non-empty machine ID")
+	}
+
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("getOrCreateMachineID must not create %s (stat err=%v)", configPath, err)
+	}
+}
+
+// TestGetOrCreateMachineIDStableForExistingID confirms a saved machine_id is
+// returned verbatim so previously derived IDs stay stable across the fix.
+func TestGetOrCreateMachineIDStableForExistingID(t *testing.T) {
+	withFreshViperAndEnv(t)
+	home := withTempHome(t)
+
+	configPath := filepath.Join(home, ".ankra.yaml")
+	if err := os.WriteFile(configPath, []byte("machine_id: saved-machine-id\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if got := getOrCreateMachineID(); got != "saved-machine-id" {
+		t.Fatalf("machine ID = %q, want saved-machine-id", got)
+	}
+}
+
+// TestLoginSaveBlockPersistsSecureConfig exercises the final save path from
+// runLogin: after ensureSecureConfigFile creates the file 0600 and the token,
+// base-url, and machine_id are written, the file must be 0600 and contain the
+// machine_id. This mirrors the production save block (login.go) so the belt
+// (SetConfigPermissions) and the moved machine_id persistence are covered.
+func TestLoginSaveBlockPersistsSecureConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission semantics differ on Windows")
+	}
+	withFreshViperAndEnv(t)
+	home := withTempHome(t)
+	t.Setenv("ANKRA_API_TOKEN", "secret-env-token")
+
+	viper.AutomaticEnv()
+	if err := viper.BindEnv("token", envAnkraAPIToken); err != nil {
+		t.Fatalf("bind token env: %v", err)
+	}
+
+	machineID := getOrCreateMachineID()
+
+	configPath := filepath.Join(home, ".ankra.yaml")
+	if err := ensureSecureConfigFile(configPath); err != nil {
+		t.Fatalf("ensureSecureConfigFile: %v", err)
+	}
+
+	viper.SetConfigFile(configPath)
+	viper.SetConfigType("yaml")
+	_ = viper.ReadInConfig()
+
+	viper.Set("token", "login-token")
+	viper.Set("base-url", "https://platform.ankra.app")
+	viper.Set("machine_id", machineID)
+	viper.SetConfigPermissions(0o600)
+
+	if err := viper.WriteConfig(); err != nil {
+		if safeErr := viper.SafeWriteConfig(); safeErr != nil {
+			t.Fatalf("write config: %v", err)
+		}
+	}
+
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Errorf("expected mode 0600, got %#o", mode)
+	}
+
+	contents, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !strings.Contains(string(contents), "machine_id: "+machineID) {
+		t.Errorf("config missing persisted machine_id; got:\n%s", contents)
 	}
 }

--- a/cmd/organisation.go
+++ b/cmd/organisation.go
@@ -115,7 +115,13 @@ var orgSwitchCmd = &cobra.Command{
 
 		targetOrg, err := resolveOrganisationReference(orgs, reference)
 		if err != nil {
-			return err
+			// A genuinely unknown organisation is a missing target (exit 3);
+			// an ambiguous reference is a fixable invocation (exit 2). Both
+			// keep their human-readable message.
+			if errors.Is(err, errOrganisationNotFound) {
+				return withExitCode(exitNotFound, err)
+			}
+			return withExitCode(exitUsage, err)
 		}
 
 		resp, err := apiClient.SwitchOrganisation(targetOrg.OrganisationID)
@@ -417,6 +423,12 @@ func resolveTargetOrganisationID(cmd *cobra.Command) (string, error) {
 // Slug and name comparisons are case-insensitive. Ambiguous or unknown
 // references return an actionable error listing the organisations available to
 // the user.
+// errOrganisationNotFound marks the case where a reference matches no
+// organisation the user belongs to, so `org switch` can exit exitNotFound(3)
+// while an ambiguous reference (the org exists, but the name/slug is shared)
+// stays a fixable usage error (exit 2).
+var errOrganisationNotFound = errors.New("organisation not found")
+
 func resolveOrganisationReference(orgs []client.OrganisationSummary, reference string) (*client.OrganisationSummary, error) {
 	trimmedReference := strings.TrimSpace(reference)
 
@@ -449,7 +461,7 @@ func resolveOrganisationReference(orgs []client.OrganisationSummary, reference s
 	case 1:
 		return nameMatches[0], nil
 	case 0:
-		return nil, fmt.Errorf("organisation %q not found. %s", reference, availableOrganisationsHint(orgs))
+		return nil, fmt.Errorf("%w: %q. %s", errOrganisationNotFound, reference, availableOrganisationsHint(orgs))
 	default:
 		return nil, fmt.Errorf("multiple organisations are named %q; pass the organisation ID instead", reference)
 	}

--- a/cmd/organisation_override_test.go
+++ b/cmd/organisation_override_test.go
@@ -114,6 +114,44 @@ func TestResolveOrgFlagToIDBySlug(t *testing.T) {
 	}
 }
 
+// TestOrgSwitchUnknownExitsNotFound asserts that switching to an organisation
+// the user does not belong to exits with exitNotFound (3) rather than the
+// generic failure code.
+func TestOrgSwitchUnknownExitsNotFound(t *testing.T) {
+	orgs := []client.OrganisationSummary{
+		{OrganisationID: "11111111-1111-1111-1111-111111111111", Name: strPtrCmd("Acme Corp"), UserCurrent: true},
+	}
+	setMockClient(t, &orgListMock{organisations: orgs})
+
+	_, err := executeCommand("org", "switch", "does-not-exist")
+	if err == nil {
+		t.Fatal("expected an error switching to an unknown organisation")
+	}
+	if got := exitCodeFor(err); got != exitNotFound {
+		t.Errorf("unknown org switch should exit %d, got %d", exitNotFound, got)
+	}
+}
+
+// TestOrgSwitchAmbiguousExitsUsage asserts that an organisation reference that
+// matches more than one membership (a shared name/slug) is a fixable usage
+// error (exit 2), not a not-found (3) - the org exists, the user just needs to
+// disambiguate with an ID.
+func TestOrgSwitchAmbiguousExitsUsage(t *testing.T) {
+	orgs := []client.OrganisationSummary{
+		{OrganisationID: "11111111-1111-1111-1111-111111111111", Name: strPtrCmd("Shared Name")},
+		{OrganisationID: "22222222-2222-2222-2222-222222222222", Name: strPtrCmd("Shared Name")},
+	}
+	setMockClient(t, &orgListMock{organisations: orgs})
+
+	_, err := executeCommand("org", "switch", "Shared Name")
+	if err == nil {
+		t.Fatal("expected an error switching to an ambiguous organisation name")
+	}
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("ambiguous org switch should exit %d, got %d", exitUsage, got)
+	}
+}
+
 func strPtrCmd(s string) *string {
 	return &s
 }

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -15,13 +15,19 @@ func registerStructuredOutputFlags(cmds ...*cobra.Command) {
 }
 
 // structuredFormatFromFlags resolves the requested structured output format
-// from -o/--output. Commands without the flag resolve to outputDefault.
+// from -o/--output. Commands without the flag resolve to outputDefault. A
+// rejected value is an invocation mistake, so it is tagged exitUsage; callers
+// pass the error straight through to Execute.
 func structuredFormatFromFlags(cmd *cobra.Command) (outputFormat, error) {
 	outputRaw := ""
 	if cmd.Flags().Lookup("output") != nil {
 		outputRaw, _ = cmd.Flags().GetString("output")
 	}
-	return parseOutputFormat(outputRaw)
+	format, err := parseOutputFormat(outputRaw)
+	if err != nil {
+		return outputDefault, withExitCode(exitUsage, err)
+	}
+	return format, nil
 }
 
 // renderStructured writes value as JSON or YAML when requested via -o. It

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -51,6 +51,35 @@ func TestStructuredFormatFromFlags(t *testing.T) {
 	}
 }
 
+// TestStructuredFormatFromFlagsRejectsWithUsageExit asserts an invalid -o value
+// is tagged exitUsage so scripts see exit 2 rather than the generic 1.
+func TestStructuredFormatFromFlagsRejectsWithUsageExit(t *testing.T) {
+	command := newStructuredOutputTestCommand()
+	if err := command.Flags().Set("output", "xml"); err != nil {
+		t.Fatalf("set --output: %v", err)
+	}
+	_, err := structuredFormatFromFlags(command)
+	if err == nil {
+		t.Fatal("expected an error for an invalid -o value")
+	}
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("invalid -o value should classify as exitUsage (%d), got %d", exitUsage, got)
+	}
+}
+
+// TestInvalidOutputOnStructuredCommandExitsUsage drives a real structured
+// command (org list) end-to-end with a bad -o value and asserts exit 2.
+func TestInvalidOutputOnStructuredCommandExitsUsage(t *testing.T) {
+	setMockClient(t, &orgListMock{organisations: nil})
+	_, err := executeCommand("org", "list", "-o", "xml")
+	if err == nil {
+		t.Fatal("expected an error for an invalid -o value")
+	}
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("invalid -o on a structured command should exit %d, got %d", exitUsage, got)
+	}
+}
+
 func TestStructuredFormatFromFlagsWithoutFlags(t *testing.T) {
 	command := &cobra.Command{Use: "bare", Run: func(*cobra.Command, []string) {}}
 	got, err := structuredFormatFromFlags(command)

--- a/cmd/ovh_cluster.go
+++ b/cmd/ovh_cluster.go
@@ -101,6 +101,13 @@ var ovhDeprovisionCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
+		yes, _ := cmd.Flags().GetBool("yes")
+
+		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Deprovision OVH cluster %q? This deletes all its servers, networks and SSH keys! [y/N]: ", clusterID),
+			yes); err != nil {
+			return err
+		}
 
 		result, err := apiClient.DeprovisionOvhCluster(clusterID)
 		if err != nil {
@@ -491,12 +498,21 @@ var ovhNodeGroupCmd = &cobra.Command{
 var ovhNodeGroupLabelsCmd = &cobra.Command{
 	Use:   "labels <cluster_id> <group_name>",
 	Short: "Set labels on all nodes in a node group",
-	Long:  "Replace the labels on every node in the group. Pass --labels as a comma-separated list of key=value pairs (empty clears all labels).",
+	Long:  "Replace the labels on every node in the group. Pass --labels as a comma-separated list of key=value pairs, or --clear to remove all labels.",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		groupName := args[1]
+		clear, _ := cmd.Flags().GetBool("clear")
+		labelsChanged := cmd.Flags().Changed("labels")
 		labelsFlag, _ := cmd.Flags().GetString("labels")
+
+		if clear && labelsChanged {
+			return withExitCode(exitUsage, errors.New("pass either --labels k=v or --clear, not both"))
+		}
+		if !clear && !labelsChanged {
+			return withExitCode(exitUsage, errors.New("provide --labels k=v to set labels, or pass --clear to remove all labels"))
+		}
 
 		labels, err := parseLabelsFlag(labelsFlag)
 		if err != nil {
@@ -511,7 +527,7 @@ var ovhNodeGroupLabelsCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.UpdateOvhNodeGroupLabels(requestContext, clusterID, groupName, labels, wait)
 		if err != nil {
-			return fmt.Errorf("updating node group labels: %w", err)
+			return asyncWriteError("updating node group labels", wait, err)
 		}
 		if submitted {
 			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group labels update")); err != nil {
@@ -535,12 +551,21 @@ var ovhNodeGroupLabelsCmd = &cobra.Command{
 var ovhNodeGroupTaintsCmd = &cobra.Command{
 	Use:   "taints <cluster_id> <group_name>",
 	Short: "Set taints on all nodes in a node group",
-	Long:  "Replace the taints on every node in the group. Pass --taints as a comma-separated list of key=value:Effect (value optional, effect defaults to NoSchedule; empty clears all taints).",
+	Long:  "Replace the taints on every node in the group. Pass --taints as a comma-separated list of key=value:Effect (value optional, effect defaults to NoSchedule), or --clear to remove all taints.",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		groupName := args[1]
+		clear, _ := cmd.Flags().GetBool("clear")
+		taintsChanged := cmd.Flags().Changed("taints")
 		taintsFlag, _ := cmd.Flags().GetString("taints")
+
+		if clear && taintsChanged {
+			return withExitCode(exitUsage, errors.New("pass either --taints k=v:Effect or --clear, not both"))
+		}
+		if !clear && !taintsChanged {
+			return withExitCode(exitUsage, errors.New("provide --taints k=v:Effect to set taints, or pass --clear to remove all taints"))
+		}
 
 		taints, err := parseTaintsFlag(taintsFlag)
 		if err != nil {
@@ -555,7 +580,7 @@ var ovhNodeGroupTaintsCmd = &cobra.Command{
 
 		result, submitted, err := apiClient.UpdateOvhNodeGroupTaints(requestContext, clusterID, groupName, taints, wait)
 		if err != nil {
-			return fmt.Errorf("updating node group taints: %w", err)
+			return asyncWriteError("updating node group taints", wait, err)
 		}
 		if submitted {
 			if handled, err := renderStructured(cmd, newAsyncSubmittedResult("Node group taints update")); err != nil {
@@ -747,6 +772,13 @@ var ovhNodeGroupDeleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		groupName := args[1]
+		yes, _ := cmd.Flags().GetBool("yes")
+
+		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Delete node group %q and all its nodes? This action is irreversible! [y/N]: ", groupName),
+			yes); err != nil {
+			return err
+		}
 
 		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
 		if err != nil {
@@ -874,8 +906,13 @@ func init() {
 	registerAsyncWriteFlags(ovhNodeGroupTaintsCmd)
 	registerAsyncWriteFlags(ovhNodeGroupDeleteCmd)
 
-	ovhNodeGroupLabelsCmd.Flags().String("labels", "", "Comma-separated key=value pairs (empty clears all labels)")
-	ovhNodeGroupTaintsCmd.Flags().String("taints", "", "Comma-separated key=value:Effect taints (empty clears all taints)")
+	ovhNodeGroupLabelsCmd.Flags().String("labels", "", "Comma-separated key=value pairs to set on the group")
+	ovhNodeGroupLabelsCmd.Flags().Bool("clear", false, "Remove all labels from the node group")
+	ovhNodeGroupTaintsCmd.Flags().String("taints", "", "Comma-separated key=value:Effect taints to set on the group")
+	ovhNodeGroupTaintsCmd.Flags().Bool("clear", false, "Remove all taints from the node group")
+
+	ovhDeprovisionCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
+	ovhNodeGroupDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
 	ovhRegionsCmd.Flags().String("credential-id", "", "OVH API credential ID (required)")
 	_ = ovhRegionsCmd.MarkFlagRequired("credential-id")

--- a/cmd/ovh_cluster_test.go
+++ b/cmd/ovh_cluster_test.go
@@ -2,10 +2,14 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type ovhStopMock struct {
@@ -189,5 +193,260 @@ func TestOvhNodeGroupAddWithLabelsAndTaints(t *testing.T) {
 	}
 	if !strings.Contains(output, "gpu") {
 		t.Errorf("expected group name in output, got: %s", output)
+	}
+}
+
+// setStdin points the root command's input at the given text for one test and
+// restores it afterwards so confirmation prompts read a deterministic answer.
+func setStdin(t *testing.T, input string) {
+	t.Helper()
+	rootCmd.SetIn(strings.NewReader(input))
+	t.Cleanup(func() { rootCmd.SetIn(nil) })
+}
+
+// resetOvhNodeGroupFlags clears flag state (notably Changed) that cobra retains
+// between Execute calls on the same command instance, so each test observes a
+// fresh invocation.
+func resetOvhNodeGroupFlags(t *testing.T) {
+	t.Helper()
+	for _, command := range []*cobra.Command{
+		ovhDeprovisionCmd, ovhNodeGroupLabelsCmd, ovhNodeGroupTaintsCmd, ovhNodeGroupDeleteCmd,
+	} {
+		command.Flags().VisitAll(func(flag *pflag.Flag) {
+			_ = flag.Value.Set(flag.DefValue)
+			flag.Changed = false
+		})
+	}
+}
+
+type ovhNodeGroupLabelsMock struct {
+	baseMock
+	called    bool
+	gotLabels map[string]string
+}
+
+func (m *ovhNodeGroupLabelsMock) UpdateOvhNodeGroupLabels(ctx context.Context, clusterID, groupName string, labels map[string]string, wait bool) (*client.UpdateNodeGroupResult, bool, error) {
+	m.called = true
+	m.gotLabels = labels
+	return &client.UpdateNodeGroupResult{GroupName: groupName, Updated: 1}, false, nil
+}
+
+func TestOvhNodeGroupLabels_BareInvocationIsUsageError(t *testing.T) {
+	resetOvhNodeGroupFlags(t)
+	mock := &ovhNodeGroupLabelsMock{}
+	setMockClient(t, mock)
+
+	_, err := executeCommand("cluster", "ovh", "node-group", "labels", "ovh-123", "gpu")
+	if err == nil {
+		t.Fatal("expected usage error when neither --labels nor --clear is given")
+	}
+	if exitCodeFor(err) != exitUsage {
+		t.Errorf("exit code = %d, want %d (usage)", exitCodeFor(err), exitUsage)
+	}
+	if mock.called {
+		t.Error("API must not be called on a bare labels invocation")
+	}
+}
+
+func TestOvhNodeGroupLabels_ClearAndLabelsTogetherIsUsageError(t *testing.T) {
+	resetOvhNodeGroupFlags(t)
+	mock := &ovhNodeGroupLabelsMock{}
+	setMockClient(t, mock)
+
+	_, err := executeCommand("cluster", "ovh", "node-group", "labels", "ovh-123", "gpu", "--labels", "a=b", "--clear")
+	if err == nil {
+		t.Fatal("expected usage error when both --labels and --clear are given")
+	}
+	if exitCodeFor(err) != exitUsage {
+		t.Errorf("exit code = %d, want %d (usage)", exitCodeFor(err), exitUsage)
+	}
+	if mock.called {
+		t.Error("API must not be called when flags conflict")
+	}
+}
+
+func TestOvhNodeGroupLabels_ClearSendsEmptyMap(t *testing.T) {
+	resetOvhNodeGroupFlags(t)
+	mock := &ovhNodeGroupLabelsMock{}
+	setMockClient(t, mock)
+
+	_, _ = executeCommand("cluster", "ovh", "node-group", "labels", "ovh-123", "gpu", "--clear")
+
+	if !mock.called {
+		t.Fatal("expected API to be called with --clear")
+	}
+	if len(mock.gotLabels) != 0 {
+		t.Errorf("labels = %v, want empty map", mock.gotLabels)
+	}
+}
+
+func TestOvhNodeGroupLabels_SetLabels(t *testing.T) {
+	resetOvhNodeGroupFlags(t)
+	mock := &ovhNodeGroupLabelsMock{}
+	setMockClient(t, mock)
+
+	_, _ = executeCommand("cluster", "ovh", "node-group", "labels", "ovh-123", "gpu", "--labels", "tier=gold")
+
+	if !mock.called {
+		t.Fatal("expected API to be called with --labels")
+	}
+	if mock.gotLabels["tier"] != "gold" {
+		t.Errorf("labels = %v, want tier=gold", mock.gotLabels)
+	}
+}
+
+type ovhNodeGroupTaintsMock struct {
+	baseMock
+	called    bool
+	gotTaints []client.NodeTaint
+}
+
+func (m *ovhNodeGroupTaintsMock) UpdateOvhNodeGroupTaints(ctx context.Context, clusterID, groupName string, taints []client.NodeTaint, wait bool) (*client.UpdateNodeGroupResult, bool, error) {
+	m.called = true
+	m.gotTaints = taints
+	return &client.UpdateNodeGroupResult{GroupName: groupName, Updated: 1}, false, nil
+}
+
+func TestOvhNodeGroupTaints_BareInvocationIsUsageError(t *testing.T) {
+	resetOvhNodeGroupFlags(t)
+	mock := &ovhNodeGroupTaintsMock{}
+	setMockClient(t, mock)
+
+	_, err := executeCommand("cluster", "ovh", "node-group", "taints", "ovh-123", "gpu")
+	if err == nil {
+		t.Fatal("expected usage error when neither --taints nor --clear is given")
+	}
+	if exitCodeFor(err) != exitUsage {
+		t.Errorf("exit code = %d, want %d (usage)", exitCodeFor(err), exitUsage)
+	}
+	if mock.called {
+		t.Error("API must not be called on a bare taints invocation")
+	}
+}
+
+func TestOvhNodeGroupTaints_ClearAndTaintsTogetherIsUsageError(t *testing.T) {
+	resetOvhNodeGroupFlags(t)
+	mock := &ovhNodeGroupTaintsMock{}
+	setMockClient(t, mock)
+
+	_, err := executeCommand("cluster", "ovh", "node-group", "taints", "ovh-123", "gpu", "--taints", "a=b:NoSchedule", "--clear")
+	if err == nil {
+		t.Fatal("expected usage error when both --taints and --clear are given")
+	}
+	if exitCodeFor(err) != exitUsage {
+		t.Errorf("exit code = %d, want %d (usage)", exitCodeFor(err), exitUsage)
+	}
+	if mock.called {
+		t.Error("API must not be called when flags conflict")
+	}
+}
+
+func TestOvhNodeGroupTaints_ClearSendsEmptySlice(t *testing.T) {
+	resetOvhNodeGroupFlags(t)
+	mock := &ovhNodeGroupTaintsMock{}
+	setMockClient(t, mock)
+
+	_, _ = executeCommand("cluster", "ovh", "node-group", "taints", "ovh-123", "gpu", "--clear")
+
+	if !mock.called {
+		t.Fatal("expected API to be called with --clear")
+	}
+	if len(mock.gotTaints) != 0 {
+		t.Errorf("taints = %v, want empty slice", mock.gotTaints)
+	}
+}
+
+func TestOvhNodeGroupTaints_SetTaints(t *testing.T) {
+	resetOvhNodeGroupFlags(t)
+	mock := &ovhNodeGroupTaintsMock{}
+	setMockClient(t, mock)
+
+	_, _ = executeCommand("cluster", "ovh", "node-group", "taints", "ovh-123", "gpu", "--taints", "dedicated=gpu:NoSchedule")
+
+	if !mock.called {
+		t.Fatal("expected API to be called with --taints")
+	}
+	if len(mock.gotTaints) != 1 || mock.gotTaints[0].Key != "dedicated" {
+		t.Errorf("taints = %v, want one dedicated taint", mock.gotTaints)
+	}
+}
+
+type ovhDeprovisionMock struct {
+	baseMock
+	called bool
+}
+
+func (m *ovhDeprovisionMock) DeprovisionOvhCluster(clusterID string) (*client.DeprovisionOvhClusterResponse, error) {
+	m.called = true
+	return &client.DeprovisionOvhClusterResponse{Success: true, ClusterID: clusterID}, nil
+}
+
+func TestOvhDeprovision_DeclinedPromptCancels(t *testing.T) {
+	resetOvhNodeGroupFlags(t)
+	mock := &ovhDeprovisionMock{}
+	setMockClient(t, mock)
+	setStdin(t, "n\n")
+
+	_, err := executeCommand("cluster", "ovh", "deprovision", "ovh-123")
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled, got %v", err)
+	}
+	if mock.called {
+		t.Error("API must not be called when the prompt is declined")
+	}
+}
+
+func TestOvhDeprovision_YesSkipsPrompt(t *testing.T) {
+	resetOvhNodeGroupFlags(t)
+	mock := &ovhDeprovisionMock{}
+	setMockClient(t, mock)
+	setStdin(t, "") // empty input would block/decline if prompted
+
+	_, err := executeCommand("cluster", "ovh", "deprovision", "ovh-123", "--yes")
+	if err != nil {
+		t.Fatalf("expected success with --yes, got %v", err)
+	}
+	if !mock.called {
+		t.Error("API must be called when --yes skips the prompt")
+	}
+}
+
+type ovhNodeGroupDeleteMock struct {
+	baseMock
+	called bool
+}
+
+func (m *ovhNodeGroupDeleteMock) DeleteOvhNodeGroup(ctx context.Context, clusterID, groupName string, wait bool) (*client.DeleteNodeGroupResult, bool, error) {
+	m.called = true
+	return &client.DeleteNodeGroupResult{GroupName: groupName, Deleted: 1}, false, nil
+}
+
+func TestOvhNodeGroupDelete_DeclinedPromptCancels(t *testing.T) {
+	resetOvhNodeGroupFlags(t)
+	mock := &ovhNodeGroupDeleteMock{}
+	setMockClient(t, mock)
+	setStdin(t, "n\n")
+
+	_, err := executeCommand("cluster", "ovh", "node-group", "delete", "ovh-123", "gpu")
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled, got %v", err)
+	}
+	if mock.called {
+		t.Error("API must not be called when the prompt is declined")
+	}
+}
+
+func TestOvhNodeGroupDelete_YesSkipsPrompt(t *testing.T) {
+	resetOvhNodeGroupFlags(t)
+	mock := &ovhNodeGroupDeleteMock{}
+	setMockClient(t, mock)
+	setStdin(t, "")
+
+	_, err := executeCommand("cluster", "ovh", "node-group", "delete", "ovh-123", "gpu", "--yes")
+	if err != nil {
+		t.Fatalf("expected success with --yes, got %v", err)
+	}
+	if !mock.called {
+		t.Error("API must be called when --yes skips the prompt")
 	}
 }

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -270,6 +270,7 @@ deprovision endpoint so cloud resources are released.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		autoDelete, _ := cmd.Flags().GetBool("auto-delete")
 		force, _ := cmd.Flags().GetBool("force")
+		yes, _ := cmd.Flags().GetBool("yes")
 
 		format, err := structuredFormatFromFlags(cmd)
 		if err != nil {
@@ -278,6 +279,14 @@ deprovision endpoint so cloud resources are released.`,
 
 		clusterID, clusterName, clusterKind, err := resolveClusterFromArgsWithKind(cmd, args)
 		if err != nil {
+			return err
+		}
+
+		if err := confirmPrompt(
+			cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Deprovision cluster %q? This deletes all its cloud resources (servers, networks, SSH keys)! [y/N]: ", clusterName),
+			yes,
+		); err != nil {
 			return err
 		}
 
@@ -413,6 +422,7 @@ Example:
 func init() {
 	clusterDeprovisionCmd.Flags().Bool("auto-delete", false, "Automatically delete the cluster after deprovisioning")
 	clusterDeprovisionCmd.Flags().Bool("force", false, "Force deprovision even if cluster is in an unexpected state")
+	clusterDeprovisionCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
 	clusterRollToCmd.Flags().String("version", "", "Resource version ID to roll to (required)")
 	_ = clusterRollToCmd.MarkFlagRequired("version")

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -152,6 +152,13 @@ var skillsUninstallCmd = &cobra.Command{
 				return err
 			}
 		}
+		// Validate every name before removing anything, so one bad argument
+		// (e.g. "." or "../x") cannot delete the skills directory or escape it.
+		for _, name := range names {
+			if err := validateSkillName(target.Directory, name); err != nil {
+				return err
+			}
+		}
 		removed := 0
 		for _, name := range names {
 			dest := filepath.Join(target.Directory, name)
@@ -166,6 +173,21 @@ var skillsUninstallCmd = &cobra.Command{
 		fmt.Printf("\nRemoved %d skill(s) from %s (%s).\n", removed, target.Directory, target.Scope)
 		return nil
 	},
+}
+
+// validateSkillName rejects skill arguments that would resolve outside dir
+// when joined onto it: empty, ".", "..", and anything containing a path
+// separator. Belt-and-braces, it also verifies the joined path stays strictly
+// inside dir (compare copySkill in internal/skills).
+func validateSkillName(dir, name string) error {
+	if name == "" || name == "." || name == ".." || strings.ContainsAny(name, `/\`) {
+		return withExitCode(exitUsage, fmt.Errorf("invalid skill name %q: must be a bare directory name", name))
+	}
+	rel, err := filepath.Rel(dir, filepath.Join(dir, name))
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return withExitCode(exitUsage, fmt.Errorf("invalid skill name %q: resolves outside %s", name, dir))
+	}
+	return nil
 }
 
 // skillsSourceFS returns the skills filesystem: a local directory when

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -118,5 +119,92 @@ func TestSkillsSourceFSDefaultsToEmbedded(t *testing.T) {
 func TestSkillsCommandIsAuthFree(t *testing.T) {
 	if commandRequiresAuth(skillsListCmd) {
 		t.Error("ankra skills should not require auth")
+	}
+}
+
+// seedInstalledSkill creates <project>/.cursor/skills/<name>/SKILL.md and
+// returns the skill directory.
+func seedInstalledSkill(t *testing.T, project, name string) string {
+	t.Helper()
+	dir := filepath.Join(project, ".cursor", "skills", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: "+name+"\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func runSkillsUninstall(t *testing.T, project string, args []string) error {
+	t.Helper()
+	c := newSkillsTestCmd()
+	if err := c.Flags().Set("project", project); err != nil {
+		t.Fatal(err)
+	}
+	var err error
+	captureStdout(t, func() {
+		err = skillsUninstallCmd.RunE(c, args)
+	})
+	return err
+}
+
+func TestSkillsUninstallRejectsUnsafeNames(t *testing.T) {
+	for _, name := range []string{"", ".", "..", "a/b", `a\b`, "../x", "ankra-cli/.."} {
+		t.Run(name, func(t *testing.T) {
+			project := t.TempDir()
+			installed := seedInstalledSkill(t, project, "ankra-cli")
+			// Decoy that "../x" would resolve to; it must survive.
+			escapeTarget := filepath.Join(project, ".cursor", "x")
+			if err := os.MkdirAll(escapeTarget, 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			err := runSkillsUninstall(t, project, []string{name})
+			if err == nil {
+				t.Fatalf("uninstall %q: expected error, got nil", name)
+			}
+			if code := exitCodeFor(err); code != exitUsage {
+				t.Fatalf("uninstall %q: exit code %d, want %d (err: %v)", name, code, exitUsage, err)
+			}
+			for _, path := range []string{installed, filepath.Join(project, ".cursor", "skills"), escapeTarget} {
+				if !dirExists(path) {
+					t.Errorf("uninstall %q removed %s", name, path)
+				}
+			}
+		})
+	}
+}
+
+func TestSkillsUninstallValidatesAllNamesBeforeRemoving(t *testing.T) {
+	project := t.TempDir()
+	installed := seedInstalledSkill(t, project, "ankra-cli")
+
+	err := runSkillsUninstall(t, project, []string{"ankra-cli", ".."})
+	if err == nil {
+		t.Fatal("expected error for invalid second argument")
+	}
+	if code := exitCodeFor(err); code != exitUsage {
+		t.Fatalf("exit code %d, want %d (err: %v)", code, exitUsage, err)
+	}
+	if !dirExists(installed) {
+		t.Error("valid skill was removed despite invalid sibling argument")
+	}
+}
+
+func TestSkillsUninstallRemovesNamedSkill(t *testing.T) {
+	project := t.TempDir()
+	removedSkill := seedInstalledSkill(t, project, "ankra-cli")
+	keptSkill := seedInstalledSkill(t, project, "ankra-gitops")
+
+	// A valid but not-installed name is silently skipped.
+	if err := runSkillsUninstall(t, project, []string{"ankra-cli", "not-installed"}); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	if dirExists(removedSkill) {
+		t.Error("ankra-cli was not removed")
+	}
+	if !dirExists(keptSkill) {
+		t.Error("ankra-gitops was removed but not requested")
 	}
 }

--- a/cmd/upcloud_cluster.go
+++ b/cmd/upcloud_cluster.go
@@ -94,6 +94,13 @@ var upcloudDeprovisionCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
+		yes, _ := cmd.Flags().GetBool("yes")
+
+		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Deprovision UpCloud cluster %q? This deletes all its servers, networks and SSH keys! [y/N]: ", clusterID),
+			yes); err != nil {
+			return err
+		}
 
 		result, err := apiClient.DeprovisionUpcloudCluster(clusterID)
 		if err != nil {
@@ -468,6 +475,13 @@ var upcloudNodeGroupDeleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		groupName := args[1]
+		yes, _ := cmd.Flags().GetBool("yes")
+
+		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Delete node group %q from cluster %q? This deletes all its nodes! [y/N]: ", groupName, clusterID),
+			yes); err != nil {
+			return err
+		}
 
 		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
 		if err != nil {
@@ -523,6 +537,9 @@ func init() {
 	_ = upcloudCreateCmd.MarkFlagRequired("zone")
 
 	upcloudStartCmd.Flags().String("scope", "all", "Provisioning scope: 'all' or 'control_plane'")
+
+	upcloudDeprovisionCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
+	upcloudNodeGroupDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
 	upcloudNodeGroupAddCmd.Flags().String("name", "", "Node group name (required)")
 	upcloudNodeGroupAddCmd.Flags().String("instance-type", "2xCPU-4GB", "Server plan for nodes")

--- a/cmd/upcloud_cluster_test.go
+++ b/cmd/upcloud_cluster_test.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type upcloudDeprovisionMock struct {
+	baseMock
+	called       bool
+	gotClusterID string
+}
+
+func (m *upcloudDeprovisionMock) DeprovisionUpcloudCluster(clusterID string) (*client.DeprovisionUpcloudClusterResponse, error) {
+	m.called = true
+	m.gotClusterID = clusterID
+	return &client.DeprovisionUpcloudClusterResponse{Success: true, ClusterID: clusterID}, nil
+}
+
+type upcloudNodeGroupDeleteMock struct {
+	baseMock
+	called       bool
+	gotClusterID string
+	gotGroupName string
+}
+
+func (m *upcloudNodeGroupDeleteMock) DeleteUpcloudNodeGroup(ctx context.Context, clusterID, groupName string, wait bool) (*client.DeleteNodeGroupResult, bool, error) {
+	m.called = true
+	m.gotClusterID = clusterID
+	m.gotGroupName = groupName
+	return &client.DeleteNodeGroupResult{GroupName: groupName, Deleted: 1}, false, nil
+}
+
+func TestUpcloudDeprovision_DeclineDoesNotCallAPI(t *testing.T) {
+	mock := &upcloudDeprovisionMock{}
+	resetConfirmFlag(t, upcloudDeprovisionCmd)
+	_, err := runWithInput(t, mock, "n\n", "cluster", "upcloud", "deprovision", "uc-123")
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled on decline, got %v", err)
+	}
+	if mock.called {
+		t.Error("expected no deprovision call when declined")
+	}
+}
+
+func TestUpcloudDeprovision_YesProceeds(t *testing.T) {
+	mock := &upcloudDeprovisionMock{}
+	resetConfirmFlag(t, upcloudDeprovisionCmd)
+	out, err := runWithInput(t, mock, "", "cluster", "upcloud", "deprovision", "uc-123", "--yes")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if !mock.called {
+		t.Fatal("expected deprovision call with --yes")
+	}
+	if mock.gotClusterID != "uc-123" {
+		t.Errorf("cluster id = %q, want uc-123", mock.gotClusterID)
+	}
+}
+
+func TestUpcloudNodeGroupDelete_DeclineDoesNotCallAPI(t *testing.T) {
+	mock := &upcloudNodeGroupDeleteMock{}
+	resetConfirmFlag(t, upcloudNodeGroupDeleteCmd)
+	_, err := runWithInput(t, mock, "n\n", "cluster", "upcloud", "node-group", "delete", "uc-123", "workers")
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled on decline, got %v", err)
+	}
+	if mock.called {
+		t.Error("expected no delete call when declined")
+	}
+}
+
+func TestUpcloudNodeGroupDelete_YesProceeds(t *testing.T) {
+	mock := &upcloudNodeGroupDeleteMock{}
+	resetConfirmFlag(t, upcloudNodeGroupDeleteCmd)
+	out, err := runWithInput(t, mock, "", "cluster", "upcloud", "node-group", "delete", "uc-123", "workers", "--yes")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if !mock.called {
+		t.Fatal("expected delete call with --yes")
+	}
+	if mock.gotClusterID != "uc-123" || mock.gotGroupName != "workers" {
+		t.Errorf("got cluster=%q group=%q, want uc-123/workers", mock.gotClusterID, mock.gotGroupName)
+	}
+}

--- a/internal/client/addons.go
+++ b/internal/client/addons.go
@@ -5,11 +5,17 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	neturl "net/url"
 	"time"
 )
+
+// ErrAddonNotFound is returned (wrapped) by GetAddonByName when no addon with
+// the requested name exists on the cluster. Callers use errors.Is to classify
+// it as a not-found condition (exit code 3) rather than a generic failure.
+var ErrAddonNotFound = errors.New("addon not found")
 
 type ClusterAddonListItem struct {
 	ID            string    `json:"id"`
@@ -237,5 +243,5 @@ func (c *Client) GetAddonByName(clusterID, addonName string) (*ClusterAddonListI
 			return &addons[i], nil
 		}
 	}
-	return nil, fmt.Errorf("addon %q not found", addonName)
+	return nil, fmt.Errorf("addon %q: %w", addonName, ErrAddonNotFound)
 }

--- a/internal/client/clusters.go
+++ b/internal/client/clusters.go
@@ -248,7 +248,8 @@ type Parent struct {
 }
 
 type AddonStandaloneConfiguration struct {
-	ValuesBase64 string `json:"values_base64,omitempty"`
+	ValuesBase64   string   `json:"values_base64,omitempty"`
+	EncryptedPaths []string `json:"encrypted_paths,omitempty"`
 }
 
 type Addon struct {

--- a/internal/client/iac.go
+++ b/internal/client/iac.go
@@ -227,7 +227,14 @@ func (c *Client) PatchClusterStackPartial(ctx context.Context, clusterID, stackN
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &PatchStackError{StatusCode: resp.StatusCode, Body: respBody}
+		perr := &PatchStackError{StatusCode: resp.StatusCode, Body: respBody}
+		if resp.StatusCode == http.StatusUnauthorized {
+			// Carry ErrUnauthorized at the source so any caller inspecting the
+			// error (not just cmd's mapPatchError) can detect auth failures with
+			// errors.Is instead of matching message text.
+			perr.Err = ErrUnauthorized
+		}
+		return nil, perr
 	}
 
 	var result PatchStackResult

--- a/internal/client/iac_test.go
+++ b/internal/client/iac_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -238,6 +239,31 @@ func TestGetClusterManifestConfiguration_ReturnsBase64(t *testing.T) {
 	}
 	if got != encoded {
 		t.Errorf("got %q, want %q", got, encoded)
+	}
+}
+
+func TestPatchClusterStackPartial_UnauthorizedCarriesErrUnauthorized(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail":"token expired"}`))
+	})
+	req := PatchStackRequest{
+		PartialStack: true,
+		Spec:         ResourceSpecSpec{Stacks: []StackSpec{{Name: "demo"}}},
+	}
+	_, err := testClient.PatchClusterStackPartial(context.Background(), "cluster-id", "demo", req)
+	if err == nil {
+		t.Fatal("expected error for 401 status")
+	}
+	perr, ok := err.(*PatchStackError)
+	if !ok {
+		t.Fatalf("expected *PatchStackError, got %T: %v", err, err)
+	}
+	if perr.StatusCode != http.StatusUnauthorized {
+		t.Errorf("StatusCode = %d, want 401", perr.StatusCode)
+	}
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Errorf("401 PatchStackError should wrap ErrUnauthorized, got %v", err)
 	}
 }
 

--- a/internal/client/unexpected_response.go
+++ b/internal/client/unexpected_response.go
@@ -36,6 +36,14 @@ func newUnexpectedResponseErrorWithMessage(statusCode int, message string) *Unex
 	}
 }
 
+// NewUnexpectedResponseError builds an *UnexpectedResponseError carrying the
+// given status code and message. It is the exported entry point for callers
+// outside this package (e.g. cmd's PATCH error mapper) that need the CLI's
+// support-hint machinery to fire on an otherwise plain error message.
+func NewUnexpectedResponseError(statusCode int, message string) *UnexpectedResponseError {
+	return newUnexpectedResponseErrorWithMessage(statusCode, message)
+}
+
 // ErrUnauthorized is returned for 401 API responses so callers — and the
 // CLI's exit-code classification — can detect authentication failures with
 // errors.Is instead of matching message text.


### PR DESCRIPTION
## Summary

Hardening pass over the ankra-cli, following a deep review of the post-merge `master` delta. PR #10 correctly moved handlers to `RunE` and introduced the exit-code contract (`cmd/exitcodes.go`), but a few paths still returned the generic code against that new contract, and several destructive commands lacked confirmation. This branch fixes those, plus a handful of correctness bugs found in review.

Each commit is one logical fix, self-contained, with tests. Full suite is green (uncached), `gofmt`/`go vet` clean.

## Fixes

- **skills**: `skills uninstall <name>` now rejects empty/`.`/`..`/path-separator names before `os.RemoveAll` (path-traversal mass-deletion guard).
- **draft**: bootstrapping a brand-new cluster now stages all stacks as drafts instead of live-deploying them.
- **ovh**: `--clear` flag for node-group labels/taints (a bare invocation is now a usage error, not clear-all); `--yes`+confirm on deprovision and node-group delete; async submit paths now surface wait-timeout as exit 5.
- **apply**: propagate addon `encrypted_paths` (backend-supported) and require quoted-string `chart_name`/`chart_version` (YAML was silently coercing `1.20` to a number).
- **login**: stop writing the API token to a world-readable config mid-login; the machine id is persisted only in the final `0600` save.
- **stacks**: classify PATCH error exit codes (401/403→auth, 404→not-found, 5xx→unexpected-response) on stack write paths.
- **addons**: confirm before uninstall, and exit 3 when the addon is absent.
- **destructive deletes**: `--yes`+confirm on stack delete, generic cluster deprovision, node-group delete, credentials delete, Hetzner/UpCloud deprovision + node-group delete, helm uninstall, chat delete.
- **exit codes**: invalid `-o` → usage (2); picker abort → cancelled (4); unknown org switch → not-found (3), ambiguous → usage (2); fixed a nil-`formatRow` panic on `get pods <name> -o wide`.

## Test plan

- `go test ./...` — all green, uncached
- `gofmt -l` clean, `go vet ./...` clean
- 28 new test functions covering each fix and its exit-code classification

🤖 Generated with [Claude Code](https://claude.com/claude-code)
