### PR TITLE
fix(agent): print the real token and reflect check-in staleness in status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Ankra CLI Changelog
 
+## Unreleased
+
+### Fixed
+
+- **`ankra cluster agent token` no longer prints an empty token.** The
+  platform's token endpoints return the agent install command (and, on newer
+  platforms, `token` and `cluster_id` fields), while the CLI decoded a
+  `token`/`expires_at` shape that no longer existed and silently rendered an
+  empty string. The CLI now decodes all returned fields, extracts the
+  `ank_cai_…` token from the helm command when the platform only returns
+  `command`, and prints the token together with the full install/update
+  command. Structured output (`-o json|yaml`) now carries `token`,
+  `cluster_id`, and `command`; the never-populated `expires_at` field is
+  gone.
+- **`ankra cluster agent status` no longer reports a stale agent as
+  `connected`.** The status was derived from `checked_in_at` merely being
+  present, so an agent that had been rejected or offline for hours (even
+  days) still displayed `Status: connected`. The CLI now uses the platform's
+  `is_online` verdict when present (30-second check-in threshold, the same
+  one that flips clusters offline) and otherwise falls back to a two-minute
+  check-in recency test; a stale check-in renders as
+  `not connected (stale check-in)`.
+
 ## v0.7.0 — 2026-07-10
 
 The stable v0.7.0 release consolidates the v0.7.0 release candidates: the

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/spf13/cobra"
+
+	"ankra/internal/client"
 )
 
 var clusterAgentCmd = &cobra.Command{
@@ -52,8 +54,10 @@ var clusterAgentStatusCmd = &cobra.Command{
 		switch {
 		case agent.Upgrading:
 			fmt.Printf("  Status:     %s\n", text.FgYellow.Sprint("upgrading"))
-		case agent.CheckedInAt != nil:
+		case agentIsConnected(agent):
 			fmt.Printf("  Status:     %s\n", text.FgGreen.Sprint("connected"))
+		case agent.CheckedInAt != nil:
+			fmt.Printf("  Status:     %s\n", text.FgRed.Sprint("not connected (stale check-in)"))
 		default:
 			fmt.Printf("  Status:     %s\n", text.FgRed.Sprint("not connected"))
 		}
@@ -67,6 +71,29 @@ var clusterAgentStatusCmd = &cobra.Command{
 		}
 		return nil
 	},
+}
+
+// agentCheckinRecencyFallback bounds how old a check-in may be and still
+// count as connected when the platform does not report is_online. The
+// platform flips clusters offline after 30s without a check-in; two minutes
+// leaves headroom for clock skew without ever showing "connected" for an
+// agent that is being rejected.
+const agentCheckinRecencyFallback = 2 * time.Minute
+
+// agentIsConnected prefers the platform's is_online verdict and falls back
+// to a check-in recency test for older platform versions.
+func agentIsConnected(agent *client.AgentInfo) bool {
+	if agent.IsOnline != nil {
+		return *agent.IsOnline
+	}
+	if agent.CheckedInAt == nil {
+		return false
+	}
+	checkedInAt, parseError := time.Parse(time.RFC3339, *agent.CheckedInAt)
+	if parseError != nil {
+		return false
+	}
+	return time.Since(checkedInAt) <= agentCheckinRecencyFallback
 }
 
 var clusterAgentTokenCmd = &cobra.Command{
@@ -95,10 +122,9 @@ var clusterAgentTokenCmd = &cobra.Command{
 
 			fmt.Println("New agent token generated!")
 			fmt.Println()
-			fmt.Printf("Token (save this, it won't be shown again):\n")
-			fmt.Printf("  %s\n", token.Token)
+			printAgentToken(token)
 			fmt.Println()
-			fmt.Printf("Expires: %s\n", formatTimeAgo(token.ExpiresAt))
+			fmt.Println("The previous token is now invalid; redeploy the agent with the command above.")
 			return nil
 		}
 
@@ -113,10 +139,22 @@ var clusterAgentTokenCmd = &cobra.Command{
 		}
 
 		fmt.Printf("Agent Token for cluster '%s':\n\n", cluster.Name)
-		fmt.Printf("  Token:   %s\n", token.Token)
-		fmt.Printf("  Expires: %s\n", formatTimeAgo(token.ExpiresAt))
+		printAgentToken(token)
 		return nil
 	},
