### PR TITLE
ci: don't open docs PRs for pre-release tags

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -8,7 +8,10 @@ name: Sync CLI reference to ankra-docs
 on:
   push:
     tags:
-      - "v*"
+      # Stable releases only (vMAJOR.MINOR.PATCH). Pre-release tags such as
+      # v0.9.0-rc1 must not open docs PRs; the docs update ships with the
+      # final release tag instead.
+      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
The docs-sync workflow ran on every `v*` tag push, so rc tags like `v0.9.0-rc1` opened CLI-reference PRs against ankra-docs (see ankraio/ankra-docs#41). This restricts the trigger to stable `vMAJOR.MINOR.PATCH` tags only — the pattern must match the whole tag name, so any pre-release suffix (`-rc1`, `-beta.2`, …) no longer triggers the workflow and the docs update ships with the final release tag instead.

Manual `workflow_dispatch` runs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)