### PR TITLE
feat(application): add full management command surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **Application management is available from the CLI.** `ankra application
+  add .` detects a local GitHub checkout and starts application setup, while
+  the application subcommands expose lifecycle, deployment, workflow,
+  repository, security, publishing, and demo operations through the bearer
+  API. `-o json|yaml` provides scriptable output.
 - **Read-only API calls now retry transient platform errors.** Bodyless
   `GET`/`HEAD` requests that fail with a transport-level timeout (for
   example `http2: timeout awaiting response headers`), a connection

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ ankra cluster operations retry <execution_id>
 ankra cluster hetzner create --name prod --credential-id <cred> \
   --location fsn1 --worker-count 3
 
+# Connect and manage an application
+ankra application add .
+ankra application list
+ankra application deployments <application-id>
+
 # Ask AI about your infrastructure
 ankra chat "why is my nginx pod crash-looping?" --cluster prod
 

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -1,0 +1,513 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+type localApplicationRepository struct {
+	Owner  string
+	Name   string
+	Branch string
+}
+
+type applicationAddOutput struct {
+	ID             string `json:"id" yaml:"id"`
+	Name           string `json:"name" yaml:"name"`
+	Repository     string `json:"repository" yaml:"repository"`
+	Branch         string `json:"branch" yaml:"branch"`
+	CredentialName string `json:"credential_name" yaml:"credential_name"`
+}
+
+func newApplicationCommand() *cobra.Command {
+	applicationCommand := &cobra.Command{
+		Use:     "application",
+		Aliases: []string{"applications", "app", "apps"},
+		Short:   "Manage applications",
+		Long:    "Connect application source repositories to Ankra for analysis, packaging, and deployment.",
+	}
+	applicationCommand.AddCommand(newApplicationAddCommand())
+	registerApplicationResourceCommands(applicationCommand)
+	return applicationCommand
+}
+
+func newApplicationAddCommand() *cobra.Command {
+	addCommand := &cobra.Command{
+		Use:   "add <path>",
+		Short: "Add an application from a local GitHub checkout",
+		Long: `Add an application by reading a local Git checkout.
+
+The command detects the GitHub repository from the selected remote, uses the
+remote's default branch when available, and falls back to the current branch.
+It selects an available GitHub credential automatically when the choice is
+unambiguous.`,
+		Example: `  ankra application add .
+  ankra application add ./services/payments --name payments
+  ankra application add . --credential github-acme --branch main`,
+		Args: cobra.ExactArgs(1),
+		RunE: runApplicationAdd,
+	}
+	addCommand.Flags().String("name", "", "Application name (defaults to the repository name)")
+	addCommand.Flags().String("credential", "", "GitHub credential name or ID (auto-detected when omitted)")
+	addCommand.Flags().String("branch", "", "Repository branch (auto-detected when omitted)")
+	addCommand.Flags().String("remote", "origin", "Git remote used to identify the GitHub repository")
+	registerStructuredOutputFlags(addCommand)
+	return addCommand
+}
+
+func runApplicationAdd(command *cobra.Command, arguments []string) error {
+	if _, outputError := structuredFormatFromFlags(command); outputError != nil {
+		return outputError
+	}
+
+	remoteName, _ := command.Flags().GetString("remote")
+	branchOverride, _ := command.Flags().GetString("branch")
+	branchOverride = strings.TrimSpace(branchOverride)
+	if command.Flags().Changed("branch") && branchOverride == "" {
+		return withExitCode(exitUsage, errors.New("branch cannot be empty"))
+	}
+	repository, repositoryError := inspectLocalApplicationRepository(
+		command.Context(),
+		arguments[0],
+		strings.TrimSpace(remoteName),
+		branchOverride,
+	)
+	if repositoryError != nil {
+		return repositoryError
+	}
+
+	applicationName, _ := command.Flags().GetString("name")
+	applicationName = strings.TrimSpace(applicationName)
+	if applicationName == "" {
+		if command.Flags().Changed("name") {
+			return withExitCode(exitUsage, errors.New("application name cannot be empty"))
+		}
+		applicationName = repository.Name
+	}
+
+	requestedCredential, _ := command.Flags().GetString("credential")
+	requestedCredential = strings.TrimSpace(requestedCredential)
+	if command.Flags().Changed("credential") && requestedCredential == "" {
+		return withExitCode(exitUsage, errors.New("credential cannot be empty"))
+	}
+	githubProvider := "github"
+	credentials, credentialsError := apiClient.ListCredentials(&githubProvider)
+	if credentialsError != nil {
+		return fmt.Errorf("listing GitHub credentials: %w", credentialsError)
+	}
+	selectedCredential, selectionError := selectApplicationCredential(
+		credentials,
+		repository.Owner,
+		requestedCredential,
+	)
+	if selectionError != nil {
+		return selectionError
+	}
+
+	applicationResponse, createError := apiClient.CreateApplication(command.Context(), client.CreateApplicationRequest{
+		Name:                     applicationName,
+		RepositoryCredentialName: selectedCredential.Name,
+		RepositoryOwner:          repository.Owner,
+		RepositoryName:           repository.Name,
+		RepositoryBranch:         repository.Branch,
+	})
+	if createError != nil {
+		return fmt.Errorf("adding application: %w", createError)
+	}
+	if applicationResponse == nil {
+		return errors.New("adding application: platform returned an empty response")
+	}
+	if len(applicationResponse.Errors) > 0 {
+		return applicationCreationError(applicationResponse.Errors)
+	}
+	if applicationResponse.ID == nil || strings.TrimSpace(*applicationResponse.ID) == "" {
+		return errors.New("adding application: platform response did not include an application ID")
+	}
+
+	result := applicationAddOutput{
+		ID:             *applicationResponse.ID,
+		Name:           applicationName,
+		Repository:     repository.Owner + "/" + repository.Name,
+		Branch:         repository.Branch,
+		CredentialName: selectedCredential.Name,
+	}
+	if rendered, renderError := renderStructured(command, result); rendered || renderError != nil {
+		return renderError
+	}
+
+	output := command.OutOrStdout()
+	_, _ = fmt.Fprintln(output, "Application added successfully.")
+	_, _ = fmt.Fprintf(output, "  ID:         %s\n", result.ID)
+	_, _ = fmt.Fprintf(output, "  Name:       %s\n", result.Name)
+	_, _ = fmt.Fprintf(output, "  Repository: %s\n", result.Repository)
+	_, _ = fmt.Fprintf(output, "  Branch:     %s\n", result.Branch)
+	_, _ = fmt.Fprintf(output, "  Credential: %s\n", result.CredentialName)
+	_, _ = fmt.Fprintln(output, "\nAnkra is now analyzing the repository.")
+	return nil
+}
+
+func inspectLocalApplicationRepository(
+	requestContext context.Context,
+	repositoryPath string,
+	remoteName string,
+	branchOverride string,
+) (localApplicationRepository, error) {
+	if remoteName == "" {
+		return localApplicationRepository{}, withExitCode(
+			exitUsage,
+			errors.New("remote name cannot be empty"),
+		)
+	}
+	pathInformation, statError := os.Stat(repositoryPath)
+	if statError != nil {
+		if os.IsNotExist(statError) {
+			return localApplicationRepository{}, withExitCode(
+				exitNotFound,
+				fmt.Errorf("application path %q does not exist", repositoryPath),
+			)
+		}
+		return localApplicationRepository{}, fmt.Errorf("cannot access application path %q: %w", repositoryPath, statError)
+	}
+	if !pathInformation.IsDir() {
+		return localApplicationRepository{}, withExitCode(
+			exitUsage,
+			fmt.Errorf("application path %q is not a directory", repositoryPath),
+		)
+	}
+
+	repositoryRoot, rootError := executeGit(
+		requestContext,
+		repositoryPath,
+		"rev-parse",
+		"--show-toplevel",
+	)
+	if rootError != nil {
+		if strings.Contains(strings.ToLower(rootError.Error()), "not a git repository") {
+			return localApplicationRepository{}, withExitCode(
+				exitUsage,
+				fmt.Errorf("application path %q is not inside a Git repository", repositoryPath),
+			)
+		}
+		return localApplicationRepository{}, fmt.Errorf(
+			"inspect Git repository at %q: %w",
+			repositoryPath,
+			rootError,
+		)
+	}
+
+	remoteURL, remoteError := executeGit(
+		requestContext,
+		repositoryRoot,
+		"remote",
+		"get-url",
+		remoteName,
+	)
+	if remoteError != nil {
+		if strings.Contains(strings.ToLower(remoteError.Error()), "no such remote") {
+			return localApplicationRepository{}, withExitCode(
+				exitUsage,
+				fmt.Errorf("git remote %q was not found; add it or pass --remote", remoteName),
+			)
+		}
+		return localApplicationRepository{}, fmt.Errorf("read git remote %q: %w", remoteName, remoteError)
+	}
+	repositoryOwner, repositoryName, parseError := parseGitHubRepositoryRemote(remoteURL)
+	if parseError != nil {
+		return localApplicationRepository{}, withExitCode(
+			exitUsage,
+			fmt.Errorf("git remote %q: %w", remoteName, parseError),
+		)
+	}
+
+	branchName := branchOverride
+	if branchName == "" {
+		var branchError error
+		branchName, branchError = detectApplicationBranch(requestContext, repositoryRoot, remoteName)
+		if branchError != nil {
+			return localApplicationRepository{}, fmt.Errorf("detect repository branch: %w", branchError)
+		}
+	}
+	if branchName == "" {
+		return localApplicationRepository{}, withExitCode(
+			exitUsage,
+			errors.New("could not determine the repository branch; pass --branch"),
+		)
+	}
+	if _, branchError := executeGit(
+		requestContext,
+		repositoryRoot,
+		"check-ref-format",
+		"--branch",
+		branchName,
+	); branchError != nil {
+		if requestContextError := requestContext.Err(); requestContextError != nil {
+			return localApplicationRepository{}, fmt.Errorf("validate repository branch: %w", requestContextError)
+		}
+		var exitError *exec.ExitError
+		if !errors.As(branchError, &exitError) {
+			return localApplicationRepository{}, fmt.Errorf("validate repository branch: %w", branchError)
+		}
+		return localApplicationRepository{}, withExitCode(
+			exitUsage,
+			fmt.Errorf("repository branch %q is invalid", branchName),
+		)
+	}
+
+	return localApplicationRepository{
+		Owner:  repositoryOwner,
+		Name:   repositoryName,
+		Branch: branchName,
+	}, nil
+}
+
+func executeGit(
+	requestContext context.Context,
+	directory string,
+	arguments ...string,
+) (string, error) {
+	commandArguments := append([]string{"-C", directory}, arguments...)
+	gitCommand := exec.CommandContext(requestContext, "git", commandArguments...)
+	gitCommand.Env = append(os.Environ(), "LC_ALL=C")
+	commandOutput, commandError := gitCommand.CombinedOutput()
+	if commandError != nil {
+		errorDetail := strings.TrimSpace(string(commandOutput))
+		if errorDetail == "" {
+			return "", fmt.Errorf("execute git: %w", commandError)
+		}
+		return "", fmt.Errorf("execute git: %w: %s", commandError, errorDetail)
+	}
+	return strings.TrimSpace(string(commandOutput)), nil
+}
+
+func detectApplicationBranch(
+	requestContext context.Context,
+	repositoryRoot string,
+	remoteName string,
+) (string, error) {
+	remoteHead, remoteHeadError := executeGit(
+		requestContext,
+		repositoryRoot,
+		"symbolic-ref",
+		"--quiet",
+		"--short",
+		"refs/remotes/"+remoteName+"/HEAD",
+	)
+	if remoteHeadError == nil {
+		remotePrefix := remoteName + "/"
+		if strings.HasPrefix(remoteHead, remotePrefix) {
+			if branchName := strings.TrimSpace(strings.TrimPrefix(remoteHead, remotePrefix)); branchName != "" {
+				return branchName, nil
+			}
+		}
+	} else {
+		if requestContextError := requestContext.Err(); requestContextError != nil {
+			return "", requestContextError
+		}
+		var exitError *exec.ExitError
+		if !errors.As(remoteHeadError, &exitError) {
+			return "", remoteHeadError
+		}
+	}
+
+	currentBranch, currentBranchError := executeGit(
+		requestContext,
+		repositoryRoot,
+		"branch",
+		"--show-current",
+	)
+	if currentBranchError != nil {
+		return "", currentBranchError
+	}
+	return strings.TrimSpace(currentBranch), nil
+}
+
+func parseGitHubRepositoryRemote(remoteURL string) (string, string, error) {
+	trimmedRemoteURL := strings.TrimSpace(remoteURL)
+	if trimmedRemoteURL == "" {
+		return "", "", errors.New("remote URL is empty")
+	}
+
+	var repositoryPath string
+	if strings.Contains(trimmedRemoteURL, "://") {
+		parsedURL, parseError := url.Parse(trimmedRemoteURL)
+		if parseError != nil || !strings.EqualFold(parsedURL.Hostname(), "github.com") {
+			return "", "", errors.New("remote is not a github.com repository")
+		}
+		switch strings.ToLower(parsedURL.Scheme) {
+		case "git", "http", "https", "ssh":
+		default:
+			return "", "", errors.New("remote uses an unsupported GitHub URL scheme")
+		}
+		repositoryPath = parsedURL.EscapedPath()
+	} else {
+		separatorIndex := strings.Index(trimmedRemoteURL, ":")
+		if separatorIndex <= 0 {
+			return "", "", errors.New("remote is not a github.com repository")
+		}
+		hostPart := trimmedRemoteURL[:separatorIndex]
+		if userSeparatorIndex := strings.LastIndex(hostPart, "@"); userSeparatorIndex >= 0 {
+			hostPart = hostPart[userSeparatorIndex+1:]
+		}
+		if !strings.EqualFold(hostPart, "github.com") {
+			return "", "", errors.New("remote is not a github.com repository")
+		}
+		repositoryPath = trimmedRemoteURL[separatorIndex+1:]
+	}
+
+	decodedPath, decodeError := url.PathUnescape(repositoryPath)
+	if decodeError != nil {
+		return "", "", errors.New("remote repository path is invalid")
+	}
+	pathParts := strings.Split(strings.Trim(decodedPath, "/"), "/")
+	if len(pathParts) != 2 {
+		return "", "", errors.New("remote must identify a GitHub repository as owner/name")
+	}
+	repositoryOwner := strings.TrimSpace(pathParts[0])
+	repositoryName := strings.TrimSuffix(strings.TrimSpace(pathParts[1]), ".git")
+	if repositoryOwner == "" || repositoryName == "" ||
+		repositoryOwner == "." || repositoryOwner == ".." ||
+		repositoryName == "." || repositoryName == ".." {
+		return "", "", errors.New("remote must identify a GitHub repository as owner/name")
+	}
+	return repositoryOwner, repositoryName, nil
+}
+
+func selectApplicationCredential(
+	credentials []client.Credential,
+	repositoryOwner string,
+	requestedCredential string,
+) (client.Credential, error) {
+	githubCredentials := make([]client.Credential, 0, len(credentials))
+	for _, credential := range credentials {
+		if strings.EqualFold(credential.Provider, "github") {
+			githubCredentials = append(githubCredentials, credential)
+		}
+	}
+
+	if requestedCredential != "" {
+		for _, credential := range githubCredentials {
+			if credential.ID == requestedCredential {
+				if !applicationCredentialAvailable(credential) {
+					return client.Credential{}, fmt.Errorf(
+						"GitHub credential %q is not available",
+						credential.Name,
+					)
+				}
+				return credential, nil
+			}
+		}
+		nameMatches := make([]client.Credential, 0, 1)
+		for _, credential := range githubCredentials {
+			if credential.Name == requestedCredential {
+				nameMatches = append(nameMatches, credential)
+			}
+		}
+		switch len(nameMatches) {
+		case 0:
+			return client.Credential{}, withExitCode(
+				exitNotFound,
+				fmt.Errorf(
+					"GitHub credential %q was not found; run `ankra credentials list --provider github`",
+					requestedCredential,
+				),
+			)
+		case 1:
+			if !applicationCredentialAvailable(nameMatches[0]) {
+				return client.Credential{}, fmt.Errorf(
+					"GitHub credential %q is not available",
+					nameMatches[0].Name,
+				)
+			}
+			return nameMatches[0], nil
+		default:
+			return client.Credential{}, withExitCode(
+				exitUsage,
+				fmt.Errorf(
+					"multiple GitHub credentials are named %q; pass the credential ID instead",
+					requestedCredential,
+				),
+			)
+		}
+	}
+
+	availableCredentials := make([]client.Credential, 0, len(githubCredentials))
+	ownerMatches := make([]client.Credential, 0, 1)
+	for _, credential := range githubCredentials {
+		if !applicationCredentialAvailable(credential) {
+			continue
+		}
+		availableCredentials = append(availableCredentials, credential)
+		if credential.AccountLogin != nil &&
+			strings.EqualFold(strings.TrimSpace(*credential.AccountLogin), repositoryOwner) {
+			ownerMatches = append(ownerMatches, credential)
+		}
+	}
+
+	if len(ownerMatches) == 1 {
+		return ownerMatches[0], nil
+	}
+	if len(ownerMatches) > 1 {
+		return client.Credential{}, ambiguousApplicationCredentialError(ownerMatches, repositoryOwner)
+	}
+	if len(availableCredentials) == 1 {
+		return availableCredentials[0], nil
+	}
+	if len(availableCredentials) == 0 {
+		return client.Credential{}, errors.New(
+			"no available GitHub credential found; install the Ankra GitHub App, then run this command again",
+		)
+	}
+	return client.Credential{}, ambiguousApplicationCredentialError(availableCredentials, repositoryOwner)
+}
+
+func applicationCredentialAvailable(credential client.Credential) bool {
+	return credential.Available
+}
+
+func ambiguousApplicationCredentialError(
+	credentials []client.Credential,
+	repositoryOwner string,
+) error {
+	credentialNames := make([]string, 0, len(credentials))
+	for _, credential := range credentials {
+		credentialNames = append(credentialNames, credential.Name)
+	}
+	sort.Strings(credentialNames)
+	return withExitCode(
+		exitUsage,
+		fmt.Errorf(
+			"multiple GitHub credentials are available for repository owner %q (%s); pass --credential <name-or-id>",
+			repositoryOwner,
+			strings.Join(credentialNames, ", "),
+		),
+	)
+}
+
+func applicationCreationError(resourceErrors []client.ApplicationResourceError) error {
+	errorMessages := make([]string, 0)
+	for _, resourceError := range resourceErrors {
+		for _, errorItem := range resourceError.Errors {
+			if strings.TrimSpace(errorItem.Message) != "" {
+				errorMessages = append(errorMessages, errorItem.Message)
+			}
+		}
+	}
+	if len(errorMessages) == 0 {
+		return errors.New("application could not be created")
+	}
+	return errors.New(strings.Join(errorMessages, "; "))
+}
+
+func init() {
+	rootCmd.AddCommand(newApplicationCommand())
+}