+}
+
+func printAgentToken(token *client.AgentToken) {
+	if token.Token != "" {
+		fmt.Printf("  Token: %s\n", token.Token)
+	} else {
+		fmt.Printf("  Token: %s\n", text.FgRed.Sprint("unavailable (unexpected API response)"))
+	}
+	if token.Command != "" {
+		fmt.Println()
+		fmt.Println("  Install or update the agent with:")
+		fmt.Printf("    %s\n", token.Command)
+	}
 }
 
 var clusterAgentUpgradeCmd = &cobra.Command{

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1609,9 +1609,9 @@ func TestClusterAgentStatusCommand(t *testing.T) {
 			writeSelectedClusterJSON(t)
 			setMockClient(t, &clusterAgentStatusMock{agent: testCase.agent})
 
-			stdoutOutput := captureStdout(t, func() {
+			stdoutOutput := stripANSICodes(captureStdout(t, func() {
 				_, _ = executeCommand("cluster", "agent", "status")
-			})
+			}))
 
 			if !strings.Contains(stdoutOutput, "test-cluster") {
 				t.Errorf("expected output to contain 'test-cluster', got: %s", stdoutOutput)

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1554,31 +1554,75 @@ func (m *clusterAgentStatusMock) GetClusterAgent(clusterID string) (*client.Agen
 }
 
 func TestClusterAgentStatusCommand(t *testing.T) {
-	writeSelectedClusterJSON(t)
 	agentVersion := "2.5.1"
-	checkedIn := "2024-05-01T08:00:00Z"
-	mock := &clusterAgentStatusMock{
-		agent: &client.AgentInfo{
-			AgentVersion: &agentVersion,
-			CreatedAt:    "2024-01-10T00:00:00Z",
-			CheckedInAt:  &checkedIn,
-			Upgrading:    false,
+	staleCheckin := "2024-05-01T08:00:00Z"
+	freshCheckin := time.Now().UTC().Add(-10 * time.Second).Format(time.RFC3339)
+	online := true
+	offline := false
+
+	cases := []struct {
+		name           string
+		agent          *client.AgentInfo
+		expectedStatus string
+	}{
+		{
+			name: "platform_reports_online",
+			agent: &client.AgentInfo{
+				AgentVersion: &agentVersion,
+				CreatedAt:    "2024-01-10T00:00:00Z",
+				CheckedInAt:  &staleCheckin,
+				IsOnline:     &online,
+			},
+			expectedStatus: "Status:     connected",
+		},
+		{
+			name: "platform_reports_offline_despite_checkin",
+			agent: &client.AgentInfo{
+				AgentVersion: &agentVersion,
+				CreatedAt:    "2024-01-10T00:00:00Z",
+				CheckedInAt:  &freshCheckin,
+				IsOnline:     &offline,
+			},
+			expectedStatus: "not connected (stale check-in)",
+		},
+		{
+			name: "fallback_fresh_checkin_is_connected",
+			agent: &client.AgentInfo{
+				AgentVersion: &agentVersion,
+				CreatedAt:    "2024-01-10T00:00:00Z",
+				CheckedInAt:  &freshCheckin,
+			},
+			expectedStatus: "Status:     connected",
+		},
+		{
+			name: "fallback_stale_checkin_is_not_connected",
+			agent: &client.AgentInfo{
+				AgentVersion: &agentVersion,
+				CreatedAt:    "2024-01-10T00:00:00Z",
+				CheckedInAt:  &staleCheckin,
+			},
+			expectedStatus: "not connected (stale check-in)",
 		},
 	}
-	setMockClient(t, mock)
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			writeSelectedClusterJSON(t)
+			setMockClient(t, &clusterAgentStatusMock{agent: testCase.agent})
 
-	stdoutOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "agent", "status")
-	})
+			stdoutOutput := captureStdout(t, func() {
+				_, _ = executeCommand("cluster", "agent", "status")
+			})
 
-	if !strings.Contains(stdoutOutput, "test-cluster") {
-		t.Errorf("expected output to contain 'test-cluster', got: %s", stdoutOutput)
-	}
-	if !strings.Contains(stdoutOutput, "2.5.1") {
-		t.Errorf("expected output to contain '2.5.1', got: %s", stdoutOutput)
-	}
-	if !strings.Contains(stdoutOutput, "connected") {
-		t.Errorf("expected output to contain 'connected', got: %s", stdoutOutput)
+			if !strings.Contains(stdoutOutput, "test-cluster") {
+				t.Errorf("expected output to contain 'test-cluster', got: %s", stdoutOutput)
+			}
+			if !strings.Contains(stdoutOutput, "2.5.1") {
+				t.Errorf("expected output to contain '2.5.1', got: %s", stdoutOutput)
+			}
+			if !strings.Contains(stdoutOutput, testCase.expectedStatus) {
+				t.Errorf("expected output to contain %q, got: %s", testCase.expectedStatus, stdoutOutput)
+			}
+		})
 	}
 }
 

