### PR TITLE
fix(cluster): point managed-cluster commands at a path the backend serves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@
 
 ### Fixed
 
+- **Every `ankra cluster managed` command now reaches the API instead of
+  failing with a 404.** The client built managed-cluster URLs under
+  `/api/v1/org/clusters/managed`, a path the backend never serves, so all
+  nine subcommands — create, deprovision, stop, start, upgrade, and the four
+  node-pool operations — failed with "not found" no matter what arguments
+  they were given. The client now calls the backend's token-authenticated
+  `/api/v1/clusters/managed` routes, which accept the CLI's bearer token and
+  serve every one of those operations.
+
 - **`ankra cluster kubeconfig add my-cluster` now works.** `kubeconfig add`
   and `kubeconfig remove` accept the cluster as a positional argument, the
   same way `ankra cluster select my-cluster` does. Previously the positional

--- a/internal/client/managed_clusters.go
+++ b/internal/client/managed_clusters.go
@@ -134,7 +134,7 @@ type UpgradeManagedK8sVersionResponse struct {
 }
 
 func (c *Client) managedClusterBasePath(provider ManagedK8sProvider) string {
-	return fmt.Sprintf("%s/api/v1/org/clusters/managed/%s", c.BaseURL, url.PathEscape(string(provider)))
+	return fmt.Sprintf("%s/api/v1/clusters/managed/%s", c.BaseURL, url.PathEscape(string(provider)))
 }
 
 func (c *Client) CreateManagedCluster(provider ManagedK8sProvider, request CreateManagedClusterRequest) (*CreateManagedClusterResponse, error) {

--- a/internal/client/managed_clusters_test.go
+++ b/internal/client/managed_clusters_test.go
@@ -16,8 +16,8 @@ func TestCreateManagedCluster_SendsKapsuleAndAutoscaling(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("method = %s, want POST", r.Method)
 		}
-		if r.URL.Path != "/api/v1/org/clusters/managed/kapsule" {
-			t.Errorf("path = %s, want /api/v1/org/clusters/managed/kapsule", r.URL.Path)
+		if r.URL.Path != "/api/v1/clusters/managed/kapsule" {
+			t.Errorf("path = %s, want /api/v1/clusters/managed/kapsule", r.URL.Path)
 		}
 		if err := json.NewDecoder(r.Body).Decode(&receivedBody); err != nil {
 			t.Fatalf("decode request body: %v", err)
@@ -97,7 +97,7 @@ func TestUpdateManagedNodePool_SendsPatchWithChangedFieldsOnly(t *testing.T) {
 		if r.Method != http.MethodPatch {
 			t.Errorf("method = %s, want PATCH", r.Method)
 		}
-		wantPath := "/api/v1/org/clusters/managed/kapsule/cluster-1/node-pools/workers"
+		wantPath := "/api/v1/clusters/managed/kapsule/cluster-1/node-pools/workers"
 		if r.URL.Path != wantPath {
 			t.Errorf("path = %s, want %s", r.URL.Path, wantPath)
 		}
@@ -197,7 +197,7 @@ func TestStopManagedCluster_PostsEmptyBody(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("method = %s, want POST", r.Method)
 		}
-		wantPath := "/api/v1/org/clusters/managed/aks/cluster-1/stop"
+		wantPath := "/api/v1/clusters/managed/aks/cluster-1/stop"
 		if r.URL.Path != wantPath {
 			t.Errorf("path = %s, want %s", r.URL.Path, wantPath)
 		}
@@ -225,7 +225,7 @@ func TestStartManagedCluster_Success(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("method = %s, want POST", r.Method)
 		}
-		wantPath := "/api/v1/org/clusters/managed/aks/cluster-1/start"
+		wantPath := "/api/v1/clusters/managed/aks/cluster-1/start"
 		if r.URL.Path != wantPath {
 			t.Errorf("path = %s, want %s", r.URL.Path, wantPath)
 		}


### PR DESCRIPTION
## What & why

Every `ankra cluster managed` subcommand — create, deprovision, stop, start, upgrade, and the four node-pool operations (add/scale/update/delete) — failed with a 404 regardless of arguments. The client built URLs under `/api/v1/org/clusters/managed/{provider}`, a path the backend never mounts: `managedk8sapi.Mount` serves these routes at the browser-session prefix `/org/clusters/managed` and the token-authenticated `/api/v1/clusters/managed`. The CLI authenticates with a bearer token, so the token lane is the correct twin — this PR drops the stray `/org` segment from `managedClusterBasePath` so all nine operations reach their handlers. Request/response shapes already matched field-for-field.

Found in the CLI/backend deep review 2026-07-27.

Bead: ankra-9bd8

## Test plan

- Updated the path expectations in `internal/client/managed_clusters_test.go` (the tests had pinned the broken path).
- `go test ./...` and `golangci-lint run` green via the pre-commit hook.
- Cross-checked all nine CLI operations against the `apiPrefix` route list in `cluster/go/internal/managedk8sapi/managedk8sapi.go` — each one (POST create, DELETE deprovision, node-pools POST/scale/PATCH/DELETE, stop, start, upgrade) is mounted under `/api/v1/clusters/managed`.

## Docs checklist

- [x] No user-facing command/flag changes — no docs needed
- [ ] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); ensure `Short`/`Long`/`Example` on new commands are written for docs readers
- [ ] Broader behaviour changes — docs updated in [ankra-docs](https://github.com/ankraio/ankra-docs) (link the PR): <!-- PR link -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
