### PR TITLE
fix(operations): include drift field paths in execution step output

### DIFF
--- a/cmd/cluster_operation.go
+++ b/cmd/cluster_operation.go
@@ -117,7 +117,7 @@ var clusterOperationsListCmd = &cobra.Command{
 		}
 
 		if !watch {
-			_, err := renderExecutionsOnce(options, executionID)
+			_, err := renderExecutionsOnce(options, executionID, true)
 			return err
 		}
 
@@ -125,7 +125,7 @@ var clusterOperationsListCmd = &cobra.Command{
 			clearScreen()
 			fmt.Printf("Watching executions (every %s, press Ctrl+C to stop) - %s\n\n",
 				interval, time.Now().Format("15:04:05"))
-			keepWatching, err := renderExecutionsOnce(options, executionID)
+			keepWatching, err := renderExecutionsOnce(options, executionID, false)
 			if err != nil {
 				return err
 			}
@@ -140,10 +140,16 @@ var clusterOperationsListCmd = &cobra.Command{
 
 // renderExecutionsOnce prints either the executions table or a single
 // execution detail, returning whether any rendered execution is still active
-// (used to decide whether a --watch loop keeps polling).
-func renderExecutionsOnce(options client.ListExecutionsOptions, executionID string) (keepWatching bool, err error) {
+// (used to decide whether a --watch loop keeps polling). Drift enrichment is
+// skipped in watch mode to avoid fetching full step results every poll tick.
+func renderExecutionsOnce(options client.ListExecutionsOptions, executionID string, includeDrift bool) (keepWatching bool, err error) {
 	if executionID != "" {
-		detail, err := loadExecutionDetailWithDrift(executionID)
+		var detail client.ExecutionDetail
+		if includeDrift {
+			detail, err = loadExecutionDetailWithDrift(executionID)
+		} else {
+			detail, err = apiClient.GetExecution(executionID)
+		}
 		if err != nil {
 			return false, err
 		}
@@ -389,13 +395,15 @@ func renderExecutionsTable(executions []client.ExecutionSummary) {
 	t.Render()
 }
 
+// loadExecutionDetailWithDrift enriches best-effort: older platforms without
+// the /result route (or permission failures) must not break the base command.
 func loadExecutionDetailWithDrift(executionID string) (client.ExecutionDetail, error) {
 	detail, detailError := apiClient.GetExecution(executionID)
 	if detailError != nil {
 		return client.ExecutionDetail{}, fmt.Errorf("fetching execution %s: %w", executionID, detailError)
 	}
 	if enrichError := apiClient.EnrichExecutionDetailWithDrift(&detail); enrichError != nil {
-		return client.ExecutionDetail{}, fmt.Errorf("fetching execution results: %w", enrichError)
+		fmt.Fprintf(os.Stderr, "Note: drift details unavailable: %v\n", enrichError)
 	}
 	return detail, nil
 }

--- a/cmd/cluster_operation.go
+++ b/cmd/cluster_operation.go
@@ -143,11 +143,12 @@ var clusterOperationsListCmd = &cobra.Command{
 // (used to decide whether a --watch loop keeps polling).
 func renderExecutionsOnce(options client.ListExecutionsOptions, executionID string) (keepWatching bool, err error) {
 	if executionID != "" {
-		detail, err := apiClient.GetExecution(executionID)
+		detail, err := loadExecutionDetailWithDrift(executionID)
 		if err != nil {
-			return false, fmt.Errorf("fetching execution %s: %w", executionID, err)
+			return false, err
 		}
 		printExecutionDetail(detail)
+		printExecutionStepDrift(detail)
 		return !isTerminalExecutionStatus(detail.Execution.Status), nil
 	}
 
@@ -173,9 +174,9 @@ func renderExecutionsOnce(options client.ListExecutionsOptions, executionID stri
 // detail) using a structured -o format (json or yaml).
 func renderExecutionsStructured(format outputFormat, options client.ListExecutionsOptions, executionID string) error {
 	if executionID != "" {
-		detail, err := apiClient.GetExecution(executionID)
+		detail, err := loadExecutionDetailWithDrift(executionID)
 		if err != nil {
-			return fmt.Errorf("fetching execution %s: %w", executionID, err)
+			return err
 		}
 		return encodeStructured(os.Stdout, format, detail)
 	}
@@ -294,7 +295,7 @@ var clusterOperationsStepsCmd = &cobra.Command{
 			return err
 		}
 
-		detail, err := apiClient.GetExecution(executionID)
+		detail, err := loadExecutionDetailWithDrift(executionID)
 		if err != nil {
 			return fmt.Errorf("fetching execution: %w", err)
 		}
@@ -345,6 +346,7 @@ var clusterOperationsStepsCmd = &cobra.Command{
 			})
 		}
 		t.Render()
+		printExecutionStepDrift(detail)
 		return nil
 	},
 }
@@ -385,6 +387,44 @@ func renderExecutionsTable(executions []client.ExecutionSummary) {
 		})
 	}
 	t.Render()
+}
+
+func loadExecutionDetailWithDrift(executionID string) (client.ExecutionDetail, error) {
+	detail, detailError := apiClient.GetExecution(executionID)
+	if detailError != nil {
+		return client.ExecutionDetail{}, fmt.Errorf("fetching execution %s: %w", executionID, detailError)
+	}
+	if enrichError := apiClient.EnrichExecutionDetailWithDrift(&detail); enrichError != nil {
+		return client.ExecutionDetail{}, fmt.Errorf("fetching execution results: %w", enrichError)
+	}
+	return detail, nil
+}
+
+func printExecutionStepDrift(detail client.ExecutionDetail) {
+	hasDrift := false
+	for _, step := range detail.Steps {
+		if len(step.DriftResources) > 0 {
+			hasDrift = true
+			break
+		}
+	}
+	if !hasDrift {
+		return
+	}
+	fmt.Println()
+	fmt.Println("Drift detected:")
+	for _, step := range detail.Steps {
+		for _, driftResource := range step.DriftResources {
+			resourceLabel := driftResource.Kind + "/" + driftResource.Name
+			if driftResource.Namespace != "" {
+				resourceLabel = driftResource.Kind + "/" + driftResource.Namespace + "/" + driftResource.Name
+			}
+			fmt.Printf("  step %s: %s (%s)\n", step.ID, resourceLabel, driftResource.DriftType)
+			for _, path := range driftResource.Paths {
+				fmt.Printf("    %s\n", path)
+			}
+		}
+	}
 }
 
 func printExecutionDetail(detail client.ExecutionDetail) {

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -133,6 +133,10 @@ func (m baseMock) GetExecution(executionID string) (client.ExecutionDetail, erro
 	return client.ExecutionDetail{}, errors.New("not implemented")
 }
 
+func (m baseMock) EnrichExecutionDetailWithDrift(detail *client.ExecutionDetail) error {
+	return nil
+}
+
 func (m baseMock) ListExecutionSteps(executionID string) ([]client.ExecutionStep, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -37,6 +37,7 @@ type APIClient interface {
 
 	ListExecutions(opts client.ListExecutionsOptions) (client.ExecutionListResponse, error)
 	GetExecution(executionID string) (client.ExecutionDetail, error)
+	EnrichExecutionDetailWithDrift(detail *client.ExecutionDetail) error
 	ListExecutionSteps(executionID string) ([]client.ExecutionStep, error)
 	CancelExecution(ctx context.Context, executionID string) (*client.CancelExecutionResponse, error)
 	CancelExecutionStep(ctx context.Context, executionID, stepID string) (*client.CancelStepResponse, error)

--- a/internal/client/drift.go
+++ b/internal/client/drift.go
@@ -1,0 +1,94 @@
+package client
+
+func DriftResourcesFromStepResult(result map[string]any) []DriftResourceDetail {
+	if result == nil {
+		return nil
+	}
+	tasks, isList := result["tasks"].([]any)
+	if !isList {
+		return nil
+	}
+	driftResources := []DriftResourceDetail{}
+	for _, taskRaw := range tasks {
+		task, isMap := taskRaw.(map[string]any)
+		if !isMap {
+			continue
+		}
+		jsonOutput, isJSONOutput := task["json_output"].(map[string]any)
+		if !isJSONOutput {
+			continue
+		}
+		detail, isDetail := jsonOutput["detail"].(map[string]any)
+		if !isDetail {
+			continue
+		}
+		driftEntries, isDriftList := detail["drift_resources"].([]any)
+		if !isDriftList {
+			continue
+		}
+		for _, driftEntryRaw := range driftEntries {
+			driftEntry, isDriftMap := driftEntryRaw.(map[string]any)
+			if !isDriftMap {
+				continue
+			}
+			parsed := DriftResourceDetail{
+				APIVersion: stringField(driftEntry, "api_version"),
+				Kind:       stringField(driftEntry, "kind"),
+				Namespace:  stringField(driftEntry, "namespace"),
+				Name:       stringField(driftEntry, "name"),
+				DriftType:  stringField(driftEntry, "drift_type"),
+				Paths:      stringListField(driftEntry, "paths"),
+			}
+			if parsed.Kind != "" && len(parsed.Paths) > 0 {
+				driftResources = append(driftResources, parsed)
+			}
+		}
+	}
+	if len(driftResources) == 0 {
+		return nil
+	}
+	return driftResources
+}
+
+func stringField(values map[string]any, key string) string {
+	value, _ := values[key].(string)
+	return value
+}
+
+func stringListField(values map[string]any, key string) []string {
+	rawList, isList := values[key].([]any)
+	if !isList {
+		return nil
+	}
+	members := make([]string, 0, len(rawList))
+	for _, rawMember := range rawList {
+		member, isString := rawMember.(string)
+		if isString {
+			members = append(members, member)
+		}
+	}
+	return members
+}
+
+func (client *Client) EnrichExecutionDetailWithDrift(detail *ExecutionDetail) error {
+	if detail == nil {
+		return nil
+	}
+	resultResponse, resultError := client.GetExecutionResult(detail.Execution.ID)
+	if resultError != nil {
+		return resultError
+	}
+	driftByStep := map[string][]DriftResourceDetail{}
+	for _, stepResult := range resultResponse.Results {
+		driftResources := DriftResourcesFromStepResult(stepResult.Result)
+		if len(driftResources) > 0 {
+			driftByStep[stepResult.StepID] = driftResources
+		}
+	}
+	for stepIndex := range detail.Steps {
+		if driftResources, hasDrift := driftByStep[detail.Steps[stepIndex].ID]; hasDrift {
+			detail.Steps[stepIndex].DriftResources = driftResources
+		}
+	}
+	return nil
+}

--- a/internal/client/drift.go
+++ b/internal/client/drift.go
@@ -39,7 +39,7 @@ func DriftResourcesFromStepResult(result map[string]any) []DriftResourceDetail {
 				DriftType:  stringField(driftEntry, "drift_type"),
 				Paths:      stringListField(driftEntry, "paths"),
 			}
-			if parsed.Kind != "" && len(parsed.Paths) > 0 {
+			if parsed.Kind != "" {
 				driftResources = append(driftResources, parsed)
 			}
 		}

--- a/internal/client/drift_test.go
+++ b/internal/client/drift_test.go
@@ -66,8 +66,8 @@ func TestDriftResourcesFromStepResultKeepsMissingResourceEntries(t *testing.T) {
 
 func TestEnrichExecutionDetailWithDrift(t *testing.T) {
 	testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
-		switch {
-		case request.URL.Path == "/api/v1/org/executions/exec-1/result":
+		switch request.URL.Path {
+		case "/api/v1/org/executions/exec-1/result":
 			jsonResponse(t, writer, http.StatusOK, ExecutionResultResponse{
 				ExecutionID: "exec-1",
 				Results: []StepResult{

--- a/internal/client/drift_test.go
+++ b/internal/client/drift_test.go
@@ -35,6 +35,35 @@ func TestDriftResourcesFromStepResult(t *testing.T) {
 	}
 }
 
+func TestDriftResourcesFromStepResultKeepsMissingResourceEntries(t *testing.T) {
+	result := map[string]any{
+		"tasks": []any{
+			map[string]any{
+				"json_output": map[string]any{
+					"detail": map[string]any{
+						"drift_resources": []any{
+							map[string]any{
+								"api_version": "v1",
+								"kind":        "ConfigMap",
+								"namespace":   "monitoring",
+								"name":        "grafana-dashboards",
+								"drift_type":  "missing",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	driftResources := DriftResourcesFromStepResult(result)
+	if len(driftResources) != 1 {
+		t.Fatalf("driftResources = %#v", driftResources)
+	}
+	if driftResources[0].DriftType != "missing" || len(driftResources[0].Paths) != 0 {
+		t.Fatalf("unexpected drift resource: %#v", driftResources[0])
+	}
+}
+
 func TestEnrichExecutionDetailWithDrift(t *testing.T) {
 	testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
 		switch {
@@ -82,5 +111,24 @@ func TestEnrichExecutionDetailWithDrift(t *testing.T) {
 	}
 	if len(detail.Steps[0].DriftResources) != 1 {
 		t.Fatalf("DriftResources = %#v", detail.Steps[0].DriftResources)
+	}
+}
+
+func TestEnrichExecutionDetailWithDriftReturnsErrorWhenRouteMissing(t *testing.T) {
+	testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusNotFound)
+	})
+
+	detail := ExecutionDetail{
+		Execution: ExecutionSummary{ID: "exec-1"},
+		Steps: []ExecutionStep{
+			{ID: "step-1", Name: "reconcile fluent-bit"},
+		},
+	}
+	if enrichError := testClient.EnrichExecutionDetailWithDrift(&detail); enrichError == nil {
+		t.Fatal("expected error when /result route is missing")
+	}
+	if len(detail.Steps[0].DriftResources) != 0 {
+		t.Fatalf("DriftResources should stay empty, got %#v", detail.Steps[0].DriftResources)
 	}
 }

--- a/internal/client/drift_test.go
+++ b/internal/client/drift_test.go
@@ -1,0 +1,86 @@
+package client
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestDriftResourcesFromStepResult(t *testing.T) {
+	result := map[string]any{
+		"tasks": []any{
+			map[string]any{
+				"json_output": map[string]any{
+					"detail": map[string]any{
+						"drift_resources": []any{
+							map[string]any{
+								"api_version": "apps/v1",
+								"kind":        "DaemonSet",
+								"namespace":   "fluent-bit",
+								"name":        "fluent-bit",
+								"drift_type":  "extra_field",
+								"paths":       []any{"/spec/template/spec/hostNetwork"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	driftResources := DriftResourcesFromStepResult(result)
+	if len(driftResources) != 1 {
+		t.Fatalf("driftResources = %#v", driftResources)
+	}
+	if driftResources[0].Kind != "DaemonSet" || driftResources[0].Paths[0] != "/spec/template/spec/hostNetwork" {
+		t.Fatalf("unexpected drift resource: %#v", driftResources[0])
+	}
+}
+
+func TestEnrichExecutionDetailWithDrift(t *testing.T) {
+	testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.URL.Path == "/api/v1/org/executions/exec-1/result":
+			jsonResponse(t, writer, http.StatusOK, ExecutionResultResponse{
+				ExecutionID: "exec-1",
+				Results: []StepResult{
+					{
+						StepID: "step-1",
+						Result: map[string]any{
+							"tasks": []any{
+								map[string]any{
+									"json_output": map[string]any{
+										"detail": map[string]any{
+											"drift_resources": []any{
+												map[string]any{
+													"kind":       "Service",
+													"name":       "prometheus",
+													"namespace":  "monitoring",
+													"drift_type": "extra_field",
+													"paths":      []any{"/spec/publishNotReadyAddresses"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+		default:
+			writer.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	detail := ExecutionDetail{
+		Execution: ExecutionSummary{ID: "exec-1"},
+		Steps: []ExecutionStep{
+			{ID: "step-1", Name: "reconcile fluent-bit"},
+		},
+	}
+	if enrichError := testClient.EnrichExecutionDetailWithDrift(&detail); enrichError != nil {
+		t.Fatalf("EnrichExecutionDetailWithDrift error = %v", enrichError)
+	}
+	if len(detail.Steps[0].DriftResources) != 1 {
+		t.Fatalf("DriftResources = %#v", detail.Steps[0].DriftResources)
+	}
+}

--- a/internal/client/executions.go
+++ b/internal/client/executions.go
@@ -35,24 +35,45 @@ type ExecutionSummary struct {
 }
 
 type ExecutionStep struct {
-	ID                 string  `json:"id"`
-	Name               string  `json:"name"`
-	Status             string  `json:"status"`
-	Type               *string `json:"type"`
-	TargetResourceKind *string `json:"target_resource_kind"`
-	TargetResourceID   *string `json:"target_resource_id"`
-	ErrorExcerpt       *string `json:"error_excerpt"`
-	SchedulerName      *string `json:"scheduler_name"`
-	StartAt            *string `json:"start_at"`
-	StopAt             *string `json:"stop_at"`
-	CreatedAt          *string `json:"created_at"`
-	UpdatedAt          *string `json:"updated_at"`
+	ID                 string                `json:"id"`
+	Name               string                `json:"name"`
+	Status             string                `json:"status"`
+	Type               *string               `json:"type"`
+	TargetResourceKind *string               `json:"target_resource_kind"`
+	TargetResourceID   *string               `json:"target_resource_id"`
+	ErrorExcerpt       *string               `json:"error_excerpt"`
+	SchedulerName      *string               `json:"scheduler_name"`
+	StartAt            *string               `json:"start_at"`
+	StopAt             *string               `json:"stop_at"`
+	CreatedAt          *string               `json:"created_at"`
+	UpdatedAt          *string               `json:"updated_at"`
+	DriftResources     []DriftResourceDetail `json:"drift_resources,omitempty"`
+}
+
+type DriftResourceDetail struct {
+	APIVersion string   `json:"api_version,omitempty"`
+	Kind       string   `json:"kind,omitempty"`
+	Namespace  string   `json:"namespace,omitempty"`
+	Name       string   `json:"name,omitempty"`
+	DriftType  string   `json:"drift_type,omitempty"`
+	Paths      []string `json:"paths,omitempty"`
 }
 
 type ExecutionDetail struct {
 	Execution   ExecutionSummary `json:"execution"`
 	Steps       []ExecutionStep  `json:"steps"`
 	StepSummary StepSummary      `json:"step_summary"`
+}
+
+type ExecutionResultResponse struct {
+	ExecutionID string       `json:"execution_id"`
+	Results     []StepResult `json:"results"`
+}
+
+type StepResult struct {
+	StepID    string         `json:"step_id"`
+	Result    map[string]any `json:"result"`
+	UpdatedAt *string        `json:"updated_at"`
 }
 
 type ExecutionListResponse struct {
@@ -136,6 +157,15 @@ func (c *Client) GetExecution(executionID string) (ExecutionDetail, error) {
 		return ExecutionDetail{}, err
 	}
 	return detail, nil
+}
+
+func (c *Client) GetExecutionResult(executionID string) (ExecutionResultResponse, error) {
+	endpoint := fmt.Sprintf("%s/api/v1/org/executions/%s/result", c.BaseURL, executionID)
+	var response ExecutionResultResponse
+	if err := c.getJSON(endpoint, &response); err != nil {
+		return ExecutionResultResponse{}, err
+	}
+	return response, nil
 }
 
 func (c *Client) ListExecutionSteps(executionID string) ([]ExecutionStep, error) {


### PR DESCRIPTION
## Summary
- Fetch `/org/executions/{id}/result` when inspecting a single operation
- Attach `drift_resources` (kind, name, paths, drift_type) to each step in JSON and human-readable output

## Test plan
- [x] `go test ./internal/client/ -run 'Drift|Enrich'`

Made with [Cursor](https://cursor.com)