### PR TITLE
fix(cluster): stop pretending deprovision --auto-delete/--force do things they don't (ankra-yx0c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,23 @@
 
 ## Unreleased
 
+### Deprecated
+
+- **`ankra cluster deprovision --auto-delete` is deprecated — it never did
+  anything.** The backend parses and discards the `auto_delete` parameter, so
+  the flag silently suggested a record deletion that never happened. The flag
+  is now hidden and prints a deprecation warning pointing at
+  `ankra delete cluster` for the record deletion; it will be removed in
+  v0.10.0 (see `DEPRECATIONS.md`).
+
 ### Changed
+
+- **`ankra cluster deprovision --force` now says when it is ignored.** Only
+  the Hetzner deprovision endpoint honors `force`; for every other cluster
+  type the CLI now prints a warning to stderr instead of implying a forced
+  teardown the backend never performs. The generic deprovision request also
+  no longer sends the `auto_delete`/`force` query parameters the backend
+  discards.
 
 - **The README now points at the hosted CLI reference instead of duplicating
   it.** The full command reference — every command, flag, and default — lives

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -16,6 +16,12 @@ version; running one prints a warning pointing at the replacement.
 
 ## Upcoming removals
 
+### v0.10.0
+
+| Deprecated | Deprecated in | Replacement | Notes |
+|---|---|---|---|
+| `ankra cluster deprovision --auto-delete` | v0.9.0 | `ankra delete cluster <name>` after the deprovision completes | The backend parses and discards `auto_delete`, so the flag has never done anything. The flag is now hidden and warns when used; the CLI no longer sends the parameter. |
+
 ### v0.6.0
 
 | Deprecated | Deprecated in | Replacement | Notes |

--- a/cmd/confirm_core_test.go
+++ b/cmd/confirm_core_test.go
@@ -167,7 +167,7 @@ func (m *deprovisionMock) GetCluster(name string) (client.ClusterListItem, error
 	return client.ClusterListItem{}, errors.New("not found")
 }
 
-func (m *deprovisionMock) DeprovisionCluster(ctx context.Context, clusterID string, autoDelete, force bool) (*client.DeprovisionClusterResult, error) {
+func (m *deprovisionMock) DeprovisionCluster(ctx context.Context, clusterID string) (*client.DeprovisionClusterResult, error) {
 	m.deleteCalls++
 	return &client.DeprovisionClusterResult{}, nil
 }
@@ -199,6 +199,52 @@ func TestClusterDeprovision_YesFlagProceeds(t *testing.T) {
 	}
 	if mock.deleteCalls != 1 {
 		t.Errorf("expected one deprovision call with --yes, got %d", mock.deleteCalls)
+	}
+}
+
+func TestClusterDeprovision_ForceWarnsWhenIgnored(t *testing.T) {
+	// Empty kind routes to the generic deprovision endpoint, which is one of
+	// the lanes where the backend discards force.
+	mock := &deprovisionMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo"}}
+	output, err := runConfirmCommand(t, mock, "",
+		[]*cobra.Command{clusterDeprovisionCmd},
+		"cluster", "deprovision", "demo", "--yes", "--force")
+	if err != nil {
+		t.Fatalf("expected success with --yes --force, got %v", err)
+	}
+	if !strings.Contains(output, "--force has no effect") {
+		t.Errorf("expected ignored---force warning in output, got %q", output)
+	}
+	if mock.deleteCalls != 1 {
+		t.Errorf("expected one deprovision call, got %d", mock.deleteCalls)
+	}
+}
+
+func TestClusterDeprovision_NoForceNoWarning(t *testing.T) {
+	mock := &deprovisionMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo"}}
+	output, err := runConfirmCommand(t, mock, "",
+		[]*cobra.Command{clusterDeprovisionCmd},
+		"cluster", "deprovision", "demo", "--yes")
+	if err != nil {
+		t.Fatalf("expected success with --yes, got %v", err)
+	}
+	if strings.Contains(output, "--force has no effect") {
+		t.Errorf("unexpected force warning without --force: %q", output)
+	}
+}
+
+func TestClusterDeprovision_DeprecatedAutoDeleteStillParses(t *testing.T) {
+	// --auto-delete is a deprecated no-op kept so existing scripts don't
+	// break on an unknown flag; it must parse and the deprovision must run.
+	mock := &deprovisionMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo"}}
+	_, err := runConfirmCommand(t, mock, "",
+		[]*cobra.Command{clusterDeprovisionCmd},
+		"cluster", "deprovision", "demo", "--yes", "--auto-delete")
+	if err != nil {
+		t.Fatalf("expected success with deprecated --auto-delete, got %v", err)
+	}
+	if mock.deleteCalls != 1 {
+		t.Errorf("expected one deprovision call, got %d", mock.deleteCalls)
 	}
 }
 

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -47,7 +47,7 @@ func (m baseMock) ProvisionCluster(ctx context.Context, clusterID string) (*clie
 	return nil, errors.New("not implemented")
 }
 
