### PR TITLE
chore(ci): don't fail the system test when the log upload hits the org storage quota

### DIFF
--- a/.github/workflows/systemtest.yml
+++ b/.github/workflows/systemtest.yml
@@ -73,8 +73,11 @@ jobs:
           if [ "$ANKRA_SYSTEMTEST_MANAGED_PROVIDERS" = "none" ]; then export ANKRA_SYSTEMTEST_MANAGED_PROVIDERS=""; fi
           ./systemtest/lifecycle_systemtest.sh
 
+      # Debug aid only — an org storage-quota block on artifact uploads
+      # must not redden a run whose cloud lifecycle actually passed.
       - name: Upload run logs
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: lifecycle-system-test-logs


### PR DESCRIPTION
## Why

The org's Actions+Packages storage meter is pegged (2 GB / 2 GB), and GitHub blocks all artifact uploads while over quota. The systemtest's `Upload run logs` step (`if: always()`) then fails the run — a false red on a workflow that provisions real, billable cloud infrastructure. Companion to ankraio/cluster#549 and ankraio/portal#917.

## What

`continue-on-error: true` on the log upload — it's a debug aid only; nothing downstream consumes it. A quota block now degrades to a step warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqqoGFhzCfjF25uvMipKBy
