### PR TITLE
feat(systemtest): make OVH gateway flavor configurable

### DIFF
--- a/systemtest/README.md
+++ b/systemtest/README.md
@@ -62,6 +62,7 @@ Common optional (defaults in parentheses):
 | `HETZNER_LOCATION` / `OVH_REGION` / `UPCLOUD_ZONE` | `nbg1` / `GRA9` / `de-fra1` |
 | `HETZNER_CP_TYPE` / `HETZNER_WORKER_TYPE` / `HETZNER_BASTION_TYPE` / `HETZNER_BIGGER_TYPE` | `cpx32` / `cpx22` / `cpx22` / `cpx32` |
 | `OVH_CP_FLAVOR` / `OVH_WORKER_FLAVOR` / `OVH_BIGGER_FLAVOR` | `b2-15` / `b2-15` / `b2-30` |
+| `OVH_GATEWAY_FLAVOR` (NAT gateway instance; `b2-7` is unavailable in some regions e.g. `EU-WEST-PAR`, set a `b3-*` there) | `b2-7` |
 | `UPCLOUD_CP_PLAN` / `UPCLOUD_WORKER_PLAN` / `UPCLOUD_BIGGER_PLAN` | `2xCPU-4GB` / `2xCPU-4GB` / `4xCPU-8GB` |
 | `K8S_UPGRADE_TARGET` | highest version from `ankra cluster k3s-versions` |
 | `ONLINE_TIMEOUT` / `ADDONS_TIMEOUT` / `DAYTWO_TIMEOUT` / `DEPROVISION_TIMEOUT` | `1500` / `900` / `900` / `1500` (seconds) |

--- a/systemtest/lifecycle_systemtest.sh
+++ b/systemtest/lifecycle_systemtest.sh
@@ -115,6 +115,7 @@ HETZNER_BIGGER_TYPE="${HETZNER_BIGGER_TYPE:-cpx32}"
 OVH_CP_FLAVOR="${OVH_CP_FLAVOR:-b2-15}"
 OVH_WORKER_FLAVOR="${OVH_WORKER_FLAVOR:-b2-15}"
 OVH_BIGGER_FLAVOR="${OVH_BIGGER_FLAVOR:-b2-30}"
+OVH_GATEWAY_FLAVOR="${OVH_GATEWAY_FLAVOR:-b2-7}"
 
 UPCLOUD_CP_PLAN="${UPCLOUD_CP_PLAN:-2xCPU-4GB}"
 UPCLOUD_WORKER_PLAN="${UPCLOUD_WORKER_PLAN:-2xCPU-4GB}"
@@ -448,6 +449,7 @@ create_cluster() {
     ovh)
       ank cluster ovh create --name "$name" --credential-id "$OVH_CREDENTIAL_ID" \
         --ssh-key-credential-id "$SSH_KEY_CREDENTIAL_ID" --region "$OVH_REGION" \
+        --gateway-flavor-id "$OVH_GATEWAY_FLAVOR" \
         --control-plane-flavor-id "$OVH_CP_FLAVOR" --control-plane-count 1 \
         --worker-flavor-id "$OVH_WORKER_FLAVOR" --worker-count 1 \
         --external-cloud-provider "${dist_args[@]}" "${gitops_args[@]}"


### PR DESCRIPTION
## Why

The OVH lifecycle system test hardcodes the default gateway (NAT) flavor `b2-7`. That flavor is not available in every OVH region — e.g. `EU-WEST-PAR` rejects the create with:

```
status 400 {"detail":"Flavor 'b2-7' is not available in OVH region 'EU-WEST-PAR'"}
```

so the OVH target can only run in regions that happen to stock `b2-7`.

## Change

Add an `OVH_GATEWAY_FLAVOR` env (default `b2-7`, unchanged behaviour) and pass `--gateway-flavor-id` on `ankra cluster ovh create`. Documented in the systemtest README. Set e.g. `OVH_GATEWAY_FLAVOR=b3-8` to run in EU-WEST-PAR.

`bash -n` clean. No behaviour change unless the env var is set.

## Context

Found while running the OVH lifecycle system test against live OVH (see PLA-709). The separate `cluster_state()` column-parse issue I initially hit was already fixed on `master` (`cluster_list_field "STATE"`), so this PR does not touch it.