### PR TITLE
Add Scaleway lifecycle commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- **Scaleway clusters now support lifecycle commands.** Use
+  `ankra cluster scaleway stop <cluster_id>` to release compute while
+  preserving the cluster definition, then `ankra cluster scaleway start
+  <cluster_id>` to re-provision it.
 - **Application management is available from the CLI.** `ankra application
   add .` detects a local GitHub checkout and starts application setup, while
   the application subcommands expose lifecycle, deployment, workflow,

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1197,6 +1197,14 @@ func (m baseMock) CreateDigitaloceanSSHKeyCredential(req client.CreateSSHKeyCred
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) StopScalewayCluster(clusterID string) (*client.ProviderStopClusterResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) StartScalewayCluster(clusterID, scope string) (*client.ProviderStartClusterResult, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) CreateManagedCluster(provider client.ManagedK8sProvider, request client.CreateManagedClusterRequest) (*client.CreateManagedClusterResponse, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/scaleway_cluster.go
+++ b/cmd/scaleway_cluster.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+)
+
+var scalewayCmd = &cobra.Command{
+	Use:   "scaleway",
+	Short: "Manage Scaleway clusters",
+	Long:  "Manage the lifecycle of Scaleway clusters.",
+}
+
+var scalewayStopCmd = &cobra.Command{
+	Use:   "stop <cluster_id>",
+	Short: "Stop a Scaleway cluster",
+	Long:  "Stop a Scaleway cluster by terminating its compute while preserving its configuration so it can be re-provisioned later.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, arguments []string) error {
+		clusterID := arguments[0]
+		result, stopError := apiClient.StopScalewayCluster(clusterID)
+		if stopError != nil {
+			return fmt.Errorf("stopping Scaleway cluster: %w", stopError)
+		}
+
+		if result.Success {
+			fmt.Println(text.FgGreen.Sprint("Scaleway cluster stop initiated."))
+		} else {
+			fmt.Println("Cluster stop request submitted.")
+		}
+		fmt.Printf("  Cluster ID: %s\n", result.ClusterID)
+		if result.OperationID != nil {
+			fmt.Printf("  Operation ID: %s\n", *result.OperationID)
+		}
+		return nil
+	},
+}
+
+var scalewayStartCmd = &cobra.Command{
+	Use:   "start <cluster_id>",
+	Short: "Start a stopped Scaleway cluster",
+	Long:  "Re-provision a stopped Scaleway cluster. Use --scope control_plane to bring up only the control plane.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(command *cobra.Command, arguments []string) error {
+		clusterID := arguments[0]
+		scope, scopeError := command.Flags().GetString("scope")
+		if scopeError != nil {
+			return fmt.Errorf("reading scope: %w", scopeError)
+		}
+		if scope != "all" && scope != "control_plane" {
+			return fmt.Errorf("invalid --scope %q: must be 'all' or 'control_plane'", scope)
+		}
+
+		result, startError := apiClient.StartScalewayCluster(clusterID, scope)
+		if startError != nil {
+			return fmt.Errorf("starting Scaleway cluster: %w", startError)
+		}
+
+		fmt.Println(text.FgGreen.Sprint("Scaleway cluster start initiated."))
+		fmt.Printf("  Scope: %s\n", result.Scope)
+		if result.MarkedToStartAt != "" {
+			fmt.Printf("  Marked to start at: %s\n", result.MarkedToStartAt)
+		}
+		fmt.Printf("  Created operations: %d\n", result.CreatedOperations)
+		return nil
+	},
+}
+
+func init() {
+	scalewayStartCmd.Flags().String("scope", "all", "Provisioning scope: 'all' or 'control_plane'")
+	scalewayCmd.AddCommand(scalewayStopCmd)
+	scalewayCmd.AddCommand(scalewayStartCmd)
+	clusterCmd.AddCommand(scalewayCmd)
+}