--- a/cmd/application_demo.go
+++ b/cmd/application_demo.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// newApplicationDemoCommand groups the ephemeral demo-workspace verbs behind
+// `ankra application demo ...`. The demo mutations skip CSRF on the bearer
+// path, so they are safe to drive from the CLI with a PAT.
+func newApplicationDemoCommand() *cobra.Command {
+	demoCommand := &cobra.Command{
+		Use:   "demo",
+		Short: "Manage ephemeral demo workspaces for an application",
+		Long:  "Deploy, inspect, and stop short-lived demo workspaces for a branch or pull request of an application.",
+	}
+	demoCommand.AddCommand(
+		newApplicationDemoListCommand(),
+		newApplicationDemoBuildCommand(),
+		newApplicationDemoDeployCommand(),
+		newApplicationDemoStopCommand(),
+	)
+	return demoCommand
+}
+
+func newApplicationDemoListCommand() *cobra.Command {
+	listCommand := &cobra.Command{
+		Use:   "list <application-id>",
+		Short: "List the application's active demo workspaces",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+				return formatError
+			}
+			payload, listError := apiClient.GetApplicationDemos(command.Context(), strings.TrimSpace(arguments[0]))
+			if listError != nil {
+				return listError
+			}
+			return renderApplicationPayload(command, payload)
+		},
+	}
+	registerStructuredOutputFlags(listCommand)
+	return listCommand
+}
+
+func newApplicationDemoBuildCommand() *cobra.Command {
+	buildCommand := &cobra.Command{
+		Use:   "build <application-id>",
+		Short: "Check whether a branch has a demo-ready container image",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+				return formatError
+			}
+			branch, _ := command.Flags().GetString("branch")
+			branch = strings.TrimSpace(branch)
+			if branch == "" {
+				return withExitCode(exitUsage, errors.New("--branch is required"))
+			}
+			payload, buildError := apiClient.CheckApplicationDemoBuild(command.Context(), strings.TrimSpace(arguments[0]), branch)
+			if buildError != nil {
+				return buildError
+			}
+			return renderApplicationPayload(command, payload)
+		},
+	}
+	buildCommand.Flags().String("branch", "", "Repository branch to inspect (required)")
+	registerStructuredOutputFlags(buildCommand)
+	return buildCommand
+}
+
+func newApplicationDemoDeployCommand() *cobra.Command {
+	deployCommand := &cobra.Command{
+		Use:   "deploy <application-id>",
+		Short: "Deploy an ephemeral demo workspace",
+		Long: `Deploy a short-lived demo workspace for a branch or pull request.
+
+All flags are optional; only the flags you set are sent, so the backend
+applies its own defaults for the rest.`,
+		Example: `  ankra application demo deploy <app-id> --branch feature/login
+  ankra application demo deploy <app-id> --pr-number 42 --ttl-hours 8`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+				return formatError
+			}
+			demoRequest := client.DeployApplicationDemoRequest{}
+			if command.Flags().Changed("branch") {
+				branch, _ := command.Flags().GetString("branch")
+				demoRequest.Branch = &branch
+			}
+			if command.Flags().Changed("pr-number") {
+				prNumber, _ := command.Flags().GetInt("pr-number")
+				demoRequest.PRNumber = &prNumber
+			}
+			if command.Flags().Changed("image-tag") {
+				imageTag, _ := command.Flags().GetString("image-tag")
+				demoRequest.ImageTag = &imageTag
+			}
+			if command.Flags().Changed("ttl-hours") {
+				ttlHours, _ := command.Flags().GetInt("ttl-hours")
+				demoRequest.TTLHours = &ttlHours
+			}
+			if command.Flags().Changed("container-port") {
+				containerPort, _ := command.Flags().GetInt("container-port")
+				demoRequest.ContainerPort = &containerPort
+			}
+			payload, deployError := apiClient.DeployApplicationDemo(command.Context(), strings.TrimSpace(arguments[0]), demoRequest)
+			if deployError != nil {
+				return deployError
+			}
+			return renderApplicationPayload(command, payload)
+		},
+	}
+	deployCommand.Flags().String("branch", "", "Repository branch to deploy")
+	deployCommand.Flags().Int("pr-number", 0, "Pull request number to deploy")
+	deployCommand.Flags().String("image-tag", "", "Explicit container image tag to deploy")
+	deployCommand.Flags().Int("ttl-hours", 0, "Lifetime of the demo workspace in hours")
+	deployCommand.Flags().Int("container-port", 0, "Container port to expose")
+	registerStructuredOutputFlags(deployCommand)
+	return deployCommand
+}
+
+func newApplicationDemoStopCommand() *cobra.Command {
+	stopCommand := &cobra.Command{
+		Use:   "stop <application-id> <workspace-id>",
+		Short: "Stop and tear down a demo workspace",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+				return formatError
+			}
+			workspaceID := strings.TrimSpace(arguments[1])
+			if workspaceID == "" {
+				return withExitCode(exitUsage, errors.New("workspace id cannot be empty"))
+			}
+			payload, stopError := apiClient.StopApplicationDemo(command.Context(), strings.TrimSpace(arguments[0]), workspaceID)
+			if stopError != nil {
+				return stopError
+			}
+			return renderApplicationPayload(command, payload)
+		},
+	}
+	registerStructuredOutputFlags(stopCommand)
+	return stopCommand
+}

