### PR TITLE
docs: add contributing guide, code of conduct, and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Bug report
+description: Something in the CLI isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug!
+
+        **Do not report security vulnerabilities here** — email
+        [security@ankra.io](mailto:security@ankra.io) instead (see
+        [SECURITY.md](https://github.com/ankraio/ankra-cli/blob/master/SECURITY.md)).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you run, and what went wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: >-
+        The exact commands to reproduce the problem. Redact bearer tokens,
+        kubeconfigs, and anything else sensitive.
+      placeholder: |
+        1. ankra login
+        2. ankra cluster list
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: output
+    attributes:
+      label: Relevant output
+      description: >-
+        Command output and exit code (`echo $?` right after the failing
+        command). Again, please redact anything sensitive.
+      render: shell
+  - type: input
+    id: version
+    attributes:
+      label: CLI version
+      description: Output of `ankra version`
+      placeholder: v0.6.0
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS and architecture
+      placeholder: e.g. macOS 15 (arm64), Ubuntu 24.04 (amd64)
+    validations:
+      required: true
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: How did you install the CLI?
+      options:
+        - install.sh (recommended installer)
+        - Manual binary download
+        - Built from source
+        - Other

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/ankraio/ankra-cli/blob/master/SECURITY.md
+    about: >-
+      Please report security issues privately to security@ankra.io — do not
+      open a public issue.
+  - name: Documentation
+    url: https://docs.ankra.ai
+    about: Guides, concepts, and the full CLI reference.
+  - name: Contact Ankra
+    url: https://ankra.io
+    about: For anything else, reach us at hello@ankra.io.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest a new command, flag, or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: >-
+        Describe the workflow or task that the CLI currently makes hard or
+        impossible.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: >-
+        What should the CLI do? If you have a command or flag in mind, sketch
+        the invocation and expected output.
+      placeholder: |
+        ankra cluster frobnicate --wait
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: >-
+        Workarounds you use today (scripts, the web UI, kubectl, ...) and why
+        they fall short.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that helps us understand the request.

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ coverage.html
 .ankra.yml
 config.yaml
 config.yml
+!.github/ISSUE_TEMPLATE/config.yml
 
 # Build directories
 build/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,129 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[hello@ankra.io](mailto:hello@ankra.io).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org
+[Mozilla CoC]: https://github.com/mozilla/diversity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Contributing to Ankra CLI
+
+Thanks for your interest in improving the Ankra CLI! This document covers how
+to report problems, propose changes, and get a pull request merged.
+
+By participating in this project you agree to follow our
+[Code of Conduct](CODE_OF_CONDUCT.md). Contributions are accepted under the
+project's [Apache 2.0 license](LICENSE).
+
+## Reporting issues
+
+- **Bugs and feature requests**: use the
+  [issue templates](https://github.com/ankraio/ankra-cli/issues/new/choose).
+- **Security vulnerabilities**: do **not** open a public issue. Follow
+  [SECURITY.md](SECURITY.md) and email
+  [security@ankra.io](mailto:security@ankra.io).
+- **Questions**: check the [documentation](https://docs.ankra.ai) first; for
+  anything else open an issue or reach us at
+  [hello@ankra.io](mailto:hello@ankra.io).
+
+## Development setup
+
+You need Go (the version pinned by the `toolchain` directive in `go.mod` —
+`go` downloads it automatically), `make`, and
+[golangci-lint](https://golangci-lint.run) for the lint gate.
+
+```bash
+git clone https://github.com/ankraio/ankra-cli.git
+cd ankra-cli
+
+make build        # go build ./...
+make test         # go test -race -count=1 ./...
+make lint         # golangci-lint run
+./build.sh        # dist/ankra with release-identical ldflags (--install → /usr/local/bin)
+```
+
+A pre-commit hook (`core.hooksPath` → `.githooks/`) runs `go test ./...` and
+`golangci-lint run` on every commit, so commits take ~30s and a red test
+blocks the commit. Please don't bypass it with `--no-verify`.
+
+## Making changes
+
+The layout in brief:
+
+- `main.go` → `cmd/` — flat package, one file per command using
+  `<family>_<sub>.go` naming (e.g. `cluster_kubeconfig.go`), with tests
+  alongside.
+- `internal/client` — typed HTTP client for the platform API, one file per
+  resource family.
+- `internal/kubeconfig` — kubeconfig read/merge/write.
+- `tools/gendocs` — generates the CLI reference published to
+  [docs.ankra.ai](https://docs.ankra.ai); it runs automatically on release
+  tags, so write `Short`/`Long`/`Example` on new commands for docs readers.
+
+A few invariants the codebase relies on:
+
+- **`cmd/services.go` defines the `APIClient` interface.** Adding a method to
+  `internal/client` means also adding it to that interface *and* to the
+  `baseMock` stub set in `cmd/e2e_test.go`. The build breaks until all three
+  agree — that is by design.
+- **Exit codes are a scripting contract** (`cmd/exitcodes.go`): 0 success,
+  1 API/runtime, 2 usage, 3 not-found, 4 confirmation declined, 5
+  `--wait`/`--timeout` expiry, 6 auth, 7 RBAC permission denied. Commands use
+  `RunE` and return errors (wrapped with `withExitCode` where the class is
+  known) — never `os.Exit`, and errors never go to stdout.
+- **Destructive commands confirm first** (delete, uninstall, deprovision);
+  declining exits 4. Use the existing prompt helpers rather than rolling new
+  ones.
+- **Structured output stays clean**: commands with `-o json|yaml` must keep
+  stdout parseable — human hints and errors go to stderr.
+- **Deprecations are managed, not ad hoc**: register forwarders with
+  `deprecateAndForward` (`cmd/deprecation.go`) and record them in
+  [DEPRECATIONS.md](DEPRECATIONS.md).
+
+## Changelog
+
+Every user-visible change gets an entry in the `## Unreleased` section of
+[CHANGELOG.md](CHANGELOG.md), written in the file's established prose style:
+bold lead-in, explaining the user-facing consequence rather than the
+implementation.
+
+## Commit style
+
+Conventional-commit subjects scoped by area — `fix(kubeconfig): ...`,
+`feat(cluster): ...`, `chore: ...` — with bodies that explain the user-visible
+why. Recent `git log` entries are the best reference.
+
+## Pull requests
+
+The default branch is `master` and all changes land via pull requests.
+
+1. Fork the repository (or branch, if you have write access) and make your
+   change on a topic branch.
+2. Make sure `make test` and `make lint` pass locally — CI runs the same
+   gates.
+3. Open a PR; the
+   [template](.github/pull_request_template.md) asks for a summary, a test
+   plan, and a docs checklist. Please fill in all three.
+4. A maintainer will review your PR. Small, focused PRs with a clear "what &
+   why" get reviewed fastest.
+
+Thanks for contributing!


### PR DESCRIPTION
## What & why

Fills the remaining gaps in the repo's GitHub community-standards checklist (Insights → Community standards). README, license, security policy, and PR template already exist; this adds the three missing items:

- **CONTRIBUTING.md** — how to report issues, dev setup (`make build/test/lint`, pre-commit hook), layout and invariants worth knowing before a first PR, changelog and commit conventions, and the PR process.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 with hello@ankra.io as the enforcement contact.
- **.github/ISSUE_TEMPLATE/** — bug-report and feature-request forms (version, OS/arch, install method, redaction reminders) plus `config.yml` contact links routing security reports to security@ankra.io and questions to the docs.

Also adds a `.gitignore` negation (`!.github/ISSUE_TEMPLATE/config.yml`) — the existing blanket `config.yml` ignore (meant for local CLI config) was swallowing the issue-template config.

Bead: ankra-h8c

## Test plan

- Docs-only change; `go test ./...` and `golangci-lint run` passed via the pre-commit hook.
- All three issue-template YAML files validated with a YAML parser.
- Links in CONTRIBUTING.md point at files that exist on this branch (SECURITY.md, DEPRECATIONS.md, CHANGELOG.md, LICENSE, PR template).

## Docs checklist

- [x] No user-facing command/flag changes — no docs needed
- [ ] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); ensure `Short`/`Long`/`Example` on new commands are written for docs readers
- [ ] Broader behaviour changes — docs updated in [ankra-docs](https://github.com/ankraio/ankra-docs) (link the PR): <!-- PR link -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
