### PR TITLE
fix(cluster): make nodes restart provider-accurate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,12 @@
 - **Proxmox VE clusters are managed from the CLI.** The new `ankra cluster
   proxmox` family covers create, deprovision, stop/start, worker and
   node-group scaling, labels and taints, autoscaling, control-plane changes,
-  node inspection, SSH keys, Kubernetes upgrades, and discovery of Proxmox
+  node inspection and restart, SSH keys, Kubernetes upgrades, and discovery of Proxmox
   nodes, storages, bridges, and templates, plus `ankra credentials proxmox`
   for credential management.
 - **HPE Morpheus clusters are managed from the CLI.** The new `ankra
-  cluster morpheus` family mirrors the Proxmox surface — full lifecycle,
+  cluster morpheus` family mirrors the Proxmox surface (node restart excepted — the
+  platform has no Morpheus restart lane) — full lifecycle,
   node groups, control plane, SSH keys, and upgrades — plus discovery of
   Morpheus groups, clouds, plans, layouts, and networks, and `ankra
   credentials morpheus` for credential management.

--- a/cmd/cluster_nodes.go
+++ b/cmd/cluster_nodes.go
@@ -58,6 +58,7 @@ func proxmoxNodesOps() clusterNodesOps {
 		provider: "proxmox",
 		list:     apiClient.ListProxmoxClusterNodes,
 		get:      apiClient.GetProxmoxClusterNode,
+		restart:  apiClient.RestartProxmoxClusterNode,
 	}
 }
 
@@ -243,7 +244,7 @@ func printEdges(title string, edges map[string][]string) {
 	}
 }
 
-func newNodesCmd(opsFn func() clusterNodesOps, provider string) *cobra.Command {
+func newNodesCmd(opsFn func() clusterNodesOps, provider string, supportsRestart bool) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "nodes",
 		Short: fmt.Sprintf("List and inspect %s cluster nodes", provider),
@@ -270,30 +271,34 @@ included so the saved topology is visible before re-provisioning.`,
 		},
 	}
 