--- a/cmd/application_resources.go
+++ b/cmd/application_resources.go
@@ -1,0 +1,497 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// renderApplicationPayload prints a raw JSON payload from an application
+// subresource. The default and -o json formats emit indented JSON; -o yaml
+// re-encodes as YAML. Application subresources are deeply nested documents
+// (security findings, chart graphs, deployment matrices), so structured
+// output is the readable default rather than a bespoke table per endpoint.
+func renderApplicationPayload(command *cobra.Command, payload json.RawMessage) error {
+	format, formatError := structuredFormatFromFlags(command)
+	if formatError != nil {
+		return formatError
+	}
+	output := command.OutOrStdout()
+	if format == outputYAML {
+		var decoded interface{}
+		if len(payload) > 0 {
+			if unmarshalError := json.Unmarshal(payload, &decoded); unmarshalError != nil {
+				return fmt.Errorf("parsing response: %w", unmarshalError)
+			}
+		}
+		return encodeStructured(output, outputYAML, decoded)
+	}
+	var buffer bytes.Buffer
+	if indentError := json.Indent(&buffer, payload, "", "  "); indentError != nil {
+		_, _ = output.Write(payload)
+		_, _ = fmt.Fprintln(output)
+		return nil
+	}
+	_, _ = output.Write(buffer.Bytes())
+	_, _ = fmt.Fprintln(output)
+	return nil
+}
+
+// applicationSubresourceInvoke fetches a raw JSON payload for a single
+// application; it is invoked at run time so the shared apiClient global is
+// already wired.
+type applicationSubresourceInvoke func(command *cobra.Command, applicationID string) (json.RawMessage, error)
+
+// newApplicationSubresourceCommand builds a `<verb> <application-id>` command
+// that fetches a JSON payload and renders it. It covers the reads and the
+// bodyless action routes (retry, reconcile, delete, make-public,
+// upgrade-workflow) that only need the application id.
+func newApplicationSubresourceCommand(name string, short string, invoke applicationSubresourceInvoke) *cobra.Command {
+	command := &cobra.Command{
+		Use:   name + " <application-id>",
+		Short: short,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+				return formatError
+			}
+			payload, invokeError := invoke(command, strings.TrimSpace(arguments[0]))
+			if invokeError != nil {
+				return invokeError
+			}
+			return renderApplicationPayload(command, payload)
+		},
+	}
+	registerStructuredOutputFlags(command)
+	return command
+}
+
+func registerApplicationResourceCommands(applicationCommand *cobra.Command) {
+	applicationCommand.AddCommand(
+		newApplicationListCommand(),
+		newApplicationSubresourceCommand("get", "Show an application's detail", func(command *cobra.Command, applicationID string) (json.RawMessage, error) {
+			return apiClient.GetApplicationRaw(command.Context(), applicationID)
+		}),
+		newApplicationJobsCommand(),
+		newApplicationSubresourceCommand("retry", "Re-trigger a failed application's setup", func(command *cobra.Command, applicationID string) (json.RawMessage, error) {
+			return apiClient.RetryApplication(command.Context(), applicationID)
+		}),
+		newApplicationSubresourceCommand("reconcile", "Request an application refresh", func(command *cobra.Command, applicationID string) (json.RawMessage, error) {
+			return apiClient.ReconcileApplication(command.Context(), applicationID)
+		}),
+		newApplicationSubresourceCommand("delete", "Delete an application", func(command *cobra.Command, applicationID string) (json.RawMessage, error) {
+			return apiClient.DeleteApplication(command.Context(), applicationID)
+		}),
+		newApplicationDeployCommand(),
+		newApplicationSubresourceCommand("deployments", "List an application's cluster deployments", func(command *cobra.Command, applicationID string) (json.RawMessage, error) {
+			return apiClient.GetApplicationDeployments(command.Context(), applicationID)
+		}),
+		newApplicationSubresourceCommand("installations", "List an application's installation intents", func(command *cobra.Command, applicationID string) (json.RawMessage, error) {
+			return apiClient.GetApplicationInstallations(command.Context(), applicationID)
+		}),
+		newApplicationSubresourceCommand("chart-versions", "List an application's published chart versions", func(command *cobra.Command, applicationID string) (json.RawMessage, error) {
+			return apiClient.GetApplicationChartVersions(command.Context(), applicationID)
+		}),
+		newApplicationPlatformCommand(),
+		newApplicationWorkflowRunsCommand(),
+		newApplicationWorkflowRunJobsCommand(),
+		newApplicationRerunWorkflowCommand(),
+		newApplicationPullRequestReviewsCommand(),
+		newApplicationSubresourceCommand("upgrade-workflow", "Add security scanning steps to the build workflow", func(command *cobra.Command, applicationID string) (json.RawMessage, error) {
+			return apiClient.UpgradeApplicationWorkflow(command.Context(), applicationID)
+		}),
+		newApplicationSubresourceCommand("branches", "List the application repository branches", func(command *cobra.Command, applicationID string) (json.RawMessage, error) {
+			return apiClient.GetApplicationBranches(command.Context(), applicationID)
+		}),
+		newApplicationSubresourceCommand("branch-files", "List the tracked files on the setup branch", func(command *cobra.Command, applicationID string) (json.RawMessage, error) {
+			return apiClient.GetApplicationBranchFiles(command.Context(), applicationID)
+		}),
+		newApplicationUpdateFilesCommand(),
+		newApplicationSubresourceCommand("publish-readiness", "Report whether the repository can publish to GHCR", func(command *cobra.Command, applicationID string) (json.RawMessage, error) {
+			return apiClient.GetApplicationPublishReadiness(command.Context(), applicationID)
+		}),
+		newApplicationSubresourceCommand("container-security", "Show container image vulnerability findings", func(command *cobra.Command, applicationID string) (json.RawMessage, error) {
+			return apiClient.GetApplicationContainerSecurity(command.Context(), applicationID)
+		}),
+		newApplicationSubresourceCommand("code-security", "Show source code security findings", func(command *cobra.Command, applicationID string) (json.RawMessage, error) {
+			return apiClient.GetApplicationCodeSecurity(command.Context(), applicationID)
+		}),
+		newApplicationSubresourceCommand("package-visibility", "Show the GHCR image and chart package visibility", func(command *cobra.Command, applicationID string) (json.RawMessage, error) {
+			return apiClient.GetApplicationPackageVisibility(command.Context(), applicationID)
+		}),
+		newApplicationSetPackageVisibilityCommand(),
+		newApplicationSubresourceCommand("make-public", "Make the GHCR image and chart packages public", func(command *cobra.Command, applicationID string) (json.RawMessage, error) {
+			return apiClient.MakeApplicationPackagesPublic(command.Context(), applicationID)
+		}),
+	)
+	applicationCommand.AddCommand(newApplicationDemoCommand())
+}
+
+func newApplicationListCommand() *cobra.Command {
+	listCommand := &cobra.Command{
+		Use:   "list",
+		Short: "List applications",
+		Args:  cobra.NoArgs,
+		RunE: func(command *cobra.Command, arguments []string) error {
+			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+				return formatError
+			}
+			page, _ := command.Flags().GetInt("page")
+			pageSize, _ := command.Flags().GetInt("page-size")
+			search, _ := command.Flags().GetString("search")
+			payload, listError := apiClient.ListApplicationsRaw(command.Context(), page, pageSize, strings.TrimSpace(search))
+			if listError != nil {
+				return listError
+			}
+			return renderApplicationPayload(command, payload)
+		},
+	}
+	listCommand.Flags().Int("page", 0, "Page number (1-based)")
+	listCommand.Flags().Int("page-size", 0, "Page size (1-100)")
+	listCommand.Flags().String("search", "", "Filter applications by name")
+	registerStructuredOutputFlags(listCommand)
+	return listCommand
+}
+
+func newApplicationJobsCommand() *cobra.Command {
+	jobsCommand := &cobra.Command{
+		Use:   "jobs <application-id>",
+		Short: "List an application's platform jobs",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+				return formatError
+			}
+			page, _ := command.Flags().GetInt("page")
+			pageSize, _ := command.Flags().GetInt("page-size")
+			payload, jobsError := apiClient.GetApplicationJobs(command.Context(), strings.TrimSpace(arguments[0]), page, pageSize)
+			if jobsError != nil {
+				return jobsError
+			}
+			return renderApplicationPayload(command, payload)
+		},
+	}
+	jobsCommand.Flags().Int("page", 0, "Page number (1-based)")
+	jobsCommand.Flags().Int("page-size", 0, "Page size (1-100)")
+	registerStructuredOutputFlags(jobsCommand)
+	return jobsCommand
+}
+
+func newApplicationDeployCommand() *cobra.Command {
+	deployCommand := &cobra.Command{
+		Use:   "deploy <application-id>",
+		Short: "Deploy an application to a cluster",
+		Long: `Deploy a packaged application to a target cluster.
+
+The cluster is identified by ID. Use --set key=value (repeatable) to pass
+deploy inputs declared by the application's chart.`,
+		Example: `  ankra application deploy <app-id> --cluster <cluster-id>
+  ankra application deploy <app-id> --cluster <cluster-id> --namespace prod --set replicas=3`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+				return formatError
+			}
+			clusterID, _ := command.Flags().GetString("cluster")
+			clusterID = strings.TrimSpace(clusterID)
+			if clusterID == "" {
+				return withExitCode(exitUsage, errors.New("--cluster is required"))
+			}
+			namespace, _ := command.Flags().GetString("namespace")
+			deployMode, _ := command.Flags().GetString("mode")
+			deployMode = strings.TrimSpace(deployMode)
+			if deployMode != "" && deployMode != "quick" && deployMode != "high_availability" {
+				return withExitCode(exitUsage, errors.New("--mode must be quick or high_availability"))
+			}
+			setValues, _ := command.Flags().GetStringArray("set")
+			inputs, parseError := parseKeyValueFlags(setValues)
+			if parseError != nil {
+				return withExitCode(exitUsage, parseError)
+			}
+			payload, deployError := apiClient.DeployApplication(command.Context(), strings.TrimSpace(arguments[0]),
+				client.DeployApplicationRequest{
+					ClusterID:  clusterID,
+					Namespace:  strings.TrimSpace(namespace),
+					DeployMode: deployMode,
+					Inputs:     inputs,
+				})
+			if deployError != nil {
+				return deployError
+			}
+			return renderApplicationPayload(command, payload)
+		},
+	}
+	deployCommand.Flags().String("cluster", "", "Target cluster ID (required)")
+	deployCommand.Flags().String("namespace", "", "Target namespace (defaults to the platform default)")
+	deployCommand.Flags().String("mode", "", "Deploy mode: quick or high_availability")
+	deployCommand.Flags().StringArray("set", nil, "Deploy input as key=value (repeatable)")
+	registerStructuredOutputFlags(deployCommand)
+	return deployCommand
+}
+
+func newApplicationPlatformCommand() *cobra.Command {
+	platformCommand := &cobra.Command{
+		Use:   "platform <application-id>",
+		Short: "Detect platform operators already present on a target cluster",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+				return formatError
+			}
+			clusterID, _ := command.Flags().GetString("cluster")
+			clusterID = strings.TrimSpace(clusterID)
+			if clusterID == "" {
+				return withExitCode(exitUsage, errors.New("--cluster is required"))
+			}
+			payload, platformError := apiClient.GetApplicationExistingPlatform(command.Context(), strings.TrimSpace(arguments[0]), clusterID)
+			if platformError != nil {
+				return platformError
+			}
+			return renderApplicationPayload(command, payload)
+		},
+	}
+	platformCommand.Flags().String("cluster", "", "Target cluster ID (required)")
+	registerStructuredOutputFlags(platformCommand)
+	return platformCommand
+}
+
+func newApplicationWorkflowRunsCommand() *cobra.Command {
+	workflowRunsCommand := &cobra.Command{
+		Use:   "workflow-runs <application-id>",
+		Short: "List the application's GitHub Actions workflow runs",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+				return formatError
+			}
+			status, _ := command.Flags().GetString("status")
+			page, _ := command.Flags().GetInt("page")
+			pageSize, _ := command.Flags().GetInt("page-size")
+			payload, runsError := apiClient.GetApplicationWorkflowRuns(command.Context(), strings.TrimSpace(arguments[0]),
+				strings.TrimSpace(status), page, pageSize)
+			if runsError != nil {
+				return runsError
+			}
+			return renderApplicationPayload(command, payload)
+		},
+	}
+	workflowRunsCommand.Flags().String("status", "", "Filter by GitHub run status")
+	workflowRunsCommand.Flags().Int("page", 0, "Page number (1-based)")
+	workflowRunsCommand.Flags().Int("page-size", 0, "Page size (1-50)")
+	registerStructuredOutputFlags(workflowRunsCommand)
+	return workflowRunsCommand
+}
+
+func newApplicationWorkflowRunJobsCommand() *cobra.Command {
+	jobsCommand := &cobra.Command{
+		Use:   "workflow-run-jobs <application-id> <run-id>",
+		Short: "List the jobs of a workflow run",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+				return formatError
+			}
+			runID, parseError := parseWorkflowRunID(arguments[1])
+			if parseError != nil {
+				return parseError
+			}
+			payload, jobsError := apiClient.GetApplicationWorkflowRunJobs(command.Context(), strings.TrimSpace(arguments[0]), runID)
+			if jobsError != nil {
+				return jobsError
+			}
+			return renderApplicationPayload(command, payload)
+		},
+	}
+	registerStructuredOutputFlags(jobsCommand)
+	return jobsCommand
+}
+
+func newApplicationRerunWorkflowCommand() *cobra.Command {
+	rerunCommand := &cobra.Command{
+		Use:   "rerun-workflow <application-id> <run-id>",
+		Short: "Re-trigger a failed workflow run",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+				return formatError
+			}
+			runID, parseError := parseWorkflowRunID(arguments[1])
+			if parseError != nil {
+				return parseError
+			}
+			payload, rerunError := apiClient.RerunApplicationWorkflowRun(command.Context(), strings.TrimSpace(arguments[0]), runID)
+			if rerunError != nil {
+				return rerunError
+			}
+			return renderApplicationPayload(command, payload)
+		},
+	}
+	registerStructuredOutputFlags(rerunCommand)
+	return rerunCommand
+}
+
+func newApplicationPullRequestReviewsCommand() *cobra.Command {
+	reviewsCommand := &cobra.Command{
+		Use:   "pull-request-reviews <application-id>",
+		Short: "Show the AI reviews of the application's pull requests",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+				return formatError
+			}
+			limit, _ := command.Flags().GetInt("limit")
+			payload, reviewsError := apiClient.GetApplicationPullRequestReviews(command.Context(), strings.TrimSpace(arguments[0]), limit)
+			if reviewsError != nil {
+				return reviewsError
+			}
+			return renderApplicationPayload(command, payload)
+		},
+	}
+	reviewsCommand.Flags().Int("limit", 0, "Maximum number of reviews (1-20)")
+	registerStructuredOutputFlags(reviewsCommand)
+	return reviewsCommand
+}
+
+func newApplicationSetPackageVisibilityCommand() *cobra.Command {
+	setCommand := &cobra.Command{
+		Use:   "set-package-visibility <application-id>",
+		Short: "Set the GHCR image or chart package visibility",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+				return formatError
+			}
+			kind, _ := command.Flags().GetString("kind")
+			kind = strings.TrimSpace(kind)
+			if kind == "" {
+				return withExitCode(exitUsage, errors.New("--kind is required"))
+			}
+			visibility, _ := command.Flags().GetString("visibility")
+			visibility = strings.TrimSpace(visibility)
+			if visibility == "" {
+				return withExitCode(exitUsage, errors.New("--visibility is required"))
+			}
+			payload, setError := apiClient.SetApplicationPackageVisibility(command.Context(), strings.TrimSpace(arguments[0]),
+				client.SetApplicationPackageVisibilityRequest{Kind: kind, Visibility: visibility})
+			if setError != nil {
+				return setError
+			}
+			return renderApplicationPayload(command, payload)
+		},
+	}
+	setCommand.Flags().String("kind", "", "Package kind: image or chart (required)")
+	setCommand.Flags().String("visibility", "", "Visibility: public or private (required)")
+	registerStructuredOutputFlags(setCommand)
+	return setCommand
+}
+
+func newApplicationUpdateFilesCommand() *cobra.Command {
+	filesCommand := &cobra.Command{
+		Use:   "files <application-id>",
+		Short: "Commit generated file changes to the setup pull request",
+		Long: `Commit changes to the application's setup pull request.
+
+Each --file maps a repository path to a local file whose contents are
+uploaded. Use --delete to remove a tracked path.`,
+		Example: `  ankra application files <app-id> --file Dockerfile=./Dockerfile --message "Update image"
+  ankra application files <app-id> --delete .ankra/manifests/app.yaml`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+				return formatError
+			}
+			fileMappings, _ := command.Flags().GetStringArray("file")
+			deletedPaths, _ := command.Flags().GetStringArray("delete")
+			if len(fileMappings) == 0 && len(deletedPaths) == 0 {
+				return withExitCode(exitUsage, errors.New("pass at least one --file or --delete"))
+			}
+			files, parseError := parseApplicationFileMappings(fileMappings)
+			if parseError != nil {
+				return parseError
+			}
+			commitMessage, _ := command.Flags().GetString("message")
+			payload, filesError := apiClient.UpdateApplicationFiles(command.Context(), strings.TrimSpace(arguments[0]),
+				client.UpdateApplicationFilesRequest{
+					Files:         files,
+					DeletedPaths:  deletedPaths,
+					CommitMessage: strings.TrimSpace(commitMessage),
+				})
+			if filesError != nil {
+				return filesError
+			}
+			return renderApplicationPayload(command, payload)
+		},
+	}
+	filesCommand.Flags().StringArray("file", nil, "Repository path mapped to a local file as path=local-file (repeatable)")
+	filesCommand.Flags().StringArray("delete", nil, "Repository path to delete (repeatable)")
+	filesCommand.Flags().String("message", "", "Commit message")
+	registerStructuredOutputFlags(filesCommand)
+	return filesCommand
+}
+
+func parseWorkflowRunID(rawRunID string) (int64, error) {
+	runID, parseError := strconv.ParseInt(strings.TrimSpace(rawRunID), 10, 64)
+	if parseError != nil {
+		return 0, withExitCode(exitUsage, fmt.Errorf("run id %q must be an integer", rawRunID))
+	}
+	return runID, nil
+}
+
+func parseKeyValueFlags(entries []string) (map[string]string, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	values := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		separatorIndex := strings.Index(entry, "=")
+		if separatorIndex <= 0 {
+			return nil, fmt.Errorf("invalid --set %q; expected key=value", entry)
+		}
+		key := strings.TrimSpace(entry[:separatorIndex])
+		if key == "" {
+			return nil, fmt.Errorf("invalid --set %q; key cannot be empty", entry)
+		}
+		values[key] = entry[separatorIndex+1:]
+	}
+	return values, nil
+}
+
+func parseApplicationFileMappings(mappings []string) ([]client.ApplicationFileUpdate, error) {
+	files := make([]client.ApplicationFileUpdate, 0, len(mappings))
+	for _, mapping := range mappings {
+		separatorIndex := strings.Index(mapping, "=")
+		if separatorIndex <= 0 {
+			return nil, withExitCode(exitUsage, fmt.Errorf("invalid --file %q; expected path=local-file", mapping))
+		}
+		repositoryPath := strings.TrimSpace(mapping[:separatorIndex])
+		localPath := strings.TrimSpace(mapping[separatorIndex+1:])
+		if repositoryPath == "" || localPath == "" {
+			return nil, withExitCode(exitUsage, fmt.Errorf("invalid --file %q; expected path=local-file", mapping))
+		}
+		contents, readError := readApplicationFile(localPath)
+		if readError != nil {
+			return nil, readError
+		}
+		files = append(files, client.ApplicationFileUpdate{Path: repositoryPath, Content: string(contents)})
+	}
+	return files, nil
+}
+
+func readApplicationFile(localPath string) ([]byte, error) {
+	contents, readError := os.ReadFile(localPath)
+	if readError != nil {
+		if os.IsNotExist(readError) {
+			return nil, withExitCode(exitNotFound, fmt.Errorf("local file %q does not exist", localPath))
+		}
+		return nil, fmt.Errorf("reading local file %q: %w", localPath, readError)
+	}
+	return contents, nil
+}

