### PR TITLE
feat(agents): inspect and cancel AI agent runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Added
+
+- **See and stop what your AI agents are doing with `ankra agents`.** The
+  new command family lists the organisation's dispatched AI agent runs
+  (`ankra agents runs`, filterable by agent and status), shows one run in
+  full (`ankra agents run <run_id>`), reads the run's session transcript —
+  what the agent actually said and did — (`ankra agents transcript
+  <run_id>`), and cancels a live run (`ankra agents cancel <run_id>`,
+  organisation admins only): the platform interrupts the in-flight turn
+  within seconds without pausing the agent itself. All four support
+  `-o json|yaml` for scripting.
+
 ## v0.9.0-rc2 — 2026-07-20
 
 ### Added

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -1,0 +1,202 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+var agentsCmd = &cobra.Command{
+	Use:   "agents",
+	Short: "Inspect and control AI agent runs",
+	Long: `Inspect and control the organisation's AI agent runs.
+
+Every time an AI agent is dispatched (a board ticket, a schedule, an
+alert, or run-now) the platform records a run with a linked session.
+These commands list those runs, show one in full, read its transcript,
+and cancel a live run — the platform interrupts the in-flight turn
+within seconds.`,
+}
+
+var agentsRunsCmd = &cobra.Command{
+	Use:   "runs",
+	Short: "List the organisation's AI agent runs, newest first",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		taskID, _ := cmd.Flags().GetString("task")
+		statuses, _ := cmd.Flags().GetStringSlice("status")
+		limit, _ := cmd.Flags().GetInt("limit")
+
+		response, err := apiClient.ListAgentRuns(taskID, statuses, limit)
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, response); handled || renderError != nil {
+			return renderError
+		}
+		if len(response.Runs) == 0 {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No agent runs found.")
+			return nil
+		}
+		writer := table.NewWriter()
+		writer.SetOutputMirror(cmd.OutOrStdout())
+		writer.AppendHeader(table.Row{"RUN ID", "AGENT", "STATUS", "STARTED", "FINISHED", "OUTCOME"})
+		for _, run := range response.Runs {
+			finished := ""
+			if run.FinishedAt != nil {
+				finished = *run.FinishedAt
+			}
+			outcome := ""
+			if run.OutcomeSummary != nil {
+				outcome = truncateCell(*run.OutcomeSummary, 60)
+			}
+			writer.AppendRow(table.Row{run.ID, run.TaskName, run.Status, run.StartedAt, finished, outcome})
+		}
+		writer.Render()
+		return nil
+	},
+}
+
+var agentsRunCmd = &cobra.Command{
+	Use:   "run <run_id>",
+	Short: "Show one AI agent run in full",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		run, err := apiClient.GetAgentRun(args[0])
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, run); handled || renderError != nil {
+			return renderError
+		}
+		out := cmd.OutOrStdout()
+		_, _ = fmt.Fprintf(out, "Run:      %s\n", run.ID)
+		_, _ = fmt.Fprintf(out, "Agent:    %s (%s)\n", run.TaskName, run.TaskID)
+		_, _ = fmt.Fprintf(out, "Status:   %s\n", run.Status)
+		_, _ = fmt.Fprintf(out, "Started:  %s\n", run.StartedAt)
+		if run.FinishedAt != nil {
+			_, _ = fmt.Fprintf(out, "Finished: %s\n", *run.FinishedAt)
+		}
+		if run.GoalStatus != nil && *run.GoalStatus != "" {
+			_, _ = fmt.Fprintf(out, "Goal:     %s\n", *run.GoalStatus)
+		}
+		if run.AiSessionID != nil {
+			_, _ = fmt.Fprintf(out, "Session:  %s\n", *run.AiSessionID)
+		}
+		if len(run.TriggerContext) > 0 {
+			encoded, marshalError := json.Marshal(run.TriggerContext)
+			if marshalError == nil {
+				_, _ = fmt.Fprintf(out, "Trigger:  %s\n", encoded)
+			}
+		}
+		if run.OutcomeSummary != nil && *run.OutcomeSummary != "" {
+			_, _ = fmt.Fprintf(out, "Outcome:  %s\n", *run.OutcomeSummary)
+		}
+		_, _ = fmt.Fprintf(out, "Turns:    %d\n", run.TurnsUsed)
+		return nil
+	},
+}
+
+var agentsTranscriptCmd = &cobra.Command{
+	Use:   "transcript <run_id>",
+	Short: "Read an AI agent run's session transcript",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		since, _ := cmd.Flags().GetInt64("since")
+		limit, _ := cmd.Flags().GetInt("limit")
+
+		transcript, err := apiClient.GetAgentRunTranscript(args[0], since, limit)
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, transcript); handled || renderError != nil {
+			return renderError
+		}
+		if len(transcript.Events) == 0 {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No transcript events (the run may not have produced output yet).")
+			return nil
+		}
+		for _, event := range transcript.Events {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%5d  %-12s %s\n", event.SequenceNumber, event.EventType,
+				transcriptEventSummary(event.Payload))
+		}
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "\nLast sequence: %d (pass --since %d for the next page)\n",
+			transcript.LastSequenceNumber, transcript.LastSequenceNumber)
+		return nil
+	},
+}
+
+var agentsCancelCmd = &cobra.Command{
+	Use:   "cancel <run_id>",
+	Short: "Cancel a live AI agent run",
+	Long: `Cancel a live AI agent run. The run and its session flip to
+'cancelled' and the platform interrupts the in-flight turn within
+seconds, without pausing the agent itself. Organisation admins only.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		runID := args[0]
+		yes, _ := cmd.Flags().GetBool("yes")
+		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Cancel agent run %q? [y/N]: ", runID), yes); err != nil {
+			return err
+		}
+		result, err := apiClient.CancelAgentRun(runID)
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, result); handled || renderError != nil {
+			return renderError
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Run cancelled. The platform interrupts the in-flight turn within seconds.")
+		if result.CancelledSessionID != "" {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Cancelled session: %s\n", result.CancelledSessionID)
+		}
+		return nil
+	},
+}
+
+// transcriptEventSummary renders a one-line human summary of a session
+// event payload: its text when present, else compact JSON.
+func transcriptEventSummary(payload map[string]interface{}) string {
+	if payload == nil {
+		return ""
+	}
+	for _, key := range []string{"text", "content", "message"} {
+		if value, ok := payload[key].(string); ok && strings.TrimSpace(value) != "" {
+			return truncateCell(strings.ReplaceAll(value, "\n", " "), 160)
+		}
+	}
+	encoded, marshalError := json.Marshal(payload)
+	if marshalError != nil {
+		return ""
+	}
+	return truncateCell(string(encoded), 160)
+}
+
+// truncateCell caps a table/summary cell without breaking the layout.
+func truncateCell(value string, maxLength int) string {
+	if len(value) <= maxLength {
+		return value
+	}
+	return value[:maxLength-1] + "…"
+}
+
+func init() {
+	agentsRunsCmd.Flags().String("task", "", "Filter to one agent task id (UUID)")
+	agentsRunsCmd.Flags().StringSlice("status", nil,
+		"Filter by run status (pending, running, awaiting_user, completed, failed, cancelled, expired, skipped); repeatable")
+	agentsRunsCmd.Flags().Int("limit", 20, "Maximum runs to return (max 100)")
+	agentsTranscriptCmd.Flags().Int64("since", 0, "Return events with a sequence number greater than this")
+	agentsTranscriptCmd.Flags().Int("limit", 200, "Maximum events to return (max 1000)")
+	agentsCancelCmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
+
+	registerStructuredOutputFlags(agentsRunsCmd, agentsRunCmd, agentsTranscriptCmd, agentsCancelCmd)
+	agentsCmd.AddCommand(agentsRunsCmd)
+	agentsCmd.AddCommand(agentsRunCmd)
+	agentsCmd.AddCommand(agentsTranscriptCmd)
+	agentsCmd.AddCommand(agentsCancelCmd)
+	rootCmd.AddCommand(agentsCmd)
+}

--- a/cmd/agents_test.go
+++ b/cmd/agents_test.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+type agentRunsMock struct {
+	baseMock
+	runs        []client.AgentRun
+	cancelCalls int
+	cancelError error
+}
+
+func (m *agentRunsMock) ListAgentRuns(taskID string, statuses []string, limit int) (*client.AgentRunListResponse, error) {
+	return &client.AgentRunListResponse{Runs: m.runs}, nil
+}
+
+func (m *agentRunsMock) GetAgentRun(runID string) (*client.AgentRun, error) {
+	for index := range m.runs {
+		if m.runs[index].ID == runID {
+			return &m.runs[index], nil
+		}
+	}
+	return nil, client.NewUnexpectedResponseError(404, "Agent run not found.")
+}
+
+func (m *agentRunsMock) CancelAgentRun(runID string) (*client.CancelAgentRunResponse, error) {
+	m.cancelCalls++
+	if m.cancelError != nil {
+		return nil, m.cancelError
+	}
+	return &client.CancelAgentRunResponse{Detail: "Run cancelled.", Status: "cancelled",
+		CancelledSessionID: "3a67c807-6f0b-45c8-9c2a-000000000001"}, nil
+}
+
+func sampleAgentRun() client.AgentRun {
+	outcome := "Investigated the ticket."
+	return client.AgentRun{
+		ID:        "1f14b8f7-0000-4000-8000-000000000001",
+		TaskID:    "2f14b8f7-0000-4000-8000-000000000002",
+		TaskName:  "SRE",
+		Status:    "running",
+		StartedAt: "2026-07-20T15:00:00Z",
+		TurnsUsed: 1, OutcomeSummary: &outcome,
+	}
+}
+
+func TestAgentsRunsListsRuns(t *testing.T) {
+	mock := &agentRunsMock{runs: []client.AgentRun{sampleAgentRun()}}
+	out, err := runConfirmCommand(t, mock, "",
+		[]*cobra.Command{agentsRunsCmd}, "agents", "runs")
+	if err != nil {
+		t.Fatalf("agents runs failed: %v", err)
+	}
+	if !strings.Contains(out, "SRE") || !strings.Contains(out, "running") {
+		t.Fatalf("run table missing fields: %s", out)
+	}
+}
+
+func TestAgentsRunNotFoundUsesExitNotFound(t *testing.T) {
+	mock := &agentRunsMock{}
+	_, err := runConfirmCommand(t, mock, "",
+		[]*cobra.Command{agentsRunCmd}, "agents", "run", "1f14b8f7-0000-4000-8000-00000000dead")
+	if err == nil {
+		t.Fatal("expected an error for a missing run")
+	}
+	if got := exitCodeFor(err); got != exitNotFound {
+		t.Errorf("expected exit code %d, got %d", exitNotFound, got)
+	}
+}
+
+func TestAgentsCancelDeclinedUsesExitCancelled(t *testing.T) {
+	mock := &agentRunsMock{}
+	_, err := runConfirmCommand(t, mock, "n\n",
+		[]*cobra.Command{agentsCancelCmd}, "agents", "cancel", "1f14b8f7-0000-4000-8000-000000000001")
+	if err == nil {
+		t.Fatal("expected the declined confirmation to error")
+	}
+	if got := exitCodeFor(err); got != exitCancelled {
+		t.Errorf("expected exit code %d, got %d", exitCancelled, got)
+	}
+	if mock.cancelCalls != 0 {
+		t.Errorf("declined confirmation must not cancel, got %d calls", mock.cancelCalls)
+	}
+}
+
+func TestAgentsCancelConfirmedCancels(t *testing.T) {
+	mock := &agentRunsMock{}
+	out, err := runConfirmCommand(t, mock, "y\n",
+		[]*cobra.Command{agentsCancelCmd}, "agents", "cancel", "1f14b8f7-0000-4000-8000-000000000001")
+	if err != nil {
+		t.Fatalf("agents cancel failed: %v", err)
+	}
+	if mock.cancelCalls != 1 {
+		t.Fatalf("expected one cancel call, got %d", mock.cancelCalls)
+	}
+	if !strings.Contains(out, "Run cancelled") {
+		t.Fatalf("missing cancel confirmation output: %s", out)
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -537,6 +537,22 @@ func (m baseMock) DeleteChatConversation(conversationID string) (*client.DeleteC
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) ListAgentRuns(taskID string, statuses []string, limit int) (*client.AgentRunListResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetAgentRun(runID string) (*client.AgentRun, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetAgentRunTranscript(runID string, since int64, limit int) (*client.AgentRunTranscript, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) CancelAgentRun(runID string) (*client.CancelAgentRunResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) GetClusterHealth(clusterID string, includeAI bool) (*client.ClusterHealth, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -159,6 +159,11 @@ type APIClient interface {
 	DeleteChatConversation(conversationID string) (*client.DeleteConversationResponse, error)
 	GetClusterHealth(clusterID string, includeAI bool) (*client.ClusterHealth, error)
 
+	ListAgentRuns(taskID string, statuses []string, limit int) (*client.AgentRunListResponse, error)
+	GetAgentRun(runID string) (*client.AgentRun, error)
+	GetAgentRunTranscript(runID string, since int64, limit int) (*client.AgentRunTranscript, error)
+	CancelAgentRun(runID string) (*client.CancelAgentRunResponse, error)
+
 	GetAIProviderStatus() (*client.AIProviderStatus, error)
 	SetAIProvider(provider string) (*client.AIProviderStatus, error)
 	SaveAnthropicKey(apiKey string) (*client.AIAnthropicStatus, error)

--- a/internal/client/agentruns.go
+++ b/internal/client/agentruns.go
@@ -1,0 +1,146 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// AgentRun mirrors one dispatched AI agent run from
+// GET /api/v1/org/ai-agent-runs (the org-wide run surface).
+type AgentRun struct {
+	ID             string                 `json:"id"`
+	TaskID         string                 `json:"task_id"`
+	TaskName       string                 `json:"task_name"`
+	AiSessionID    *string                `json:"ai_session_id"`
+	Status         string                 `json:"status"`
+	TriggerContext map[string]interface{} `json:"trigger_context"`
+	OutcomeSummary *string                `json:"outcome_summary"`
+	TurnsUsed      int                    `json:"turns_used"`
+	GoalStatus     *string                `json:"goal_status"`
+	StartedAt      string                 `json:"started_at"`
+	FinishedAt     *string                `json:"finished_at"`
+}
+
+// AgentRunListResponse is the GET /api/v1/org/ai-agent-runs body.
+type AgentRunListResponse struct {
+	Runs []AgentRun `json:"runs"`
+}
+
+// AgentRunTranscriptEvent is one session event in a run transcript.
+type AgentRunTranscriptEvent struct {
+	ID             string                 `json:"id"`
+	SessionID      string                 `json:"session_id"`
+	SequenceNumber int64                  `json:"sequence_number"`
+	EventType      string                 `json:"event_type"`
+	Payload        map[string]interface{} `json:"payload"`
+	CreatedAt      string                 `json:"created_at"`
+}
+
+// AgentRunTranscript is the GET /api/v1/org/ai-agent-runs/{id}/transcript
+// body: the ascending page of session events after `since`.
+type AgentRunTranscript struct {
+	SessionID          string                    `json:"session_id"`
+	LastSequenceNumber int64                     `json:"last_sequence_number"`
+	Events             []AgentRunTranscriptEvent `json:"events"`
+}
+
+// CancelAgentRunResponse is the POST /api/v1/org/ai-agent-runs/{id}/cancel
+// body on success.
+type CancelAgentRunResponse struct {
+	Detail             string `json:"detail"`
+	Status             string `json:"status"`
+	CancelledSessionID string `json:"cancelled_session_id,omitempty"`
+}
+
+// ListAgentRuns lists the organisation's dispatched AI agent runs, newest
+// first, optionally filtered by task id and statuses.
+func (c *Client) ListAgentRuns(taskID string, statuses []string, limit int) (*AgentRunListResponse, error) {
+	query := url.Values{}
+	if taskID != "" {
+		query.Set("task_id", taskID)
+	}
+	for _, status := range statuses {
+		query.Add("status", status)
+	}
+	if limit > 0 {
+		query.Set("limit", strconv.Itoa(limit))
+	}
+	requestURL := c.BaseURL + "/api/v1/org/ai-agent-runs"
+	if encoded := query.Encode(); encoded != "" {
+		requestURL += "?" + encoded
+	}
+	var response AgentRunListResponse
+	if err := c.getJSON(requestURL, &response); err != nil {
+		return nil, fmt.Errorf("listing agent runs: %w", err)
+	}
+	return &response, nil
+}
+
+// GetAgentRun fetches one dispatched run with its owning agent's name.
+func (c *Client) GetAgentRun(runID string) (*AgentRun, error) {
+	var run AgentRun
+	if err := c.getJSON(c.BaseURL+"/api/v1/org/ai-agent-runs/"+url.PathEscape(runID), &run); err != nil {
+		return nil, fmt.Errorf("getting agent run: %w", err)
+	}
+	return &run, nil
+}
+
+// GetAgentRunTranscript reads the run's linked session transcript: the
+// ascending page of session events strictly after `since`.
+func (c *Client) GetAgentRunTranscript(runID string, since int64, limit int) (*AgentRunTranscript, error) {
+	query := url.Values{}
+	if since > 0 {
+		query.Set("since", strconv.FormatInt(since, 10))
+	}
+	if limit > 0 {
+		query.Set("limit", strconv.Itoa(limit))
+	}
+	requestURL := c.BaseURL + "/api/v1/org/ai-agent-runs/" + url.PathEscape(runID) + "/transcript"
+	if encoded := query.Encode(); encoded != "" {
+		requestURL += "?" + encoded
+	}
+	var transcript AgentRunTranscript
+	if err := c.getJSON(requestURL, &transcript); err != nil {
+		return nil, fmt.Errorf("getting agent run transcript: %w", err)
+	}
+	return &transcript, nil
+}
+
+// CancelAgentRun cancels one live run; the platform interrupts the
+// in-flight turn within seconds. Already-finished runs answer 409 with
+// their final status in the detail.
+func (c *Client) CancelAgentRun(runID string) (*CancelAgentRunResponse, error) {
+	requestURL := c.BaseURL + "/api/v1/org/ai-agent-runs/" + url.PathEscape(runID) + "/cancel"
+	request, requestError := http.NewRequest(http.MethodPost, requestURL, nil)
+	if requestError != nil {
+		return nil, fmt.Errorf("create request: %w", requestError)
+	}
+	request.Header.Set("Authorization", "Bearer "+c.Token)
+
+	response, sendError := c.HTTP.Do(request)
+	if sendError != nil {
+		return nil, fmt.Errorf("cancelling agent run: %w", sendError)
+	}
+	defer closeBody(response)
+	if response.StatusCode == http.StatusUnauthorized {
+		return nil, ErrUnauthorized
+	}
+	body, _ := readResponseBody(response)
+	if response.StatusCode != http.StatusOK {
+		if denied := PermissionDeniedFromResponse(response.StatusCode, body); denied != nil {
+			return nil, denied
+		}
+		message := detailFromBody(body)
+		if message == "" {
+			message = fmt.Sprintf("unexpected status: %s", response.Status)
+		}
+		return nil, newUnexpectedResponseErrorWithMessage(response.StatusCode, message)
+	}
+	var result CancelAgentRunResponse
+	if err := parseJSON(body, &result); err != nil {
+		return nil, fmt.Errorf("parsing cancel response: %w", err)
+	}
+	return &result, nil
+}


### PR DESCRIPTION
## What

New **`ankra agents`** command family for the AI agent run surface shipping in ankraio/cluster#395:

- `ankra agents runs` — list the organisation's dispatched AI agent runs, newest first (`--task`, repeatable `--status`, `--limit`)
- `ankra agents run <run_id>` — one run in full (agent, status, trigger, timings, outcome, session id)
- `ankra agents transcript <run_id>` — the run's session transcript (what the agent actually said and did), `--since`/`--limit` paging
- `ankra agents cancel <run_id>` — confirmation-gated cancel of a live run (organisation admins only); the platform interrupts the in-flight turn within seconds without pausing the agent

All four support `-o json|yaml` with clean stdout; not-found → exit 3, declined confirmation → exit 4. Client methods added to the `APIClient` interface + `baseMock` triangle per repo convention; CHANGELOG entry included.

## Verification

`make test` (includes 4 new cmd tests: table render, not-found exit code, declined-confirmation exit code + no-call assertion, confirmed cancel) and `make lint` — both green on this exact tree in a scratch checkout of `origin/master` + this change. Note: the commands need the backend routes from ankraio/cluster#395 to be deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
