### PR TITLE
Guide MCP-scoped token setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ agent-status accuracy fixes, plus drift field-path visibility in
 
 ### Fixed
 
+- **`ankra tokens create` now gives MCP-specific guidance for scoped tokens.**
+  The previous examples named permission scopes the platform rejects.
+  The help text now shows `mcp:read` and `mcp:write`, and successful scoped
+  token creation prints the MCP endpoint instead of suggesting a REST
+  `ANKRA_API_TOKEN` configuration that would be refused.
 - **`ankra cluster agent token` no longer prints an empty token.** The
   platform's token endpoints return the agent install command (and, on newer
   platforms, `token` and `cluster_id` fields), while the CLI decoded a

--- a/cmd/tokens.go
+++ b/cmd/tokens.go
@@ -108,6 +108,12 @@ var tokensCreateCmd = &cobra.Command{
 		fmt.Println("Token (save this, it won't be shown again):")
 		fmt.Printf("  %s\n", result.Token)
 		fmt.Println()
+		if len(scopes) > 0 {
+			fmt.Println("Use this token only with the Ankra MCP server:")
+			fmt.Println("  URL: https://platform.ankra.app/api/v1/mcp")
+			fmt.Printf("  Authorization: Bearer %s\n", result.Token)
+			return nil
+		}
 		fmt.Println("To use this token, set it as ANKRA_API_TOKEN environment variable:")
 		fmt.Printf("  export ANKRA_API_TOKEN='%s'\n", result.Token)
 		return nil
@@ -157,7 +163,7 @@ var tokensDeleteCmd = &cobra.Command{
 func init() {
 	tokensCreateCmd.Flags().String("expires", "", "Token expiration date (ISO 8601 format)")
 	tokensCreateCmd.Flags().StringSlice("scopes", nil,
-		"Permission allowlist for the token (e.g. clusters.read,stacks.deploy); omitted grants the user's full authority")
+		"MCP access scopes: mcp:read or mcp:read,mcp:write; omitted creates a REST-only token")
 
 	registerStructuredOutputFlags(tokensListCmd, tokensCreateCmd)
 


### PR DESCRIPTION
## Summary
- document the valid `mcp:read` and `mcp:write` token scopes in CLI help
- print hosted MCP connection guidance for scoped tokens instead of REST configuration
- record the correction in the changelog

## Test plan
- [x] `make build`
- [x] `make test`
- [x] `make lint`


Made with [Cursor](https://cursor.com)