### PR TITLE
fix(kubeconfig): accept the cluster as a positional argument on add/remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@
 
 ### Fixed
 
+- **`ankra cluster kubeconfig add my-cluster` now works.** `kubeconfig add`
+  and `kubeconfig remove` accept the cluster as a positional argument, the
+  same way `ankra cluster select my-cluster` does. Previously the positional
+  was silently ignored, so `ankra cluster kubeconfig add production --use`
+  confusingly failed with "no cluster specified" even though the cluster was
+  right there in the command. `--cluster` still works; giving both spellings
+  with different values is rejected as a usage error (exit code 2), and a
+  second stray positional argument now errors instead of being dropped.
+
 - **`ankra helm registries create` validates the spec file before sending
   it.** The API requires the registry nested under exactly one of
   `helm_oci_registry` or `helm_http_registry` and answers any other shape

--- a/cmd/cluster_kubeconfig.go
+++ b/cmd/cluster_kubeconfig.go
@@ -49,26 +49,34 @@ These commands read and write a single file: --kubeconfig if given, otherwise
 the first entry of $KUBECONFIG, otherwise ~/.kube/config.
 
 Examples:
-  ankra cluster kubeconfig add --cluster my-cluster --use
+  ankra cluster kubeconfig add my-cluster --use
   ankra cluster kubeconfig add --all
-  ankra cluster kubeconfig add --cluster my-cluster --print > my-cluster.yaml
+  ankra cluster kubeconfig add my-cluster --print > my-cluster.yaml
   ankra cluster kubeconfig list
