### PR TITLE
feat(kubeconfig): suggest the access-grant command on kube-gateway 403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@
 
 ### Added
 
+- **A kube-gateway access denial now suggests the command that fixes it.**
+  When `ankra cluster kubeconfig add` or `ankra cluster kube-token` is
+  rejected with a 403 because the caller has no access grant on the cluster,
+  the error now explains that an organisation admin can grant access and
+  shows the exact invocation (`ankra cluster access grant <email>
+  --cluster <name> --role view`) instead of leaving only the raw 403
+  response to decipher.
 - **Stack manifests and addons can carry an AGENTS.md.** Every manifest and
   addon entry in a stack spec now accepts `agents_md` (inline markdown) or
   `agents_md_from_file` (a repo-relative path, mirroring how the stack-level

--- a/cmd/cluster_kube_token.go
+++ b/cmd/cluster_kube_token.go
@@ -3,8 +3,12 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"time"
+
+	"ankra/internal/client"
 
 	"github.com/spf13/cobra"
 )
@@ -52,7 +56,7 @@ It prints JSON to stdout and never prompts; run 'ankra login' first.`,
 
 		kubeToken, err := apiClient.GetClusterKubeToken(context.Background(), clusterID)
 		if err != nil {
-			return err
+			return suggestAccessOnKubeTokenDenied(err, kubeTokenClusterReference(clusterFlag, clusterID))
 		}
 
 		credential := execCredential{
@@ -70,6 +74,34 @@ It prints JSON to stdout and never prompts; run 'ankra login' first.`,
 		fmt.Println(string(output))
 		return nil
 	},