-	restartCmd := &cobra.Command{
-		Use:   "restart <cluster_id> <node_id>",
-		Short: "Restart a node (control plane, worker, or bastion/gateway)",
-		Long: `Schedule a native reboot (falling back to a power cycle) of the node as a
+	registerStructuredOutputFlags(listCmd, getCmd)
+	cmd.AddCommand(listCmd, getCmd)
+
+	if supportsRestart {
+		restartCmd := &cobra.Command{
+			Use:   "restart <cluster_id> <node_id>",
+			Short: "Restart a node (control plane, worker, or bastion/gateway)",
+			Long: `Schedule a native reboot (falling back to a power cycle) of the node as a
 tracked operation. The node must be in the 'up' state and have no restart
 already in flight. Workloads on the node are briefly unavailable while it
 reboots. Works for any node returned by 'nodes list', including the
 bastion/gateway.`,
-		Args: cobra.ExactArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runNodesRestart(cmd, opsFn, args[0], args[1])
-		},
+			Args: cobra.ExactArgs(2),
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return runNodesRestart(cmd, opsFn, args[0], args[1])
+			},
+		}
+		registerStructuredOutputFlags(restartCmd)
+		cmd.AddCommand(restartCmd)
 	}
-
-	registerStructuredOutputFlags(listCmd, getCmd, restartCmd)
-	cmd.AddCommand(listCmd, getCmd, restartCmd)
 	return cmd
 }
 
 func init() {
-	hetznerCmd.AddCommand(newNodesCmd(hetznerNodesOps, "Hetzner"))
-	ovhCmd.AddCommand(newNodesCmd(ovhNodesOps, "OVH"))
-	upcloudCmd.AddCommand(newNodesCmd(upcloudNodesOps, "UpCloud"))
-	digitaloceanCmd.AddCommand(newNodesCmd(digitaloceanNodesOps, "DigitalOcean"))
-	proxmoxCmd.AddCommand(newNodesCmd(proxmoxNodesOps, "Proxmox VE"))
-	morpheusCmd.AddCommand(newNodesCmd(morpheusNodesOps, "HPE Morpheus"))
+	hetznerCmd.AddCommand(newNodesCmd(hetznerNodesOps, "Hetzner", true))
+	ovhCmd.AddCommand(newNodesCmd(ovhNodesOps, "OVH", true))
+	upcloudCmd.AddCommand(newNodesCmd(upcloudNodesOps, "UpCloud", true))
+	digitaloceanCmd.AddCommand(newNodesCmd(digitaloceanNodesOps, "DigitalOcean", true))
+	proxmoxCmd.AddCommand(newNodesCmd(proxmoxNodesOps, "Proxmox VE", true))
+	morpheusCmd.AddCommand(newNodesCmd(morpheusNodesOps, "HPE Morpheus", false))
 }

--- a/cmd/cluster_nodes_test.go
+++ b/cmd/cluster_nodes_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+
 	"ankra/internal/client"
 )
 
@@ -70,4 +72,46 @@ func TestClusterNodesRestartCommandRequiresBothArgs(t *testing.T) {
 	if _, err := executeCommand("cluster", "hetzner", "nodes", "restart", "cluster-1"); err == nil {
 		t.Fatal("expected an error when node_id is missing")
 	}
+}
+
+func TestClusterNodesRestartSurfaceMatchesProviderSupport(t *testing.T) {
+	expectations := map[string]bool{
+		"hetzner":      true,
+		"ovh":          true,
+		"upcloud":      true,
+		"digitalocean": true,
+		"proxmox":      true,
+		"morpheus":     false,
+	}
+	for providerName, shouldHaveRestart := range expectations {
+		nodesCmd := findSubcommandPath(t, "cluster", providerName, "nodes")
+		hasRestart := false
+		for _, child := range nodesCmd.Commands() {
+			if child.Name() == "restart" {
+				hasRestart = true
+			}
+		}
+		if hasRestart != shouldHaveRestart {
+			t.Errorf("cluster %s nodes restart offered=%v, want %v (the platform has no Morpheus restart lane)", providerName, hasRestart, shouldHaveRestart)
+		}
+	}
+}
+
+func findSubcommandPath(t *testing.T, path ...string) *cobra.Command {
+	t.Helper()
+	current := rootCmd
+	for _, name := range path {
+		var next *cobra.Command
+		for _, child := range current.Commands() {
+			if child.Name() == name {
+				next = child
+				break
+			}
+		}
+		if next == nil {
+			t.Fatalf("command path %v: %q not found", path, name)
+		}
+		current = next
+	}
+	return current
 }

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1315,6 +1315,10 @@ func (m baseMock) GetProxmoxClusterNode(clusterID, nodeID string) (*client.NodeD
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) RestartProxmoxClusterNode(clusterID, nodeID string) (*client.RestartNodeResult, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) GetProxmoxClusterSSHKeys(clusterID string) (*client.ClusterSSHKeysResult, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -374,6 +374,7 @@ type APIClient interface {
 	ChangeProxmoxControlPlaneInstanceType(clusterID, instanceType string) (*client.ChangeControlPlaneInstanceTypeResult, error)
 	ListProxmoxClusterNodes(clusterID string) (*client.NodeListResult, error)
 	GetProxmoxClusterNode(clusterID, nodeID string) (*client.NodeDetail, error)
+	RestartProxmoxClusterNode(clusterID, nodeID string) (*client.RestartNodeResult, error)
 	GetProxmoxClusterSSHKeys(clusterID string) (*client.ClusterSSHKeysResult, error)
 	UpdateProxmoxClusterSSHKeys(clusterID string, sshKeyCredentialIDs []string) (*client.UpdateClusterSSHKeysResult, error)
 	ResyncProxmoxClusterSSHKeys(clusterID string) (*client.ResyncSSHKeysResult, error)

--- a/internal/client/cluster_nodes.go
+++ b/internal/client/cluster_nodes.go
@@ -103,6 +103,10 @@ func (c *Client) RestartDigitaloceanClusterNode(clusterID, nodeID string) (*Rest
 	return c.restartClusterNode("digitalocean", clusterID, nodeID)
 }
 
+func (c *Client) RestartProxmoxClusterNode(clusterID, nodeID string) (*RestartNodeResult, error) {
+	return c.restartClusterNode("proxmox", clusterID, nodeID)
+}
+
 // restartClusterNode schedules a one-shot restart operation. Unlike the
 // node-group writes, this endpoint has no async accept/wait contract - it
 // always runs synchronously and answers 200 with the scheduled operation.


### PR DESCRIPTION
## What

Follow-up to #31. The `nodes` command group registered `restart` for every provider, but `proxmoxNodesOps`/`morpheusNodesOps` wired no restart function — running `ankra cluster proxmox|morpheus nodes restart` panicked on a nil function call.

- **Proxmox**: wires `RestartProxmoxClusterNode` (the platform supports it — `proxmox_restart_server` job).
- **Morpheus**: the platform deliberately has no restart lane, so the `restart` subcommand is no longer registered for it.
- Adds `TestClusterNodesRestartSurfaceMatchesProviderSupport` pinning per-provider restart availability, and notes the Morpheus exception in the unreleased changelog entries.

## Verification

`go build`, `go vet`, full `go test`, `golangci-lint` (0 issues) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)