### PR TITLE
Support per-addon/per-manifest AGENTS.md in stack specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Added
 
+- **Stack manifests and addons can carry an AGENTS.md.** Every manifest and
+  addon entry in a stack spec now accepts `agents_md` (inline markdown) or
+  `agents_md_from_file` (a repo-relative path, mirroring how the stack-level
+  `description_from_file` works), so operational learnings live next to the
+  resource they describe. The platform stores the content as a sibling file
+  in the GitOps repo (`add-ons/<addon>/AGENTS.md`,
+  `manifests/<name>.AGENTS.md`); omitting the field preserves what is
+  stored, an explicit empty string clears it, and editing it never triggers
+  a redeploy. `ankra cluster clone` transfers the referenced AGENTS.md files
+  alongside the other stack files, and `ankra cluster addons upgrade` /
+  `manifests upgrade` keep them intact.
+
 - **`ankra cluster info` now shows the cluster's provider network
   identifiers.** For Ankra-provisioned clusters (DigitalOcean first) the
   details include a Network section with the VPC UUID, IP range, NAT

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -475,6 +475,37 @@ func parseDeployWave(raw interface{}) (*int, error) {
 	return &wave, nil
 }
 
+// parseAgentsMdFields extracts the optional 'agents_md' /
+// 'agents_md_from_file' pair shared by manifests and addons. The returned
+// pointers carry the backend's tri-state semantics: nil = key absent (the
+// backend preserves the stored AGENTS.md), pointer to "" = explicit clear.
+// When 'agents_md_from_file' is set, the file's content is read (mirroring
+// how the stack-level 'description_from_file' is handled) and the path is
+// passed through so the stored pointer matches the file the user authored;
+// a non-empty inline 'agents_md' wins over the file content.
+func parseAgentsMdFields(m map[string]interface{}, baseDir string) (*string, *string, error) {
+	var agentsMd, agentsMdFromFile *string
+	if inline, ok := m["agents_md"].(string); ok {
+		agentsMd = &inline
+	}
+	if fileRef, ok := m["agents_md_from_file"].(string); ok && fileRef != "" {
+		full, err := resolveSafePath(baseDir, fileRef)
+		if err != nil {
+			return nil, nil, fmt.Errorf("refusing to read the file referenced by 'agents_md_from_file' (%q): %w", fileRef, err)
+		}
+		fileContent, err := os.ReadFile(full)
+		if err != nil {
+			return nil, nil, fmt.Errorf("could not read the file referenced by 'agents_md_from_file' (%q): %w", full, err)
+		}
+		if agentsMd == nil || *agentsMd == "" {
+			content := string(fileContent)
+			agentsMd = &content
+		}
+		agentsMdFromFile = &fileRef
+	}
+	return agentsMd, agentsMdFromFile, nil
+}
+
 func buildManifest(mm map[string]interface{}, baseDir string) (client.Manifest, error) {
 	name, _ := mm["name"].(string)
 	if name == "" {
@@ -519,12 +550,19 @@ func buildManifest(mm map[string]interface{}, baseDir string) (client.Manifest, 
 		}
 	}
 
+	agentsMd, agentsMdFromFile, err := parseAgentsMdFields(mm, baseDir)
+	if err != nil {
+		return client.Manifest{}, err
+	}
+
 	return client.Manifest{
-		Name:           name,
-		ManifestBase64: encoded,
-		Namespace:      ns,
-		Parents:        parents,
-		EncryptedPaths: encryptedPaths,
+		Name:             name,
+		ManifestBase64:   encoded,
+		Namespace:        ns,
+		Parents:          parents,
+		EncryptedPaths:   encryptedPaths,
+		AgentsMd:         agentsMd,
+		AgentsMdFromFile: agentsMdFromFile,
 	}, nil
 }
 
@@ -601,6 +639,11 @@ func buildAddon(am map[string]interface{}, baseDir string) (client.Addon, error)
 		}
 	}
 
