### PR TITLE
feat(encrypt): atomic --set on cluster-mode encrypt manifest; SOPS-aware --from-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Added
 
+- **Secrets can be set and encrypted in a single commit.** `ankra cluster
+  encrypt manifest` (cluster mode) now accepts repeatable `--set` edits that
+  are applied in-memory before encryption, so the new value and its SOPS
+  encryption land in one partial-stack PATCH — the plaintext value never
+  reaches git history. Previously the documented flow (`manifests upgrade
+  --set` followed by `encrypt manifest`) committed the plaintext secret
+  first, leaving it recoverable from the repository history.
+- **`ankra cluster manifests upgrade --from-file` accepts SOPS-encrypted
+  files.** When the file carries SOPS metadata, the keys holding `ENC[...]`
+  ciphertext are detected and recorded as `encrypted_paths` automatically
+  (merged with the manifest's existing paths), and the new repeatable
+  `--encrypted-path` flag declares keys explicitly. Previously such uploads
+  dropped the encryption metadata and the backend rejected them with a
+  generic 500.
 - **`ankra helm registries list` supports pagination, search, and sorting.**
   The command used to fetch only the server's first page (20 registries) and
   gave no hint that more existed. It now accepts `--page` and `--page-size`

--- a/cmd/cluster_encrypt.go
+++ b/cmd/cluster_encrypt.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"errors"
@@ -50,6 +51,7 @@ var (
 	encryptAddonName   string
 	encryptClusterFlag string
 	encryptStackFlag   string
+	encryptSetEntries  []string
 )
 
 var clusterEncryptCmd = &cobra.Command{
@@ -79,12 +81,27 @@ Two modes:
     from_file in place, adding the key to encrypted_paths in the file. Used by
     GitOps workflows where the source of truth is on disk.
 
+In cluster mode, --set applies value edits in-memory BEFORE encrypting, so the
+new secret value and its encryption land in a single commit - the plaintext
+value never reaches git history. This is the recommended way to set a new
+secret value:
+
+  ankra cluster encrypt manifest db-secret --key password \
+    --set 'data.password=aHVudGVyMg==' --cluster prod
+
+(compared to "manifests upgrade --set" followed by "encrypt manifest", which
+commits the plaintext value first).
+
 Examples:
   # Cluster mode against the selected cluster
   ankra cluster encrypt manifest db-secret --key password
 
   # Cluster mode against a specific cluster
   ankra cluster encrypt manifest db-secret --key password --cluster prod
+
+  # Set a new value and encrypt it atomically (single commit, no plaintext)
+  ankra cluster encrypt manifest db-secret --key password \
+    --set 'data.password=bmV3LXNlY3JldA==' --cluster prod
 
   # File mode
   ankra cluster encrypt manifest db-secret --key password -f cluster.yaml`,
@@ -127,8 +144,10 @@ func init() {
 	clusterEncryptManifestCmd.Flags().StringVarP(&encryptClusterFile, "file", "f", "", "Path to a local cluster YAML (enables file mode)")
 	clusterEncryptManifestCmd.Flags().StringVar(&encryptKey, "key", "", "YAML key name to encrypt (required); dotted paths are normalised to the last segment, a leading-dot key like .dockerconfigjson is kept literally")
 	clusterEncryptManifestCmd.Flags().StringVar(&encryptClusterFlag, "cluster", "", "Target cluster (name or ID); defaults to the active selection (cluster mode)")
+	clusterEncryptManifestCmd.Flags().StringArrayVar(&encryptSetEntries, "set", nil, "Apply value edits in-memory before encrypting (same syntax as manifests upgrade --set, e.g. --set 'data.password=bmV3'); the plaintext value never reaches git (cluster mode only; repeatable)")
 	_ = clusterEncryptManifestCmd.MarkFlagRequired("key")
 	clusterEncryptManifestCmd.MarkFlagsMutuallyExclusive("file", "cluster")
+	clusterEncryptManifestCmd.MarkFlagsMutuallyExclusive("file", "set")
 
 	clusterEncryptAddonCmd.Flags().StringVarP(&encryptClusterFile, "file", "f", "", "Path to a local cluster YAML (enables file mode)")
 	clusterEncryptAddonCmd.Flags().StringVar(&encryptKey, "key", "", "YAML key name to encrypt (required); dotted paths are normalised to the last segment, a leading-dot key like .dockerconfigjson is kept literally")
@@ -487,6 +506,90 @@ func runEncryptAddonFile(cmd *cobra.Command, leafKey string) error {
 	return nil
 }
 
+// deriveSopsEncryptedPaths inspects raw manifest YAML for SOPS encryption
+// state. isSopsDocument reports whether any document carries a top-level
+// "sops" metadata mapping. The returned paths are the YAML key names whose
+// values are ENC[...] ciphertext - the same leaf-key convention that
+// `ankra cluster encrypt` records in encrypted_paths. The sops metadata
+// subtree itself is skipped (its mac/lastmodified entries are ciphertext but
+// are not user data).
+func deriveSopsEncryptedPaths(rawYAML []byte) (paths []string, isSopsDocument bool, err error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(rawYAML))
+	seenPaths := map[string]bool{}
+	for {
+		var document yaml.Node
+		decodeErr := decoder.Decode(&document)
+		if errors.Is(decodeErr, io.EOF) {
+			break
+		}
+		if decodeErr != nil {
+			return nil, false, fmt.Errorf("parse manifest YAML: %w", decodeErr)
+		}
+		rootNode := &document
+		if rootNode.Kind == yaml.DocumentNode && len(rootNode.Content) > 0 {
+			rootNode = rootNode.Content[0]
+		}
+		if rootNode.Kind != yaml.MappingNode {
+			continue
+		}
+		for entryIndex := 0; entryIndex+1 < len(rootNode.Content); entryIndex += 2 {
+			if rootNode.Content[entryIndex].Value == sopsMetadataKey &&
+				rootNode.Content[entryIndex+1].Kind == yaml.MappingNode {
+				isSopsDocument = true
+			}
+		}
+		collectEncryptedLeafKeys(rootNode, true, seenPaths, &paths)
+	}
+	return paths, isSopsDocument, nil
+}
+
+// collectEncryptedLeafKeys walks a YAML tree recording the mapping key names
+// whose scalar values are ENC[...] ciphertext, skipping the document-root
+// sops metadata mapping.
+func collectEncryptedLeafKeys(node *yaml.Node, isDocumentRoot bool, seenPaths map[string]bool, paths *[]string) {
+	if node == nil {
+		return
+	}
+	switch node.Kind {
+	case yaml.MappingNode:
+		for entryIndex := 0; entryIndex+1 < len(node.Content); entryIndex += 2 {
+			keyNode := node.Content[entryIndex]
+			valueNode := node.Content[entryIndex+1]
+			if isDocumentRoot && keyNode.Value == sopsMetadataKey {
+				continue
+			}
+			if valueNode.Kind == yaml.ScalarNode && strings.HasPrefix(valueNode.Value, sopsEncryptedValuePrefix) {
+				if !seenPaths[keyNode.Value] {
+					seenPaths[keyNode.Value] = true
+					*paths = append(*paths, keyNode.Value)
+				}
+				continue
+			}
+			collectEncryptedLeafKeys(valueNode, false, seenPaths, paths)
+		}
+	case yaml.SequenceNode:
+		for _, itemNode := range node.Content {
+			collectEncryptedLeafKeys(itemNode, false, seenPaths, paths)
+		}
+	}
+}
+
+// unionStringLists merges the given lists preserving first-seen order and
+// dropping duplicates.
+func unionStringLists(lists ...[]string) []string {
+	seenValues := map[string]bool{}
+	var merged []string
+	for _, list := range lists {
+		for _, value := range list {
+			if !seenValues[value] {
+				seenValues[value] = true
+				merged = append(merged, value)
+			}
+		}
+	}
+	return merged
+}
+
 func containsString(slice []string, str string) bool {
 	for _, s := range slice {
 		if s == str {
@@ -567,6 +670,20 @@ func runEncryptManifestCluster(cmd *cobra.Command, manifestName, leafKey string)
 	if err != nil {
 		return fmt.Errorf("fetch current manifest content: %w", err)
 	}
+
+	if len(encryptSetEntries) > 0 {
+		assignments, assignErr := collectSetAssignments(encryptSetEntries, nil, nil)
+		if assignErr != nil {
+			return assignErr
+		}
+		mutatedB64, setErr := applyManifestSet(encoded, assignments, "", "")
+		if setErr != nil {
+			return setErr
+		}
+		encoded = mutatedB64
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Applied %d --set edit(s) in-memory; the new values are encrypted before anything is pushed.\n", len(assignments))
+	}
+
 	decoded, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return fmt.Errorf("base64-decode manifest content: %w", err)

--- a/cmd/cluster_manifests.go
+++ b/cmd/cluster_manifests.go
@@ -278,6 +278,12 @@ list items by a stable field (e.g. containers[name=app]) as well as by numeric
 index (containers[0]). --from-file / --manifest - REPLACE the whole manifest
 and are mutually exclusive with --set*.
 
+--from-file / --manifest - accept SOPS-encrypted content: when the file
+carries a top-level sops: metadata mapping, the keys holding ENC[...]
+ciphertext are detected and recorded as encrypted_paths automatically (merged
+with the manifest's existing encrypted_paths). Use --encrypted-path to declare
+keys explicitly when auto-detection cannot see them.
+
 When no content or --set flag is supplied, the existing content is re-sent
 unchanged (only namespace is updated). This is required because the backend's
 manifest validation rejects empty manifest_base64.`,
@@ -340,6 +346,17 @@ func runManifestsUpgrade(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("read manifest source: %w", readErr)
 		}
 		mutated.ManifestBase64 = base64.StdEncoding.EncodeToString(raw)
+		derivedPaths, isSopsDocument, deriveErr := deriveSopsEncryptedPaths(raw)
+		if deriveErr != nil {
+			return fmt.Errorf("inspect manifest for SOPS metadata: %w", deriveErr)
+		}
+		if isSopsDocument || len(flags.EncryptedPaths) > 0 {
+			mergedPaths := unionStringLists(manifest.EncryptedPaths, derivedPaths, flags.EncryptedPaths)
+			if len(mergedPaths) == 0 {
+				return errors.New("manifest content is SOPS-encrypted but no encrypted key paths could be derived; pass --encrypted-path <key> for each encrypted key so the backend keeps the encryption metadata")
+			}
+			mutated.EncryptedPaths = mergedPaths
+		}
 	case flags.HasSet():
 		existing, mErr := apiClient.GetClusterManifestConfiguration(ctx, clusterID, manifestName)
 		if mErr != nil {
@@ -381,8 +398,8 @@ func runManifestsUpgrade(cmd *cobra.Command, args []string) error {
 	beforeStack.Manifests = []client.ManifestSpec{*manifest}
 
 	var notices []string
-	if len(manifest.EncryptedPaths) > 0 {
-		notices = append(notices, fmt.Sprintf("manifest will be SOPS-encrypted on git push (encrypted_paths: %s)", strings.Join(manifest.EncryptedPaths, ", ")))
+	if len(mutated.EncryptedPaths) > 0 {
+		notices = append(notices, fmt.Sprintf("manifest will be SOPS-encrypted on git push (encrypted_paths: %s)", strings.Join(mutated.EncryptedPaths, ", ")))
 	}
 
 	if flags.DryRun {
@@ -417,6 +434,7 @@ func parseManifestsUpgradeFlags(cmd *cobra.Command) (manifestsUpgradeFlags, erro
 	setFiles, _ := cmd.Flags().GetStringArray("set-file")
 	targetKind, _ := cmd.Flags().GetString("target-kind")
 	targetName, _ := cmd.Flags().GetString("target-name")
+	encryptedPaths, _ := cmd.Flags().GetStringArray("encrypted-path")
 	addParents, _ := cmd.Flags().GetStringArray("add-parent")
 	removeParents, _ := cmd.Flags().GetStringArray("remove-parent")
 	setParents, _ := cmd.Flags().GetStringArray("set-parent")
@@ -432,21 +450,22 @@ func parseManifestsUpgradeFlags(cmd *cobra.Command) (manifestsUpgradeFlags, erro
 		return manifestsUpgradeFlags{}, err
 	}
 	return manifestsUpgradeFlags{
-		FromFile:      fromFile,
-		ManifestStdin: manifestStdin,
-		Namespace:     namespace,
-		SetEntries:    setEntries,
-		SetStrings:    setStrings,
-		SetFiles:      setFiles,
-		TargetKind:    targetKind,
-		TargetName:    targetName,
-		AddParents:    addParents,
-		RemoveParents: removeParents,
-		SetParents:    setParents,
-		Cluster:       cluster,
-		DryRun:        dryRun,
-		Yes:           yes,
-		Output:        out,
+		FromFile:       fromFile,
+		ManifestStdin:  manifestStdin,
+		Namespace:      namespace,
+		SetEntries:     setEntries,
+		SetStrings:     setStrings,
+		SetFiles:       setFiles,
+		TargetKind:     targetKind,
+		TargetName:     targetName,
+		EncryptedPaths: encryptedPaths,
+		AddParents:     addParents,
+		RemoveParents:  removeParents,
+		SetParents:     setParents,
+		Cluster:        cluster,
+		DryRun:         dryRun,
+		Yes:            yes,
+		Output:         out,
 	}, nil
 }
 
@@ -459,6 +478,7 @@ func init() {
 	clusterManifestsUpgradeCmd.Flags().StringArray("set-file", nil, "Like --set but reads the value from a file: key=path or key=@path")
 	clusterManifestsUpgradeCmd.Flags().String("target-kind", "", "With --set: select the document to edit by Kubernetes kind (e.g. Deployment) when the manifest holds multiple documents")
 	clusterManifestsUpgradeCmd.Flags().String("target-name", "", "With --set: select the document to edit by metadata.name when the manifest holds multiple documents")
+	clusterManifestsUpgradeCmd.Flags().StringArray("encrypted-path", nil, "With --from-file / --manifest -: declare a YAML key name that is (or must stay) SOPS-encrypted; merged with auto-detected ENC[...] keys and the manifest's existing encrypted_paths (repeatable)")
 	clusterManifestsUpgradeCmd.Flags().StringArray("add-parent", nil, "Add a dependency parent, e.g. --add-parent name=infisical-ns,kind=manifest (kind defaults to manifest; repeatable)")
 	clusterManifestsUpgradeCmd.Flags().StringArray("remove-parent", nil, "Remove a dependency parent, e.g. --remove-parent name=infisical-ns,kind=manifest (repeatable)")
 	clusterManifestsUpgradeCmd.Flags().StringArray("set-parent", nil, "Replace ALL dependency parents with the given set (repeatable)")

--- a/cmd/cluster_partial.go
+++ b/cmd/cluster_partial.go
@@ -546,6 +546,8 @@ type manifestsUpgradeFlags struct {
 	TargetKind string
 	TargetName string
 
+	EncryptedPaths []string
+
 	AddParents    []string
 	RemoveParents []string
 	SetParents    []string

--- a/cmd/encrypt_test.go
+++ b/cmd/encrypt_test.go
@@ -378,3 +378,105 @@ func TestGetEncryptedPathsFromConfig(t *testing.T) {
 		}
 	})
 }
+
+func TestDeriveSopsEncryptedPaths(t *testing.T) {
+	t.Run("sops document with ciphertext leaves", func(t *testing.T) {
+		content := `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+data:
+  username: YWRtaW4=
+  password: ENC[AES256_GCM,data:abc,iv:def,tag:ghi,type:str]
+  token: ENC[AES256_GCM,data:xyz,iv:def,tag:ghi,type:str]
+sops:
+  age:
+    - recipient: age1example
+  mac: ENC[AES256_GCM,data:mac]
+  encrypted_regex: ^(password|token)$
+`
+		paths, isSops, err := deriveSopsEncryptedPaths([]byte(content))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !isSops {
+			t.Error("expected isSopsDocument=true")
+		}
+		if len(paths) != 2 || paths[0] != "password" || paths[1] != "token" {
+			t.Errorf("paths = %v, want [password token]", paths)
+		}
+	})
+
+	t.Run("sops metadata subtree is not treated as user data", func(t *testing.T) {
+		content := `data:
+  password: ENC[AES256_GCM,data:abc]
+sops:
+  mac: ENC[AES256_GCM,data:mac]
+`
+		paths, isSops, err := deriveSopsEncryptedPaths([]byte(content))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !isSops {
+			t.Error("expected isSopsDocument=true")
+		}
+		for _, path := range paths {
+			if path == "mac" {
+				t.Errorf("sops metadata key leaked into paths: %v", paths)
+			}
+		}
+	})
+
+	t.Run("plain document is not sops", func(t *testing.T) {
+		content := "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: web\n"
+		paths, isSops, err := deriveSopsEncryptedPaths([]byte(content))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if isSops {
+			t.Error("expected isSopsDocument=false")
+		}
+		if len(paths) != 0 {
+			t.Errorf("paths = %v, want none", paths)
+		}
+	})
+
+	t.Run("multi-document detects sops in any document", func(t *testing.T) {
+		content := `apiVersion: v1
+kind: Namespace
+metadata:
+  name: web
+---
+data:
+  password: ENC[AES256_GCM,data:abc]
+sops:
+  version: 3.8.1
+`
+		paths, isSops, err := deriveSopsEncryptedPaths([]byte(content))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !isSops {
+			t.Error("expected isSopsDocument=true")
+		}
+		if len(paths) != 1 || paths[0] != "password" {
+			t.Errorf("paths = %v, want [password]", paths)
+		}
+	})
+
+	t.Run("invalid yaml errors", func(t *testing.T) {
+		if _, _, err := deriveSopsEncryptedPaths([]byte(":\n  - ][")); err == nil {
+			t.Error("expected a parse error")
+		}
+	})
+}
+
+func TestUnionStringLists(t *testing.T) {
+	merged := unionStringLists([]string{"password"}, []string{"token", "password"}, []string{"apiKey"})
+	if len(merged) != 3 || merged[0] != "password" || merged[1] != "token" || merged[2] != "apiKey" {
+		t.Errorf("merged = %v, want [password token apiKey]", merged)
+	}
+	if merged := unionStringLists(nil, nil); merged != nil {
+		t.Errorf("union of empties = %v, want nil", merged)
+	}
+}

--- a/cmd/upgrade_e2e_test.go
+++ b/cmd/upgrade_e2e_test.go
@@ -1265,3 +1265,214 @@ func TestRunManifestsDelete_DryRunNoCall(t *testing.T) {
 		t.Errorf("expected dry-run notice, got:\n%s", out.String())
 	}
 }
+
+const sopsEncryptedFromFileYAML = `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: web
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: ENC[AES256_GCM,data:abc,iv:def,tag:ghi,type:str]
+sops:
+  age:
+    - recipient: age1example
+  mac: ENC[AES256_GCM,data:mac]
+  encrypted_regex: ^(password)$
+`
+
+func TestRunManifestsUpgrade_FromFileSopsContentSetsEncryptedPaths(t *testing.T) {
+	mock := &upgradeMock{iac: sampleIaCYAMLForCmd}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	sourcePath := filepath.Join(t.TempDir(), "secret.yaml")
+	if err := os.WriteFile(sourcePath, []byte(sopsEncryptedFromFileYAML), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "manifests", "upgrade", "demo-namespace",
+		"--from-file", sourcePath,
+		"--cluster", fakeClusterUUID,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+
+	if len(mock.capturedRequests) != 1 {
+		t.Fatalf("expected one PATCH, got %d", len(mock.capturedRequests))
+	}
+	manifest := mock.capturedRequests[0].Body.Spec.Stacks[0].Manifests[0]
+	if len(manifest.EncryptedPaths) != 1 || manifest.EncryptedPaths[0] != "password" {
+		t.Errorf("manifest.encrypted_paths = %v, want [password]", manifest.EncryptedPaths)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(manifest.ManifestBase64)
+	if err != nil {
+		t.Fatalf("decode manifest_base64: %v", err)
+	}
+	if string(decoded) != sopsEncryptedFromFileYAML {
+		t.Errorf("manifest content altered:\n%s", decoded)
+	}
+}
+
+func TestRunManifestsUpgrade_FromFilePlainContentLeavesEncryptedPathsAlone(t *testing.T) {
+	mock := &upgradeMock{iac: sampleIaCYAMLForCmd}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	sourcePath := filepath.Join(t.TempDir(), "plain.yaml")
+	if err := os.WriteFile(sourcePath, []byte("apiVersion: v1\nkind: Namespace\nmetadata:\n  name: web\n"), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "manifests", "upgrade", "demo-namespace",
+		"--from-file", sourcePath,
+		"--cluster", fakeClusterUUID,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+	manifest := mock.capturedRequests[0].Body.Spec.Stacks[0].Manifests[0]
+	if len(manifest.EncryptedPaths) != 0 {
+		t.Errorf("manifest.encrypted_paths = %v, want none", manifest.EncryptedPaths)
+	}
+}
+
+func TestRunManifestsUpgrade_FromFileExplicitEncryptedPathFlagMerges(t *testing.T) {
+	mock := &upgradeMock{iac: sampleIaCYAMLForCmd}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	sourcePath := filepath.Join(t.TempDir(), "secret.yaml")
+	if err := os.WriteFile(sourcePath, []byte(sopsEncryptedFromFileYAML), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "manifests", "upgrade", "demo-namespace",
+		"--from-file", sourcePath,
+		"--encrypted-path", "token",
+		"--cluster", fakeClusterUUID,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+	manifest := mock.capturedRequests[0].Body.Spec.Stacks[0].Manifests[0]
+	if len(manifest.EncryptedPaths) != 2 || manifest.EncryptedPaths[0] != "password" || manifest.EncryptedPaths[1] != "token" {
+		t.Errorf("manifest.encrypted_paths = %v, want [password token]", manifest.EncryptedPaths)
+	}
+}
+
+func TestRunEncryptManifest_ClusterModeSetAppliesBeforeEncrypt(t *testing.T) {
+	mock := &upgradeMock{
+		iac:           sampleIaCYAMLForCmd,
+		manifestB64:   base64.StdEncoding.EncodeToString([]byte(plainSecretManifestYAML)),
+		encryptResult: encryptedSecretManifestYAML,
+	}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "demo-namespace",
+		"--key", "password",
+		"--set", "data.password=bmV3LXNlY3JldA==",
+		"--cluster", fakeClusterUUID,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+
+	if len(mock.encryptCalls) != 1 {
+		t.Fatalf("expected one EncryptYAML call, got %d", len(mock.encryptCalls))
+	}
+	if !strings.Contains(mock.encryptCalls[0].YamlContent, "bmV3LXNlY3JldA==") {
+		t.Errorf("EncryptYAML must receive the mutated plaintext, got:\n%s", mock.encryptCalls[0].YamlContent)
+	}
+	if strings.Contains(mock.encryptCalls[0].YamlContent, "aHVudGVyMg==") {
+		t.Errorf("old value must be replaced before encryption, got:\n%s", mock.encryptCalls[0].YamlContent)
+	}
+
+	if len(mock.capturedRequests) != 1 {
+		t.Fatalf("expected exactly one PATCH (single commit), got %d", len(mock.capturedRequests))
+	}
+	manifest := mock.capturedRequests[0].Body.Spec.Stacks[0].Manifests[0]
+	if len(manifest.EncryptedPaths) != 1 || manifest.EncryptedPaths[0] != "password" {
+		t.Errorf("manifest.encrypted_paths = %v, want [password]", manifest.EncryptedPaths)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(manifest.ManifestBase64)
+	if err != nil {
+		t.Fatalf("decode manifest_base64: %v", err)
+	}
+	if !strings.Contains(string(decoded), "ENC[AES256_GCM") {
+		t.Errorf("pushed content must be ciphertext, got:\n%s", decoded)
+	}
+}
+
+func TestRunEncryptManifest_SetAndFileMutuallyExclusive(t *testing.T) {
+	mock := &upgradeMock{iac: sampleIaCYAMLForCmd}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "demo-namespace",
+		"--key", "password",
+		"--set", "data.password=bmV3",
+		"-f", "cluster.yaml",
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected mutually-exclusive flag error")
+	}
+	if !strings.Contains(err.Error(), "none of the others can be") && !strings.Contains(err.Error(), "set") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(mock.capturedRequests) != 0 {
+		t.Errorf("must not PATCH on flag conflict, got %d", len(mock.capturedRequests))
+	}
+}
+
+func TestRunEncryptManifest_ClusterModeSetFailureDoesNotPatch(t *testing.T) {
+	mock := &upgradeMock{
+		iac:         sampleIaCYAMLForCmd,
+		manifestB64: base64.StdEncoding.EncodeToString([]byte(plainSecretManifestYAML)),
+	}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "demo-namespace",
+		"--key", "password",
+		"--set", "not-an-assignment",
+		"--cluster", fakeClusterUUID,
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for a malformed --set assignment")
+	}
+	if len(mock.encryptCalls) != 0 {
+		t.Errorf("must not encrypt on --set failure, got %d calls", len(mock.encryptCalls))
+	}
+	if len(mock.capturedRequests) != 0 {
+		t.Errorf("must not PATCH on --set failure, got %d calls", len(mock.capturedRequests))
+	}
+}


### PR DESCRIPTION
## Customer context (PLA-713 / #1040)

Rotating a secret with the documented flow — `ankra cluster manifests upgrade --set ...` followed by `ankra cluster encrypt manifest ...` — writes the **plaintext secret value into the cluster's GitOps repository** in the first commit; only the second commit encrypts it. The plaintext stays recoverable from git history forever. Separately, `ankra cluster manifests upgrade --from-file <sops-encrypted-file>` failed with a generic backend 500.

## Root cause

- Cluster-mode `encrypt manifest` could only encrypt the *current live* value, forcing a prior plaintext `manifests upgrade --set` commit.
- `manifests upgrade --from-file` base64-encoded the raw file and PATCHed it without ever setting `encrypted_paths` (`omitempty` drops the field). The backend's fail-closed guard (`assertNoSilentPlaintext`: SOPS document + empty `encrypted_paths`) correctly rejected it, but the rejection was mapped to a blind 500.

## Fix

1. **Atomic set-and-encrypt** — `ankra cluster encrypt manifest <name> --set 'data.password=...'` (repeatable, same syntax as `manifests upgrade --set`, reusing `applyManifestSet`) fetches the current content, applies the edits **in-memory**, encrypts via the platform SOPS endpoint, verifies the ciphertext, and pushes a **single** partial-stack PATCH with updated `encrypted_paths`. One commit, no plaintext in git, ever. Mutually exclusive with `-f`. Help text documents this as the recommended flow.
2. **SOPS-aware `--from-file`** — when the uploaded YAML carries a top-level `sops:` metadata mapping, the CLI derives `encrypted_paths` from the mapping keys whose values are `ENC[...]` ciphertext (the same leaf-key convention `encrypt manifest` records), unions them with the manifest's existing `encrypted_paths`, and sends them in the PATCH. A repeatable `--encrypted-path` flag declares keys explicitly when auto-detection cannot see them; if the content is SOPS but no path can be derived, the CLI fails with an actionable message instead of letting the server 500.

## Relationship to the server PR

ankraio/cluster#546 turns the backend's guard rejection into an actionable 422 instead of a 500. The two PRs are independent: this CLI change stops tripping the guard at all; the server change makes any remaining trip (older CLI, raw API users) diagnosable.

## Tests

- Unit tests for `deriveSopsEncryptedPaths` (sops detection, ENC leaf-key collection, sops-metadata subtree exclusion, multi-document, parse failure) and `unionStringLists`.
- e2e-style command tests (mock client): SOPS `--from-file` sets `encrypted_paths`; plain `--from-file` leaves them untouched; `--encrypted-path` merges; `--set` on encrypt applies before `EncryptYAML` and results in exactly one PATCH with ciphertext; malformed `--set` aborts before any API write; `--set`/`-f` mutual exclusion.

`make build`, `make test` (race), `make lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