--- a/cmd/scaleway_cluster_test.go
+++ b/cmd/scaleway_cluster_test.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type scalewayLifecycleMock struct {
+	baseMock
+	startClusterID string
+	startScope     string
+	stopClusterID  string
+}
+
+func (mock *scalewayLifecycleMock) StopScalewayCluster(clusterID string) (*client.ProviderStopClusterResponse, error) {
+	mock.stopClusterID = clusterID
+	return &client.ProviderStopClusterResponse{Success: true, ClusterID: clusterID}, nil
+}
+
+func (mock *scalewayLifecycleMock) StartScalewayCluster(clusterID, scope string) (*client.ProviderStartClusterResult, error) {
+	mock.startClusterID = clusterID
+	mock.startScope = scope
+	return &client.ProviderStartClusterResult{Scope: scope, CreatedOperations: 2}, nil
+}
+
+func TestScalewayStopCommand(t *testing.T) {
+	mock := &scalewayLifecycleMock{}
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		_, _ = executeCommand("cluster", "scaleway", "stop", "cluster-123")
+	})
+
+	if mock.stopClusterID != "cluster-123" {
+		t.Fatalf("cluster id = %q, want cluster-123", mock.stopClusterID)
+	}
+	if !strings.Contains(output, "Scaleway cluster stop initiated") {
+		t.Fatalf("unexpected output: %s", output)
+	}
+}
+
+func TestScalewayStartCommandWithScope(t *testing.T) {
+	mock := &scalewayLifecycleMock{}
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		_, _ = executeCommand("cluster", "scaleway", "start", "cluster-123", "--scope", "control_plane")
+	})
+
+	if mock.startClusterID != "cluster-123" {
+		t.Fatalf("cluster id = %q, want cluster-123", mock.startClusterID)
+	}
+	if mock.startScope != "control_plane" {
+		t.Fatalf("scope = %q, want control_plane", mock.startScope)
+	}
+	if !strings.Contains(output, "Scaleway cluster start initiated") {
+		t.Fatalf("unexpected output: %s", output)
+	}
+}

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -336,6 +336,9 @@ type APIClient interface {
 	ListDigitaloceanSSHKeyCredentials() ([]client.DigitaloceanCredentialListItem, error)
 	CreateDigitaloceanSSHKeyCredential(req client.CreateSSHKeyCredentialRequest) (*client.CreateSSHKeyCredentialResponse, error)
 
+	StopScalewayCluster(clusterID string) (*client.ProviderStopClusterResponse, error)
+	StartScalewayCluster(clusterID, scope string) (*client.ProviderStartClusterResult, error)
+
 	CreateManagedCluster(provider client.ManagedK8sProvider, request client.CreateManagedClusterRequest) (*client.CreateManagedClusterResponse, error)
 	DeprovisionManagedCluster(provider client.ManagedK8sProvider, clusterID string, force bool) (*client.DeprovisionManagedClusterResponse, error)
 	AddManagedNodePool(provider client.ManagedK8sProvider, clusterID string, request client.AddManagedNodePoolRequest) (*client.AddManagedNodePoolResponse, error)

--- a/internal/client/provider_lifecycle.go
+++ b/internal/client/provider_lifecycle.go
@@ -1,0 +1,105 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+type ProviderStopClusterResponse struct {
+	Success     bool    `json:"success"`
+	ClusterID   string  `json:"cluster_id"`
+	OperationID *string `json:"operation_id,omitempty"`
+}
+
+type ProviderStartClusterResult struct {
+	MarkedToStartAt   string `json:"marked_to_start_at"`
+	Scope             string `json:"scope"`
+	CreatedOperations int    `json:"created_operations"`
+}
+
+func (c *Client) providerClusterURL(provider, clusterID, suffix string) string {
+	endpoint := fmt.Sprintf(
+		"%s/api/v1/clusters/%s/%s",
+		c.BaseURL,
+		url.PathEscape(provider),
+		url.PathEscape(clusterID),
+	)
+	if suffix != "" {
+		endpoint += "/" + url.PathEscape(suffix)
+	}
+	return endpoint
+}
+
+func (c *Client) stopProviderCluster(provider, clusterID string) (*ProviderStopClusterResponse, error) {
+	request, requestError := http.NewRequest(
+		http.MethodPost,
+		c.providerClusterURL(provider, clusterID, "stop"),
+		nil,
+	)
+	if requestError != nil {
+		return nil, fmt.Errorf("create request: %w", requestError)
+	}
+	request.Header.Set("Authorization", "Bearer "+c.Token)
+
+	response, responseError := c.HTTP.Do(request)
+	if responseError != nil {
+		return nil, fmt.Errorf("request failed: %w", responseError)
+	}
+	defer closeBody(response)
+
+	body, readError := readResponseBody(response)
+	if readError != nil {
+		return nil, fmt.Errorf("read response: %w", readError)
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, newUnexpectedResponseError(
+			"stop failed",
+			response.StatusCode,
+			redactedBodyForError(body, 500),
+		)
+	}
+
+	var result ProviderStopClusterResponse
+	if parseError := json.Unmarshal(body, &result); parseError != nil {
+		return nil, fmt.Errorf("parse response: %w", parseError)
+	}
+	return &result, nil
+}
+
+func (c *Client) startProviderCluster(provider, clusterID, scope string) (*ProviderStartClusterResult, error) {
+	endpoint := c.providerClusterURL(provider, clusterID, "start")
+	if scope != "" {
+		endpoint += "?scope=" + url.QueryEscape(scope)
+	}
+	request, requestError := http.NewRequest(http.MethodPost, endpoint, nil)
+	if requestError != nil {
+		return nil, fmt.Errorf("create request: %w", requestError)
+	}
+	request.Header.Set("Authorization", "Bearer "+c.Token)
+
+	response, responseError := c.HTTP.Do(request)
+	if responseError != nil {
+		return nil, fmt.Errorf("request failed: %w", responseError)
+	}
+	defer closeBody(response)
+
+	body, readError := readResponseBody(response)
+	if readError != nil {
+		return nil, fmt.Errorf("read response: %w", readError)
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, newUnexpectedResponseError(
+			"start failed",
+			response.StatusCode,
+			redactedBodyForError(body, 500),
+		)
+	}
+
+	var result ProviderStartClusterResult
+	if parseError := json.Unmarshal(body, &result); parseError != nil {
+		return nil, fmt.Errorf("parse response: %w", parseError)
+	}
+	return &result, nil
+}

--- a/internal/client/scaleway_clusters.go
+++ b/internal/client/scaleway_clusters.go
@@ -1,0 +1,9 @@
+package client
+
+func (c *Client) StopScalewayCluster(clusterID string) (*ProviderStopClusterResponse, error) {
+	return c.stopProviderCluster("scaleway", clusterID)
+}
+
+func (c *Client) StartScalewayCluster(clusterID, scope string) (*ProviderStartClusterResult, error) {
+	return c.startProviderCluster("scaleway", clusterID, scope)
+}

--- a/internal/client/scaleway_clusters_test.go
+++ b/internal/client/scaleway_clusters_test.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestStopScalewayCluster(t *testing.T) {
+	testClient := newTestClient(t, func(responseWriter http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", request.Method)
+		}
+		if request.URL.Path != "/api/v1/clusters/scaleway/cluster-123/stop" {
+			t.Errorf("path = %s, want /api/v1/clusters/scaleway/cluster-123/stop", request.URL.Path)
+		}
+		jsonResponse(t, responseWriter, http.StatusOK, ProviderStopClusterResponse{
+			Success:   true,
+			ClusterID: "cluster-123",
+		})
+	})
+
+	result, stopError := testClient.StopScalewayCluster("cluster-123")
+	if stopError != nil {
+		t.Fatalf("StopScalewayCluster: %v", stopError)
+	}
+	if !result.Success {
+		t.Error("Success = false, want true")
+	}
+	if result.ClusterID != "cluster-123" {
+		t.Errorf("ClusterID = %q, want cluster-123", result.ClusterID)
+	}
+}
+
+func TestStartScalewayCluster(t *testing.T) {
+	testClient := newTestClient(t, func(responseWriter http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", request.Method)
+		}
+		if request.URL.Path != "/api/v1/clusters/scaleway/cluster-123/start" {
+			t.Errorf("path = %s, want /api/v1/clusters/scaleway/cluster-123/start", request.URL.Path)
+		}
+		if scope := request.URL.Query().Get("scope"); scope != "control_plane" {
+			t.Errorf("scope = %q, want control_plane", scope)
+		}
+		jsonResponse(t, responseWriter, http.StatusOK, ProviderStartClusterResult{
+			MarkedToStartAt:   "2026-07-20T09:00:00Z",
+			Scope:             "control_plane",
+			CreatedOperations: 2,
+		})
+	})
+
+	result, startError := testClient.StartScalewayCluster("cluster-123", "control_plane")
+	if startError != nil {
+		t.Fatalf("StartScalewayCluster: %v", startError)
+	}
+	if result.Scope != "control_plane" {
+		t.Errorf("Scope = %q, want control_plane", result.Scope)
+	}
+	if result.CreatedOperations != 2 {
+		t.Errorf("CreatedOperations = %d, want 2", result.CreatedOperations)
+	}
+}


### PR DESCRIPTION
## Summary
- add ankra cluster scaleway stop and start commands
- share provider lifecycle request and response handling
- cover client routing, scope propagation, command output, and interface wiring

## Test plan
- [x] Run make build test lint


Made with [Cursor](https://cursor.com)