### PR TITLE
docs(changelog): cut v0.8.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Ankra CLI Changelog
 
-## Unreleased
+## v0.8.0 — 2026-07-14
+
+The stable v0.8.0 release promotes v0.8.0-rc0: agent-token output and
+agent-status accuracy fixes, plus drift field-path visibility in
+`ankra cluster operations`.
 
 ### Added
 


### PR DESCRIPTION
## Summary
- Promotes v0.8.0-rc0 to a stable v0.8.0 changelog section (agent token/status fixes + operations drift field paths).

Merging this, then tagging v0.8.0 on master triggers the stable release (binaries + Homebrew formula).

Made with [Cursor](https://cursor.com)