--- a/cmd/testutil_test.go
+++ b/cmd/testutil_test.go
@@ -3,8 +3,15 @@ package cmd
 import (
 	"bytes"
 	"os"
+	"regexp"
 	"testing"
 )
+
+var ansiEscapePattern = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+func stripANSICodes(input string) string {
+	return ansiEscapePattern.ReplaceAllString(input, "")
+}
 
 func executeCommand(args ...string) (string, error) {
 	buf := new(bytes.Buffer)

--- a/internal/client/agent.go
+++ b/internal/client/agent.go
@@ -4,22 +4,41 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 )
 
 type AgentInfo struct {
-	UpgradeAvailable    bool    `json:"upgrade_available"`
-	Upgrading           bool    `json:"upgrading"`
-	CreatedAt           string  `json:"created_at"`
-	CheckedInAt         *string `json:"checked_in_at,omitempty"`
-	AgentVersion        *string `json:"agent_version,omitempty"`
-	LatestAgentVersion  *string `json:"latest_agent_version,omitempty"`
-	DisableAutoUpgrade  bool    `json:"disable_auto_upgrade"`
+	UpgradeAvailable   bool    `json:"upgrade_available"`
+	Upgrading          bool    `json:"upgrading"`
+	CreatedAt          string  `json:"created_at"`
+	CheckedInAt        *string `json:"checked_in_at,omitempty"`
+	AgentVersion       *string `json:"agent_version,omitempty"`
+	LatestAgentVersion *string `json:"latest_agent_version,omitempty"`
+	DisableAutoUpgrade bool    `json:"disable_auto_upgrade"`
+	IsOnline           *bool   `json:"is_online,omitempty"`
 }
 
 type AgentToken struct {
 	Token     string `json:"token"`
-	ExpiresAt string `json:"expires_at"`
 	ClusterID string `json:"cluster_id"`
+	Command   string `json:"command"`
+}
+
+// tokenInInstallCommandPattern matches the --set config.token=<token> value
+// inside the helm install command the token endpoints return.
+var tokenInInstallCommandPattern = regexp.MustCompile(`--set config\.token=(\S+)`)
+
+// fillFromCommand backfills Token and ClusterID for platform versions whose
+// token endpoints only return the helm install command.
+func (agentToken *AgentToken) fillFromCommand(clusterID string) {
+	if agentToken.Token == "" && agentToken.Command != "" {
+		if match := tokenInInstallCommandPattern.FindStringSubmatch(agentToken.Command); match != nil {
+			agentToken.Token = match[1]
+		}
+	}
+	if agentToken.ClusterID == "" {
+		agentToken.ClusterID = clusterID
+	}
 }
 
 type UpgradeAgentResult struct {
@@ -44,6 +63,7 @@ func (c *Client) GetAgentToken(clusterID string) (*AgentToken, error) {
 	if err := c.getJSON(url, &agentToken); err != nil {
 		return nil, fmt.Errorf("failed to get agent token: %w", err)
 	}
+	agentToken.fillFromCommand(clusterID)
 	return &agentToken, nil
 }
 
@@ -75,6 +95,7 @@ func (c *Client) GenerateAgentToken(ctx context.Context, clusterID string) (*Age
 	if err := parseJSON(body, &agentToken); err != nil {
 		return nil, err
 	}
+	agentToken.fillFromCommand(clusterID)
 	return &agentToken, nil
 }
 

--- a/internal/client/agent_test.go
+++ b/internal/client/agent_test.go
@@ -38,11 +38,17 @@ func TestGetClusterAgent(t *testing.T) {
 	}
 }
 
