### PR TITLE
Prepare ankra-cli v0.9.0-rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.9.0-rc3 — 2026-07-21
+
 ### Added
 
 - **See and stop what your AI agents are doing with `ankra agents`.** The


### PR DESCRIPTION
Promotes the post-rc2 Unreleased notes (the `ankra agents` run inspection family from #30) into a `v0.9.0-rc3` changelog section dated today, so the release workflow extracts the right notes when the tag is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)