--- a/cmd/application_resources_test.go
+++ b/cmd/application_resources_test.go
@@ -1,0 +1,315 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type applicationResourceMock struct {
+	baseMock
+	payload json.RawMessage
+	fail    error
+
+	deployRequest     client.DeployApplicationRequest
+	deployCalls       int
+	demoRequest       client.DeployApplicationDemoRequest
+	demoCalls         int
+	filesRequest      client.UpdateApplicationFilesRequest
+	filesCalls        int
+	deploymentsAppID  string
+	workflowRunID     int64
+	visibilityRequest client.SetApplicationPackageVisibilityRequest
+}
+
+func (mock *applicationResourceMock) GetApplicationDeployments(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	mock.deploymentsAppID = applicationID
+	if mock.fail != nil {
+		return nil, mock.fail
+	}
+	return mock.payload, nil
+}
+
+func (mock *applicationResourceMock) DeployApplication(requestContext context.Context, applicationID string, deployRequest client.DeployApplicationRequest) (json.RawMessage, error) {
+	mock.deployCalls++
+	mock.deployRequest = deployRequest
+	if mock.fail != nil {
+		return nil, mock.fail
+	}
+	return mock.payload, nil
+}
+
+func (mock *applicationResourceMock) DeployApplicationDemo(requestContext context.Context, applicationID string, demoRequest client.DeployApplicationDemoRequest) (json.RawMessage, error) {
+	mock.demoCalls++
+	mock.demoRequest = demoRequest
+	if mock.fail != nil {
+		return nil, mock.fail
+	}
+	return mock.payload, nil
+}
+
+func (mock *applicationResourceMock) UpdateApplicationFiles(requestContext context.Context, applicationID string, filesRequest client.UpdateApplicationFilesRequest) (json.RawMessage, error) {
+	mock.filesCalls++
+	mock.filesRequest = filesRequest
+	if mock.fail != nil {
+		return nil, mock.fail
+	}
+	return mock.payload, nil
+}
+
+func (mock *applicationResourceMock) GetApplicationWorkflowRunJobs(requestContext context.Context, applicationID string, runID int64) (json.RawMessage, error) {
+	mock.workflowRunID = runID
+	if mock.fail != nil {
+		return nil, mock.fail
+	}
+	return mock.payload, nil
+}
+
+func (mock *applicationResourceMock) SetApplicationPackageVisibility(requestContext context.Context, applicationID string, visibilityRequest client.SetApplicationPackageVisibilityRequest) (json.RawMessage, error) {
+	mock.visibilityRequest = visibilityRequest
+	if mock.fail != nil {
+		return nil, mock.fail
+	}
+	return mock.payload, nil
+}
+
+func runApplicationCommand(t *testing.T, mockClient APIClient, arguments ...string) (string, error) {
+	t.Helper()
+	previousClient := apiClient
+	apiClient = mockClient
+	t.Cleanup(func() { apiClient = previousClient })
+
+	applicationCommand := newApplicationCommand()
+	var output bytes.Buffer
+	applicationCommand.SetOut(&output)
+	applicationCommand.SetErr(&output)
+	applicationCommand.SetArgs(arguments)
+	executeError := applicationCommand.Execute()
+	return output.String(), executeError
+}
+
+func TestApplicationResourceCommandsRegistered(t *testing.T) {
+	applicationCommand := newApplicationCommand()
+	registered := map[string]bool{}
+	for _, subcommand := range applicationCommand.Commands() {
+		registered[subcommand.Name()] = true
+	}
+	for _, expected := range []string{
+		"add", "get", "list", "jobs", "retry", "reconcile", "delete", "deploy",
+		"deployments", "installations", "chart-versions", "platform",
+		"workflow-runs", "workflow-run-jobs", "rerun-workflow",
+		"pull-request-reviews", "upgrade-workflow", "branches", "branch-files",
+		"files", "publish-readiness", "container-security", "code-security",
+		"package-visibility", "set-package-visibility", "make-public", "demo",
+	} {
+		if !registered[expected] {
+			t.Errorf("subcommand %q is not registered", expected)
+		}
+	}
+}
+
+func TestApplicationSubresourceRendersJSON(t *testing.T) {
+	mockClient := &applicationResourceMock{payload: json.RawMessage(`{"deployments":[{"cluster_id":"c1"}]}`)}
+	output, executeError := runApplicationCommand(t, mockClient, "deployments", "app-1")
+	if executeError != nil {
+		t.Fatalf("deployments error = %v", executeError)
+	}
+	if mockClient.deploymentsAppID != "app-1" {
+		t.Errorf("application id = %q, want app-1", mockClient.deploymentsAppID)
+	}
+	if !strings.Contains(output, "\"cluster_id\": \"c1\"") {
+		t.Errorf("output is not indented JSON: %q", output)
+	}
+}
+
+func TestApplicationSubresourceRendersYAML(t *testing.T) {
+	mockClient := &applicationResourceMock{payload: json.RawMessage(`{"ready":true}`)}
+	output, executeError := runApplicationCommand(t, mockClient, "deployments", "app-1", "-o", "yaml")
+	if executeError != nil {
+		t.Fatalf("deployments error = %v", executeError)
+	}
+	if !strings.Contains(output, "ready: true") {
+		t.Errorf("output is not YAML: %q", output)
+	}
+}
+
+func TestApplicationDeployRequiresCluster(t *testing.T) {
+	mockClient := &applicationResourceMock{}
+	_, executeError := runApplicationCommand(t, mockClient, "deploy", "app-1")
+	if executeError == nil {
+		t.Fatal("expected missing --cluster to fail")
+	}
+	if exitCodeFor(executeError) != exitUsage {
+		t.Errorf("exit code = %d, want %d", exitCodeFor(executeError), exitUsage)
+	}
+	if mockClient.deployCalls != 0 {
+		t.Errorf("DeployApplication calls = %d, want 0", mockClient.deployCalls)
+	}
+}
+
+func TestApplicationDeployMapsRequest(t *testing.T) {
+	mockClient := &applicationResourceMock{payload: json.RawMessage(`{"status":"queued"}`)}
+	_, executeError := runApplicationCommand(t, mockClient,
+		"deploy", "app-1",
+		"--cluster", "cluster-1",
+		"--namespace", "prod",
+		"--mode", "high_availability",
+		"--set", "replicas=3",
+		"--set", "image.tag=v2",
+	)
+	if executeError != nil {
+		t.Fatalf("deploy error = %v", executeError)
+	}
+	if mockClient.deployCalls != 1 {
+		t.Fatalf("DeployApplication calls = %d, want 1", mockClient.deployCalls)
+	}
+	request := mockClient.deployRequest
+	if request.ClusterID != "cluster-1" || request.Namespace != "prod" || request.DeployMode != "high_availability" {
+		t.Errorf("deploy request = %+v", request)
+	}
+	if request.Inputs["replicas"] != "3" || request.Inputs["image.tag"] != "v2" {
+		t.Errorf("deploy inputs = %+v", request.Inputs)
+	}
+}
+
+func TestApplicationDeployRejectsInvalidMode(t *testing.T) {
+	mockClient := &applicationResourceMock{}
+	_, executeError := runApplicationCommand(t, mockClient, "deploy", "app-1", "--cluster", "c1", "--mode", "turbo")
+	if exitCodeFor(executeError) != exitUsage {
+		t.Errorf("exit code = %d, want %d: %v", exitCodeFor(executeError), exitUsage, executeError)
+	}
+	if mockClient.deployCalls != 0 {
+		t.Errorf("DeployApplication calls = %d, want 0", mockClient.deployCalls)
+	}
+}
+
+func TestApplicationDemoDeployOnlySendsSetFlags(t *testing.T) {
+	mockClient := &applicationResourceMock{payload: json.RawMessage(`{"workspace_id":"w1"}`)}
+	_, executeError := runApplicationCommand(t, mockClient, "demo", "deploy", "app-1", "--branch", "feature/x")
+	if executeError != nil {
+		t.Fatalf("demo deploy error = %v", executeError)
+	}
+	if mockClient.demoCalls != 1 {
+		t.Fatalf("DeployApplicationDemo calls = %d, want 1", mockClient.demoCalls)
+	}
+	request := mockClient.demoRequest
+	if request.Branch == nil || *request.Branch != "feature/x" {
+		t.Errorf("branch = %v, want feature/x", request.Branch)
+	}
+	if request.PRNumber != nil || request.ImageTag != nil || request.TTLHours != nil || request.ContainerPort != nil {
+		t.Errorf("unset flags were sent: %+v", request)
+	}
+}
+
+func TestApplicationFilesReadsLocalFile(t *testing.T) {
+	localPath := filepath.Join(t.TempDir(), "Dockerfile")
+	if writeError := os.WriteFile(localPath, []byte("FROM scratch\n"), 0o600); writeError != nil {
+		t.Fatalf("write fixture: %v", writeError)
+	}
+	mockClient := &applicationResourceMock{payload: json.RawMessage(`{"committed":true}`)}
+	_, executeError := runApplicationCommand(t, mockClient,
+		"files", "app-1",
+		"--file", "Dockerfile="+localPath,
+		"--delete", "old/path.yaml",
+		"--message", "Update image",
+	)
+	if executeError != nil {
+		t.Fatalf("files error = %v", executeError)
+	}
+	if mockClient.filesCalls != 1 {
+		t.Fatalf("UpdateApplicationFiles calls = %d, want 1", mockClient.filesCalls)
+	}
+	request := mockClient.filesRequest
+	if len(request.Files) != 1 || request.Files[0].Path != "Dockerfile" || request.Files[0].Content != "FROM scratch\n" {
+		t.Errorf("files = %+v", request.Files)
+	}
+	if len(request.DeletedPaths) != 1 || request.DeletedPaths[0] != "old/path.yaml" {
+		t.Errorf("deleted paths = %+v", request.DeletedPaths)
+	}
+	if request.CommitMessage != "Update image" {
+		t.Errorf("commit message = %q", request.CommitMessage)
+	}
+}
+
+func TestApplicationFilesMissingLocalFile(t *testing.T) {
+	mockClient := &applicationResourceMock{}
+	_, executeError := runApplicationCommand(t, mockClient,
+		"files", "app-1",
+		"--file", "Dockerfile="+filepath.Join(t.TempDir(), "missing"),
+	)
+	if exitCodeFor(executeError) != exitNotFound {
+		t.Errorf("exit code = %d, want %d: %v", exitCodeFor(executeError), exitNotFound, executeError)
+	}
+	if mockClient.filesCalls != 0 {
+		t.Errorf("UpdateApplicationFiles calls = %d, want 0", mockClient.filesCalls)
+	}
+}
+
+func TestApplicationFilesRequiresChange(t *testing.T) {
+	mockClient := &applicationResourceMock{}
+	_, executeError := runApplicationCommand(t, mockClient, "files", "app-1")
+	if exitCodeFor(executeError) != exitUsage {
+		t.Errorf("exit code = %d, want %d: %v", exitCodeFor(executeError), exitUsage, executeError)
+	}
+}
+
+func TestApplicationWorkflowRunJobsParsesRunID(t *testing.T) {
+	mockClient := &applicationResourceMock{payload: json.RawMessage(`{"jobs":[]}`)}
+	_, executeError := runApplicationCommand(t, mockClient, "workflow-run-jobs", "app-1", "12345")
+	if executeError != nil {
+		t.Fatalf("workflow-run-jobs error = %v", executeError)
+	}
+	if mockClient.workflowRunID != 12345 {
+		t.Errorf("run id = %d, want 12345", mockClient.workflowRunID)
+	}
+}
+
+func TestApplicationWorkflowRunJobsRejectsNonNumericRunID(t *testing.T) {
+	mockClient := &applicationResourceMock{}
+	_, executeError := runApplicationCommand(t, mockClient, "workflow-run-jobs", "app-1", "not-a-number")
+	if exitCodeFor(executeError) != exitUsage {
+		t.Errorf("exit code = %d, want %d: %v", exitCodeFor(executeError), exitUsage, executeError)
+	}
+}
+
+func TestApplicationSetPackageVisibilityRequiresFlags(t *testing.T) {
+	mockClient := &applicationResourceMock{}
+	_, executeError := runApplicationCommand(t, mockClient, "set-package-visibility", "app-1", "--kind", "image")
+	if exitCodeFor(executeError) != exitUsage {
+		t.Errorf("exit code = %d, want %d: %v", exitCodeFor(executeError), exitUsage, executeError)
+	}
+}
+
+func TestApplicationRejectsInvalidOutputBeforeRequest(t *testing.T) {
+	mockClient := &applicationResourceMock{fail: errors.New("should not be called")}
+	_, executeError := runApplicationCommand(t, mockClient, "deployments", "app-1", "-o", "xml")
+	if executeError == nil {
+		t.Fatal("expected invalid output format to fail")
+	}
+	if mockClient.deploymentsAppID != "" {
+		t.Errorf("client was called before format validation: %q", mockClient.deploymentsAppID)
+	}
+}
+
+func TestParseKeyValueFlags(t *testing.T) {
+	values, parseError := parseKeyValueFlags([]string{"a=1", "b=x=y"})
+	if parseError != nil {
+		t.Fatalf("parseKeyValueFlags error = %v", parseError)
+	}
+	if values["a"] != "1" || values["b"] != "x=y" {
+		t.Errorf("values = %+v", values)
+	}
+	if _, missingError := parseKeyValueFlags([]string{"noequals"}); missingError == nil {
+		t.Error("expected error for entry without =")
+	}
+	if _, emptyKeyError := parseKeyValueFlags([]string{"=value"}); emptyKeyError == nil {
+		t.Error("expected error for empty key")
+	}
+}

