### PR TITLE
feat(cluster): show provider network details in cluster view (PLA-716)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **`ankra cluster info` now shows the cluster's provider network
+  identifiers.** For Ankra-provisioned clusters (DigitalOcean first) the
+  details include a Network section with the VPC UUID, IP range, NAT
+  gateway id, egress IP, and bastion droplet id/IPs — machine-readable via
+  `-o json` — so operators no longer have to dig through per-node
+  relationships to find the VPC a cluster lives in.
 - **Secrets can be set and encrypted in a single commit.** `ankra cluster
   encrypt manifest` (cluster mode) now accepts repeatable `--set` edits that
   are applied in-memory before encryption, so the new value and its SOPS

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1684,6 +1684,67 @@ func TestClusterInfoCommand(t *testing.T) {
 	}
 }
 
+func TestClusterInfoNetworkSectionCommand(t *testing.T) {
+	mock := &clusterGetMock{
+		cluster: client.ClusterListItem{
+			ID:          "test-cluster-id",
+			Name:        "my-cluster",
+			Environment: "production",
+			KubeVersion: "1.28.0",
+			State:       "online",
+			Network: &client.ClusterNetwork{
+				Provider:     "digitalocean",
+				VPCID:        "3f2a1b0c-1111-2222-3333-444455556666",
+				IPRange:      "10.116.0.0/20",
+				NATGatewayID: "nat-gateway-id",
+				EgressIP:     "203.0.113.10",
+				Bastion: &client.ClusterNetworkBastion{
+					ID:        "bastion-droplet-id",
+					PublicIP:  "198.51.100.7",
+					PrivateIP: "10.116.0.5",
+				},
+			},
+		},
+	}
+	setMockClient(t, mock)
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("cluster", "info", "my-cluster")
+	})
+
+	for _, expected := range []string{
+		"Network (digitalocean):",
+		"VPC ID: 3f2a1b0c-1111-2222-3333-444455556666",
+		"IP Range: 10.116.0.0/20",
+		"NAT Gateway ID: nat-gateway-id",
+		"Egress IP: 203.0.113.10",
+		"Bastion: bastion-droplet-id (public 198.51.100.7, private 10.116.0.5)",
+	} {
+		if !strings.Contains(stdoutOutput, expected) {
+			t.Errorf("expected output to contain %q, got: %s", expected, stdoutOutput)
+		}
+	}
+}
+
+func TestClusterInfoWithoutNetworkOmitsSection(t *testing.T) {
+	mock := &clusterGetMock{
+		cluster: client.ClusterListItem{
+			ID:    "test-cluster-id",
+			Name:  "my-cluster",
+			State: "online",
+		},
+	}
+	setMockClient(t, mock)
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("cluster", "info", "my-cluster")
+	})
+
+	if strings.Contains(stdoutOutput, "Network") {
+		t.Errorf("expected no Network section for a cluster without network identifiers, got: %s", stdoutOutput)
+	}
+}
+
 func TestClusterInfoNotFoundCommand(t *testing.T) {
 	mock := &clusterGetMock{
 		cluster: client.ClusterListItem{

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -138,6 +138,25 @@ If no name is provided, shows details for the currently selected cluster.`,
 		fmt.Printf("  Control Planes: %d\n", cluster.ControlPlanes)
 		fmt.Printf("  Nodes: %d\n", cluster.Nodes)
 		fmt.Printf("  Kind: %s\n", cluster.Kind)
+		if network := cluster.Network; network != nil {
+			fmt.Printf("  Network (%s):\n", network.Provider)
+			if network.VPCID != "" {
+				fmt.Printf("    VPC ID: %s\n", network.VPCID)
+			}
+			if network.IPRange != "" {
+				fmt.Printf("    IP Range: %s\n", network.IPRange)
+			}
+			if network.NATGatewayID != "" {
+				fmt.Printf("    NAT Gateway ID: %s\n", network.NATGatewayID)
+			}
+			if network.EgressIP != "" {
+				fmt.Printf("    Egress IP: %s\n", network.EgressIP)
+			}
+			if bastion := network.Bastion; bastion != nil {
+				fmt.Printf("    Bastion: %s (public %s, private %s)\n",
+					bastion.ID, bastion.PublicIP, bastion.PrivateIP)
+			}
+		}
 		return nil
 	},
 }

--- a/internal/client/clusters.go
+++ b/internal/client/clusters.go
@@ -15,20 +15,39 @@ import (
 // currently render (operation, agent_*, resources, *_count, etc.) are
 // silently ignored by Go's JSON decoder.
 type ClusterListItem struct {
-	ID                string  `json:"id"`
-	Name              string  `json:"name"`
-	State             string  `json:"state"`
-	Description       string  `json:"description"`
-	Environment       string  `json:"environment"`
-	OrganisationID    string  `json:"organisation_id"`
-	KubeVersion       string  `json:"kube_version"`
-	ControlPlanes     int     `json:"control_planes"`
-	Nodes             int     `json:"nodes"`
-	CreatedAt         string  `json:"created_at"`
-	OperationalAt     *string `json:"operational_at"`
-	SlatedForDeletion *string `json:"slated_for_deletion_at"`
-	DeletedAt         *string `json:"deleted_at"`
-	Kind              string  `json:"kind"`
+	ID                string          `json:"id"`
+	Name              string          `json:"name"`
+	State             string          `json:"state"`
+	Description       string          `json:"description"`
+	Environment       string          `json:"environment"`
+	OrganisationID    string          `json:"organisation_id"`
+	KubeVersion       string          `json:"kube_version"`
+	ControlPlanes     int             `json:"control_planes"`
+	Nodes             int             `json:"nodes"`
+	CreatedAt         string          `json:"created_at"`
+	OperationalAt     *string         `json:"operational_at"`
+	SlatedForDeletion *string         `json:"slated_for_deletion_at"`
+	DeletedAt         *string         `json:"deleted_at"`
+	Kind              string          `json:"kind"`
+	Network           *ClusterNetwork `json:"network,omitempty"`
+}
+
+// ClusterNetwork mirrors the backend's optional provider network identifiers
+// for Ankra-provisioned clusters (VPC, NAT gateway, bastion).
+type ClusterNetwork struct {
+	Provider     string                 `json:"provider"`
+	VPCID        string                 `json:"vpc_id,omitempty"`
+	IPRange      string                 `json:"ip_range,omitempty"`
+	NATGatewayID string                 `json:"nat_gateway_id,omitempty"`
+	EgressIP     string                 `json:"egress_ip,omitempty"`
+	Bastion      *ClusterNetworkBastion `json:"bastion,omitempty"`
+}
+
+// ClusterNetworkBastion carries the bastion identifiers inside ClusterNetwork.
+type ClusterNetworkBastion struct {
+	ID        string `json:"id,omitempty"`
+	PublicIP  string `json:"public_ip,omitempty"`
+	PrivateIP string `json:"private_ip,omitempty"`
 }
 
 type ClusterListResponse struct {


### PR DESCRIPTION
## What

`ankra cluster info` (and `-o json|yaml`) now surfaces the provider network identifiers the backend attaches to cluster details for Ankra-provisioned clusters (DigitalOcean first):

- `internal/client/clusters.go`: new `ClusterNetwork` / `ClusterNetworkBastion` types, wired as `Network *ClusterNetwork \`json:"network,omitempty"\`` on `ClusterListItem`.
- `cmd/reconcile.go`: `cluster info` prints a `Network (<provider>):` section with VPC ID, IP range, NAT gateway ID, egress IP, and bastion id/IPs — omitted entirely when the backend sends no network object.
- Tests: `TestClusterInfoNetworkSectionCommand` (full section rendered) and `TestClusterInfoWithoutNetworkOmitsSection` (section absent when `network` is null).
- CHANGELOG: entry under Unreleased.

## Wire contract

Field names and shape match the merged backend surface from cluster#545 (`go/internal/usecase/networkinfo/networkinfo.go`, attached to cluster list/details as the optional `network` object): `provider`, `vpc_id`, `ip_range`, `nat_gateway_id`, `egress_ip`, `bastion.{id,public_ip,private_ip}` — all snake_case, all omitempty except `provider`.

## Gates

- `go build ./...`, `go vet ./...` clean
- `go test -race -count=1 ./...` all green
- `golangci-lint run` (v2.12.2): 0 issues

Refs PLA-716.