+	agentsMd, agentsMdFromFile, err := parseAgentsMdFields(am, baseDir)
+	if err != nil {
+		return client.Addon{}, err
+	}
+
 	return client.Addon{
 		Name:                   name,
 		ChartName:              chart,
@@ -613,6 +656,8 @@ func buildAddon(am map[string]interface{}, baseDir string) (client.Addon, error)
 		RegistryURL:            registryURL,
 		RegistryCredentialName: registryCredentialName,
 		Settings:               settings,
+		AgentsMd:               agentsMd,
+		AgentsMdFromFile:       agentsMdFromFile,
 	}, nil
 }
 

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -180,6 +180,110 @@ func TestBuildManifest(t *testing.T) {
 		}
 	})
 
+	t.Run("agents_md absent leaves both fields nil", func(t *testing.T) {
+		mm := map[string]interface{}{
+			"name":     "plain",
+			"manifest": "apiVersion: v1\nkind: Namespace",
+		}
+		m, err := buildManifest(mm, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m.AgentsMd != nil {
+			t.Errorf("agents_md should be nil when absent, got %q", *m.AgentsMd)
+		}
+		if m.AgentsMdFromFile != nil {
+			t.Errorf("agents_md_from_file should be nil when absent, got %q", *m.AgentsMdFromFile)
+		}
+	})
+
+	t.Run("inline agents_md passes through", func(t *testing.T) {
+		mm := map[string]interface{}{
+			"name":      "with-agents",
+			"manifest":  "apiVersion: v1\nkind: Namespace",
+			"agents_md": "# Learnings\nnamespace must exist first",
+		}
+		m, err := buildManifest(mm, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m.AgentsMd == nil || *m.AgentsMd != "# Learnings\nnamespace must exist first" {
+			t.Errorf("agents_md = %v, want inline content", m.AgentsMd)
+		}
+		if m.AgentsMdFromFile != nil {
+			t.Errorf("agents_md_from_file should stay nil for inline agents_md, got %q", *m.AgentsMdFromFile)
+		}
+	})
+
+	t.Run("empty agents_md is an explicit clear", func(t *testing.T) {
+		mm := map[string]interface{}{
+			"name":      "clear-agents",
+			"manifest":  "apiVersion: v1\nkind: Namespace",
+			"agents_md": "",
+		}
+		m, err := buildManifest(mm, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m.AgentsMd == nil || *m.AgentsMd != "" {
+			t.Errorf("agents_md should be a pointer to \"\" (clear), got %v", m.AgentsMd)
+		}
+	})
+
+	t.Run("agents_md_from_file reads content and keeps the path", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		agentsContent := "# fluent-bit\nDo not touch the lua filter."
+		agentsPath := filepath.Join(tmpDir, "manifests", "fluent-bit.AGENTS.md")
+		if err := os.MkdirAll(filepath.Dir(agentsPath), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(agentsPath, []byte(agentsContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+		mm := map[string]interface{}{
+			"name":                "fluent-bit",
+			"manifest":            "apiVersion: v1\nkind: Namespace",
+			"agents_md_from_file": "manifests/fluent-bit.AGENTS.md",
+		}
+		m, err := buildManifest(mm, tmpDir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m.AgentsMd == nil || *m.AgentsMd != agentsContent {
+			t.Errorf("agents_md = %v, want file content", m.AgentsMd)
+		}
+		if m.AgentsMdFromFile == nil || *m.AgentsMdFromFile != "manifests/fluent-bit.AGENTS.md" {
+			t.Errorf("agents_md_from_file = %v, want the authored path", m.AgentsMdFromFile)
+		}
+	})
+
+	t.Run("agents_md_from_file escaping baseDir is refused", func(t *testing.T) {
+		mm := map[string]interface{}{
+			"name":                "escape",
+			"manifest":            "apiVersion: v1\nkind: Namespace",
+			"agents_md_from_file": "../outside.AGENTS.md",
+		}
+		_, err := buildManifest(mm, t.TempDir())
+		if err == nil {
+			t.Fatal("expected error for path escaping the base directory")
+		}
+		if !strings.Contains(err.Error(), "agents_md_from_file") {
+			t.Errorf("error should name the field, got: %v", err)
+		}
+	})
+
+	t.Run("missing agents_md_from_file target errors", func(t *testing.T) {
+		mm := map[string]interface{}{
+			"name":                "missing-file",
+			"manifest":            "apiVersion: v1\nkind: Namespace",
+			"agents_md_from_file": "nope.AGENTS.md",
+		}
+		_, err := buildManifest(mm, t.TempDir())
+		if err == nil {
+			t.Fatal("expected error for missing agents_md_from_file target")
+		}
+	})
+
 	t.Run("invalid from_file YAML names the file", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		manifestPath := filepath.Join(tmpDir, "broken.yaml")
@@ -304,6 +408,109 @@ func TestBuildAddon(t *testing.T) {
 		}
 		if a.Settings == nil {
 			t.Error("expected settings to be populated")
+		}
+	})
+
+	t.Run("agents_md absent leaves both fields nil", func(t *testing.T) {
+		am := map[string]interface{}{
+			"name":          "plain",
+			"chart_name":    "plain",
+			"chart_version": "1.0.0",
+		}
+		a, err := buildAddon(am, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a.AgentsMd != nil || a.AgentsMdFromFile != nil {
+			t.Errorf("agents_md fields should be nil when absent, got %v / %v", a.AgentsMd, a.AgentsMdFromFile)
+		}
+	})
+
+	t.Run("inline agents_md passes through", func(t *testing.T) {
+		am := map[string]interface{}{
+			"name":          "with-agents",
+			"chart_name":    "test",
+			"chart_version": "1.0.0",
+			"agents_md":     "# cert-manager\nCRDs install separately.",
+		}
+		a, err := buildAddon(am, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a.AgentsMd == nil || *a.AgentsMd != "# cert-manager\nCRDs install separately." {
+			t.Errorf("agents_md = %v, want inline content", a.AgentsMd)
+		}
+		if a.AgentsMdFromFile != nil {
+			t.Errorf("agents_md_from_file should stay nil for inline agents_md, got %q", *a.AgentsMdFromFile)
+		}
+	})
+
+	t.Run("agents_md_from_file reads content and keeps the path", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		agentsContent := "# website addon\nPin the registry credential."
+		agentsPath := filepath.Join(tmpDir, "agents", "website.AGENTS.md")
+		if err := os.MkdirAll(filepath.Dir(agentsPath), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(agentsPath, []byte(agentsContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+		am := map[string]interface{}{
+			"name":                "website",
+			"chart_name":          "website",
+			"chart_version":       "1.0.0",
+			"agents_md_from_file": "agents/website.AGENTS.md",
+		}
+		a, err := buildAddon(am, tmpDir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a.AgentsMd == nil || *a.AgentsMd != agentsContent {
+			t.Errorf("agents_md = %v, want file content", a.AgentsMd)
+		}
+		if a.AgentsMdFromFile == nil || *a.AgentsMdFromFile != "agents/website.AGENTS.md" {
+			t.Errorf("agents_md_from_file = %v, want the authored path", a.AgentsMdFromFile)
+		}
+	})
+
+	t.Run("non-empty inline agents_md wins over agents_md_from_file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		agentsPath := filepath.Join(tmpDir, "a.AGENTS.md")
+		if err := os.WriteFile(agentsPath, []byte("file content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		am := map[string]interface{}{
+			"name":                "both",
+			"chart_name":          "test",
+			"chart_version":       "1.0.0",
+			"agents_md":           "inline wins",
+			"agents_md_from_file": "a.AGENTS.md",
+		}
+		a, err := buildAddon(am, tmpDir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a.AgentsMd == nil || *a.AgentsMd != "inline wins" {
+			t.Errorf("agents_md = %v, want the inline content to win", a.AgentsMd)
+		}
+		if a.AgentsMdFromFile == nil || *a.AgentsMdFromFile != "a.AGENTS.md" {
+			t.Errorf("agents_md_from_file = %v, want the authored path", a.AgentsMdFromFile)
+		}
+	})
+
+	t.Run("agents_md_from_file escaping baseDir is refused", func(t *testing.T) {
+		am := map[string]interface{}{
+			"name":                "escape",
+			"chart_name":          "test",
+			"chart_version":       "1.0.0",
+			"agents_md_from_file": "../outside.AGENTS.md",
+		}
+		_, err := buildAddon(am, t.TempDir())
+		if err == nil {
+			t.Fatal("expected error for path escaping the base directory")
+		}
+		if !strings.Contains(err.Error(), "agents_md_from_file") {
+			t.Errorf("error should name the field, got: %v", err)
 		}
 	})
 

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -241,12 +241,14 @@ type StackConfig struct {
 }
 
 type ManifestConfig struct {
-	Name           string         `yaml:"name"`
-	Parents        []ParentConfig `yaml:"parents,omitempty"`
-	FromFile       string         `yaml:"from_file,omitempty"`
-	Manifest       string         `yaml:"manifest,omitempty"`
-	Namespace      string         `yaml:"namespace,omitempty"`
-	EncryptedPaths []string       `yaml:"encrypted_paths,omitempty"`
+	Name             string         `yaml:"name"`
+	Parents          []ParentConfig `yaml:"parents,omitempty"`
+	FromFile         string         `yaml:"from_file,omitempty"`
+	Manifest         string         `yaml:"manifest,omitempty"`
+	Namespace        string         `yaml:"namespace,omitempty"`
+	EncryptedPaths   []string       `yaml:"encrypted_paths,omitempty"`
+	AgentsMd         string         `yaml:"agents_md,omitempty"`
+	AgentsMdFromFile string         `yaml:"agents_md_from_file,omitempty"`
 }
 
 type AddonConfig struct {
@@ -261,6 +263,8 @@ type AddonConfig struct {
 	RegistryURL            string                 `yaml:"registry_url,omitempty"`
 	RegistryCredentialName string                 `yaml:"registry_credential_name,omitempty"`
 	Settings               map[string]interface{} `yaml:"settings,omitempty"`
+	AgentsMd               string                 `yaml:"agents_md,omitempty"`
+	AgentsMdFromFile       string                 `yaml:"agents_md_from_file,omitempty"`
 }
 
 type ParentConfig struct {
@@ -519,16 +523,24 @@ func copyStackFiles(stack StackConfig, existingBaseDir, newBaseDir string, onlyM
 	}
 
 	for i := range stack.Manifests {
-		fromFile := stack.Manifests[i].FromFile
-		if fromFile == "" {
-			continue
+		if fromFile := stack.Manifests[i].FromFile; fromFile != "" {
+			if err := transferStackFile(existingBaseDir, newBaseDir, fromFile, "manifest file", onlyMissing, fromURL); err != nil {
+				return err
+			}
 		}
-		if err := transferStackFile(existingBaseDir, newBaseDir, fromFile, "manifest file", onlyMissing, fromURL); err != nil {
-			return err
+		if agentsFile := stack.Manifests[i].AgentsMdFromFile; agentsFile != "" {
+			if err := transferStackFile(existingBaseDir, newBaseDir, agentsFile, "manifest AGENTS.md file", onlyMissing, fromURL); err != nil {
+				return err
+			}
 		}
 	}
 
 	for i := range stack.Addons {
+		if agentsFile := stack.Addons[i].AgentsMdFromFile; agentsFile != "" {
+			if err := transferStackFile(existingBaseDir, newBaseDir, agentsFile, "addon AGENTS.md file", onlyMissing, fromURL); err != nil {
+				return err
+			}
+		}
 		config := stack.Addons[i].Configuration
 		if config == nil {
 			continue

--- a/cmd/clone_integration_test.go
+++ b/cmd/clone_integration_test.go
@@ -217,6 +217,54 @@ func TestCopyStackFiles_LocalFiles(t *testing.T) {
 	}
 }
 
+func TestCopyStackFiles_AgentsMdFiles(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+
+	for relPath, content := range map[string]string{
+		"manifests/ns.AGENTS.md":      "# ns learnings",
+		"agents/prometheus.AGENTS.md": "# prometheus learnings",
+	} {
+		full := filepath.Join(srcDir, relPath)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stack := StackConfig{
+		Manifests: []ManifestConfig{
+			{Name: "namespace", Manifest: "kind: Namespace", AgentsMdFromFile: "manifests/ns.AGENTS.md"},
+		},
+		Addons: []AddonConfig{
+			{Name: "prometheus", ChartName: "kube-prometheus-stack", ChartVersion: "56.0.0", AgentsMdFromFile: "agents/prometheus.AGENTS.md"},
+		},
+	}
+
+	originalForce := forceFlag
+	forceFlag = false
+	t.Cleanup(func() { forceFlag = originalForce })
+
+	if err := copyStackFiles(stack, srcDir, dstDir, false, false); err != nil {
+		t.Fatalf("copyStackFiles failed: %v", err)
+	}
+
+	for relPath, want := range map[string]string{
+		"manifests/ns.AGENTS.md":      "# ns learnings",
+		"agents/prometheus.AGENTS.md": "# prometheus learnings",
+	} {
+		content, err := os.ReadFile(filepath.Join(dstDir, relPath))
+		if err != nil {
+			t.Fatalf("expected %s to be transferred: %v", relPath, err)
+		}
+		if string(content) != want {
+			t.Errorf("%s content = %q, want %q", relPath, string(content), want)
+		}
+	}
+}
+
 func TestWriteClusterFile_RoundTrip(t *testing.T) {
 	tmpDir := t.TempDir()
 	outputPath := filepath.Join(tmpDir, "cluster.yaml")

--- a/cmd/cluster_partial.go
+++ b/cmd/cluster_partial.go
@@ -507,6 +507,12 @@ func applyAddonMutations(orig client.AddonSpec, flags addonsUpgradeFlags, newVal
 		RegistryCredentialName: orig.RegistryCredentialName,
 		Parents:                orig.Parents,
 		Settings:               orig.Settings,
+		// Carry the AGENTS.md fields untouched so the patched addon keeps
+		// round-tripping the IaC's agents_md_from_file pointer verbatim
+		// (absent would also preserve server-side, but never rely on that
+		// here: this function's contract is "orig with only flags changed").
+		AgentsMd:         orig.AgentsMd,
+		AgentsMdFromFile: orig.AgentsMdFromFile,
 	}
 	if flags.ChartVersion != "" {
 		out.ChartVersion = flags.ChartVersion

--- a/cmd/cluster_partial_test.go
+++ b/cmd/cluster_partial_test.go
@@ -32,9 +32,11 @@ spec:
           chart_name: cert-manager
           chart_version: 1.14.0
           namespace: cert-manager
+          agents_md_from_file: stacks/demo-web-app/add-ons/cert-manager/AGENTS.md
       manifests:
         - name: demo-namespace
           namespace: web
+          agents_md_from_file: stacks/demo-web-app/manifests/demo-namespace.AGENTS.md
     - name: monitoring
       addons:
         - name: prometheus
@@ -67,6 +69,21 @@ func TestParseImportClusterYAML_OK(t *testing.T) {
 	}
 	if len(doc.Spec.Stacks[0].Addons) != 2 {
 		t.Errorf("stacks[0].Addons = %d, want 2", len(doc.Spec.Stacks[0].Addons))
+	}
+	certManager := doc.Spec.Stacks[0].Addons[1]
+	if certManager.AgentsMdFromFile == nil || *certManager.AgentsMdFromFile != "stacks/demo-web-app/add-ons/cert-manager/AGENTS.md" {
+		t.Errorf("addon agents_md_from_file = %v, want the exported pointer path", certManager.AgentsMdFromFile)
+	}
+	if certManager.AgentsMd != nil {
+		t.Errorf("addon agents_md should be nil in exported IaC, got %q", *certManager.AgentsMd)
+	}
+	demoNamespace := doc.Spec.Stacks[0].Manifests[0]
+	if demoNamespace.AgentsMdFromFile == nil || *demoNamespace.AgentsMdFromFile != "stacks/demo-web-app/manifests/demo-namespace.AGENTS.md" {
+		t.Errorf("manifest agents_md_from_file = %v, want the exported pointer path", demoNamespace.AgentsMdFromFile)
+	}
+	website := doc.Spec.Stacks[0].Addons[0]
+	if website.AgentsMdFromFile != nil {
+		t.Errorf("addon without AGENTS.md should have nil agents_md_from_file, got %q", *website.AgentsMdFromFile)
 	}
 }
 
@@ -234,6 +251,8 @@ func TestBuildPartialStackPatch_Shape(t *testing.T) {
 }
 
 func TestApplyAddonMutations_OnlyChangesRequestedFields(t *testing.T) {
+	agentsMd := "# website\nlearnings"
+	agentsMdFromFile := "stacks/demo/add-ons/website/AGENTS.md"
 	orig := client.AddonSpec{
 		Name:                   "website",
 		ChartName:              "website",
@@ -242,6 +261,8 @@ func TestApplyAddonMutations_OnlyChangesRequestedFields(t *testing.T) {
 		RegistryName:           "regA",
 		RegistryURL:            "oci://a",
 		RegistryCredentialName: "credA",
+		AgentsMd:               &agentsMd,
+		AgentsMdFromFile:       &agentsMdFromFile,
 	}
 	flags := addonsUpgradeFlags{ChartVersion: "1.0.146"}
 	out := applyAddonMutations(orig, flags, nil)
@@ -256,6 +277,12 @@ func TestApplyAddonMutations_OnlyChangesRequestedFields(t *testing.T) {
 	}
 	if out.Configuration != nil {
 		t.Errorf("configuration should remain nil when no values flags, got %v", out.Configuration)
+	}
+	if out.AgentsMd == nil || *out.AgentsMd != agentsMd {
+		t.Errorf("agents_md should be carried untouched, got %v", out.AgentsMd)
+	}
+	if out.AgentsMdFromFile == nil || *out.AgentsMdFromFile != agentsMdFromFile {
+		t.Errorf("agents_md_from_file should be carried untouched, got %v", out.AgentsMdFromFile)
 	}
 }
 

--- a/internal/client/clusters.go
+++ b/internal/client/clusters.go
@@ -283,6 +283,13 @@ type Addon struct {
 	RegistryURL            string                 `json:"registry_url,omitempty"`
 	RegistryCredentialName string                 `json:"registry_credential_name,omitempty"`
 	Settings               map[string]interface{} `json:"settings,omitempty"`
+	// AgentsMd is the addon's AGENTS.md content (operational learnings in
+	// plain markdown). Pointer semantics matter: nil = field absent, the
+	// backend preserves the stored value; pointer to "" = explicit clear.
+	AgentsMd *string `json:"agents_md,omitempty"`
+	// AgentsMdFromFile is the repo-relative path the AGENTS.md content was
+	// authored in, stored by the backend as the pointer in the exported IaC.
+	AgentsMdFromFile *string `json:"agents_md_from_file,omitempty"`
 }
 
 type Manifest struct {
@@ -291,6 +298,10 @@ type Manifest struct {
 	Namespace      string   `json:"namespace,omitempty"`
 	Parents        []Parent `json:"parents"`
 	EncryptedPaths []string `json:"encrypted_paths,omitempty"`
+	// AgentsMd / AgentsMdFromFile: see the Addon fields of the same name.
+	// nil = preserve stored value, pointer to "" = clear.
+	AgentsMd         *string `json:"agents_md,omitempty"`
+	AgentsMdFromFile *string `json:"agents_md_from_file,omitempty"`
 }
 
 type Stack struct {

--- a/internal/client/iac.go
+++ b/internal/client/iac.go
@@ -49,6 +49,14 @@ type AddonSpec struct {
 	// Group is the optional organizational grouping label within the stack
 	// (purely organizational; never triggers a redeploy).
 	Group string `json:"group,omitempty" yaml:"group,omitempty"`
+	// AgentsMd is the addon's AGENTS.md content (operational learnings,
+	// plain markdown; never encrypted; editing never redeploys). Pointer
+	// semantics: nil = absent, the backend preserves the stored file;
+	// pointer to "" = explicit clear (file deleted from the GitOps repo).
+	AgentsMd *string `json:"agents_md,omitempty" yaml:"agents_md,omitempty"`
+	// AgentsMdFromFile is the repo-relative path of the AGENTS.md file; the
+	// exported IaC YAML carries only this pointer, not the content.
+	AgentsMdFromFile *string `json:"agents_md_from_file,omitempty" yaml:"agents_md_from_file,omitempty"`
 }
 
 // ManifestSpec is the typed manifest shape used for partial-stack patches.
@@ -61,6 +69,10 @@ type ManifestSpec struct {
 	EncryptedPaths []string `json:"encrypted_paths,omitempty" yaml:"encrypted_paths,omitempty"`
 	// Group is the optional organizational grouping label within the stack.
 	Group string `json:"group,omitempty" yaml:"group,omitempty"`
+	// AgentsMd / AgentsMdFromFile: see the AddonSpec fields of the same
+	// name. nil = preserve stored value, pointer to "" = clear.
+	AgentsMd         *string `json:"agents_md,omitempty" yaml:"agents_md,omitempty"`
+	AgentsMdFromFile *string `json:"agents_md_from_file,omitempty" yaml:"agents_md_from_file,omitempty"`
 }
 
 // StackSpec is the typed stack shape used for partial-stack patches.

--- a/internal/client/iac_test.go
+++ b/internal/client/iac_test.go
@@ -96,6 +96,61 @@ func TestGetClusterIaC_Error(t *testing.T) {
 	}
 }
 
+// TestSpecAgentsMdWireSemantics pins the tri-state JSON encoding of the
+// AGENTS.md fields on AddonSpec and ManifestSpec: nil pointers are omitted
+// entirely (backend preserves the stored file), a pointer to "" is sent as an
+// explicit empty string (backend clears the file), and content passes
+// through verbatim.
+func TestSpecAgentsMdWireSemantics(t *testing.T) {
+	t.Run("nil is omitted", func(t *testing.T) {
+		b, err := json.Marshal(AddonSpec{Name: "x", ChartName: "c", ChartVersion: "1"})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if strings.Contains(string(b), "agents_md") {
+			t.Errorf("nil agents_md fields must be omitted, got %s", string(b))
+		}
+	})
+
+	t.Run("empty string is an explicit clear", func(t *testing.T) {
+		empty := ""
+		b, err := json.Marshal(ManifestSpec{Name: "m", AgentsMd: &empty})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var generic map[string]any
+		if err := json.Unmarshal(b, &generic); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		v, present := generic["agents_md"]
+		if !present {
+			t.Fatalf("explicit empty agents_md must be serialized, got %s", string(b))
+		}
+		if s, _ := v.(string); s != "" {
+			t.Errorf("agents_md = %q, want empty string", s)
+		}
+	})
+
+	t.Run("content and pointer round-trip", func(t *testing.T) {
+		content := "# learnings\nplain markdown"
+		path := "stacks/demo/add-ons/x/AGENTS.md"
+		b, err := json.Marshal(AddonSpec{Name: "x", ChartName: "c", ChartVersion: "1", AgentsMd: &content, AgentsMdFromFile: &path})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var back AddonSpec
+		if err := json.Unmarshal(b, &back); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if back.AgentsMd == nil || *back.AgentsMd != content {
+			t.Errorf("agents_md round-trip = %v, want %q", back.AgentsMd, content)
+		}
+		if back.AgentsMdFromFile == nil || *back.AgentsMdFromFile != path {
+			t.Errorf("agents_md_from_file round-trip = %v, want %q", back.AgentsMdFromFile, path)
+		}
+	})
+}
+
 func TestPatchClusterStackPartial_OK(t *testing.T) {
 	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPatch {

--- a/internal/skills/embedded/skills/ankra-import-cluster/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-import-cluster/SKILL.md
@@ -52,6 +52,7 @@ spec:
 - `spec.stacks[]` — each stack groups related `manifests` and `addons`.
 - `manifests[]` — raw Kubernetes YAML. Use `from_file: "path.yaml"` to reference a file, or `manifest: |-` for inline content.
 - `addons[]` — Helm releases. Required: `chart_name`, `chart_version`, `repository_url`, `namespace`. Configure via `configuration.values: |-` (inline) or `configuration.from_file:`.
+- `agents_md` / `agents_md_from_file` — optional per-manifest and per-addon AGENTS.md: operational learnings in plain markdown, stored as a sibling file in the GitOps repo (e.g. `agents_md_from_file: "manifests/fluent-bit.AGENTS.md"`). Omitting the field preserves the stored content, an explicit empty string clears it, and editing it never triggers a redeploy. Plaintext only — never put secrets in it. After any non-obvious operation (a values quirk, an upgrade pitfall, a dependency gotcha), record what you learned here so future agents working on the same addon or manifest benefit.
 - `parents` — the dependency edges that control deployment order. A resource only deploys after its parents succeed. Reference a parent as `- manifest: <name>` or `- addon: <name>`.
 
 ## Workflow

--- a/internal/skills/embedded/skills/ankra-stacks-addons/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-stacks-addons/SKILL.md
@@ -9,10 +9,12 @@ A Stack is Ankra's reusable unit of deployment: it bundles Helm addons, raw mani
 
 ## Building blocks
 
-- **Addon** — a Helm release: `chart_name`, `chart_version`, `repository_url`, `namespace`, and `configuration.values`.
-- **Manifest** — raw Kubernetes YAML (namespaces, ConfigMaps, CRDs, RBAC, anything Helm does not own).
+- **Addon** — a Helm release: `chart_name`, `chart_version`, `repository_url`, `namespace`, and `configuration.values`. Optional `agents_md` (inline markdown) or `agents_md_from_file` (path) attaches an AGENTS.md of operational learnings, stored next to the addon in the GitOps repo.
+- **Manifest** — raw Kubernetes YAML (namespaces, ConfigMaps, CRDs, RBAC, anything Helm does not own). Also takes optional `agents_md` / `agents_md_from_file`.
 - **Variable** — a named value substituted into manifests/addon values, so the same stack works across environments.
 - **Parents** — dependency edges. A resource deploys only after every parent has succeeded.
+
+AGENTS.md semantics: omit the field to preserve what is stored, set `""` to clear it, and editing it never redeploys anything. Content is plain markdown (never encrypted — no secrets). Use it to record durable operational learnings after non-obvious operations so future agents benefit.
 
 ## Deployment order via `parents`
 
@@ -31,6 +33,7 @@ addons:
     chart_version: 65.1.1
     repository_url: https://prometheus-community.github.io/helm-charts
     namespace: monitoring
+    agents_md_from_file: agents/kube-prometheus-stack.AGENTS.md
     parents:
       - manifest: monitoring-ns
       - manifest: grafana-dashboards


### PR DESCRIPTION
## What

CLI support for the new per-addon / per-manifest `agents_md` and `agents_md_from_file` stack-spec fields (backend: ankraio/cluster#586). Operational learnings live next to the resource they describe: the platform writes the markdown as a sibling file in the GitOps repo (`stacks/<stack>/add-ons/<addon>/AGENTS.md`, `stacks/<stack>/manifests/<name>.AGENTS.md`) and the exported IaC YAML carries only the `agents_md_from_file` pointer.

## Semantics

- Field absent → the backend preserves the stored AGENTS.md (pointer fields, `nil` omitted).
- Explicit empty string → clears it (file deleted from the repo).
- Plain markdown, never encrypted; editing never triggers a redeploy.
- Mirrors how stack-level `description` / `description_from_file` → README.md works today.

## Lanes touched

- **POST wire structs** (`internal/client/clusters.go`): `AgentsMd` / `AgentsMdFromFile` (`*string`) on `Manifest` and `Addon`.
- **Apply** (`cmd/apply.go`): `buildManifest` / `buildAddon` share a `parseAgentsMdFields` helper — `agents_md_from_file` resolves through `resolveSafePath` exactly like `description_from_file`, its content is sent as `agents_md` and the authored path passes through so the stored pointer matches; non-empty inline `agents_md` wins.
- **Typed IaC round-trip** (`internal/client/iac.go`): both fields on `AddonSpec` / `ManifestSpec` with json+yaml tags.
- **Carry-forward** (`cmd/cluster_partial.go`): `applyAddonMutations` carries both fields so `ankra cluster addons upgrade` round-trips them. `manifests upgrade` copies the whole spec struct and only resets `from_file`; `agents_md_from_file` is deliberately not reset — the pointer is repo-relative and stays valid when manifest content is replaced.
- **Clone** (`cmd/clone.go`): `ManifestConfig` / `AddonConfig` round-trip both fields, and `copyStackFiles` transfers the referenced AGENTS.md files alongside the existing `from_file` transfers.
- **Skills** (embedded, canonical here): `ankra-import-cluster` and `ankra-stacks-addons` document the fields, semantics, and why agents should record durable learnings there.
- **CHANGELOG**: `## Unreleased` entry.

## Tests

Extended `TestBuildManifest` / `TestBuildAddon` (inline pass-through, from-file resolution + path carry, explicit-empty clear, absent = nil, safe-path refusal, inline-wins), `TestApplyAddonMutations_OnlyChangesRequestedFields` (carry), `TestParseImportClusterYAML_OK` (exported-pointer round-trip), new `TestSpecAgentsMdWireSemantics` (tri-state JSON encoding) and `TestCopyStackFiles_AgentsMdFiles` (clone transfer). `make build`, `make test` (race), `make lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ES6QcW73moQyeRjJVGZCnL