--- a/cmd/application_test.go
+++ b/cmd/application_test.go
@@ -1,0 +1,418 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type applicationAddMock struct {
+	baseMock
+	credentials         []client.Credential
+	applicationResponse *client.CreateApplicationResponse
+	applicationRequest  client.CreateApplicationRequest
+	createError         error
+	createCalls         int
+}
+
+func (mock *applicationAddMock) ListCredentials(provider *string) ([]client.Credential, error) {
+	return mock.credentials, nil
+}
+
+func (mock *applicationAddMock) CreateApplication(
+	requestContext context.Context,
+	applicationRequest client.CreateApplicationRequest,
+) (*client.CreateApplicationResponse, error) {
+	mock.createCalls++
+	mock.applicationRequest = applicationRequest
+	if mock.createError != nil {
+		return nil, mock.createError
+	}
+	return mock.applicationResponse, nil
+}
+
+func TestParseGitHubRepositoryRemote(t *testing.T) {
+	testCases := []struct {
+		name              string
+		remoteURL         string
+		expectedOwner     string
+		expectedName      string
+		shouldReturnError bool
+	}{
+		{
+			name:          "https",
+			remoteURL:     "https://github.com/ankraio/ankra-cli.git",
+			expectedOwner: "ankraio",
+			expectedName:  "ankra-cli",
+		},
+		{
+			name:          "scp_ssh",
+			remoteURL:     "git@github.com:ankraio/ankra-cli.git",
+			expectedOwner: "ankraio",
+			expectedName:  "ankra-cli",
+		},
+		{
+			name:          "ssh_url",
+			remoteURL:     "ssh://git@github.com/ankraio/ankra-cli.git",
+			expectedOwner: "ankraio",
+			expectedName:  "ankra-cli",
+		},
+		{
+			name:              "other_provider",
+			remoteURL:         "git@gitlab.com:ankraio/ankra-cli.git",
+			shouldReturnError: true,
+		},
+		{
+			name:              "missing_owner",
+			remoteURL:         "https://github.com/ankra-cli.git",
+			shouldReturnError: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			owner, repositoryName, parseError := parseGitHubRepositoryRemote(testCase.remoteURL)
+			if testCase.shouldReturnError {
+				if parseError == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if parseError != nil {
+				t.Fatalf("parseGitHubRepositoryRemote() error = %v", parseError)
+			}
+			if owner != testCase.expectedOwner || repositoryName != testCase.expectedName {
+				t.Errorf(
+					"parseGitHubRepositoryRemote() = %s/%s, want %s/%s",
+					owner,
+					repositoryName,
+					testCase.expectedOwner,
+					testCase.expectedName,
+				)
+			}
+		})
+	}
+}
+
+func TestInspectLocalApplicationRepositoryUsesRemoteDefaultBranch(t *testing.T) {
+	repositoryPath := createTestGitRepository(
+		t,
+		"feature/local-work",
+		"git@github.com:acme/payments.git",
+	)
+	runTestGit(t, repositoryPath, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+	nestedPath := filepath.Join(repositoryPath, "services", "api")
+	if makeDirectoryError := os.MkdirAll(nestedPath, 0o755); makeDirectoryError != nil {
+		t.Fatalf("create nested directory: %v", makeDirectoryError)
+	}
+
+	repository, inspectError := inspectLocalApplicationRepository(
+		context.Background(),
+		nestedPath,
+		"origin",
+		"",
+	)
+	if inspectError != nil {
+		t.Fatalf("inspectLocalApplicationRepository() error = %v", inspectError)
+	}
+	if repository.Owner != "acme" || repository.Name != "payments" {
+		t.Errorf("repository = %s/%s, want acme/payments", repository.Owner, repository.Name)
+	}
+	if repository.Branch != "main" {
+		t.Errorf("branch = %q, want main", repository.Branch)
+	}
+}
+
+func TestInspectLocalApplicationRepositoryExitCodes(t *testing.T) {
+	t.Run("missing_path", func(t *testing.T) {
+		_, inspectError := inspectLocalApplicationRepository(
+			context.Background(),
+			filepath.Join(t.TempDir(), "missing"),
+			"origin",
+			"",
+		)
+		if exitCodeFor(inspectError) != exitNotFound {
+			t.Errorf("exit code = %d, want %d: %v", exitCodeFor(inspectError), exitNotFound, inspectError)
+		}
+	})
+
+	t.Run("not_a_repository", func(t *testing.T) {
+		_, inspectError := inspectLocalApplicationRepository(
+			context.Background(),
+			t.TempDir(),
+			"origin",
+			"",
+		)
+		if exitCodeFor(inspectError) != exitUsage {
+			t.Errorf("exit code = %d, want %d: %v", exitCodeFor(inspectError), exitUsage, inspectError)
+		}
+	})
+
+	t.Run("git_not_installed", func(t *testing.T) {
+		t.Setenv("PATH", "")
+		_, inspectError := inspectLocalApplicationRepository(
+			context.Background(),
+			t.TempDir(),
+			"origin",
+			"",
+		)
+		if exitCodeFor(inspectError) != exitError {
+			t.Errorf("exit code = %d, want %d: %v", exitCodeFor(inspectError), exitError, inspectError)
+		}
+		if inspectError == nil || !strings.Contains(inspectError.Error(), "execute git") {
+			t.Errorf("error = %v, want preserved Git execution failure", inspectError)
+		}
+	})
+}
+
+func TestSelectApplicationCredential(t *testing.T) {
+	acmeLogin := "acme"
+	otherLogin := "other"
+	credentials := []client.Credential{
+		{
+			ID:           "credential-acme",
+			Name:         "github-acme",
+			Provider:     "github",
+			Available:    true,
+			AccountLogin: &acmeLogin,
+		},
+		{
+			ID:           "credential-other",
+			Name:         "github-other",
+			Provider:     "github",
+			Available:    true,
+			AccountLogin: &otherLogin,
+		},
+	}
+
+	selectedCredential, selectionError := selectApplicationCredential(credentials, "acme", "")
+	if selectionError != nil {
+		t.Fatalf("selectApplicationCredential() error = %v", selectionError)
+	}
+	if selectedCredential.ID != "credential-acme" {
+		t.Errorf("selected credential = %q, want credential-acme", selectedCredential.ID)
+	}
+
+	selectedCredential, selectionError = selectApplicationCredential(
+		credentials,
+		"unmatched-owner",
+		"credential-other",
+	)
+	if selectionError != nil {
+		t.Fatalf("selectApplicationCredential() explicit error = %v", selectionError)
+	}
+	if selectedCredential.ID != "credential-other" {
+		t.Errorf("explicit credential = %q, want credential-other", selectedCredential.ID)
+	}
+
+	_, selectionError = selectApplicationCredential(credentials, "unmatched-owner", "")
+	if selectionError == nil || !strings.Contains(selectionError.Error(), "--credential") {
+		t.Errorf("ambiguous selection error = %v, want --credential guidance", selectionError)
+	}
+	if exitCodeFor(selectionError) != exitUsage {
+		t.Errorf("ambiguous selection exit code = %d, want %d", exitCodeFor(selectionError), exitUsage)
+	}
+
+	upState := "up"
+	_, selectionError = selectApplicationCredential(
+		[]client.Credential{
+			{
+				ID:        "unavailable-credential",
+				Name:      "github-unavailable",
+				Provider:  "github",
+				Available: false,
+				State:     &upState,
+			},
+		},
+		"acme",
+		"unavailable-credential",
+	)
+	if selectionError == nil || !strings.Contains(selectionError.Error(), "not available") {
+		t.Errorf("unavailable selection error = %v, want availability error", selectionError)
+	}
+}
+
+func TestApplicationAddCommand(t *testing.T) {
+	repositoryPath := createTestGitRepository(
+		t,
+		"main",
+		"https://github.com/acme/payments.git",
+	)
+	applicationID := "application-id"
+	acmeLogin := "acme"
+	mockClient := &applicationAddMock{
+		credentials: []client.Credential{
+			{
+				ID:           "credential-id",
+				Name:         "github-acme",
+				Provider:     "github",
+				Available:    true,
+				AccountLogin: &acmeLogin,
+			},
+		},
+		applicationResponse: &client.CreateApplicationResponse{
+			ID:     &applicationID,
+			Errors: []client.ApplicationResourceError{},
+		},
+	}
+	previousClient := apiClient
+	apiClient = mockClient
+	t.Cleanup(func() {
+		apiClient = previousClient
+	})
+
+	applicationCommand := newApplicationCommand()
+	var output bytes.Buffer
+	applicationCommand.SetOut(&output)
+	applicationCommand.SetErr(&output)
+	applicationCommand.SetArgs([]string{"add", repositoryPath})
+	if executeError := applicationCommand.Execute(); executeError != nil {
+		t.Fatalf("application add error = %v", executeError)
+	}
+
+	if mockClient.applicationRequest.Name != "payments" {
+		t.Errorf("application name = %q, want payments", mockClient.applicationRequest.Name)
+	}
+	if mockClient.applicationRequest.RepositoryCredentialName != "github-acme" {
+		t.Errorf(
+			"credential name = %q, want github-acme",
+			mockClient.applicationRequest.RepositoryCredentialName,
+		)
+	}
+	if mockClient.applicationRequest.RepositoryOwner != "acme" ||
+		mockClient.applicationRequest.RepositoryName != "payments" {
+		t.Errorf(
+			"repository = %s/%s, want acme/payments",
+			mockClient.applicationRequest.RepositoryOwner,
+			mockClient.applicationRequest.RepositoryName,
+		)
+	}
+	if mockClient.applicationRequest.RepositoryBranch != "main" {
+		t.Errorf(
+			"repository branch = %q, want main",
+			mockClient.applicationRequest.RepositoryBranch,
+		)
+	}
+	if !strings.Contains(output.String(), "Application added successfully.") ||
+		!strings.Contains(output.String(), applicationID) {
+		t.Errorf("output = %q", output.String())
+	}
+}
+
+func TestApplicationAddCommandStructuredOutput(t *testing.T) {
+	repositoryPath := createTestGitRepository(
+		t,
+		"main",
+		"https://github.com/acme/payments.git",
+	)
+	applicationID := "application-id"
+	mockClient := &applicationAddMock{
+		credentials: []client.Credential{
+			{
+				ID:        "credential-id",
+				Name:      "github-acme",
+				Provider:  "github",
+				Available: true,
+			},
+		},
+		applicationResponse: &client.CreateApplicationResponse{
+			ID:     &applicationID,
+			Errors: []client.ApplicationResourceError{},
+		},
+	}
+	previousClient := apiClient
+	apiClient = mockClient
+	t.Cleanup(func() {
+		apiClient = previousClient
+	})
+
+	applicationCommand := newApplicationCommand()
+	var output bytes.Buffer
+	applicationCommand.SetOut(&output)
+	applicationCommand.SetErr(&output)
+	applicationCommand.SetArgs([]string{"add", repositoryPath, "-o", "json"})
+	if executeError := applicationCommand.Execute(); executeError != nil {
+		t.Fatalf("application add error = %v", executeError)
+	}
+
+	var result applicationAddOutput
+	if decodeError := json.Unmarshal(output.Bytes(), &result); decodeError != nil {
+		t.Fatalf("structured output is not JSON: %v\n%s", decodeError, output.String())
+	}
+	if result.ID != applicationID || result.Repository != "acme/payments" {
+		t.Errorf("structured output = %+v", result)
+	}
+	if strings.Contains(output.String(), "successfully") {
+		t.Errorf("structured output contains human text: %q", output.String())
+	}
+}
+
+func TestApplicationAddCommandRejectsInvalidOutputBeforeCreating(t *testing.T) {
+	mockClient := &applicationAddMock{}
+	previousClient := apiClient
+	apiClient = mockClient
+	t.Cleanup(func() {
+		apiClient = previousClient
+	})
+
+	applicationCommand := newApplicationCommand()
+	applicationCommand.SetArgs([]string{"add", ".", "-o", "xml"})
+	executeError := applicationCommand.Execute()
+	if executeError == nil {
+		t.Fatal("expected invalid output format to fail")
+	}
+	if mockClient.createCalls != 0 {
+		t.Errorf("CreateApplication() calls = %d, want 0", mockClient.createCalls)
+	}
+}
+
+func TestApplicationCreationError(t *testing.T) {
+	creationError := applicationCreationError([]client.ApplicationResourceError{
+		{
+			Name: "payments",
+			Kind: "application",
+			Errors: []client.ApplicationErrorItem{
+				{Key: "name", Message: "Application already exists."},
+			},
+		},
+	})
+	if creationError.Error() != "Application already exists." {
+		t.Errorf("applicationCreationError() = %v", creationError)
+	}
+}
+
+func createTestGitRepository(t *testing.T, branchName string, remoteURL string) string {
+	t.Helper()
+	if _, lookupError := exec.LookPath("git"); lookupError != nil {
+		t.Skip("git is not installed")
+	}
+	repositoryPath := filepath.Join(t.TempDir(), "repository")
+	runExternalCommand(t, "git", "init", "--initial-branch", branchName, repositoryPath)
+	runTestGit(t, repositoryPath, "remote", "add", "origin", remoteURL)
+	return repositoryPath
+}
+
+func runTestGit(t *testing.T, repositoryPath string, arguments ...string) {
+	t.Helper()
+	commandArguments := append([]string{"-C", repositoryPath}, arguments...)
+	runExternalCommand(t, "git", commandArguments...)
+}
+
+func runExternalCommand(
+	t *testing.T,
+	commandName string,
+	arguments ...string,
+) {
+	t.Helper()
+	command := exec.Command(commandName, arguments...)
+	if commandOutput, commandError := command.CombinedOutput(); commandError != nil {
+		t.Fatalf("%s failed: %v\n%s", commandName, commandError, commandOutput)
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -101,6 +101,126 @@ func (m baseMock) InstantiateStackProfile(ctx context.Context, clusterID string,
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) CreateApplication(requestContext context.Context, applicationRequest client.CreateApplicationRequest) (*client.CreateApplicationResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ListApplicationsRaw(requestContext context.Context, page int, pageSize int, search string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetApplicationRaw(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetApplicationJobs(requestContext context.Context, applicationID string, page int, pageSize int) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) RetryApplication(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ReconcileApplication(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) DeleteApplication(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) DeployApplication(requestContext context.Context, applicationID string, deployRequest client.DeployApplicationRequest) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetApplicationDeployments(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetApplicationInstallations(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetApplicationChartVersions(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetApplicationExistingPlatform(requestContext context.Context, applicationID string, clusterID string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetApplicationWorkflowRuns(requestContext context.Context, applicationID string, status string, page int, pageSize int) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetApplicationWorkflowRunJobs(requestContext context.Context, applicationID string, runID int64) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) RerunApplicationWorkflowRun(requestContext context.Context, applicationID string, runID int64) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetApplicationPullRequestReviews(requestContext context.Context, applicationID string, limit int) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) UpgradeApplicationWorkflow(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetApplicationBranches(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetApplicationBranchFiles(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) UpdateApplicationFiles(requestContext context.Context, applicationID string, filesRequest client.UpdateApplicationFilesRequest) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetApplicationPublishReadiness(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetApplicationContainerSecurity(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetApplicationCodeSecurity(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetApplicationPackageVisibility(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) SetApplicationPackageVisibility(requestContext context.Context, applicationID string, visibilityRequest client.SetApplicationPackageVisibilityRequest) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) MakeApplicationPackagesPublic(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetApplicationDemos(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) CheckApplicationDemoBuild(requestContext context.Context, applicationID string, branch string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) DeployApplicationDemo(requestContext context.Context, applicationID string, demoRequest client.DeployApplicationDemoRequest) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) StopApplicationDemo(requestContext context.Context, applicationID string, workspaceID string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) ListClusterAddons(clusterID string) ([]client.ClusterAddonListItem, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,7 +52,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:   "ankra",
 	Short: "CLI for the Ankra platform",
-	Long: `Ankra CLI allows you to manage clusters, operations,
+	Long: `Ankra CLI allows you to manage clusters, applications, operations,
 addons, persistent selection, and more.`,
 	SilenceUsage:      true,
 	PersistentPreRunE: persistentPreRunE,

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 
 	"ankra/internal/client"
@@ -85,6 +86,37 @@ type APIClient interface {
 	ImportStackProfile(importRequest client.ImportStackProfileRequest) (*client.CreateStackProfileResult, error)
 	GetStackProfile(profileID string) (*client.StackProfileDetail, error)
 	InstantiateStackProfile(ctx context.Context, clusterID string, instantiateRequest client.InstantiateStackProfileRequest) (*client.InstantiateStackProfileResult, error)
+
+	CreateApplication(requestContext context.Context, applicationRequest client.CreateApplicationRequest) (*client.CreateApplicationResponse, error)
+	ListApplicationsRaw(requestContext context.Context, page int, pageSize int, search string) (json.RawMessage, error)
+	GetApplicationRaw(requestContext context.Context, applicationID string) (json.RawMessage, error)
+	GetApplicationJobs(requestContext context.Context, applicationID string, page int, pageSize int) (json.RawMessage, error)
+	RetryApplication(requestContext context.Context, applicationID string) (json.RawMessage, error)
+	ReconcileApplication(requestContext context.Context, applicationID string) (json.RawMessage, error)
+	DeleteApplication(requestContext context.Context, applicationID string) (json.RawMessage, error)
+	DeployApplication(requestContext context.Context, applicationID string, deployRequest client.DeployApplicationRequest) (json.RawMessage, error)
+	GetApplicationDeployments(requestContext context.Context, applicationID string) (json.RawMessage, error)
+	GetApplicationInstallations(requestContext context.Context, applicationID string) (json.RawMessage, error)
+	GetApplicationChartVersions(requestContext context.Context, applicationID string) (json.RawMessage, error)
+	GetApplicationExistingPlatform(requestContext context.Context, applicationID string, clusterID string) (json.RawMessage, error)
+	GetApplicationWorkflowRuns(requestContext context.Context, applicationID string, status string, page int, pageSize int) (json.RawMessage, error)
+	GetApplicationWorkflowRunJobs(requestContext context.Context, applicationID string, runID int64) (json.RawMessage, error)
+	RerunApplicationWorkflowRun(requestContext context.Context, applicationID string, runID int64) (json.RawMessage, error)
+	GetApplicationPullRequestReviews(requestContext context.Context, applicationID string, limit int) (json.RawMessage, error)
+	UpgradeApplicationWorkflow(requestContext context.Context, applicationID string) (json.RawMessage, error)
+	GetApplicationBranches(requestContext context.Context, applicationID string) (json.RawMessage, error)
+	GetApplicationBranchFiles(requestContext context.Context, applicationID string) (json.RawMessage, error)
+	UpdateApplicationFiles(requestContext context.Context, applicationID string, filesRequest client.UpdateApplicationFilesRequest) (json.RawMessage, error)
+	GetApplicationPublishReadiness(requestContext context.Context, applicationID string) (json.RawMessage, error)
+	GetApplicationContainerSecurity(requestContext context.Context, applicationID string) (json.RawMessage, error)
+	GetApplicationCodeSecurity(requestContext context.Context, applicationID string) (json.RawMessage, error)
+	GetApplicationPackageVisibility(requestContext context.Context, applicationID string) (json.RawMessage, error)
+	SetApplicationPackageVisibility(requestContext context.Context, applicationID string, visibilityRequest client.SetApplicationPackageVisibilityRequest) (json.RawMessage, error)
+	MakeApplicationPackagesPublic(requestContext context.Context, applicationID string) (json.RawMessage, error)
+	GetApplicationDemos(requestContext context.Context, applicationID string) (json.RawMessage, error)
+	CheckApplicationDemoBuild(requestContext context.Context, applicationID string, branch string) (json.RawMessage, error)
+	DeployApplicationDemo(requestContext context.Context, applicationID string, demoRequest client.DeployApplicationDemoRequest) (json.RawMessage, error)
+	StopApplicationDemo(requestContext context.Context, applicationID string, workspaceID string) (json.RawMessage, error)
 
 	ListOrganisations() ([]client.OrganisationSummary, error)
 	SwitchOrganisation(orgID string) (*client.SwitchOrganisationResponse, error)

--- a/internal/client/application_resources.go
+++ b/internal/client/application_resources.go
@@ -1,0 +1,283 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+const applicationsAPIPath = "/api/v1/org/applications"
+
+// DeployApplicationRequest mirrors the platform deploy_application body.
+type DeployApplicationRequest struct {
+	ClusterID  string            `json:"cluster_id"`
+	Namespace  string            `json:"namespace,omitempty"`
+	DeployMode string            `json:"deploy_mode,omitempty"`
+	Inputs     map[string]string `json:"inputs,omitempty"`
+}
+
+// SetApplicationPackageVisibilityRequest mirrors the set_package_visibility
+// body.
+type SetApplicationPackageVisibilityRequest struct {
+	Kind       string `json:"kind"`
+	Visibility string `json:"visibility"`
+}
+
+// ApplicationFileUpdate mirrors a single FileUpdate entry.
+type ApplicationFileUpdate struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+// UpdateApplicationFilesRequest mirrors the update_application_files body.
+type UpdateApplicationFilesRequest struct {
+	Files         []ApplicationFileUpdate `json:"files"`
+	DeletedPaths  []string                `json:"deleted_paths,omitempty"`
+	CommitMessage string                  `json:"commit_message,omitempty"`
+}
+
+// DeployApplicationDemoRequest mirrors the deploy-demo body. Every field is
+// optional; only the flags the user set are sent.
+type DeployApplicationDemoRequest struct {
+	Branch        *string `json:"branch,omitempty"`
+	PRNumber      *int    `json:"pr_number,omitempty"`
+	ImageTag      *string `json:"image_tag,omitempty"`
+	TTLHours      *int    `json:"ttl_hours,omitempty"`
+	ContainerPort *int    `json:"container_port,omitempty"`
+}
+
+// applicationResourceRequest performs a bearer-authenticated request against
+// an application subresource and returns the raw JSON body on success. The
+// FastAPI `detail` string is surfaced as the error message on non-200 so the
+// CLI can print the backend's human-readable reason, and the HTTP status is
+// preserved for exit-code classification.
+func (client *Client) applicationResourceRequest(
+	requestContext context.Context,
+	method string,
+	path string,
+	query url.Values,
+	requestBody any,
+) (json.RawMessage, error) {
+	var bodyReader io.Reader
+	if requestBody != nil {
+		encoded, marshalError := json.Marshal(requestBody)
+		if marshalError != nil {
+			return nil, fmt.Errorf("marshal request: %w", marshalError)
+		}
+		bodyReader = bytes.NewReader(encoded)
+	}
+	requestURL := client.BaseURL + path
+	if len(query) > 0 {
+		requestURL += "?" + query.Encode()
+	}
+	request, requestError := http.NewRequestWithContext(requestContext, method, requestURL, bodyReader)
+	if requestError != nil {
+		return nil, fmt.Errorf("create request: %w", requestError)
+	}
+	request.Header.Set("Authorization", "Bearer "+client.Token)
+	if requestBody != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+
+	response, sendError := client.HTTP.Do(request)
+	if sendError != nil {
+		return nil, fmt.Errorf("request failed: %w", sendError)
+	}
+	defer closeBody(response)
+
+	responseBody, readError := readResponseBody(response)
+	if readError != nil {
+		return nil, fmt.Errorf("read response: %w", readError)
+	}
+	if response.StatusCode == http.StatusUnauthorized {
+		return nil, ErrUnauthorized
+	}
+	if response.StatusCode != http.StatusOK {
+		if permissionDenied := PermissionDeniedFromResponse(response.StatusCode, responseBody); permissionDenied != nil {
+			return nil, permissionDenied
+		}
+		message := detailFromBody(responseBody)
+		if message == "" {
+			message = "application request failed"
+		}
+		return nil, newUnexpectedResponseError(
+			message,
+			response.StatusCode,
+			redactedBodyForError(responseBody, 500),
+		)
+	}
+	return json.RawMessage(responseBody), nil
+}
+
+func applicationPath(applicationID string, suffix string) string {
+	return applicationsAPIPath + "/" + applicationID + suffix
+}
+
+// --- lifecycle reads / writes ---
+
+func (client *Client) ListApplicationsRaw(requestContext context.Context, page int, pageSize int, search string) (json.RawMessage, error) {
+	query := url.Values{}
+	if page > 0 {
+		query.Set("page", strconv.Itoa(page))
+	}
+	if pageSize > 0 {
+		query.Set("page_size", strconv.Itoa(pageSize))
+	}
+	if search != "" {
+		query.Set("search", search)
+	}
+	return client.applicationResourceRequest(requestContext, http.MethodGet, applicationsAPIPath, query, nil)
+}
+
+func (client *Client) GetApplicationRaw(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodGet, applicationPath(applicationID, ""), nil, nil)
+}
+
+func (client *Client) GetApplicationJobs(requestContext context.Context, applicationID string, page int, pageSize int) (json.RawMessage, error) {
+	query := url.Values{}
+	if page > 0 {
+		query.Set("page", strconv.Itoa(page))
+	}
+	if pageSize > 0 {
+		query.Set("page_size", strconv.Itoa(pageSize))
+	}
+	return client.applicationResourceRequest(requestContext, http.MethodGet, applicationPath(applicationID, "/jobs"), query, nil)
+}
+
+func (client *Client) RetryApplication(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodPost, applicationPath(applicationID, "/retry"), nil, nil)
+}
+
+func (client *Client) ReconcileApplication(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodPost, applicationPath(applicationID, "/reconcile"), nil, nil)
+}
+
+func (client *Client) DeleteApplication(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodDelete, applicationPath(applicationID, ""), nil, nil)
+}
+
+func (client *Client) DeployApplication(requestContext context.Context, applicationID string, deployRequest DeployApplicationRequest) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodPost, applicationPath(applicationID, "/deploy"), nil, deployRequest)
+}
+
+// --- deployment / installation / chart reads ---
+
+func (client *Client) GetApplicationDeployments(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodGet, applicationPath(applicationID, "/deployments"), nil, nil)
+}
+
+func (client *Client) GetApplicationInstallations(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodGet, applicationPath(applicationID, "/installations"), nil, nil)
+}
+
+func (client *Client) GetApplicationChartVersions(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodGet, applicationPath(applicationID, "/chart-versions"), nil, nil)
+}
+
+func (client *Client) GetApplicationExistingPlatform(requestContext context.Context, applicationID string, clusterID string) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodGet,
+		applicationPath(applicationID, "/deploy/clusters/"+clusterID+"/platform"), nil, nil)
+}
+
+// --- workflow (CI/CD) reads / writes ---
+
+func (client *Client) GetApplicationWorkflowRuns(requestContext context.Context, applicationID string, status string, page int, pageSize int) (json.RawMessage, error) {
+	query := url.Values{}
+	if status != "" {
+		query.Set("status", status)
+	}
+	if page > 0 {
+		query.Set("page", strconv.Itoa(page))
+	}
+	if pageSize > 0 {
+		query.Set("page_size", strconv.Itoa(pageSize))
+	}
+	return client.applicationResourceRequest(requestContext, http.MethodGet, applicationPath(applicationID, "/workflow-runs"), query, nil)
+}
+
+func (client *Client) GetApplicationWorkflowRunJobs(requestContext context.Context, applicationID string, runID int64) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodGet,
+		applicationPath(applicationID, "/workflow-runs/"+strconv.FormatInt(runID, 10)+"/jobs"), nil, nil)
+}
+
+func (client *Client) RerunApplicationWorkflowRun(requestContext context.Context, applicationID string, runID int64) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodPost,
+		applicationPath(applicationID, "/workflow-runs/"+strconv.FormatInt(runID, 10)+"/rerun"), nil, nil)
+}
+
+func (client *Client) GetApplicationPullRequestReviews(requestContext context.Context, applicationID string, limit int) (json.RawMessage, error) {
+	query := url.Values{}
+	if limit > 0 {
+		query.Set("limit", strconv.Itoa(limit))
+	}
+	return client.applicationResourceRequest(requestContext, http.MethodGet, applicationPath(applicationID, "/pull-request-reviews"), query, nil)
+}
+
+func (client *Client) UpgradeApplicationWorkflow(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodPost, applicationPath(applicationID, "/upgrade-workflow"), nil, nil)
+}
+
+// --- repository files ---
+
+func (client *Client) GetApplicationBranches(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodGet, applicationPath(applicationID, "/branches"), nil, nil)
+}
+
+func (client *Client) GetApplicationBranchFiles(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodGet, applicationPath(applicationID, "/branch-files"), nil, nil)
+}
+
+func (client *Client) UpdateApplicationFiles(requestContext context.Context, applicationID string, filesRequest UpdateApplicationFilesRequest) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodPatch, applicationPath(applicationID, "/files"), nil, filesRequest)
+}
+
+// --- security / publishing ---
+
+func (client *Client) GetApplicationPublishReadiness(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodGet, applicationPath(applicationID, "/publish-readiness"), nil, nil)
+}
+
+func (client *Client) GetApplicationContainerSecurity(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodGet, applicationPath(applicationID, "/container-security"), nil, nil)
+}
+
+func (client *Client) GetApplicationCodeSecurity(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodGet, applicationPath(applicationID, "/code-security"), nil, nil)
+}
+
+func (client *Client) GetApplicationPackageVisibility(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodGet, applicationPath(applicationID, "/package-visibility"), nil, nil)
+}
+
+func (client *Client) SetApplicationPackageVisibility(requestContext context.Context, applicationID string, visibilityRequest SetApplicationPackageVisibilityRequest) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodPost, applicationPath(applicationID, "/package-visibility"), nil, visibilityRequest)
+}
+
+func (client *Client) MakeApplicationPackagesPublic(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodPost, applicationPath(applicationID, "/make-public"), nil, nil)
+}
+
+// --- demos ---
+
+func (client *Client) GetApplicationDemos(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodGet, applicationPath(applicationID, "/demos"), nil, nil)
+}
+
+func (client *Client) CheckApplicationDemoBuild(requestContext context.Context, applicationID string, branch string) (json.RawMessage, error) {
+	query := url.Values{}
+	query.Set("branch", branch)
+	return client.applicationResourceRequest(requestContext, http.MethodGet, applicationPath(applicationID, "/demos/build"), query, nil)
+}
+
+func (client *Client) DeployApplicationDemo(requestContext context.Context, applicationID string, demoRequest DeployApplicationDemoRequest) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodPost, applicationPath(applicationID, "/demos"), nil, demoRequest)
+}
+
+func (client *Client) StopApplicationDemo(requestContext context.Context, applicationID string, workspaceID string) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodDelete, applicationPath(applicationID, "/demos/"+workspaceID), nil, nil)
+}

--- a/internal/client/applications.go
+++ b/internal/client/applications.go
@@ -1,0 +1,82 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type CreateApplicationRequest struct {
+	Name                     string `json:"name"`
+	RepositoryCredentialName string `json:"app_repo_credential_name"`
+	RepositoryOwner          string `json:"app_repo_owner"`
+	RepositoryName           string `json:"app_repo_name"`
+	RepositoryBranch         string `json:"app_repo_branch"`
+}
+
+type ApplicationErrorItem struct {
+	Key     string `json:"key"`
+	Message string `json:"message"`
+}
+
+type ApplicationResourceError struct {
+	Name   string                 `json:"name"`
+	Kind   string                 `json:"kind"`
+	Errors []ApplicationErrorItem `json:"errors"`
+}
+
+type CreateApplicationResponse struct {
+	ID     *string                    `json:"id"`
+	Errors []ApplicationResourceError `json:"errors"`
+}
+
+func (client *Client) CreateApplication(requestContext context.Context, applicationRequest CreateApplicationRequest) (*CreateApplicationResponse, error) {
+	requestBody, marshalError := json.Marshal(applicationRequest)
+	if marshalError != nil {
+		return nil, fmt.Errorf("marshal request: %w", marshalError)
+	}
+
+	request, requestError := http.NewRequestWithContext(
+		requestContext,
+		http.MethodPost,
+		client.BaseURL+"/api/v1/org/applications",
+		bytes.NewReader(requestBody),
+	)
+	if requestError != nil {
+		return nil, fmt.Errorf("create request: %w", requestError)
+	}
+	request.Header.Set("Authorization", "Bearer "+client.Token)
+	request.Header.Set("Content-Type", "application/json")
+
+	response, sendError := client.HTTP.Do(request)
+	if sendError != nil {
+		return nil, fmt.Errorf("request failed: %w", sendError)
+	}
+	defer closeBody(response)
+
+	responseBody, readError := readResponseBody(response)
+	if readError != nil {
+		return nil, fmt.Errorf("read response: %w", readError)
+	}
+	if response.StatusCode == http.StatusUnauthorized {
+		return nil, ErrUnauthorized
+	}
+	if response.StatusCode != http.StatusOK {
+		if permissionDenied := PermissionDeniedFromResponse(response.StatusCode, responseBody); permissionDenied != nil {
+			return nil, permissionDenied
+		}
+		return nil, newUnexpectedResponseError(
+			"create application failed",
+			response.StatusCode,
+			redactedBodyForError(responseBody, 500),
+		)
+	}
+
+	var applicationResponse CreateApplicationResponse
+	if unmarshalError := json.Unmarshal(responseBody, &applicationResponse); unmarshalError != nil {
+		return nil, fmt.Errorf("parse response: %w", unmarshalError)
+	}
+	return &applicationResponse, nil
+}

--- a/internal/client/applications_test.go
+++ b/internal/client/applications_test.go
@@ -1,0 +1,89 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestCreateApplication(t *testing.T) {
+	applicationID := "application-id"
+	testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", request.Method)
+		}
+		if request.URL.Path != "/api/v1/org/applications" {
+			t.Errorf("path = %s, want /api/v1/org/applications", request.URL.Path)
+		}
+		if request.Header.Get("Authorization") != "Bearer "+testToken {
+			t.Errorf("authorization header = %q", request.Header.Get("Authorization"))
+		}
+		if request.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("content type = %q, want application/json", request.Header.Get("Content-Type"))
+		}
+
+		var applicationRequest map[string]string
+		if decodeError := json.NewDecoder(request.Body).Decode(&applicationRequest); decodeError != nil {
+			t.Fatalf("decode request: %v", decodeError)
+		}
+		if len(applicationRequest) != 5 {
+			t.Errorf("request keys = %v, want exactly five application fields", applicationRequest)
+		}
+		if applicationRequest["name"] != "payments" {
+			t.Errorf("name = %q, want payments", applicationRequest["name"])
+		}
+		if applicationRequest["app_repo_credential_name"] != "github-acme" {
+			t.Errorf("credential = %q, want github-acme", applicationRequest["app_repo_credential_name"])
+		}
+		if applicationRequest["app_repo_owner"] != "acme" ||
+			applicationRequest["app_repo_name"] != "payments" {
+			t.Errorf(
+				"repository = %s/%s, want acme/payments",
+				applicationRequest["app_repo_owner"],
+				applicationRequest["app_repo_name"],
+			)
+		}
+		if applicationRequest["app_repo_branch"] != "main" {
+			t.Errorf("branch = %q, want main", applicationRequest["app_repo_branch"])
+		}
+
+		jsonResponse(t, writer, http.StatusOK, CreateApplicationResponse{
+			ID:     &applicationID,
+			Errors: []ApplicationResourceError{},
+		})
+	})
+
+	applicationResponse, createError := testClient.CreateApplication(context.Background(), CreateApplicationRequest{
+		Name:                     "payments",
+		RepositoryCredentialName: "github-acme",
+		RepositoryOwner:          "acme",
+		RepositoryName:           "payments",
+		RepositoryBranch:         "main",
+	})
+	if createError != nil {
+		t.Fatalf("CreateApplication() error = %v", createError)
+	}
+	if applicationResponse.ID == nil || *applicationResponse.ID != applicationID {
+		t.Errorf("CreateApplication() ID = %v, want %s", applicationResponse.ID, applicationID)
+	}
+}
+
+func TestCreateApplicationReturnsPermissionDenied(t *testing.T) {
+	testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		jsonResponse(t, writer, http.StatusForbidden, map[string]string{
+			"detail":     "permission_denied",
+			"permission": "applications.write",
+		})
+	})
+
+	_, createError := testClient.CreateApplication(context.Background(), CreateApplicationRequest{})
+	var permissionDenied *PermissionDeniedError
+	if !errors.As(createError, &permissionDenied) {
+		t.Fatalf("CreateApplication() error = %v, want PermissionDeniedError", createError)
+	}
+	if permissionDenied.Permission != "applications.write" {
+		t.Errorf("permission = %q, want applications.write", permissionDenied.Permission)
+	}
+}


### PR DESCRIPTION
## Summary
- add `ankra application add .` with local Git repository detection and credential selection
- expose application lifecycle, deployment, workflow, repository, security, publishing, and demo commands
- add bearer API client methods, structured JSON/YAML output, validation, and command/client tests

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 ./cmd/... ./internal/client/...`
- [x] `golangci-lint run ./cmd/... ./internal/client/...`

Made with [Cursor](https://cursor.com)