-  ankra cluster kubeconfig remove --cluster my-cluster
+  ankra cluster kubeconfig remove my-cluster
   ankra cluster kubeconfig remove --all`,
 }
 
 var clusterKubeconfigAddCmd = &cobra.Command{
-	Use:   "add",
+	Use:   "add [cluster]",
 	Short: "Add or update an Ankra context in your kubeconfig",
+	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := applyKubeconfigPositionalCluster(args); err != nil {
+			return err
+		}
 		return kubeconfigAdd(os.Stdout)
 	},
 }
 
 var clusterKubeconfigRemoveCmd = &cobra.Command{
-	Use:   "remove",
+	Use:   "remove [cluster]",
 	Short: "Remove Ankra contexts from your kubeconfig",
+	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := applyKubeconfigPositionalCluster(args); err != nil {
+			return err
+		}
 		return kubeconfigRemove(os.Stdout)
 	},
 }
@@ -76,9 +84,24 @@ var clusterKubeconfigRemoveCmd = &cobra.Command{
 var clusterKubeconfigListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List Ankra-managed contexts in your kubeconfig",
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return kubeconfigList(os.Stdout)
 	},
+}
+
+// applyKubeconfigPositionalCluster folds an optional positional cluster
+// argument into the --cluster flag so both spellings behave identically
+// everywhere downstream.
+func applyKubeconfigPositionalCluster(args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	if kubeconfigClusterFlag != "" && kubeconfigClusterFlag != args[0] {
+		return withExitCode(exitUsage, fmt.Errorf("cluster specified twice: %q as argument and %q via --cluster; pass only one", args[0], kubeconfigClusterFlag))
+	}
+	kubeconfigClusterFlag = args[0]
+	return nil
 }
 
 func kubeconfigAdd(out io.Writer) error {
@@ -225,7 +248,7 @@ func printStandaloneKubeconfig(out io.Writer, entries []kubeconfig.Entry) error 
 
 func emitAddNotes() {
 	if kubeconfigAllFlag && kubeconfigClusterFlag != "" {
-		fmt.Fprintln(os.Stderr, "Note: --cluster is ignored when --all is set.")
+		fmt.Fprintln(os.Stderr, "Note: the specified cluster is ignored when --all is set.")
 	}
 	if kubeconfigAllFlag && kubeconfigEmbedToken {
 		fmt.Fprintln(os.Stderr, "Note: --embed-token mints one token per cluster and may hit the mint rate limit on large fleets; the default exec mode mints only once.")
@@ -377,7 +400,7 @@ func resolveKubeconfigTargets() ([]kubeTarget, error) {
 	}
 	selected, err := loadSelectedCluster()
 	if err != nil || selected.ID == "" {
-		return nil, errors.New("no cluster specified; pass --cluster <name|id>, use --all, or run 'ankra cluster select' first")
+		return nil, errors.New("no cluster specified; pass a cluster name or ID, use --all, or run 'ankra cluster select' first")
 	}
 	return []kubeTarget{{id: selected.ID, name: selected.Name, orgID: selected.OrganisationID}}, nil
 }
@@ -392,7 +415,7 @@ func resolveKubeconfigClusterName() (string, error) {
 	}
 	selected, err := loadSelectedCluster()
 	if err != nil || selected.Name == "" {
-		return "", errors.New("no cluster specified; pass --cluster <name|id> or --all")
+		return "", errors.New("no cluster specified; pass a cluster name or ID, or use --all")
 	}
 	return selected.Name, nil
 }
@@ -435,7 +458,7 @@ func resolveKubeconfigPath(flag string) (string, error) {
 }
 
 func init() {
-	clusterKubeconfigAddCmd.Flags().StringVar(&kubeconfigClusterFlag, "cluster", "", "Cluster name or ID (defaults to the selected cluster)")
+	clusterKubeconfigAddCmd.Flags().StringVar(&kubeconfigClusterFlag, "cluster", "", "Cluster name or ID (same as the positional argument; defaults to the selected cluster)")
 	clusterKubeconfigAddCmd.Flags().BoolVar(&kubeconfigAllFlag, "all", false, "Add every cluster you can access")
 	clusterKubeconfigAddCmd.Flags().BoolVar(&kubeconfigEmbedToken, "embed-token", false, "Embed a short-lived token instead of the exec credential plugin")
 	clusterKubeconfigAddCmd.Flags().StringVar(&kubeconfigNamespace, "namespace", "", "Default namespace for the context")
@@ -445,7 +468,7 @@ func init() {
 	clusterKubeconfigAddCmd.Flags().BoolVar(&kubeconfigInsecure, "insecure-skip-tls-verify", false, "Skip TLS verification for the cluster server (dev only)")
 	clusterKubeconfigAddCmd.Flags().StringVar(&kubeconfigExecCommand, "exec-command", "ankra", "Executable kubectl invokes for credentials in exec mode (use an absolute path if 'ankra' is not on PATH)")
 
-	clusterKubeconfigRemoveCmd.Flags().StringVar(&kubeconfigClusterFlag, "cluster", "", "Cluster name or ID")
+	clusterKubeconfigRemoveCmd.Flags().StringVar(&kubeconfigClusterFlag, "cluster", "", "Cluster name or ID (same as the positional argument)")
 	clusterKubeconfigRemoveCmd.Flags().BoolVar(&kubeconfigAllFlag, "all", false, "Remove all Ankra-managed contexts")
 	clusterKubeconfigRemoveCmd.Flags().StringVar(&kubeconfigPathFlag, "kubeconfig", "", "Path to the kubeconfig file (default: $KUBECONFIG or ~/.kube/config)")
 

--- a/cmd/cluster_kubeconfig_test.go
+++ b/cmd/cluster_kubeconfig_test.go
@@ -578,3 +578,86 @@ func TestResolveKubeconfigPath(t *testing.T) {
 		t.Fatalf("default path = %q, want %q, err=%v", got, want, err)
 	}
 }
+
+// runKubeconfigCommand executes a full 'ankra cluster kubeconfig ...'
+// invocation through the root command so cobra's argument handling
+// (positional args, flag binding) is exercised, not just the run helpers.
+func runKubeconfigCommand(t *testing.T, args ...string) error {
+	t.Helper()
+	t.Setenv("ANKRA_API_TOKEN", "test-token")
+	rootCmd.SetArgs(append([]string{"cluster", "kubeconfig"}, args...))
+	return rootCmd.Execute()
+}
+
+func TestKubeconfigAddPositionalCluster(t *testing.T) {
+	withKubeconfigMock(t, kubeconfigMock{cluster: client.ClusterListItem{ID: "id-1", Name: "production", OrganisationID: "org-1"}})
+	path := filepath.Join(t.TempDir(), "config")
+	resetKubeconfigFlags(path)
+
+	if err := runKubeconfigCommand(t, "add", "production", "--use", "--kubeconfig", path); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := kubeconfig.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := kubeconfig.ContextName("production")
+	names := config.ManagedContextNames()
+	if len(names) != 1 || names[0] != want {
+		t.Fatalf("managed contexts = %v, want [%s]", names, want)
+	}
+	if config.CurrentContext != want {
+		t.Errorf("current context = %q, want %q", config.CurrentContext, want)
+	}
+}
+
+func TestKubeconfigAddPositionalConflictsWithFlag(t *testing.T) {
+	withKubeconfigMock(t, kubeconfigMock{cluster: client.ClusterListItem{ID: "id-1", Name: "demo"}})
+	path := filepath.Join(t.TempDir(), "config")
+	resetKubeconfigFlags(path)
+
+	err := runKubeconfigCommand(t, "add", "other", "--cluster", "demo", "--kubeconfig", path)
+	if err == nil {
+		t.Fatal("expected an error when the cluster is given both positionally and via --cluster")
+	}
+	if code := exitCodeFor(err); code != exitUsage {
+		t.Errorf("exit code = %d, want %d", code, exitUsage)
+	}
+
+	resetKubeconfigFlags(path)
+	if err := runKubeconfigCommand(t, "add", "demo", "--cluster", "demo", "--kubeconfig", path); err != nil {
+		t.Fatalf("same cluster via both spellings should not error: %v", err)
+	}
+}
+
+func TestKubeconfigAddRejectsExtraArgs(t *testing.T) {
+	withKubeconfigMock(t, kubeconfigMock{})
+	path := filepath.Join(t.TempDir(), "config")
+	resetKubeconfigFlags(path)
+
+	if err := runKubeconfigCommand(t, "add", "one", "two", "--kubeconfig", path); err == nil {
+		t.Fatal("expected an error for more than one positional argument")
+	}
+}
+
+func TestKubeconfigRemovePositionalCluster(t *testing.T) {
+	withKubeconfigMock(t, kubeconfigMock{cluster: client.ClusterListItem{ID: "id-1", Name: "demo"}})
+	path := filepath.Join(t.TempDir(), "config")
+	resetKubeconfigFlags(path)
+	kubeconfigClusterFlag = "demo"
+
+	var out bytes.Buffer
+	if err := kubeconfigAdd(&out); err != nil {
+		t.Fatal(err)
+	}
+
+	resetKubeconfigFlags(path)
+	if err := runKubeconfigCommand(t, "remove", "demo", "--kubeconfig", path); err != nil {
+		t.Fatal(err)
+	}
+	config, _ := kubeconfig.Load(path)
+	if len(config.ManagedContextNames()) != 0 {
+		t.Fatalf("expected no managed contexts after positional remove, got %v", config.ManagedContextNames())
+	}
+}


### PR DESCRIPTION
## Summary

`ankra cluster kubeconfig add production --use` failed with `no cluster specified; pass --cluster <name|id>...` — the positional argument was silently discarded because `add`/`remove` only read `--cluster`. Users reasonably expect the positional to name the cluster, the way `ankra cluster select my-cluster` already works.

- `kubeconfig add [cluster]` and `kubeconfig remove [cluster]` now accept the cluster positionally, folded into the same resolution path as `--cluster`.
- Giving both spellings with different values is a usage error (exit code 2); the same value twice is accepted.
- `add`/`remove` cap positionals at one and `list` now rejects arguments — stray args error instead of being silently dropped.
- Help text and examples lead with the positional form (the generated CLI reference picks this up), and the "no cluster specified" errors no longer steer users exclusively to `--cluster`.

## Testing

- `go test -race -count=1 ./...` green locally.
- New tests drive the full cobra path (`rootCmd.Execute`) for: positional add with `--use`, positional/flag conflict (asserts exit-usage classification), extra-arg rejection, and positional remove.

Bead: ankra-1fg0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
