### PR TITLE
fix(cluster): stop encrypt -f and clone deleting fields from cluster.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@
 
 ### Fixed
 
+- **`ankra cluster encrypt -f` and `ankra cluster clone` no longer strip
+  fields and comments from your cluster YAML.** Both commands used to rewrite
+  the file by re-serialising an internal struct, which silently deleted
+  anything the struct didn't model — `deploy_wave` on stacks and
+  `spec.prometheus_metrics` were lost outright, and comments, anchors, and key
+  ordering were destroyed — corrupting a file that is often the GitOps source
+  of truth. The commands now edit the parsed YAML document in place, touching
+  only the nodes they change: encrypting adds the key to `encrypted_paths` and
+  nothing else, and cloning grafts the source's stack entries verbatim
+  (comments and all) into the target file.
+
 - **`ankra cluster kubeconfig add my-cluster` now works.** `kubeconfig add`
   and `kubeconfig remove` accept the cluster as a positional argument, the
   same way `ankra cluster select my-cluster` does. Previously the positional

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -129,6 +129,11 @@ func runClone(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("existing file is not an ImportCluster (kind: %s)", existingCluster.Kind)
 	}
 
+	existingDoc, err := parseClusterYAMLDoc(existingData)
+	if err != nil {
+		return fmt.Errorf("failed to parse existing cluster YAML: %w", err)
+	}
+
 	if len(stackFlag) > 0 {
 		availableStacks := make(map[string]bool)
 		for _, stack := range existingCluster.Spec.Stacks {
@@ -151,8 +156,12 @@ func runClone(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Read or create new cluster
+	// Read or create new cluster. The struct view drives lookups and the
+	// summary; the document node is what gets written back, so fields the
+	// structs do not model (deploy_wave, prometheus_metrics, future keys),
+	// comments, and ordering survive the rewrite.
 	var newCluster ImportClusterConfig
+	var newDoc *yaml.Node
 	var newClusterExists bool
 
 	if _, err := os.Stat(newClusterPath); err == nil {
@@ -169,6 +178,10 @@ func runClone(cmd *cobra.Command, args []string) error {
 		if newCluster.Kind != "ImportCluster" {
 			return fmt.Errorf("new file is not an ImportCluster (kind: %s)", newCluster.Kind)
 		}
+
+		if newDoc, err = parseClusterYAMLDoc(newData); err != nil {
+			return fmt.Errorf("failed to parse new cluster YAML: %w", err)
+		}
 	} else {
 		// Create new cluster structure
 		newCluster = ImportClusterConfig{
@@ -183,18 +196,21 @@ func runClone(cmd *cobra.Command, args []string) error {
 				Stacks:        []StackConfig{},
 			},
 		}
+		if newDoc, err = newImportClusterDoc(newCluster.Metadata.Name, newCluster.Metadata.Description, existingDoc); err != nil {
+			return fmt.Errorf("failed to build new cluster YAML: %w", err)
+		}
 	}
 
 	// Get base directories
 	newBaseDir := filepath.Dir(newClusterPath)
 
 	// Clone stacks with conflict resolution
-	if err := cloneStacks(&existingCluster, &newCluster, existingBaseDir, newBaseDir, isURL(existingFileOrURL)); err != nil {
+	if err := cloneStacks(&existingCluster, &newCluster, existingDoc, newDoc, existingBaseDir, newBaseDir, isURL(existingFileOrURL)); err != nil {
 		return fmt.Errorf("failed to clone stacks: %w", err)
 	}
 
 	// Write the new cluster file
-	if err := writeClusterFile(newClusterPath, &newCluster); err != nil {
+	if err := writeClusterFile(newClusterPath, newDoc); err != nil {
 		return fmt.Errorf("failed to write new cluster file: %w", err)
 	}
 
@@ -384,9 +400,23 @@ func downloadFileFromURL(baseURL, relPath, dstPath string) error {
 	return nil
 }
 
-func cloneStacks(existing, new *ImportClusterConfig, existingBaseDir, newBaseDir string, fromURL bool) error {
+// cloneStacks merges stacks from the existing cluster into the new one. The
+// struct views drive name/conflict decisions; every mutation is mirrored onto
+// the target document node (newDoc) by grafting the source's stack nodes, so
+// the written file keeps fields, comments, and ordering the structs would drop.
+func cloneStacks(existing, new *ImportClusterConfig, existingDoc, newDoc *yaml.Node, existingBaseDir, newBaseDir string, fromURL bool) error {
+	sourceStacks, err := clusterStacksNode(existingDoc, false)
+	if err != nil {
+		return err
+	}
+	targetStacks, err := clusterStacksNode(newDoc, true)
+	if err != nil {
+		return err
+	}
+
 	if cleanFlag {
 		new.Spec.Stacks = []StackConfig{}
+		targetStacks.Content = nil
 	}
 
 	existingStackNames := getStackNames(new.Spec.Stacks)
@@ -404,7 +434,7 @@ func cloneStacks(existing, new *ImportClusterConfig, existingBaseDir, newBaseDir
 	stacksSkipped := 0
 	stacksFiltered := 0
 
-	for _, existingStack := range existing.Spec.Stacks {
+	for stackIdx, existingStack := range existing.Spec.Stacks {
 		if len(stackFlag) > 0 && !requestedStacks[existingStack.Name] {
 			fmt.Printf("Filtering out stack %q - not in requested list\n", existingStack.Name)
 			stacksFiltered++
@@ -453,6 +483,11 @@ func cloneStacks(existing, new *ImportClusterConfig, existingBaseDir, newBaseDir
 			return fmt.Errorf("failed to copy files for stack %q: %w", clonedStack.Name, err)
 		}
 
+		if sourceStacks == nil || stackIdx >= len(sourceStacks.Content) {
+			return fmt.Errorf("internal error: no YAML node for source stack %q", existingStack.Name)
+		}
+		clonedStackNode := deepCopyYAMLNode(sourceStacks.Content[stackIdx])
+
 		if forceFlag && existingStackNames[existingStack.Name] {
 			for i, stack := range new.Spec.Stacks {
 				if stack.Name == existingStack.Name {
@@ -460,8 +495,20 @@ func cloneStacks(existing, new *ImportClusterConfig, existingBaseDir, newBaseDir
 					break
 				}
 			}
+			replaced := false
+			for i, item := range targetStacks.Content {
+				if stackNodeName(item) == existingStack.Name {
+					targetStacks.Content[i] = clonedStackNode
+					replaced = true
+					break
+				}
+			}
+			if !replaced {
+				return fmt.Errorf("internal error: stack %q not found in target YAML for --force replace", existingStack.Name)
+			}
 		} else {
 			new.Spec.Stacks = append(new.Spec.Stacks, clonedStack)
+			targetStacks.Content = append(targetStacks.Content, clonedStackNode)
 		}
 
 		stacksAdded++
@@ -647,7 +694,10 @@ func generateNewClusterName(existingName string) string {
 	return existingName + "-cloned"
 }
 
-func writeClusterFile(path string, cluster *ImportClusterConfig) error {
+// writeClusterFile encodes a parsed cluster document node back to disk.
+// Callers mutate the node tree rather than the ImportClusterConfig structs so
+// fields the CLI does not model, comments, and key ordering survive the write.
+func writeClusterFile(path string, doc *yaml.Node) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("failed to create directory %q: %w", dir, err)
@@ -657,7 +707,7 @@ func writeClusterFile(path string, cluster *ImportClusterConfig) error {
 	encoder := yaml.NewEncoder(&buf)
 	encoder.SetIndent(2)
 
-	if err := encoder.Encode(cluster); err != nil {
+	if err := encoder.Encode(doc); err != nil {
 		return fmt.Errorf("failed to marshal cluster YAML: %w", err)
 	}
 	if err := encoder.Close(); err != nil {

--- a/cmd/clone_integration_test.go
+++ b/cmd/clone_integration_test.go
@@ -8,6 +8,21 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// mustClusterDoc builds the document-node view of a cluster config the same
+// way runClone does for files on disk: marshal, then parse into a yaml.Node.
+func mustClusterDoc(t *testing.T, cluster *ImportClusterConfig) *yaml.Node {
+	t.Helper()
+	data, err := yaml.Marshal(cluster)
+	if err != nil {
+		t.Fatalf("marshal cluster config: %v", err)
+	}
+	doc, err := parseClusterYAMLDoc(data)
+	if err != nil {
+		t.Fatalf("parse cluster config: %v", err)
+	}
+	return doc
+}
+
 func TestCloneStacks_CleanFlag(t *testing.T) {
 	tmpDir := t.TempDir()
 	srcDir := filepath.Join(tmpDir, "src")
@@ -47,7 +62,7 @@ func TestCloneStacks_CleanFlag(t *testing.T) {
 	stackFlag = []string{}
 	t.Cleanup(func() { stackFlag = originalStack })
 
-	if err := cloneStacks(existing, target, srcDir, dstDir, false); err != nil {
+	if err := cloneStacks(existing, target, mustClusterDoc(t, existing), mustClusterDoc(t, target), srcDir, dstDir, false); err != nil {
 		t.Fatalf("cloneStacks failed: %v", err)
 	}
 
@@ -91,7 +106,7 @@ func TestCloneStacks_SkipConflictingNames(t *testing.T) {
 	copyMissingFlag = false
 	t.Cleanup(func() { copyMissingFlag = originalCopyMissing })
 
-	if err := cloneStacks(existing, target, tmpDir, tmpDir, false); err != nil {
+	if err := cloneStacks(existing, target, mustClusterDoc(t, existing), mustClusterDoc(t, target), tmpDir, tmpDir, false); err != nil {
 		t.Fatalf("cloneStacks failed: %v", err)
 	}
 
@@ -130,7 +145,7 @@ func TestCloneStacks_ForceOverride(t *testing.T) {
 	stackFlag = []string{}
 	t.Cleanup(func() { stackFlag = originalStack })
 
-	if err := cloneStacks(existing, target, tmpDir, tmpDir, false); err != nil {
+	if err := cloneStacks(existing, target, mustClusterDoc(t, existing), mustClusterDoc(t, target), tmpDir, tmpDir, false); err != nil {
 		t.Fatalf("cloneStacks failed: %v", err)
 	}
 
@@ -172,7 +187,7 @@ func TestCloneStacks_StackFilter(t *testing.T) {
 	stackFlag = []string{"monitoring", "storage"}
 	t.Cleanup(func() { stackFlag = originalStack })
 
-	if err := cloneStacks(existing, target, tmpDir, tmpDir, false); err != nil {
+	if err := cloneStacks(existing, target, mustClusterDoc(t, existing), mustClusterDoc(t, target), tmpDir, tmpDir, false); err != nil {
 		t.Fatalf("cloneStacks failed: %v", err)
 	}
 
@@ -291,7 +306,7 @@ func TestWriteClusterFile_RoundTrip(t *testing.T) {
 		},
 	}
 
-	if err := writeClusterFile(outputPath, original); err != nil {
+	if err := writeClusterFile(outputPath, mustClusterDoc(t, original)); err != nil {
 		t.Fatalf("writeClusterFile failed: %v", err)
 	}
 

--- a/cmd/cluster_encrypt.go
+++ b/cmd/cluster_encrypt.go
@@ -326,14 +326,12 @@ func runEncryptManifestFile(cmd *cobra.Command, manifestName, leafKey string) er
 
 	// Find the manifest across all stacks
 	var foundManifest *ManifestConfig
-	var foundStackIdx, foundManifestIdx int
 
-	for stackIdx, stack := range cluster.Spec.Stacks {
-		for manifestIdx, manifest := range stack.Manifests {
-			if manifest.Name == manifestName {
-				foundManifest = &cluster.Spec.Stacks[stackIdx].Manifests[manifestIdx]
-				foundStackIdx = stackIdx
-				foundManifestIdx = manifestIdx
+	for stackIdx := range cluster.Spec.Stacks {
+		manifests := cluster.Spec.Stacks[stackIdx].Manifests
+		for manifestIdx := range manifests {
+			if manifests[manifestIdx].Name == manifestName {
+				foundManifest = &manifests[manifestIdx]
 				break
 			}
 		}
@@ -378,15 +376,19 @@ func runEncryptManifestFile(cmd *cobra.Command, manifestName, leafKey string) er
 
 	fmt.Printf("Updated manifest file: %s\n", manifestFilePath)
 
-	// Update the cluster YAML with encrypted_paths
+	// Update the cluster YAML with encrypted_paths. The file is mutated at
+	// the yaml.Node level so fields the CLI structs do not model
+	// (deploy_wave, prometheus_metrics, future keys), comments, and ordering
+	// survive the rewrite of this GitOps source of truth.
 	if !containsString(foundManifest.EncryptedPaths, leafKey) {
-		cluster.Spec.Stacks[foundStackIdx].Manifests[foundManifestIdx].EncryptedPaths = append(
-			cluster.Spec.Stacks[foundStackIdx].Manifests[foundManifestIdx].EncryptedPaths,
-			leafKey,
-		)
-
-		// Write the updated cluster YAML
-		if err := writeClusterFile(encryptClusterFile, &cluster); err != nil {
+		clusterDoc, err := parseClusterYAMLDoc(clusterData)
+		if err != nil {
+			return fmt.Errorf("failed to update cluster file: %w", err)
+		}
+		if err := appendManifestEncryptedPath(clusterDoc, manifestName, leafKey); err != nil {
+			return fmt.Errorf("failed to update cluster file: %w", err)
+		}
+		if err := writeClusterFile(encryptClusterFile, clusterDoc); err != nil {
 			return fmt.Errorf("failed to update cluster file: %w", err)
 		}
 
@@ -428,14 +430,12 @@ func runEncryptAddonFile(cmd *cobra.Command, leafKey string) error {
 
 	// Find the addon across all stacks
 	var foundAddon *AddonConfig
-	var foundStackIdx, foundAddonIdx int
 
-	for stackIdx, stack := range cluster.Spec.Stacks {
-		for addonIdx, addon := range stack.Addons {
-			if addon.Name == encryptAddonName {
-				foundAddon = &cluster.Spec.Stacks[stackIdx].Addons[addonIdx]
-				foundStackIdx = stackIdx
-				foundAddonIdx = addonIdx
+	for stackIdx := range cluster.Spec.Stacks {
+		addons := cluster.Spec.Stacks[stackIdx].Addons
+		for addonIdx := range addons {
+			if addons[addonIdx].Name == encryptAddonName {
+				foundAddon = &addons[addonIdx]
 				break
 			}
 		}
@@ -486,14 +486,20 @@ func runEncryptAddonFile(cmd *cobra.Command, leafKey string) error {
 
 	fmt.Printf("Updated addon configuration file: %s\n", addonFilePath)
 
-	// Update the cluster YAML with encrypted_paths in the configuration
+	// Update the cluster YAML with encrypted_paths in the configuration. The
+	// file is mutated at the yaml.Node level so fields the CLI structs do not
+	// model (deploy_wave, prometheus_metrics, future keys), comments, and
+	// ordering survive the rewrite of this GitOps source of truth.
 	encryptedPaths := getEncryptedPathsFromConfig(foundAddon.Configuration)
 	if !containsString(encryptedPaths, leafKey) {
-		encryptedPaths = append(encryptedPaths, leafKey)
-		cluster.Spec.Stacks[foundStackIdx].Addons[foundAddonIdx].Configuration["encrypted_paths"] = encryptedPaths
-
-		// Write the updated cluster YAML
-		if err := writeClusterFile(encryptClusterFile, &cluster); err != nil {
+		clusterDoc, err := parseClusterYAMLDoc(clusterData)
+		if err != nil {
+			return fmt.Errorf("failed to update cluster file: %w", err)
+		}
+		if err := appendAddonEncryptedPath(clusterDoc, encryptAddonName, leafKey); err != nil {
+			return fmt.Errorf("failed to update cluster file: %w", err)
+		}
+		if err := writeClusterFile(encryptClusterFile, clusterDoc); err != nil {
 			return fmt.Errorf("failed to update cluster file: %w", err)
 		}
 

--- a/cmd/cluster_yaml_edit.go
+++ b/cmd/cluster_yaml_edit.go
@@ -1,0 +1,273 @@
+package cmd
+
+// Node-level editing for ImportCluster YAML files.
+//
+// `cluster encrypt -f` and `cluster clone` rewrite cluster.yaml files that are
+// often a GitOps source of truth. Round-tripping them through the
+// ImportClusterConfig structs silently deletes everything the structs do not
+// model (stack deploy_wave, spec.prometheus_metrics, any field added after the
+// structs were written) along with comments, anchors, and key ordering. The
+// helpers here instead mutate the parsed yaml.Node tree so only the touched
+// nodes change; the structs remain read-side lookups only.
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// parseClusterYAMLDoc parses raw cluster YAML into a document node, preserving
+// comments and ordering for round-trip re-encoding.
+func parseClusterYAMLDoc(data []byte) (*yaml.Node, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse cluster YAML: %w", err)
+	}
+	return &doc, nil
+}
+
+// clusterDocRoot returns the root mapping of a parsed cluster document.
+func clusterDocRoot(doc *yaml.Node) (*yaml.Node, error) {
+	node := doc
+	if node.Kind == yaml.DocumentNode {
+		if len(node.Content) == 0 {
+			return nil, fmt.Errorf("cluster YAML document is empty")
+		}
+		node = node.Content[0]
+	}
+	node = resolveYAMLAlias(node)
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("cluster YAML root is not a mapping")
+	}
+	return node, nil
+}
+
+// resolveYAMLAlias follows alias nodes to the anchored node they reference.
+func resolveYAMLAlias(node *yaml.Node) *yaml.Node {
+	for node != nil && node.Kind == yaml.AliasNode {
+		node = node.Alias
+	}
+	return node
+}
+
+// yamlMapValue returns the value node for key in a mapping (aliases resolved),
+// or nil when the mapping or key is absent.
+func yamlMapValue(mapping *yaml.Node, key string) *yaml.Node {
+	if mapping == nil || mapping.Kind != yaml.MappingNode {
+		return nil
+	}
+	idx := mapIndexOf(mapping, key)
+	if idx < 0 {
+		return nil
+	}
+	return resolveYAMLAlias(mapping.Content[idx+1])
+}
+
+// yamlMapString returns the scalar string value for key, or "".
+func yamlMapString(mapping *yaml.Node, key string) string {
+	value := yamlMapValue(mapping, key)
+	if value == nil || value.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return value.Value
+}
+
+// yamlMapEnsure returns the value node for key, appending an empty node of the
+// requested kind when the key is absent. A null placeholder value (e.g. a bare
+// `stacks:` line) is converted in place, mirroring ApplySetAssignments.
+func yamlMapEnsure(mapping *yaml.Node, key string, kind yaml.Kind, tag string) (*yaml.Node, error) {
+	if mapping == nil || mapping.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("cannot add %q: parent is not a mapping", key)
+	}
+	idx := mapIndexOf(mapping, key)
+	if idx < 0 {
+		value := &yaml.Node{Kind: kind, Tag: tag}
+		mapping.Content = append(mapping.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+			value)
+		return value, nil
+	}
+	value := resolveYAMLAlias(mapping.Content[idx+1])
+	if value.Kind == yaml.ScalarNode && (value.Tag == "!!null" || value.Value == "") {
+		value.Kind = kind
+		value.Tag = tag
+		value.Value = ""
+		value.Content = nil
+	}
+	if value.Kind != kind {
+		return nil, fmt.Errorf("%q is a %s, expected a %s", key, kindName(value.Kind), kindName(kind))
+	}
+	return value, nil
+}
+
+// clusterStacksNode returns the spec.stacks sequence of doc. With create set,
+// missing spec/stacks keys are added; otherwise nil is returned when the path
+// does not resolve to a sequence.
+func clusterStacksNode(doc *yaml.Node, create bool) (*yaml.Node, error) {
+	root, err := clusterDocRoot(doc)
+	if err != nil {
+		return nil, err
+	}
+	if !create {
+		stacks := yamlMapValue(yamlMapValue(root, "spec"), "stacks")
+		if stacks == nil || stacks.Kind != yaml.SequenceNode {
+			return nil, nil
+		}
+		return stacks, nil
+	}
+	spec, err := yamlMapEnsure(root, "spec", yaml.MappingNode, "!!map")
+	if err != nil {
+		return nil, err
+	}
+	return yamlMapEnsure(spec, "stacks", yaml.SequenceNode, "!!seq")
+}
+
+// stackNodeName returns the name field of a spec.stacks[] item.
+func stackNodeName(item *yaml.Node) string {
+	return yamlMapString(resolveYAMLAlias(item), "name")
+}
+
+// findClusterListEntry walks spec.stacks[*].<listKey> for the first mapping
+// entry whose name equals name — the same first-match order as the
+// struct-based lookups in cluster_encrypt.go.
+func findClusterListEntry(doc *yaml.Node, listKey, name string) (*yaml.Node, error) {
+	stacks, err := clusterStacksNode(doc, false)
+	if err != nil {
+		return nil, err
+	}
+	if stacks == nil {
+		return nil, nil
+	}
+	for _, stackItem := range stacks.Content {
+		list := yamlMapValue(resolveYAMLAlias(stackItem), listKey)
+		if list == nil || list.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, item := range list.Content {
+			entry := resolveYAMLAlias(item)
+			if entry != nil && entry.Kind == yaml.MappingNode && yamlMapString(entry, "name") == name {
+				return entry, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+// appendManifestEncryptedPath records leafKey in the encrypted_paths list of
+// the named manifest, creating the list when missing. Nothing else in the
+// document is touched.
+func appendManifestEncryptedPath(doc *yaml.Node, manifestName, leafKey string) error {
+	manifest, err := findClusterListEntry(doc, "manifests", manifestName)
+	if err != nil {
+		return err
+	}
+	if manifest == nil {
+		return fmt.Errorf("manifest %q not found in cluster YAML", manifestName)
+	}
+	return appendYAMLStringListEntry(manifest, "encrypted_paths", leafKey)
+}
+
+// appendAddonEncryptedPath records leafKey in the configuration.encrypted_paths
+// list of the named addon.
+func appendAddonEncryptedPath(doc *yaml.Node, addonName, leafKey string) error {
+	addon, err := findClusterListEntry(doc, "addons", addonName)
+	if err != nil {
+		return err
+	}
+	if addon == nil {
+		return fmt.Errorf("addon %q not found in cluster YAML", addonName)
+	}
+	configuration := yamlMapValue(addon, "configuration")
+	if configuration == nil || configuration.Kind != yaml.MappingNode {
+		return fmt.Errorf("addon %q has no configuration mapping in cluster YAML", addonName)
+	}
+	return appendYAMLStringListEntry(configuration, "encrypted_paths", leafKey)
+}
+
+func appendYAMLStringListEntry(mapping *yaml.Node, key, value string) error {
+	list, err := yamlMapEnsure(mapping, key, yaml.SequenceNode, "!!seq")
+	if err != nil {
+		return err
+	}
+	list.Content = append(list.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value})
+	return nil
+}
+
+// deepCopyYAMLNode returns a copy of n that is safe to graft into another
+// document. Aliases whose anchor lives inside the copied subtree keep pointing
+// at the copied anchor; aliases to anchors outside the subtree are expanded
+// inline, since their definition would not exist in the destination document.
+func deepCopyYAMLNode(n *yaml.Node) *yaml.Node {
+	return copyYAMLNode(n, map[*yaml.Node]*yaml.Node{})
+}
+
+func copyYAMLNode(n *yaml.Node, copies map[*yaml.Node]*yaml.Node) *yaml.Node {
+	if n == nil {
+		return nil
+	}
+	if copied, ok := copies[n]; ok {
+		return copied
+	}
+	if n.Kind == yaml.AliasNode {
+		// Anchors are defined before their aliases in document order, so an
+		// in-subtree anchor has already been copied by the time its alias is
+		// visited.
+		if target, ok := copies[n.Alias]; ok {
+			aliasCopy := *n
+			aliasCopy.Alias = target
+			copies[n] = &aliasCopy
+			return &aliasCopy
+		}
+		expanded := copyYAMLNode(n.Alias, copies)
+		copies[n] = expanded
+		return expanded
+	}
+	nodeCopy := *n
+	copies[n] = &nodeCopy
+	if len(n.Content) > 0 {
+		nodeCopy.Content = make([]*yaml.Node, len(n.Content))
+		for i, child := range n.Content {
+			nodeCopy.Content[i] = copyYAMLNode(child, copies)
+		}
+	}
+	return &nodeCopy
+}
+
+// newImportClusterDoc builds a fresh ImportCluster document for a clone
+// target, carrying over the source's spec.git_repository node (comments,
+// unknown keys and all) when present.
+func newImportClusterDoc(name, description string, sourceDoc *yaml.Node) (*yaml.Node, error) {
+	metadata := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	appendYAMLMapEntry(metadata, "name", yamlStringNode(name))
+	if description != "" {
+		appendYAMLMapEntry(metadata, "description", yamlStringNode(description))
+	}
+
+	sourceRoot, err := clusterDocRoot(sourceDoc)
+	if err != nil {
+		return nil, err
+	}
+	spec := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	if gitRepository := yamlMapValue(yamlMapValue(sourceRoot, "spec"), "git_repository"); gitRepository != nil {
+		appendYAMLMapEntry(spec, "git_repository", deepCopyYAMLNode(gitRepository))
+	}
+	appendYAMLMapEntry(spec, "stacks", &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"})
+
+	root := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	appendYAMLMapEntry(root, "apiVersion", yamlStringNode("v1"))
+	appendYAMLMapEntry(root, "kind", yamlStringNode("ImportCluster"))
+	appendYAMLMapEntry(root, "metadata", metadata)
+	appendYAMLMapEntry(root, "spec", spec)
+
+	return &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}, nil
+}
+
+func appendYAMLMapEntry(mapping *yaml.Node, key string, value *yaml.Node) {
+	mapping.Content = append(mapping.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		value)
+}
+
+func yamlStringNode(value string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value}
+}

--- a/cmd/cluster_yaml_edit_test.go
+++ b/cmd/cluster_yaml_edit_test.go
@@ -1,0 +1,398 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// The regression scenario behind these tests (bead ankra-qh3z): cluster.yaml
+// files rewritten by `cluster encrypt -f` and `cluster clone` used to be
+// round-tripped through the ImportClusterConfig structs, silently deleting
+// stack deploy_wave, spec.prometheus_metrics, comments, and ordering from a
+// GitOps source of truth.
+
+const preservationClusterYAML = `apiVersion: v1
+kind: ImportCluster
+metadata:
+  name: prod
+spec:
+  # prometheus scraping for this cluster
+  prometheus_metrics:
+    endpoint: https://prom.example.com
+    flavor: victoriametrics
+  stacks:
+    - name: core
+      deploy_wave: 2 # after networking
+      manifests:
+        - name: db-secret
+          from_file: manifests/secret.yaml
+      addons:
+        - name: grafana
+          chart_name: grafana
+          chart_version: "7.0.0"
+          configuration:
+            from_file: values/grafana.yaml
+`
+
+func encodeClusterDoc(t *testing.T, doc *yaml.Node) string {
+	t.Helper()
+	var buf strings.Builder
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(doc); err != nil {
+		t.Fatalf("encode cluster doc: %v", err)
+	}
+	if err := encoder.Close(); err != nil {
+		t.Fatalf("close encoder: %v", err)
+	}
+	return buf.String()
+}
+
+func assertContainsAll(t *testing.T, output string, wants []string) {
+	t.Helper()
+	for _, want := range wants {
+		if !strings.Contains(output, want) {
+			t.Errorf("output is missing %q\n---\n%s", want, output)
+		}
+	}
+}
+
+func TestAppendManifestEncryptedPath_PreservesUnmodeledFields(t *testing.T) {
+	doc, err := parseClusterYAMLDoc([]byte(preservationClusterYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := appendManifestEncryptedPath(doc, "db-secret", "password"); err != nil {
+		t.Fatalf("appendManifestEncryptedPath failed: %v", err)
+	}
+
+	output := encodeClusterDoc(t, doc)
+	assertContainsAll(t, output, []string{
+		"prometheus_metrics:",
+		"endpoint: https://prom.example.com",
+		"deploy_wave: 2",
+		"# prometheus scraping for this cluster",
+		"# after networking",
+	})
+
+	var roundTripped ImportClusterConfig
+	if err := yaml.Unmarshal([]byte(output), &roundTripped); err != nil {
+		t.Fatalf("parse output: %v", err)
+	}
+	paths := roundTripped.Spec.Stacks[0].Manifests[0].EncryptedPaths
+	if len(paths) != 1 || paths[0] != "password" {
+		t.Errorf("encrypted_paths = %v, want [password]", paths)
+	}
+}
+
+func TestAppendManifestEncryptedPath_AppendsToExistingList(t *testing.T) {
+	clusterYAML := strings.Replace(preservationClusterYAML,
+		"          from_file: manifests/secret.yaml\n",
+		"          from_file: manifests/secret.yaml\n          encrypted_paths:\n            - username\n", 1)
+	doc, err := parseClusterYAMLDoc([]byte(clusterYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := appendManifestEncryptedPath(doc, "db-secret", "password"); err != nil {
+		t.Fatalf("appendManifestEncryptedPath failed: %v", err)
+	}
+
+	var roundTripped ImportClusterConfig
+	if err := yaml.Unmarshal([]byte(encodeClusterDoc(t, doc)), &roundTripped); err != nil {
+		t.Fatalf("parse output: %v", err)
+	}
+	paths := roundTripped.Spec.Stacks[0].Manifests[0].EncryptedPaths
+	if len(paths) != 2 || paths[0] != "username" || paths[1] != "password" {
+		t.Errorf("encrypted_paths = %v, want [username password]", paths)
+	}
+}
+
+func TestAppendManifestEncryptedPath_MissingManifest(t *testing.T) {
+	doc, err := parseClusterYAMLDoc([]byte(preservationClusterYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := appendManifestEncryptedPath(doc, "nonexistent", "password"); err == nil {
+		t.Error("expected error for missing manifest")
+	}
+}
+
+func TestAppendAddonEncryptedPath_PreservesUnmodeledFields(t *testing.T) {
+	doc, err := parseClusterYAMLDoc([]byte(preservationClusterYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := appendAddonEncryptedPath(doc, "grafana", "adminPassword"); err != nil {
+		t.Fatalf("appendAddonEncryptedPath failed: %v", err)
+	}
+
+	output := encodeClusterDoc(t, doc)
+	assertContainsAll(t, output, []string{
+		"prometheus_metrics:",
+		"deploy_wave: 2",
+		"# after networking",
+	})
+
+	var roundTripped ImportClusterConfig
+	if err := yaml.Unmarshal([]byte(output), &roundTripped); err != nil {
+		t.Fatalf("parse output: %v", err)
+	}
+	paths := getEncryptedPathsFromConfig(roundTripped.Spec.Stacks[0].Addons[0].Configuration)
+	if len(paths) != 1 || paths[0] != "adminPassword" {
+		t.Errorf("configuration.encrypted_paths = %v, want [adminPassword]", paths)
+	}
+}
+
+func setCloneFlags(t *testing.T, clean, force, copyMissing bool, stacks []string) {
+	t.Helper()
+	originalClean, originalForce, originalCopyMissing, originalStack := cleanFlag, forceFlag, copyMissingFlag, stackFlag
+	cleanFlag, forceFlag, copyMissingFlag, stackFlag = clean, force, copyMissing, stacks
+	t.Cleanup(func() {
+		cleanFlag, forceFlag, copyMissingFlag, stackFlag = originalClean, originalForce, originalCopyMissing, originalStack
+	})
+}
+
+const cloneSourceClusterYAML = `apiVersion: v1
+kind: ImportCluster
+metadata:
+  name: source-cluster
+spec:
+  git_repository:
+    provider: github
+    credential_name: gh
+    branch: main
+    future_field: keep-me
+  stacks:
+    - name: monitoring
+      deploy_wave: 3 # deploy last
+      manifests:
+        - name: grafana-ns
+          from_file: manifests/ns.yaml
+`
+
+func writeCloneSource(t *testing.T) string {
+	t.Helper()
+	srcDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(srcDir, "manifests"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "manifests", "ns.yaml"), []byte("kind: Namespace"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcPath := filepath.Join(srcDir, "cluster.yaml")
+	if err := os.WriteFile(srcPath, []byte(cloneSourceClusterYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return srcPath
+}
+
+func TestRunClone_ExistingTargetPreservesUnmodeledFields(t *testing.T) {
+	srcPath := writeCloneSource(t)
+
+	dstDir := t.TempDir()
+	dstPath := filepath.Join(dstDir, "cluster.yaml")
+	targetYAML := `apiVersion: v1
+kind: ImportCluster
+metadata:
+  name: target-cluster
+spec:
+  # keep prometheus wired
+  prometheus_metrics:
+    endpoint: https://prom.target.example
+  stacks:
+    - name: networking
+      deploy_wave: 1
+      manifests:
+        - name: ingress
+          from_file: manifests/ingress.yaml
+`
+	if err := os.WriteFile(dstPath, []byte(targetYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	setCloneFlags(t, false, false, false, []string{})
+
+	if err := runClone(nil, []string{srcPath, dstPath}); err != nil {
+		t.Fatalf("runClone failed: %v", err)
+	}
+
+	written, err := os.ReadFile(dstPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertContainsAll(t, string(written), []string{
+		"# keep prometheus wired",
+		"prometheus_metrics:",
+		"endpoint: https://prom.target.example",
+		"deploy_wave: 1",
+		"deploy_wave: 3",
+		"# deploy last",
+	})
+
+	var result ImportClusterConfig
+	if err := yaml.Unmarshal(written, &result); err != nil {
+		t.Fatalf("parse written target: %v", err)
+	}
+	if len(result.Spec.Stacks) != 2 {
+		t.Fatalf("stacks = %d, want 2 (networking + monitoring)", len(result.Spec.Stacks))
+	}
+}
+
+func TestRunClone_ForceReplacePreservesUnmodeledFields(t *testing.T) {
+	srcPath := writeCloneSource(t)
+
+	dstDir := t.TempDir()
+	dstPath := filepath.Join(dstDir, "cluster.yaml")
+	targetYAML := `apiVersion: v1
+kind: ImportCluster
+metadata:
+  name: target-cluster
+spec:
+  prometheus_metrics:
+    endpoint: https://prom.target.example
+  stacks:
+    - name: monitoring
+      deploy_wave: 1
+      manifests:
+        - name: old-ns
+          from_file: manifests/old.yaml
+`
+	if err := os.WriteFile(dstPath, []byte(targetYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	setCloneFlags(t, false, true, false, []string{})
+
+	if err := runClone(nil, []string{srcPath, dstPath}); err != nil {
+		t.Fatalf("runClone failed: %v", err)
+	}
+
+	written, err := os.ReadFile(dstPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertContainsAll(t, string(written), []string{
+		"prometheus_metrics:",
+		"deploy_wave: 3",
+		"# deploy last",
+	})
+
+	var result ImportClusterConfig
+	if err := yaml.Unmarshal(written, &result); err != nil {
+		t.Fatalf("parse written target: %v", err)
+	}
+	if len(result.Spec.Stacks) != 1 {
+		t.Fatalf("stacks = %d, want 1 (replaced monitoring)", len(result.Spec.Stacks))
+	}
+	if name := result.Spec.Stacks[0].Manifests[0].Name; name != "grafana-ns" {
+		t.Errorf("replaced stack manifest = %q, want %q", name, "grafana-ns")
+	}
+}
+
+func TestRunClone_NewTargetCarriesUnmodeledFields(t *testing.T) {
+	srcPath := writeCloneSource(t)
+
+	dstDir := t.TempDir()
+	dstPath := filepath.Join(dstDir, "new-cluster.yaml")
+
+	setCloneFlags(t, false, false, false, []string{})
+
+	if err := runClone(nil, []string{srcPath, dstPath}); err != nil {
+		t.Fatalf("runClone failed: %v", err)
+	}
+
+	written, err := os.ReadFile(dstPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertContainsAll(t, string(written), []string{
+		"kind: ImportCluster",
+		"future_field: keep-me",
+		"deploy_wave: 3",
+		"# deploy last",
+	})
+
+	var result ImportClusterConfig
+	if err := yaml.Unmarshal(written, &result); err != nil {
+		t.Fatalf("parse written target: %v", err)
+	}
+	if result.Metadata.Name != "source-cloned-cluster" {
+		t.Errorf("metadata.name = %q, want %q", result.Metadata.Name, "source-cloned-cluster")
+	}
+	if len(result.Spec.Stacks) != 1 {
+		t.Fatalf("stacks = %d, want 1", len(result.Spec.Stacks))
+	}
+}
+
+type encryptFileMock struct {
+	baseMock
+	encrypted string
+}
+
+func (m encryptFileMock) EncryptYAML(yamlContent string, encryptedPaths []string) (string, error) {
+	return m.encrypted, nil
+}
+
+func TestRunEncryptManifestFile_PreservesUnmodeledFields(t *testing.T) {
+	dir := t.TempDir()
+	clusterPath := filepath.Join(dir, "cluster.yaml")
+	if err := os.WriteFile(clusterPath, []byte(preservationClusterYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "manifests"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(dir, "manifests", "secret.yaml")
+	if err := os.WriteFile(manifestPath, []byte("apiVersion: v1\nkind: Secret\nmetadata:\n  name: db\ndata:\n  password: aHVudGVyMg==\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	encryptedManifest := "apiVersion: v1\nkind: Secret\nmetadata:\n  name: db\ndata:\n  password: ENC[AES256_GCM,data:abc,tag:def]\nsops:\n  mac: ENC[AES256_GCM,data:mac]\n"
+	previousClient := apiClient
+	apiClient = encryptFileMock{encrypted: encryptedManifest}
+	t.Cleanup(func() { apiClient = previousClient })
+
+	previousFile := encryptClusterFile
+	encryptClusterFile = clusterPath
+	t.Cleanup(func() { encryptClusterFile = previousFile })
+
+	if err := runEncryptManifestFile(nil, "db-secret", "password"); err != nil {
+		t.Fatalf("runEncryptManifestFile failed: %v", err)
+	}
+
+	manifestContent, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(manifestContent) != encryptedManifest {
+		t.Errorf("manifest file = %q, want the encrypted content", string(manifestContent))
+	}
+
+	written, err := os.ReadFile(clusterPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertContainsAll(t, string(written), []string{
+		"prometheus_metrics:",
+		"endpoint: https://prom.example.com",
+		"deploy_wave: 2",
+		"# prometheus scraping for this cluster",
+		"# after networking",
+	})
+
+	var result ImportClusterConfig
+	if err := yaml.Unmarshal(written, &result); err != nil {
+		t.Fatalf("parse written cluster file: %v", err)
+	}
+	paths := result.Spec.Stacks[0].Manifests[0].EncryptedPaths
+	if len(paths) != 1 || paths[0] != "password" {
+		t.Errorf("encrypted_paths = %v, want [password]", paths)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes **ankra-qh3z** (P1): `ankra cluster encrypt -f` and `ankra cluster clone` rewrote `cluster.yaml` by re-serialising the lossy `ImportClusterConfig` structs. Anything the structs don't model was silently deleted — stack `deploy_wave` and `spec.prometheus_metrics` (both officially parsed by `cluster apply`) were dropped outright, and comments, anchors, and key ordering were destroyed. For GitOps users the file is the source of truth, so the next apply lost wave ordering and metrics with no warning.

## Approach

Both commands now mutate the parsed `yaml.Node` document in place — the same comment-preserving engine `setvalues.go` / `manifest_set.go` already use — and the structs remain read-side lookups/validation only:

- **New `cmd/cluster_yaml_edit.go`**: small node-level engine for ImportCluster docs — parse/navigate helpers, `appendManifestEncryptedPath` / `appendAddonEncryptedPath`, a graft-safe `deepCopyYAMLNode` (aliases whose anchor lives inside the copied subtree stay aliases; aliases to outside anchors are expanded inline so the grafted node stays valid), and a fresh-target doc builder that carries the source's `git_repository` node verbatim.
- **`cluster encrypt -f` (manifest + addon file modes)**: append the key to `encrypted_paths` on the node tree; nothing else in the file changes.
- **`cluster clone`**: struct views still drive name/conflict decisions, but every mutation is mirrored by grafting deep-copied stack nodes from the source document into the target document, which is what gets written.

## Testing

- `go test -race -count=1 ./...` green; `golangci-lint run` clean.
- New regression tests: node-engine preservation (deploy_wave / prometheus_metrics / comments survive, encrypted_paths created + appended), `runClone` end-to-end for existing-target merge, `--force` replace, and fresh-target clone (unknown `git_repository` key carried), and `runEncryptManifestFile` end-to-end with a mocked SOPS encrypt.
- Manually verified with the real binary: cloning onto a commented target with a `&prom` anchor, `deploy_wave` on both sides — everything survives byte-identically except the appended stack.

Bead: ankra-qh3z

🤖 Generated with [Claude Code](https://claude.com/claude-code)
