### PR TITLE
fix(helm): validate registry create spec nesting before POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Fixed
+
+- **`ankra helm registries create` validates the spec file before sending
+  it.** The API requires the registry nested under exactly one of
+  `helm_oci_registry` or `helm_http_registry` and answers any other shape
+  with an unexplained server error (`No registry provided!`). The CLI now
+  catches malformed files up front with an example of the expected shape
+  (exit code 2), and accepts a flat `{"name": ..., "url": ...}` file by
+  nesting it automatically — inferring an OCI registry from an `oci://`
+  URL.
+
 ### Added
 
 - **Stack manifests and addons can carry an AGENTS.md.** Every manifest and

--- a/cmd/helm.go
+++ b/cmd/helm.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"ankra/internal/client"
 
@@ -135,6 +136,15 @@ var helmRegistriesCreateCmd = &cobra.Command{
 	Short: "Create a Helm chart registry from a spec file",
 	Long: `Create a Helm chart registry by providing a JSON spec file.
 
+The registry must be nested under exactly one of "helm_oci_registry" or
+"helm_http_registry":
+
+  {"spec": {"helm_oci_registry": {"name": "my-charts", "url": "oci://ghcr.io/acme/charts"}}}
+  {"spec": {"helm_http_registry": {"name": "my-charts", "url": "https://charts.example.com"}}}
+
+A flat {"name": ..., "url": ...} file is accepted and nested automatically,
+inferring the registry type from the URL scheme (oci:// means OCI).
+
 Example:
   ankra helm registries create -f registry-spec.json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -145,9 +155,12 @@ Example:
 			return fmt.Errorf("reading file: %w", err)
 		}
 
-		var specJSON json.RawMessage
-		if err := json.Unmarshal(fileData, &specJSON); err != nil {
-			return fmt.Errorf("parsing JSON: %w", err)
+		specJSON, note, err := normalizeHelmRegistrySpec(fileData)
+		if err != nil {
+			return withExitCode(exitUsage, err)
+		}
+		if note != "" {
+			fmt.Fprintln(os.Stderr, note)
 		}
 
 		result, err := apiClient.CreateHelmRegistry(client.CreateHelmRegistryRequest{Spec: specJSON})
@@ -166,6 +179,67 @@ Example:
 		fmt.Println("Helm registry created successfully!")
 		return nil
 	},
+}
+
+const helmRegistrySpecHint = `the registry must be nested under exactly one of "helm_oci_registry" or "helm_http_registry", for example:
+  {"spec": {"helm_oci_registry": {"name": "my-charts", "url": "oci://ghcr.io/acme/charts"}}}
+  {"spec": {"helm_http_registry": {"name": "my-charts", "url": "https://charts.example.com"}}}`
+
+// normalizeHelmRegistrySpec validates the spec file before it is POSTed. The
+// API requires the registry nested under exactly one of helm_oci_registry /
+// helm_http_registry and answers a bare 500 "No registry provided!" to any
+// other shape, so shape problems must be caught client-side. A flat
+// {name, url} spec is auto-nested, inferring OCI from an oci:// URL; the
+// returned note tells the user when that happened.
+func normalizeHelmRegistrySpec(fileData []byte) (json.RawMessage, string, error) {
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(fileData, &doc); err != nil {
+		if !json.Valid(fileData) {
+			return nil, "", fmt.Errorf("parsing JSON: %w", err)
+		}
+		return nil, "", fmt.Errorf("invalid registry spec: file must contain a JSON object; %s", helmRegistrySpecHint)
+	}
+
+	spec := doc
+	if rawSpec, ok := doc["spec"]; ok {
+		var inner map[string]json.RawMessage
+		if err := json.Unmarshal(rawSpec, &inner); err != nil {
+			return nil, "", fmt.Errorf(`invalid registry spec: "spec" must be a JSON object; %s`, helmRegistrySpecHint)
+		}
+		spec = inner
+	}
+
+	_, hasOCI := spec["helm_oci_registry"]
+	_, hasHTTP := spec["helm_http_registry"]
+	if hasOCI && hasHTTP {
+		return nil, "", fmt.Errorf(`invalid registry spec: found both "helm_oci_registry" and "helm_http_registry"; %s`, helmRegistrySpecHint)
+	}
+	if hasOCI || hasHTTP {
+		specJSON, err := json.Marshal(spec)
+		if err != nil {
+			return nil, "", fmt.Errorf("encoding spec: %w", err)
+		}
+		return specJSON, "", nil
+	}
+
+	// Flat spec: nest the whole object under the type inferred from the URL.
+	var registryURL string
+	if rawURL, ok := spec["url"]; ok {
+		_ = json.Unmarshal(rawURL, &registryURL)
+	}
+	if _, hasName := spec["name"]; !hasName || registryURL == "" {
+		return nil, "", fmt.Errorf("invalid registry spec: %s", helmRegistrySpecHint)
+	}
+	registryKey := "helm_http_registry"
+	if strings.HasPrefix(strings.ToLower(registryURL), "oci://") {
+		registryKey = "helm_oci_registry"
+	}
+	specJSON, err := json.Marshal(map[string]map[string]json.RawMessage{registryKey: spec})
+	if err != nil {
+		return nil, "", fmt.Errorf("encoding spec: %w", err)
+	}
+	note := fmt.Sprintf("Note: nested the flat registry spec under %q (inferred from url %q).", registryKey, registryURL)
+	return specJSON, note, nil
 }
 
 var helmRegistriesDeleteCmd = &cobra.Command{

--- a/cmd/helm_registries_create_test.go
+++ b/cmd/helm_registries_create_test.go
@@ -1,0 +1,172 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+func TestNormalizeHelmRegistrySpec(t *testing.T) {
+	cases := []struct {
+		name     string
+		file     string
+		wantSpec string // canonical JSON the API should receive; "" means error expected
+		wantNote bool
+		wantErr  string
+	}{
+		{
+			name:     "nested OCI under spec envelope",
+			file:     `{"spec": {"helm_oci_registry": {"name": "acme", "url": "oci://ghcr.io/acme/charts"}}}`,
+			wantSpec: `{"helm_oci_registry":{"name":"acme","url":"oci://ghcr.io/acme/charts"}}`,
+		},
+		{
+			name:     "nested HTTP without envelope",
+			file:     `{"helm_http_registry": {"name": "acme", "url": "https://charts.example.com"}}`,
+			wantSpec: `{"helm_http_registry":{"name":"acme","url":"https://charts.example.com"}}`,
+		},
+		{
+			name:     "flat OCI spec is auto-nested",
+			file:     `{"name": "acme", "url": "oci://ghcr.io/acme/charts"}`,
+			wantSpec: `{"helm_oci_registry":{"name":"acme","url":"oci://ghcr.io/acme/charts"}}`,
+			wantNote: true,
+		},
+		{
+			name:     "flat HTTP spec is auto-nested with extra fields kept",
+			file:     `{"name": "acme", "url": "https://charts.example.com", "credential_name": "cred"}`,
+			wantSpec: `{"helm_http_registry":{"credential_name":"cred","name":"acme","url":"https://charts.example.com"}}`,
+			wantNote: true,
+		},
+		{
+			name:     "flat spec under spec envelope is auto-nested",
+			file:     `{"spec": {"name": "acme", "url": "oci://ghcr.io/acme/charts"}}`,
+			wantSpec: `{"helm_oci_registry":{"name":"acme","url":"oci://ghcr.io/acme/charts"}}`,
+			wantNote: true,
+		},
+		{
+			name:    "both registry types rejected",
+			file:    `{"spec": {"helm_oci_registry": {"name": "a", "url": "oci://x"}, "helm_http_registry": {"name": "b", "url": "https://y"}}}`,
+			wantErr: "found both",
+		},
+		{
+			name:    "flat spec without url rejected",
+			file:    `{"name": "acme"}`,
+			wantErr: "helm_oci_registry",
+		},
+		{
+			name:    "non-object file rejected",
+			file:    `[{"name": "acme"}]`,
+			wantErr: "must contain a JSON object",
+		},
+		{
+			name:    "non-object spec value rejected",
+			file:    `{"spec": "acme"}`,
+			wantErr: `"spec" must be a JSON object`,
+		},
+		{
+			name:    "invalid JSON rejected",
+			file:    `{"name": `,
+			wantErr: "parsing JSON",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec, note, err := normalizeHelmRegistrySpec([]byte(tc.file))
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got spec %s", tc.wantErr, spec)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got: %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			got := mustCanonicalJSON(t, spec)
+			want := mustCanonicalJSON(t, json.RawMessage(tc.wantSpec))
+			if got != want {
+				t.Errorf("spec mismatch:\n  got:  %s\n  want: %s", got, want)
+			}
+			if tc.wantNote != (note != "") {
+				t.Errorf("note presence mismatch: wantNote=%v, note=%q", tc.wantNote, note)
+			}
+		})
+	}
+}
+
+func mustCanonicalJSON(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		t.Fatalf("unmarshal %s: %v", raw, err)
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(out)
+}
+
+type helmRegistryCreateMock struct {
+	baseMock
+	lastReq *client.CreateHelmRegistryRequest
+}
+
+func (m *helmRegistryCreateMock) CreateHelmRegistry(req client.CreateHelmRegistryRequest) (*client.CreateHelmRegistryResponse, error) {
+	m.lastReq = &req
+	return &client.CreateHelmRegistryResponse{}, nil
+}
+
+func writeHelmSpecFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "registry-spec.json")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing spec file: %v", err)
+	}
+	return path
+}
+
+func TestHelmRegistriesCreateAutoNestsFlatSpec(t *testing.T) {
+	mock := &helmRegistryCreateMock{}
+	setMockClient(t, mock)
+	path := writeHelmSpecFile(t, `{"name": "acme", "url": "oci://ghcr.io/acme/charts"}`)
+
+	_, err := executeCommand("helm", "registries", "create", "-f", path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.lastReq == nil {
+		t.Fatal("expected CreateHelmRegistry to be called")
+	}
+	got := mustCanonicalJSON(t, mock.lastReq.Spec)
+	want := `{"helm_oci_registry":{"name":"acme","url":"oci://ghcr.io/acme/charts"}}`
+	if got != want {
+		t.Errorf("posted spec mismatch:\n  got:  %s\n  want: %s", got, want)
+	}
+}
+
+func TestHelmRegistriesCreateRejectsUnrecognizedSpecBeforePost(t *testing.T) {
+	mock := &helmRegistryCreateMock{}
+	setMockClient(t, mock)
+	path := writeHelmSpecFile(t, `{"registry": {"name": "acme", "url": "oci://x"}}`)
+
+	_, err := executeCommand("helm", "registries", "create", "-f", path)
+	if err == nil {
+		t.Fatal("expected an error for an unrecognized spec shape")
+	}
+	if !strings.Contains(err.Error(), "helm_oci_registry") {
+		t.Errorf("expected actionable error naming helm_oci_registry, got: %v", err)
+	}
+	if code := exitCodeFor(err); code != exitUsage {
+		t.Errorf("expected usage exit code %d, got %d", exitUsage, code)
+	}
+	if mock.lastReq != nil {
+		t.Error("expected no API call for an invalid spec file")
+	}
+}


### PR DESCRIPTION
## What & why

`ankra helm registries create -f <file>` passed the file JSON verbatim as the request spec. The API requires the registry nested under exactly one of `spec.helm_oci_registry` / `spec.helm_http_registry` and deliberately answers any other shape with a frozen 500 `No registry provided!` (Python-parity in cluster's `helmapi` `createRegistryHandler`) — this produced 6 prod ERROR hits from one user session on 2026-07-24 with zero hint about the real problem.

The CLI now:

- validates the spec shape before POSTing: exactly one of `helm_oci_registry` / `helm_http_registry` must be present (an envelope `{"spec": {...}}` and a bare spec object are both accepted);
- auto-nests a flat `{"name": ..., "url": ...}` file under the right key, inferring OCI from an `oci://` URL, with a stderr note saying what it did;
- rejects anything else with an actionable error showing the expected shape, exit code 2 (usage).

Bead: ankra-8p7

## Test plan

- Table-driven unit tests for the normalizer (nested OCI/HTTP, envelope and bare forms, flat auto-nest incl. extra fields, both-keys rejection, missing url, non-object file/spec, invalid JSON).
- Command-level tests: flat file POSTs the nested spec; unrecognized shape errors with exit code 2 and never reaches the API.
- `go test -count=1 ./...` and `golangci-lint run` green locally.

## Docs checklist

- [x] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); the `Long` help now documents the expected spec shapes
- [ ] No user-facing command/flag changes — no docs needed
- [ ] Broader behaviour changes — docs updated in [ankra-docs](https://github.com/ankraio/ankra-docs) (link the PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)