### PR TITLE
feat(helm): pagination, search, and sorting for registries list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Added
+
+- **`ankra helm registries list` supports pagination, search, and sorting.**
+  The command used to fetch only the server's first page (20 registries) and
+  gave no hint that more existed. It now accepts `--page` and `--page-size`
+  (up to 100 per page), `--search` for a case-insensitive name filter, and
+  `--sort-by` (`name`, `url`, `created_at`, `updated_at`, `chart_count`,
+  `last_indexed_at`, `is_global`) with `--sort-order asc|desc`, and every
+  listing ends with a `Page X of Y (total N)` footer so truncation is always
+  visible.
+
 ## v0.9.0-rc4 — 2026-07-21
 
 ### Added

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -659,7 +659,7 @@ func (m baseMock) QueryPrometheusRange(clusterID string, opts client.PrometheusR
 	return nil, errors.New("not implemented")
 }
 
-func (m baseMock) ListHelmRegistries() (*client.ListHelmRegistriesResponse, error) {
+func (m baseMock) ListHelmRegistries(opts *client.ListHelmRegistriesOptions) (*client.ListHelmRegistriesResponse, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -2102,11 +2102,19 @@ func TestClusterAgentStatusCommand(t *testing.T) {
 type helmRegistriesListMock struct {
 	baseMock
 	registries []client.HelmRegistryListItem
+	lastOpts   *client.ListHelmRegistriesOptions
 }
 
-func (m *helmRegistriesListMock) ListHelmRegistries() (*client.ListHelmRegistriesResponse, error) {
+func (m *helmRegistriesListMock) ListHelmRegistries(opts *client.ListHelmRegistriesOptions) (*client.ListHelmRegistriesResponse, error) {
+	m.lastOpts = opts
 	return &client.ListHelmRegistriesResponse{
 		Result: m.registries,
+		Pagination: client.Pagination{
+			TotalCount: len(m.registries),
+			TotalPages: 1,
+			Page:       1,
+			PageSize:   20,
+		},
 	}, nil
 }
 
@@ -2154,6 +2162,9 @@ func TestHelmRegistriesListCommand(t *testing.T) {
 	if !strings.Contains(stdoutOutput, "github-charts") {
 		t.Errorf("expected output to contain 'github-charts', got: %s", stdoutOutput)
 	}
+	if !strings.Contains(stdoutOutput, "Page 1 of 1 (total 2)") {
+		t.Errorf("expected pagination footer, got: %s", stdoutOutput)
+	}
 }
 
 func TestHelmRegistriesListEmptyCommand(t *testing.T) {
@@ -2168,6 +2179,41 @@ func TestHelmRegistriesListEmptyCommand(t *testing.T) {
 
 	if !strings.Contains(stdoutOutput, "No Helm registries found.") {
 		t.Errorf("expected 'No Helm registries found.' message, got: %s", stdoutOutput)
+	}
+}
+
+func TestHelmRegistriesListFlagsForwarded(t *testing.T) {
+	mock := &helmRegistriesListMock{
+		registries: []client.HelmRegistryListItem{},
+	}
+	setMockClient(t, mock)
+	// rootCmd is shared across tests, so restore flag defaults to avoid
+	// leaking values into later "helm registries list" invocations.
+	t.Cleanup(func() {
+		flags := helmRegistriesListCmd.Flags()
+		_ = flags.Set("page", "1")
+		_ = flags.Set("page-size", "20")
+		_ = flags.Set("search", "")
+		_ = flags.Set("sort-by", "")
+		_ = flags.Set("sort-order", "")
+	})
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("helm", "registries", "list",
+			"--page", "3", "--page-size", "50", "--search", "bitnami",
+			"--sort-by", "chart_count", "--sort-order", "desc")
+	})
+
+	if mock.lastOpts == nil {
+		t.Fatal("expected ListHelmRegistries to receive options")
+	}
+	if mock.lastOpts.Page != 3 || mock.lastOpts.PageSize != 50 ||
+		mock.lastOpts.Search != "bitnami" ||
+		mock.lastOpts.SortBy != "chart_count" || mock.lastOpts.SortOrder != "desc" {
+		t.Errorf("unexpected options forwarded: %+v", mock.lastOpts)
+	}
+	if !strings.Contains(stdoutOutput, "No Helm registries found matching 'bitnami'.") {
+		t.Errorf("expected search-aware empty message, got: %s", stdoutOutput)
 	}
 }
 

--- a/cmd/helm.go
+++ b/cmd/helm.go
@@ -26,8 +26,29 @@ var helmRegistriesCmd = &cobra.Command{
 var helmRegistriesListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List Helm chart registries",
+	Long: `List Helm chart registries.
+
+Results are paginated (20 per page by default). Use --search to filter
+by name and --page/--page-size to navigate.
+
+Examples:
+  ankra helm registries list --search bitnami
+  ankra helm registries list --page 2 --page-size 100
+  ankra helm registries list --sort-by chart_count --sort-order desc`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		response, err := apiClient.ListHelmRegistries()
+		page, _ := cmd.Flags().GetInt("page")
+		pageSize, _ := cmd.Flags().GetInt("page-size")
+		search, _ := cmd.Flags().GetString("search")
+		sortBy, _ := cmd.Flags().GetString("sort-by")
+		sortOrder, _ := cmd.Flags().GetString("sort-order")
+
+		response, err := apiClient.ListHelmRegistries(&client.ListHelmRegistriesOptions{
+			Page:      page,
+			PageSize:  pageSize,
+			Search:    search,
+			SortBy:    sortBy,
+			SortOrder: sortOrder,
+		})
 		if err != nil {
 			return fmt.Errorf("listing registries: %w", err)
 		}
@@ -37,7 +58,11 @@ var helmRegistriesListCmd = &cobra.Command{
 		}
 
 		if len(response.Result) == 0 {
-			fmt.Println("No Helm registries found.")
+			if search != "" {
+				fmt.Printf("No Helm registries found matching '%s'.\n", search)
+			} else {
+				fmt.Println("No Helm registries found.")
+			}
 			return nil
 		}
 
@@ -62,6 +87,8 @@ var helmRegistriesListCmd = &cobra.Command{
 			})
 		}
 		t.Render()
+		fmt.Printf("\nPage %d of %d (total %d)\n",
+			response.Pagination.Page, response.Pagination.TotalPages, response.Pagination.TotalCount)
 		return nil
 	},
 }