+}
+
+// suggestAccessOnKubeTokenDenied decorates a kube-token mint failure. A 403
+// from the token endpoint means the caller has no access grant on the cluster
+// (the gateway's per-user access check), not bad credentials — re-login won't
+// help, but an organisation admin running 'ankra cluster access grant' will,
+// so the error points at that command. Every other error passes through
+// untouched, and the original error stays in the chain so exit-code
+// classification is unchanged.
+func suggestAccessOnKubeTokenDenied(err error, clusterRef string) error {
+	var unexpected *client.UnexpectedResponseError
+	if !errors.As(err, &unexpected) || unexpected.StatusCode != http.StatusForbidden {
+		return err
+	}
+	return fmt.Errorf("%w\nYou have no access grant on this cluster. Ask an organisation admin to add one, then retry:\n  ankra cluster access grant <your-email> --cluster %s --role view", err, clusterRef)
+}
+
+// kubeTokenClusterReference picks the most readable cluster reference for the
+// access-grant suggestion: what the user typed, else the selected cluster's
+// name, else the resolved ID.
+func kubeTokenClusterReference(clusterFlag, clusterID string) string {
+	if clusterFlag != "" {
+		return clusterFlag
+	}
+	if selected, err := loadSelectedCluster(); err == nil && selected.Name != "" {
+		return selected.Name
+	}
+	return clusterID
 }
 
 func resolveKubeTokenClusterID(clusterFlag string) (string, error) {

--- a/cmd/cluster_kube_token_test.go
+++ b/cmd/cluster_kube_token_test.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+func TestSuggestAccessOnKubeTokenDenied(t *testing.T) {
+	original := client.NewUnexpectedResponseError(403, `kube token request failed: status 403, body: {"detail":"You do not have access to this cluster"}`)
+	err := suggestAccessOnKubeTokenDenied(original, "arm64-build")
+
+	if !strings.Contains(err.Error(), "ankra cluster access grant <your-email> --cluster arm64-build --role view") {
+		t.Fatalf("expected access-grant suggestion, got: %v", err)
+	}
+	// The original error must stay in the chain so exit-code classification
+	// still sees the 403.
+	var unexpected *client.UnexpectedResponseError
+	if !errors.As(err, &unexpected) || unexpected.StatusCode != 403 {
+		t.Fatalf("expected wrapped UnexpectedResponseError with status 403, got: %v", err)
+	}
+	if code := exitCodeFor(err); code != exitAuth {
+		t.Fatalf("expected exit code %d, got %d", exitAuth, code)
+	}
+}
+
+func TestSuggestAccessOnKubeTokenDeniedPassesOtherErrorsThrough(t *testing.T) {
+	for _, err := range []error{
+		client.NewUnexpectedResponseError(500, "kube token request failed: status 500"),
+		errors.New("dial tcp: connection refused"),
+	} {
+		if got := suggestAccessOnKubeTokenDenied(err, "demo"); got != err {
+			t.Fatalf("expected %v to pass through unchanged, got: %v", err, got)
+		}
+	}
+}

--- a/cmd/cluster_kubeconfig.go
+++ b/cmd/cluster_kubeconfig.go
@@ -279,7 +279,7 @@ func buildManagedEntries(targets []kubeTarget, names []string) ([]kubeconfig.Ent
 		for index, target := range targets {
 			token, err := apiClient.GetClusterKubeToken(context.Background(), target.id)
 			if err != nil {
-				return nil, fmt.Errorf("mint token for %s: %w", target.name, err)
+				return nil, suggestAccessOnKubeTokenDenied(fmt.Errorf("mint token for %s: %w", target.name, err), target.name)
 			}
 			entry, buildErr := kubeconfig.BuildTokenEntry(names[index], token.Server, token.Token, kubeconfigNamespace, kubeconfigInsecure)
 			if buildErr != nil {
@@ -345,7 +345,7 @@ func proxyServerPath(clusterID string) string {
 func resolveProxyBaseURL(sample kubeTarget) (string, error) {
 	token, err := apiClient.GetClusterKubeToken(context.Background(), sample.id)
 	if err != nil {
-		return "", fmt.Errorf("resolve kube proxy URL for %s: %w", sample.name, err)
+		return "", suggestAccessOnKubeTokenDenied(fmt.Errorf("resolve kube proxy URL for %s: %w", sample.name, err), sample.name)
 	}
 	suffix := proxyServerPath(sample.id)
 	if !strings.HasSuffix(token.Server, suffix) {

--- a/cmd/cluster_kubeconfig_test.go
+++ b/cmd/cluster_kubeconfig_test.go
@@ -19,6 +19,7 @@ type kubeconfigMock struct {
 	byIDCluster client.ClusterListItem
 	clusters    []client.ClusterListItem
 	token       string
+	tokenErr    error
 	proxyBase   string
 	orgOverride string
 }
@@ -40,6 +41,9 @@ func (m kubeconfigMock) GetClusterByID(clusterID string) (client.ClusterListItem
 }
 
 func (m kubeconfigMock) GetClusterKubeToken(ctx context.Context, clusterID string) (*client.KubeToken, error) {
+	if m.tokenErr != nil {
+		return nil, m.tokenErr
+	}
 	base := m.proxyBase
 	if base == "" {
 		base = "https://api.platform.ankra.dev"
@@ -537,6 +541,37 @@ func TestKubeconfigAddUnknownNameReturnsError(t *testing.T) {
 	}
 	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
 		t.Errorf("no kubeconfig should be written on failure: %s", path)
+	}
+}
+
+func TestKubeconfigAddDeniedSuggestsAccessGrant(t *testing.T) {
+	// A 403 from the token mint means the caller has no access grant on the
+	// cluster; the error must point at the command that fixes it.
+	withKubeconfigMock(t, kubeconfigMock{
+		cluster:  client.ClusterListItem{ID: "id-1", Name: "arm64-build", OrganisationID: "org-1"},
+		tokenErr: client.NewUnexpectedResponseError(403, `kube token request failed: status 403, body: {"detail":"You do not have access to this cluster"}`),
+	})
+	path := filepath.Join(t.TempDir(), "config")
+	resetKubeconfigFlags(path)
+	kubeconfigClusterFlag = "arm64-build"
+
+	var out bytes.Buffer
+	err := kubeconfigAdd(&out)
+	if err == nil {
+		t.Fatal("expected an error when the token mint is denied")
+	}
+	if !strings.Contains(err.Error(), "ankra cluster access grant <your-email> --cluster arm64-build --role view") {
+		t.Errorf("error = %v, want the access-grant suggestion", err)
+	}
+
+	// Embed-token mode mints per cluster through a different call site and
+	// must carry the same suggestion.
+	resetKubeconfigFlags(path)
+	kubeconfigClusterFlag = "arm64-build"
+	kubeconfigEmbedToken = true
+	err = kubeconfigAdd(&out)
+	if err == nil || !strings.Contains(err.Error(), "ankra cluster access grant <your-email> --cluster arm64-build --role view") {
+		t.Errorf("embed-token error = %v, want the access-grant suggestion", err)
 	}
 }
 


### PR DESCRIPTION
## What & why

When `ankra cluster kubeconfig add` or `ankra cluster kube-token` is rejected by the kube gateway with a 403, the CLI previously surfaced only the raw response:

```
Error: resolve kube proxy URL for arm64-build: kube token request failed: status 403, body: {"detail":"You do not have access to this cluster"}
```

That 403 means the caller has no access grant on the cluster — re-login won't help, but an organisation admin running `ankra cluster access grant` will. The error now says so and shows the exact invocation:

```
Error: resolve kube proxy URL for arm64-build: kube token request failed: status 403, body: {"detail":"You do not have access to this cluster"}
You have no access grant on this cluster. Ask an organisation admin to add one, then retry:
  ankra cluster access grant <your-email> --cluster arm64-build --role view
```

The hint is applied at all three token-mint sites (`kubeconfig add` exec mode, `--embed-token` mode, and `kube-token`). The original `UnexpectedResponseError` stays in the wrap chain, so exit-code classification is unchanged (still 6) and non-403 errors pass through untouched.

Bead: ankra-ju33

## Test plan

- New unit tests for the decorator: 403 gets the suggestion and keeps the 403/exit-code classification; 500 and transport errors pass through unchanged.
- New flow test through `kubeconfigAdd` covering both the exec-mode and embed-token mint sites.
- `go build ./...` and full `go test -race -count=1 ./...` green (pre-commit hook also ran golangci-lint).

## Docs checklist

- [x] No user-facing command/flag changes — no docs needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