+const agentInstallCommand = "helm upgrade --install ankra-agent oci://registry.ankra.cloud/ankra/ankra-agent " +
+	"--version 2.1.439 --set config.ankra_url=https://platform.ankra.app " +
+	"--set config.token=ank_cai_commandtoken --namespace=ankra --create-namespace"
+
 func TestGetAgentToken(t *testing.T) {
 	tests := []struct {
-		name    string
-		handler http.HandlerFunc
-		wantErr bool
+		name          string
+		handler       http.HandlerFunc
+		wantErr       bool
+		wantToken     string
+		wantClusterID string
 	}{
 		{
 			name: "success",
@@ -53,11 +59,22 @@ func TestGetAgentToken(t *testing.T) {
 				}
 				jsonResponse(t, w, http.StatusOK, AgentToken{
 					Token:     "existing-agent-token",
-					ExpiresAt: "2025-12-31",
 					ClusterID: "cluster-id",
+					Command:   agentInstallCommand,
 				})
 			},
-			wantErr: false,
+			wantErr:       false,
+			wantToken:     "existing-agent-token",
+			wantClusterID: "cluster-id",
+		},
+		{
+			name: "command_only_response_extracts_token",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				jsonResponse(t, w, http.StatusOK, map[string]string{"command": agentInstallCommand})
+			},
+			wantErr:       false,
+			wantToken:     "ank_cai_commandtoken",
+			wantClusterID: "cluster-id",
 		},
 		{
 			name: "unauthorized",
@@ -75,8 +92,14 @@ func TestGetAgentToken(t *testing.T) {
 				t.Errorf("GetAgentToken() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !tt.wantErr && got.Token != "existing-agent-token" {
-				t.Errorf("GetAgentToken() got.Token = %v, want existing-agent-token", got.Token)
+			if tt.wantErr {
+				return
+			}
+			if got.Token != tt.wantToken {
+				t.Errorf("GetAgentToken() got.Token = %v, want %v", got.Token, tt.wantToken)
+			}
+			if got.ClusterID != tt.wantClusterID {
+				t.Errorf("GetAgentToken() got.ClusterID = %v, want %v", got.ClusterID, tt.wantClusterID)
 			}
 		})
 	}
@@ -90,8 +113,8 @@ func TestGenerateAgentToken(t *testing.T) {
 		}
 		jsonResponse(t, w, http.StatusOK, AgentToken{
 			Token:     "new-agent-token",
-			ExpiresAt: "2025-12-31",
 			ClusterID: "cluster-id",
+			Command:   agentInstallCommand,
 		})
 	})
 	got, err := testClient.GenerateAgentToken(context.Background(), "cluster-id")
@@ -100,6 +123,22 @@ func TestGenerateAgentToken(t *testing.T) {
 	}
 	if got.Token != "new-agent-token" {
 		t.Errorf("GenerateAgentToken() got.Token = %v, want new-agent-token", got.Token)
+	}
+}
+
+func TestGenerateAgentTokenCommandOnlyResponse(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(t, w, http.StatusOK, map[string]string{"command": agentInstallCommand})
+	})
+	got, err := testClient.GenerateAgentToken(context.Background(), "cluster-id")
+	if err != nil {
+		t.Fatalf("GenerateAgentToken() error = %v", err)
+	}
+	if got.Token != "ank_cai_commandtoken" {
+		t.Errorf("GenerateAgentToken() got.Token = %v, want the token extracted from the command", got.Token)
+	}
+	if got.ClusterID != "cluster-id" {
+		t.Errorf("GenerateAgentToken() got.ClusterID = %v, want cluster-id", got.ClusterID)
 	}
 }
 


### PR DESCRIPTION
## Summary

Two agent-command regressions surfaced during an incident recovery:

- `ankra cluster agent token` printed an empty token. The platform's token endpoints return the helm install command (and, on newer platforms, `token` and `cluster_id`), but the CLI decoded a `token`/`expires_at` shape that no longer exists. The CLI now decodes `command`/`token`/`cluster_id`, extracts the `ank_cai_` token from the command when the platform returns only `command`, prints the token with the full install/update command, and carries `token`/`cluster_id`/`command` in `-o json|yaml` output. The never-populated `expires_at` field is removed.
- `ankra cluster agent status` showed `connected` whenever `checked_in_at` was present, so an agent rejected or offline for hours still read `connected`. It now prefers the platform's `is_online` verdict (30s threshold) when present, else falls back to a two-minute check-in recency test; a stale check-in renders as `not connected (stale check-in)`.

## Test plan

- [ ] `go test ./...`
- [ ] `ankra cluster agent token` prints a non-empty token
- [ ] `ankra cluster agent status` reflects a stale/rejected agent


Made with [Cursor](https://cursor.com)