@@ -432,6 +459,11 @@ var helmCredentialsDeleteCmd = &cobra.Command{
 }
 
 func init() {
+	helmRegistriesListCmd.Flags().Int("page", 1, "Page number")
+	helmRegistriesListCmd.Flags().Int("page-size", 20, "Number of registries per page (max 100)")
+	helmRegistriesListCmd.Flags().String("search", "", "Filter registries by name (case-insensitive substring)")
+	helmRegistriesListCmd.Flags().String("sort-by", "", "Sort column: name, url, created_at, updated_at, chart_count, last_indexed_at, is_global")
+	helmRegistriesListCmd.Flags().String("sort-order", "", "Sort order: asc or desc")
 	helmRegistriesCreateCmd.Flags().StringP("file", "f", "", "Path to registry spec JSON file (required)")
 	_ = helmRegistriesCreateCmd.MarkFlagRequired("file")
 	helmRegistriesDeleteCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -192,7 +192,7 @@ type APIClient interface {
 	QueryPrometheusInstant(clusterID, query string, timeoutSeconds int) (*client.PrometheusQueryResult, error)
 	QueryPrometheusRange(clusterID string, opts client.PrometheusRangeOptions) (*client.PrometheusQueryResult, error)
 
-	ListHelmRegistries() (*client.ListHelmRegistriesResponse, error)
+	ListHelmRegistries(opts *client.ListHelmRegistriesOptions) (*client.ListHelmRegistriesResponse, error)
 	GetHelmRegistry(registryName string) (*client.GetHelmRegistryResponse, error)
 	CreateHelmRegistry(req client.CreateHelmRegistryRequest) (*client.CreateHelmRegistryResponse, error)
 	UpdateHelmRegistry(registryName string, readJobInterval *int) error

--- a/internal/client/helm.go
+++ b/internal/client/helm.go
@@ -88,8 +88,41 @@ type DeleteHelmRegistryResponse struct {
 	Success bool `json:"success"`
 }
 
-func (c *Client) ListHelmRegistries() (*ListHelmRegistriesResponse, error) {
+// ListHelmRegistriesOptions mirrors the query parameters accepted by the
+// backend's list endpoint (see cluster's helmapi handleListRegistries):
+// page (default 1), page_size (default 20, max 100), search (case-insensitive
+// substring match on registry name), sort_by and sort_order.
+type ListHelmRegistriesOptions struct {
+	Page      int
+	PageSize  int
+	Search    string
+	SortBy    string
+	SortOrder string
+}
+
+func (c *Client) ListHelmRegistries(opts *ListHelmRegistriesOptions) (*ListHelmRegistriesResponse, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/org/helm/registries", c.BaseURL)
+	params := url.Values{}
+	if opts != nil {
+		if opts.Page > 0 {
+			params.Set("page", fmt.Sprintf("%d", opts.Page))
+		}
+		if opts.PageSize > 0 {
+			params.Set("page_size", fmt.Sprintf("%d", opts.PageSize))
+		}
+		if opts.Search != "" {
+			params.Set("search", opts.Search)
+		}
+		if opts.SortBy != "" {
+			params.Set("sort_by", opts.SortBy)
+		}
+		if opts.SortOrder != "" {
+			params.Set("sort_order", opts.SortOrder)
+		}
+	}
+	if encoded := params.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
 	var response ListHelmRegistriesResponse
 	if err := c.getJSON(endpoint, &response); err != nil {
 		return nil, err

--- a/internal/client/helm_test.go
+++ b/internal/client/helm_test.go
@@ -11,15 +11,19 @@ func TestListHelmRegistries(t *testing.T) {
 	tests := []struct {
 		name    string
 		handler http.HandlerFunc
+		opts    *ListHelmRegistriesOptions
 		wantErr bool
 		wantLen int
 	}{
 		{
-			name: "success",
+			name: "success without options",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path != "/api/v1/org/helm/registries" {
 					w.WriteHeader(http.StatusNotFound)
 					return
+				}
+				if r.URL.RawQuery != "" {
+					t.Errorf("expected no query parameters, got %q", r.URL.RawQuery)
 				}
 				createdA := "2025-01-01T00:00:00Z"
 				createdB := "2025-02-01T00:00:00Z"
@@ -31,8 +35,35 @@ func TestListHelmRegistries(t *testing.T) {
 					Pagination: Pagination{TotalCount: 2, Page: 1, PageSize: 25, TotalPages: 1},
 				})
 			},
+			opts:    nil,
 			wantErr: false,
 			wantLen: 2,
+		},
+		{
+			name: "options become query parameters",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				q := r.URL.Query()
+				if q.Get("page") != "2" || q.Get("page_size") != "50" ||
+					q.Get("search") != "bitnami" ||
+					q.Get("sort_by") != "chart_count" || q.Get("sort_order") != "desc" {
+					t.Errorf("unexpected query parameters: %q", r.URL.RawQuery)
+				}
+				jsonResponse(t, w, http.StatusOK, ListHelmRegistriesResponse{
+					Result: []HelmRegistryListItem{
+						{Name: "bitnami", URL: "https://charts.bitnami.com/bitnami", ChartCount: 100},
+					},
+					Pagination: Pagination{TotalCount: 51, Page: 2, PageSize: 50, TotalPages: 2},
+				})
+			},
+			opts: &ListHelmRegistriesOptions{
+				Page:      2,
+				PageSize:  50,
+				Search:    "bitnami",
+				SortBy:    "chart_count",
+				SortOrder: "desc",
+			},
+			wantErr: false,
+			wantLen: 1,
 		},
 		{
 			name: "401 unauthorized",
@@ -46,7 +77,7 @@ func TestListHelmRegistries(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testClient := newTestClient(t, tt.handler)
-			got, err := testClient.ListHelmRegistries()
+			got, err := testClient.ListHelmRegistries(tt.opts)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ListHelmRegistries() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
## What & why

`ankra helm registries list` fetched only the server's first page (20 registries) and gave no hint that more existed — organisations with more registries silently saw a truncated list.

The command now forwards the full query surface of the backend's list endpoint (cluster `helmapi handleListRegistries`):

- `--page` / `--page-size` (server max 100)
- `--search` — case-insensitive substring filter on registry name
- `--sort-by` (`name`, `url`, `created_at`, `updated_at`, `chart_count`, `last_indexed_at`, `is_global`) and `--sort-order asc|desc`

Every table listing now ends with a `Page X of Y (total N)` footer so truncation is always visible, and the empty-result message mentions the active search filter. `-o json|yaml` output is unchanged and stays machine-parseable (the footer renders only in table mode, after the `renderStructured` early return).

Client-side, `ListHelmRegistries` takes a nil-safe `ListHelmRegistriesOptions` struct and only sets query parameters that are non-zero, so the no-flag invocation still sends a bare request. Invalid `sort_by`/`sort_order`/`page_size` values are rejected server-side with proper validation errors, matching the portal's behaviour.

## Test plan

- `internal/client`: new table-driven case asserting the options encode to the exact expected query parameters, plus an assertion that the no-options call sends no query string.
- `cmd`: new e2e-style test asserting all five flags are forwarded to the client and the search-aware empty message renders; existing list test extended to assert the pagination footer. Shared cobra flags are reset in `t.Cleanup` to avoid cross-test leakage.
- `go build ./...` and full `go test ./...` green on this branch (pre-commit hook also ran the lint gate).

## Docs checklist

- [ ] No user-facing command/flag changes — no docs needed
- [x] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); ensure `Short`/`Long`/`Example` on new commands are written for docs readers
- [ ] Broader behaviour changes — docs updated in [ankra-docs](https://github.com/ankraio/ankra-docs) (link the PR): <!-- PR link -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