-func (m baseMock) DeprovisionCluster(ctx context.Context, clusterID string, autoDelete, force bool) (*client.DeprovisionClusterResult, error) {
+func (m baseMock) DeprovisionCluster(ctx context.Context, clusterID string) (*client.DeprovisionClusterResult, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -309,8 +309,8 @@ to the provider-specific deprovision endpoint so cloud resources are released.`,
 		// lane would silently drop it, so say so instead of implying a
 		// forced teardown that never happens.
 		if force && cloudClusterKind(clusterKind) != cloudClusterKindHetzner {
-			fmt.Fprintf(cmd.ErrOrStderr(),
-				"warning: --force has no effect for this cluster type (only Hetzner deprovision supports it)\n")
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
+				"warning: --force has no effect for this cluster type (only Hetzner deprovision supports it)")
 		}
 
 		if err := confirmPrompt(

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -292,7 +292,6 @@ For cloud clusters (hetzner, ovh, upcloud, digitalocean, proxmox, morpheus) this
 to the provider-specific deprovision endpoint so cloud resources are released.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		autoDelete, _ := cmd.Flags().GetBool("auto-delete")
 		force, _ := cmd.Flags().GetBool("force")
 		yes, _ := cmd.Flags().GetBool("yes")
 
@@ -304,6 +303,14 @@ to the provider-specific deprovision endpoint so cloud resources are released.`,
 		clusterID, clusterName, clusterKind, err := resolveClusterFromArgsWithKind(cmd, args)
 		if err != nil {
 			return err
+		}
+
+		// Only the Hetzner deprovision endpoint honors force; every other
+		// lane would silently drop it, so say so instead of implying a
+		// forced teardown that never happens.
+		if force && cloudClusterKind(clusterKind) != cloudClusterKindHetzner {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"warning: --force has no effect for this cluster type (only Hetzner deprovision supports it)\n")
 		}
 
 		if err := confirmPrompt(
@@ -405,7 +412,7 @@ to the provider-specific deprovision endpoint so cloud resources are released.`,
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 
-		result, err := apiClient.DeprovisionCluster(ctx, clusterID, autoDelete, force)
+		result, err := apiClient.DeprovisionCluster(ctx, clusterID)
 		if err != nil {
 			return fmt.Errorf("deprovisioning cluster: %w", err)
 		}
@@ -487,7 +494,12 @@ Example:
 
 func init() {
 	clusterDeprovisionCmd.Flags().Bool("auto-delete", false, "Automatically delete the cluster after deprovisioning")
-	clusterDeprovisionCmd.Flags().Bool("force", false, "Force deprovision even if cluster is in an unexpected state")
+	// The backend never implemented auto_delete: it parsed and discarded the
+	// parameter, so the flag has always been a silent no-op. Kept (hidden)
+	// so existing scripts don't break on an unknown flag; see DEPRECATIONS.md.
+	_ = clusterDeprovisionCmd.Flags().MarkDeprecated("auto-delete",
+		"the backend does not support it; deprovision never deletes the cluster record (use 'ankra delete cluster' afterwards)")
+	clusterDeprovisionCmd.Flags().Bool("force", false, "Force deprovision even if cluster is in an unexpected state (only honored for Hetzner clusters)")
 	clusterDeprovisionCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
 	clusterRollToCmd.Flags().String("version", "", "Resource version ID to roll to (required)")

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -18,7 +18,7 @@ type APIClient interface {
 	DeleteCluster(ctx context.Context, name string) error
 	TriggerReconcile(ctx context.Context, clusterID string) (*client.TriggerReconcileResult, error)
 	ProvisionCluster(ctx context.Context, clusterID string) (*client.ProvisionClusterResult, error)
-	DeprovisionCluster(ctx context.Context, clusterID string, autoDelete, force bool) (*client.DeprovisionClusterResult, error)
+	DeprovisionCluster(ctx context.Context, clusterID string) (*client.DeprovisionClusterResult, error)
 	RollToClusterResourceVersion(ctx context.Context, clusterID, versionID string) (*client.RollToClusterResourceVersionResult, error)
 	ApplyCluster(ctx context.Context, clusterReq client.CreateImportClusterRequest, wait bool) (*client.ImportResponse, bool, error)
 	ValidateCluster(ctx context.Context, spec client.CreateResourceSpec, strictSecrets bool, clusterID string) (*client.ValidateClusterResponse, error)

--- a/internal/client/clusters.go
+++ b/internal/client/clusters.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	neturl "net/url"
-	"strings"
 )
 
 // ClusterListItem mirrors cluster's ClusterListItem from
@@ -170,18 +169,12 @@ func (c *Client) ProvisionCluster(ctx context.Context, clusterID string) (*Provi
 	return &result, nil
 }
 
-func (c *Client) DeprovisionCluster(ctx context.Context, clusterID string, autoDelete, force bool) (*DeprovisionClusterResult, error) {
+// DeprovisionCluster calls the generic deprovision endpoint. The historical
+// auto_delete/force query parameters are gone: the backend parses and
+// discards both (a preserved quirk of the original API), so sending them
+// only suggested behaviour that never happened.
+func (c *Client) DeprovisionCluster(ctx context.Context, clusterID string) (*DeprovisionClusterResult, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/clusters/%s/deprovision", c.BaseURL, neturl.PathEscape(clusterID))
-	if autoDelete || force {
-		params := "?"
-		if autoDelete {
-			params += "auto_delete=true&"
-		}
-		if force {
-			params += "force=true&"
-		}
-		endpoint += strings.TrimRight(params, "&")
-	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, nil)
 	if err != nil {

--- a/internal/client/clusters_test.go
+++ b/internal/client/clusters_test.go
@@ -234,33 +234,21 @@ func TestProvisionCluster(t *testing.T) {
 
 func TestDeprovisionCluster(t *testing.T) {
 	tests := []struct {
-		name       string
-		autoDelete bool
-		force      bool
-		handler    http.HandlerFunc
-		wantErr    bool
+		name    string
+		handler http.HandlerFunc
+		wantErr bool
 	}{
 		{
-			name:       "success without flags",
-			autoDelete: false,
-			force:      false,
+			name: "success",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodPost || !strings.Contains(r.URL.Path, "/deprovision") {
 					w.WriteHeader(http.StatusMethodNotAllowed)
 					return
 				}
-				jsonResponse(t, w, http.StatusOK, DeprovisionClusterResult{MarkedForDeprovisionAt: "2025-06-01T00:00:00Z"})
-			},
-			wantErr: false,
-		},
-		{
-			name:       "success with auto_delete and force",
-			autoDelete: true,
-			force:      true,
-			handler: func(w http.ResponseWriter, r *http.Request) {
-				query := r.URL.RawQuery
-				if !strings.Contains(query, "auto_delete=true") || !strings.Contains(query, "force=true") {
-					t.Errorf("expected auto_delete=true&force=true in query, got %s", query)
+				// The historical auto_delete/force parameters were parsed and
+				// discarded server-side, so the client no longer sends them.
+				if r.URL.RawQuery != "" {
+					t.Errorf("expected no query parameters, got %s", r.URL.RawQuery)
 				}
 				jsonResponse(t, w, http.StatusOK, DeprovisionClusterResult{MarkedForDeprovisionAt: "2025-06-01T00:00:00Z"})
 			},
@@ -278,7 +266,7 @@ func TestDeprovisionCluster(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testClient := newTestClient(t, tt.handler)
-			got, err := testClient.DeprovisionCluster(context.Background(), "cluster-id", tt.autoDelete, tt.force)
+			got, err := testClient.DeprovisionCluster(context.Background(), "cluster-id")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DeprovisionCluster() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
## Summary

Fixes half of **ankra-yx0c**: `ankra cluster deprovision --auto-delete` and `--force` were silent no-ops on most lanes — the backend's generic deprovision endpoint (`cliapi/lifecycle.go`) parses and discards both query parameters (a preserved quirk of the original API), so users asked for record deletion / forced teardown and got a plain deprovision with no warning.

- **`--auto-delete` is deprecated** (hidden from help, warns on use, removal scheduled v0.10.0 in `DEPRECATIONS.md`): the backend never implemented it. The deprecation message points at `ankra delete cluster` for actually removing the record.
- **`--force` now warns on stderr when it will be ignored** — only the Hetzner deprovision endpoint honors `force`; OVH/UpCloud/DigitalOcean/Proxmox/Morpheus and the generic lane all drop it. The flag's help text now says it is Hetzner-only.
- **The generic deprovision request no longer sends the discarded `auto_delete`/`force` query parameters.**

The other half of ankra-yx0c (CLI-created platform credentials 404ing on CLI delete) is fixed backend-side in ankraio/cluster.

## Testing

- `make test` (full `-race` suite) green.
- New tests: warning printed on ignored `--force`, no warning without it, deprecated `--auto-delete` still parses and deprovisions (script compat).
- Client test now asserts the deprovision request carries no query parameters.

Bead: ankra-yx0c

🤖 Generated with [Claude Code](https://claude.com/claude-code)
