### PR TITLE
fix(client): decode the response shapes the API actually sends (ankra-y9k4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,34 @@
 
 ### Fixed
 
+- **Seven commands that decoded the wrong response shape now show real
+  data.** `cluster manifests list` always printed "No manifests found",
+  `org members` always printed "No members found", `chat health` printed an
+  empty status with a score of 0, and `cluster stacks history` rendered
+  blank rows — in every case the CLI was reading JSON keys the API never
+  sends. Each now decodes the actual response: manifests show their stack
+  and creation time, members show role and invite status, health shows the
+  scored report with issues and AI insights, and stack history lists every
+  version of each stack member. Validation errors from manifest/addon
+  upgrades and `encrypt` (which arrive nested per resource) are unpacked
+  instead of printing empty brackets, and OVH/UpCloud/DigitalOcean
+  deprovision report the created operation id instead of resource counts
+  the API never returned.
+
+- **`ankra cluster addons uninstall` can now actually uninstall.** The
+  uninstall endpoint takes an addon resource UUID, but the addon listing
+  carries no ids, so every uninstall attempt sent an empty id and failed
+  with a 404. The CLI now resolves the resource id through the stack
+  history before deleting. Addons that are not part of an Ankra-managed
+  stack are rejected with a clear message instead of a server error, and
+  `addons get`/`addons list` no longer show an always-empty ID column and
+  repository (the API sends the registry URL under a different key).
+
+- **`cluster stacks` and `cluster addons list` are no longer capped at 25
+  entries.** The API pages both listings at 25 by default and the CLI never
+  asked for more, silently hiding everything past the first page. Both now
+  walk every page.
+
 - **`ankra cluster kubeconfig add my-cluster` now works.** `kubeconfig add`
   and `kubeconfig remove` accept the cluster as a positional argument, the
   same way `ankra cluster select my-cluster` does. Previously the positional

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -379,30 +379,41 @@ var chatHealthCmd = &cobra.Command{
 		fmt.Printf("Cluster Health for '%s'\n", cluster.Name)
 		fmt.Println("─────────────────────────────────────────")
 
+		report := health.HealthReport
+
 		// Color code health status
 		healthColor := text.FgGreen
-		switch strings.ToLower(health.OverallHealth) {
+		switch strings.ToLower(report.Status) {
 		case "degraded", "warning":
 			healthColor = text.FgYellow
 		case "critical", "unhealthy":
 			healthColor = text.FgRed
 		}
 
-		fmt.Printf("  Status: %s\n", healthColor.Sprint(health.OverallHealth))
-		fmt.Printf("  Score:  %d/100\n", health.Score)
-		fmt.Printf("  Last Updated: %s\n", formatTimeAgo(health.LastUpdated))
+		fmt.Printf("  Status: %s\n", healthColor.Sprint(report.Status))
+		fmt.Printf("  Score:  %d/100\n", report.Score)
+		fmt.Printf("  Last Updated: %s\n", formatTimeAgo(report.EvaluatedAt))
+		if health.Summary != "" {
+			fmt.Printf("  Summary: %s\n", health.Summary)
+		}
 
-		if len(health.Issues) > 0 {
+		if len(report.Issues) > 0 {
 			fmt.Println("\n  Issues:")
-			for _, issue := range health.Issues {
-				fmt.Printf("    - %s\n", text.FgYellow.Sprint(issue))
+			for _, issue := range report.Issues {
+				fmt.Printf("    - [%s] %s\n", issue.Severity, text.FgYellow.Sprint(issue.Title))
+				for _, action := range issue.SuggestedActions {
+					fmt.Printf("        · %s\n", action)
+				}
 			}
 		}
 
-		if len(health.Recommendations) > 0 {
-			fmt.Println("\n  Recommendations:")
-			for _, rec := range health.Recommendations {
-				fmt.Printf("    - %s\n", rec)
+		if len(health.AIInsights) > 0 {
+			fmt.Println("\n  AI Insights:")
+			for _, insight := range health.AIInsights {
+				fmt.Printf("    - [%s] %s\n", insight.Severity, insight.Title)
+				if insight.RootCauseAnalysis != "" {
+					fmt.Printf("        Root cause: %s\n", insight.RootCauseAnalysis)
+				}
 			}
 		}
 		return nil

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -18,6 +18,15 @@ func formatTimeAgo(tStr string) string {
 	return humanize.Time(t)
 }
 
+// formatOptionalTimeAgo renders a nullable timestamp as a relative time,
+// with "-" for absent values.
+func formatOptionalTimeAgo(t *time.Time) string {
+	if t == nil {
+		return "-"
+	}
+	return humanize.Time(*t)
+}
+
 var clusterIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 
 // isLikelyClusterID reports whether value has the shape of a cluster UUID. It

--- a/cmd/cluster_addon.go
+++ b/cmd/cluster_addon.go
@@ -71,12 +71,14 @@ var clusterAddonsListCmd = &cobra.Command{
 			}
 
 			fmt.Println("Addon Details:")
-			fmt.Printf("  ID:              %s\n", found.ID)
 			fmt.Printf("  Name:            %s\n", found.Name)
 			fmt.Printf("  Chart:           %s\n", found.ChartName)
 			fmt.Printf("  Version:         %s\n", found.ChartVersion)
-			fmt.Printf("  Repository:      %s\n", found.RepositoryURL)
+			fmt.Printf("  Registry:        %s\n", found.RegistryURL)
 			fmt.Printf("  Namespace:       %s\n", found.Namespace)
+			if found.StackName != nil {
+				fmt.Printf("  Stack:           %s\n", *found.StackName)
+			}
 			fmt.Printf("  Through Ankra:   %t\n", found.ThroughAnkra)
 			if found.Health != nil {
 				fmt.Printf("  Health:          %s\n", *found.Health)
@@ -84,8 +86,11 @@ var clusterAddonsListCmd = &cobra.Command{
 			if found.State != nil {
 				fmt.Printf("  State:           %s\n", *found.State)
 			}
-			fmt.Printf("  Created:         %s\n", formatTimeAgo(found.CreatedAt.Format(time.RFC3339)))
-			fmt.Printf("  Updated:         %s\n", formatTimeAgo(found.UpdatedAt.Format(time.RFC3339)))
+			if found.LatestChartVersion != nil && *found.LatestChartVersion != found.ChartVersion {
+				fmt.Printf("  Latest Version:  %s\n", *found.LatestChartVersion)
+			}
+			fmt.Printf("  Created:         %s\n", formatOptionalTimeAgo(found.CreatedAt))
+			fmt.Printf("  Updated:         %s\n", formatOptionalTimeAgo(found.UpdatedAt))
 			return nil
 		}
 
@@ -123,8 +128,8 @@ var clusterAddonsListCmd = &cobra.Command{
 				a.Namespace,
 				health,
 				a.ThroughAnkra,
-				formatTimeAgo(a.CreatedAt.Format(time.RFC3339)),
-				formatTimeAgo(a.UpdatedAt.Format(time.RFC3339)),
+				formatOptionalTimeAgo(a.CreatedAt),
+				formatOptionalTimeAgo(a.UpdatedAt),
 				state,
 			})
 		}
@@ -278,6 +283,19 @@ var clusterAddonsUninstallCmd = &cobra.Command{
 			return fmt.Errorf("finding addon: %w", err)
 		}
 
+		// The addon listing carries no resource id; the uninstall endpoint
+		// takes only the resource UUID, which the stack history exposes.
+		if addon.StackName == nil || *addon.StackName == "" {
+			return fmt.Errorf("addon %q is not part of an Ankra-managed stack and cannot be uninstalled via the CLI", addonName)
+		}
+		addonResourceID, err := apiClient.GetStackAddonResourceID(cluster.ID, *addon.StackName, addonName)
+		if err != nil {
+			if errors.Is(err, client.ErrAddonNotFound) {
+				return withExitCode(exitNotFound, fmt.Errorf("resolving addon: %w", err))
+			}
+			return fmt.Errorf("resolving addon: %w", err)
+		}
+
 		var msg string
 		if deletePermanently {
 			msg = fmt.Sprintf("Uninstall and PERMANENTLY delete addon %q from cluster %q? [y/N]: ", addonName, cluster.Name)
@@ -291,7 +309,7 @@ var clusterAddonsUninstallCmd = &cobra.Command{
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 
-		result, err := apiClient.UninstallAddon(ctx, cluster.ID, addon.ID, deletePermanently)
+		result, err := apiClient.UninstallAddon(ctx, cluster.ID, addonResourceID, deletePermanently)
 		if err != nil {
 			return fmt.Errorf("uninstalling addon: %w", err)
 		}
@@ -520,9 +538,7 @@ func runAddonsUpgrade(cmd *cobra.Command, args []string) error {
 	}
 	if len(res.Errors) > 0 {
 		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Update completed with resource errors:")
-		for _, e := range res.Errors {
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  - %s %s [%s]: %s\n", e.Kind, e.Name, e.Key, e.Message)
-		}
+		renderPatchResourceErrors(cmd.ErrOrStderr(), res.Errors)
 		return errors.New("update partially failed; see errors above")
 	}
 	return printAsOutput(cmd.OutOrStdout(), res, flags.Output)

--- a/cmd/cluster_addon_test.go
+++ b/cmd/cluster_addon_test.go
@@ -14,7 +14,10 @@ import (
 
 type clusterAddonUninstallMock struct {
 	baseMock
-	addons        []client.ClusterAddonListItem
+	addons []client.ClusterAddonListItem
+	// resourceIDs maps addon name -> resource id, mirroring the stack-history
+	// resolution the real client performs (the listing carries no id).
+	resourceIDs   map[string]string
 	uninstalls    []uninstallCall
 	uninstallErr  error
 	getClusterErr error
@@ -48,6 +51,15 @@ func (m *clusterAddonUninstallMock) GetAddonByName(clusterID, addonName string) 
 	return nil, fmt.Errorf("addon %q: %w", addonName, client.ErrAddonNotFound)
 }
 
+// GetStackAddonResourceID mirrors the real client: the resource id is
+// resolved through the stack history, not the addon listing.
+func (m *clusterAddonUninstallMock) GetStackAddonResourceID(clusterID, stackName, addonName string) (string, error) {
+	if id, ok := m.resourceIDs[addonName]; ok {
+		return id, nil
+	}
+	return "", fmt.Errorf("addon %q: %w", addonName, client.ErrAddonNotFound)
+}
+
 func (m *clusterAddonUninstallMock) UninstallAddon(ctx context.Context, clusterID, addonResourceID string, deletePermanently bool) (*client.UninstallAddonResult, error) {
 	m.uninstalls = append(m.uninstalls, uninstallCall{
 		ClusterID:       clusterID,
@@ -60,8 +72,9 @@ func (m *clusterAddonUninstallMock) UninstallAddon(ctx context.Context, clusterI
 	return &client.UninstallAddonResult{Success: true, Message: "Addon uninstalled"}, nil
 }
 
-func addonFixture(name, id string) client.ClusterAddonListItem {
-	return client.ClusterAddonListItem{ID: id, Name: name}
+func addonFixture(name string) client.ClusterAddonListItem {
+	stackName := "core"
+	return client.ClusterAddonListItem{Name: name, StackName: &stackName}
 }
 
 // executeAddonCommand runs the given args against rootCmd with stdin wired to
@@ -97,7 +110,8 @@ func resetAddonUninstallFlags() {
 
 func TestClusterAddonUninstall_MissingAddonExitsNotFound(t *testing.T) {
 	mock := &clusterAddonUninstallMock{
-		addons: []client.ClusterAddonListItem{addonFixture("present", "addon-1")},
+		addons:      []client.ClusterAddonListItem{addonFixture("present")},
+		resourceIDs: map[string]string{"present": "addon-1"},
 	}
 	setMockClient(t, mock)
 
@@ -118,7 +132,8 @@ func TestClusterAddonUninstall_MissingAddonExitsNotFound(t *testing.T) {
 
 func TestClusterAddonUninstall_DeclinedPromptCancels(t *testing.T) {
 	mock := &clusterAddonUninstallMock{
-		addons: []client.ClusterAddonListItem{addonFixture("present", "addon-1")},
+		addons:      []client.ClusterAddonListItem{addonFixture("present")},
+		resourceIDs: map[string]string{"present": "addon-1"},
 	}
 	setMockClient(t, mock)
 
@@ -139,7 +154,8 @@ func TestClusterAddonUninstall_DeclinedPromptCancels(t *testing.T) {
 
 func TestClusterAddonUninstall_ConfirmProceeds(t *testing.T) {
 	mock := &clusterAddonUninstallMock{
-		addons: []client.ClusterAddonListItem{addonFixture("present", "addon-1")},
+		addons:      []client.ClusterAddonListItem{addonFixture("present")},
+		resourceIDs: map[string]string{"present": "addon-1"},
 	}
 	setMockClient(t, mock)
 
@@ -160,7 +176,8 @@ func TestClusterAddonUninstall_ConfirmProceeds(t *testing.T) {
 
 func TestClusterAddonUninstall_YesSkipsPromptAndProceeds(t *testing.T) {
 	mock := &clusterAddonUninstallMock{
-		addons: []client.ClusterAddonListItem{addonFixture("present", "addon-1")},
+		addons:      []client.ClusterAddonListItem{addonFixture("present")},
+		resourceIDs: map[string]string{"present": "addon-1"},
 	}
 	setMockClient(t, mock)
 

--- a/cmd/cluster_encrypt.go
+++ b/cmd/cluster_encrypt.go
@@ -723,9 +723,7 @@ func runEncryptManifestCluster(cmd *cobra.Command, manifestName, leafKey string)
 	}
 	if len(res.Errors) > 0 {
 		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Encryption completed with resource errors:")
-		for _, e := range res.Errors {
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  - %s %s [%s]: %s\n", e.Kind, e.Name, e.Key, e.Message)
-		}
+		renderPatchResourceErrors(cmd.ErrOrStderr(), res.Errors)
 		return errors.New("encryption partially failed; see errors above")
 	}
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Manifest %q encrypted in stack %q.\n", manifestName, stack.Name)
@@ -794,9 +792,7 @@ func runEncryptAddonCluster(cmd *cobra.Command, addonName, leafKey string) error
 	}
 	if len(res.Errors) > 0 {
 		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Encryption completed with resource errors:")
-		for _, e := range res.Errors {
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  - %s %s [%s]: %s\n", e.Kind, e.Name, e.Key, e.Message)
-		}
+		renderPatchResourceErrors(cmd.ErrOrStderr(), res.Errors)
 		return errors.New("encryption partially failed; see errors above")
 	}
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Addon %q encrypted in stack %q.\n", addonName, stack.Name)

--- a/cmd/cluster_manifests.go
+++ b/cmd/cluster_manifests.go
@@ -167,21 +167,17 @@ var clusterManifestsListCmd = &cobra.Command{
 			fmt.Println("Manifest Details:")
 			fmt.Printf("  Name:        %s\n", found.Name)
 			fmt.Printf("  Kind:        %s\n", kind)
-			fmt.Printf("  Namespace:   %s\n", found.Namespace)
+			if namespace := extractNamespaceFromBase64(found.ManifestBase64); namespace != "" {
+				fmt.Printf("  Namespace:   %s\n", namespace)
+			}
 			fmt.Printf("  State:       %s\n", found.State)
 
-			if len(found.Parents) > 0 {
-				fmt.Printf("  Parents:     ")
-				for i, parent := range found.Parents {
-					if i > 0 {
-						fmt.Print(", ")
-					}
-					fmt.Printf("%s (%s)", parent.Name, parent.Kind)
-				}
-				fmt.Println()
-			} else {
-				fmt.Printf("  Parents:     none\n")
+			stackName := "none"
+			if found.StackName != nil && *found.StackName != "" {
+				stackName = *found.StackName
 			}
+			fmt.Printf("  Stack:       %s\n", stackName)
+			fmt.Printf("  Created:     %s\n", formatOptionalTimeAgo(found.CreatedAt))
 
 			if found.ManifestBase64 != "" {
 				fmt.Println("\n  Manifest Content:")
@@ -201,7 +197,7 @@ var clusterManifestsListCmd = &cobra.Command{
 		t.SetOutputMirror(os.Stdout)
 		t.SetStyle(table.StyleRounded)
 		t.AppendHeader(table.Row{
-			"Name", "Kind", "Namespace", "State", "Parents",
+			"Name", "Kind", "Namespace", "State", "Stack",
 		})
 		t.SetColumnConfigs([]table.ColumnConfig{
 			{Number: 1, WidthMin: 25},
@@ -224,24 +220,17 @@ var clusterManifestsListCmd = &cobra.Command{
 				state = "✗ " + state
 			}
 
-			parents := "none"
-			if len(m.Parents) > 0 {
-				var parentList []string
-				for _, parent := range m.Parents {
-					parentList = append(parentList, fmt.Sprintf("%s (%s)", parent.Name, parent.Kind))
-				}
-				parents = strings.Join(parentList, ", ")
-				if len(parents) > 30 {
-					parents = parents[:27] + "..."
-				}
+			stackName := "none"
+			if m.StackName != nil && *m.StackName != "" {
+				stackName = *m.StackName
 			}
 
 			t.AppendRow(table.Row{
 				m.Name,
 				kind,
-				m.Namespace,
+				extractNamespaceFromBase64(m.ManifestBase64),
 				state,
-				parents,
+				stackName,
 			})
 		}
 		t.Render()
@@ -417,9 +406,7 @@ func runManifestsUpgrade(cmd *cobra.Command, args []string) error {
 	}
 	if len(res.Errors) > 0 {
 		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Update completed with resource errors:")
-		for _, e := range res.Errors {
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  - %s %s [%s]: %s\n", e.Kind, e.Name, e.Key, e.Message)
-		}
+		renderPatchResourceErrors(cmd.ErrOrStderr(), res.Errors)
 		return errors.New("update partially failed; see errors above")
 	}
 	return printAsOutput(cmd.OutOrStdout(), res, flags.Output)

--- a/cmd/cluster_partial.go
+++ b/cmd/cluster_partial.go
@@ -336,6 +336,21 @@ func printAsOutput(out io.Writer, res *client.PatchStackResult, format outputFor
 	return nil
 }
 
+// renderPatchResourceErrors prints the per-resource validation errors from a
+// PATCH /stacks result — the backend nests the key/message pairs inside each
+// resource entry.
+func renderPatchResourceErrors(w io.Writer, resourceErrors []client.PatchStackResourceError) {
+	for _, resourceError := range resourceErrors {
+		if len(resourceError.Errors) == 0 {
+			_, _ = fmt.Fprintf(w, "  - %s %s: validation failed\n", resourceError.Kind, resourceError.Name)
+			continue
+		}
+		for _, detail := range resourceError.Errors {
+			_, _ = fmt.Fprintf(w, "  - %s %s [%s]: %s\n", resourceError.Kind, resourceError.Name, detail.Key, detail.Message)
+		}
+	}
+}
+
 // mapPatchError converts a typed PatchStackError into a friendly, actionable
 // message. The backend status code semantics are documented in the use-case
 // layer:

--- a/cmd/cluster_stacks.go
+++ b/cmd/cluster_stacks.go
@@ -289,36 +289,43 @@ var clusterStacksHistoryCmd = &cobra.Command{
 			return nil
 		}
 
-		fmt.Printf("History for stack '%s':\n\n", history.StackName)
+		fmt.Printf("History for stack '%s':\n\n", stackName)
 
 		t := table.NewWriter()
 		t.SetOutputMirror(os.Stdout)
 		t.SetStyle(table.StyleRounded)
-		t.AppendHeader(table.Row{"Version", "Change Type", "Created At", "Created By", "Description"})
+		t.AppendHeader(table.Row{"Resource", "Type", "Change Type", "Created At", "Created By"})
 		t.SetColumnConfigs([]table.ColumnConfig{
-			{Number: 1, WidthMin: 8},
-			{Number: 2, WidthMin: 12},
-			{Number: 3, WidthMin: 15},
-			{Number: 4, WidthMin: 20},
-			{Number: 5, WidthMin: 30},
+			{Number: 1, WidthMin: 20},
+			{Number: 2, WidthMin: 10},
+			{Number: 3, WidthMin: 12},
+			{Number: 4, WidthMin: 15},
+			{Number: 5, WidthMin: 20},
 		})
 
-		for _, entry := range history.History {
-			createdBy := "-"
-			if entry.CreatedBy != nil {
-				createdBy = *entry.CreatedBy
+		for _, item := range history.History {
+			for _, entry := range item.VersionHistory {
+				changeType := "-"
+				if entry.ChangeType != nil {
+					changeType = *entry.ChangeType
+				}
+				createdBy := "-"
+				switch {
+				case entry.UserName != nil && *entry.UserName != "":
+					createdBy = *entry.UserName
+				case entry.ExternalUser != nil && *entry.ExternalUser != "":
+					createdBy = *entry.ExternalUser
+				case entry.UserID != "":
+					createdBy = entry.UserID
+				}
+				t.AppendRow(table.Row{
+					item.ResourceName,
+					item.ResourceType,
+					changeType,
+					formatOptionalTimeAgo(entry.CreatedAt),
+					createdBy,
+				})
 			}
-			description := "-"
-			if entry.Description != nil {
-				description = *entry.Description
-			}
-			t.AppendRow(table.Row{
-				entry.Version,
-				entry.ChangeType,
-				formatTimeAgo(entry.CreatedAt),
-				createdBy,
-				description,
-			})
 		}
 		t.Render()
 		return nil

--- a/cmd/digitalocean_cluster.go
+++ b/cmd/digitalocean_cluster.go
@@ -130,15 +130,6 @@ var digitaloceanDeprovisionCmd = &cobra.Command{
 		if result.OperationID != nil {
 			fmt.Printf("  Operation ID: %s\n", *result.OperationID)
 		}
-		if result.ResourcesMarked > 0 {
-			fmt.Printf("  Resources queued for deletion: %d\n", result.ResourcesMarked)
-		}
-		if len(result.Errors) > 0 {
-			fmt.Println(text.FgYellow.Sprint("  Warnings:"))
-			for _, e := range result.Errors {
-				fmt.Printf("    - %s\n", e)
-			}
-		}
 		return nil
 	},
 }

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -379,6 +379,14 @@ func (m baseMock) GetStackHistory(clusterID, stackName string) (*client.GetStack
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) GetStackAddonResourceID(clusterID, stackName, addonName string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}
+
 func (m baseMock) CloneStackToCluster(ctx context.Context, targetClusterID string, cloneReq client.CloneStackToClusterRequest) (*client.CloneStackToClusterResult, error) {
 	return nil, errors.New("not implemented")
 }
@@ -1887,15 +1895,14 @@ func TestClusterAddonsListCommand(t *testing.T) {
 	mock := &clusterAddonsListMock{
 		addons: []client.ClusterAddonListItem{
 			{
-				ID:            "addon-res-id",
-				Name:          "nginx-ingress",
-				ChartName:     "ingress-nginx",
-				ChartVersion:  "4.11.0",
-				RepositoryURL: "https://kubernetes.github.io/ingress-nginx",
-				Namespace:     "ingress-nginx",
-				CreatedAt:     time.Date(2024, 3, 1, 12, 0, 0, 0, time.UTC),
-				UpdatedAt:     time.Date(2024, 3, 2, 12, 0, 0, 0, time.UTC),
-				ThroughAnkra:  true,
+				Name:         "nginx-ingress",
+				ChartName:    "ingress-nginx",
+				ChartVersion: "4.11.0",
+				RegistryURL:  "https://kubernetes.github.io/ingress-nginx",
+				Namespace:    "ingress-nginx",
+				CreatedAt:    timePtr(time.Date(2024, 3, 1, 12, 0, 0, 0, time.UTC)),
+				UpdatedAt:    timePtr(time.Date(2024, 3, 2, 12, 0, 0, 0, time.UTC)),
+				ThroughAnkra: true,
 			},
 		},
 	}
@@ -1956,13 +1963,12 @@ func (m *clusterManifestsListMock) ListClusterManifests(clusterID string) ([]cli
 
 func TestClusterManifestsListCommand(t *testing.T) {
 	writeSelectedClusterJSON(t)
-	yamlBody := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm1\n"
+	yamlBody := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm1\n  namespace: default\n"
 	mock := &clusterManifestsListMock{
 		manifests: []client.ClusterManifestListItem{
 			{
 				Name:           "cm-manifest",
 				ManifestBase64: base64.StdEncoding.EncodeToString([]byte(yamlBody)),
-				Namespace:      "default",
 				State:          "up",
 			},
 		},

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -29,3 +29,28 @@ func extractKindFromBase64(manifestBase64 string) string {
 
 	return manifest.Kind
 }
+
+// extractNamespaceFromBase64 pulls metadata.namespace out of a base64
+// manifest document; the manifest listing itself carries no namespace.
+func extractNamespaceFromBase64(manifestBase64 string) string {
+	if manifestBase64 == "" {
+		return ""
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(manifestBase64)
+	if err != nil {
+		return ""
+	}
+
+	var manifest struct {
+		Metadata struct {
+			Namespace string `yaml:"namespace"`
+		} `yaml:"metadata"`
+	}
+
+	if err := yaml.Unmarshal(decoded, &manifest); err != nil {
+		return ""
+	}
+
+	return manifest.Metadata.Namespace
+}

--- a/cmd/organisation.go
+++ b/cmd/organisation.go
@@ -275,24 +275,36 @@ var orgMembersCmd = &cobra.Command{
 		t := table.NewWriter()
 		t.SetOutputMirror(os.Stdout)
 		t.SetStyle(table.StyleRounded)
-		t.AppendHeader(table.Row{"Email", "Name", "Role", "Joined"})
+		t.AppendHeader(table.Row{"Email", "Role", "Status", "Current"})
 		t.SetColumnConfigs([]table.ColumnConfig{
 			{Number: 1, WidthMin: 30},
-			{Number: 2, WidthMin: 20},
+			{Number: 2, WidthMin: 10},
 			{Number: 3, WidthMin: 10},
-			{Number: 4, WidthMin: 15},
+			{Number: 4, WidthMin: 8},
 		})
 
 		for _, member := range org.Members {
-			memberName := ""
-			if member.Name != nil {
-				memberName = *member.Name
+			email := ""
+			if member.Email != nil {
+				email = *member.Email
+			}
+			role := ""
+			if member.Role != nil {
+				role = *member.Role
+			}
+			status := ""
+			if member.Status != nil {
+				status = *member.Status
+			}
+			current := ""
+			if member.UserCurrent != nil && *member.UserCurrent {
+				current = text.FgGreen.Sprint("✓")
 			}
 			t.AppendRow(table.Row{
-				member.Email,
-				memberName,
-				member.Role,
-				formatTimeAgo(member.JoinedAt),
+				email,
+				role,
+				status,
+				current,
 			})
 		}
 		t.Render()

--- a/cmd/ovh_cluster.go
+++ b/cmd/ovh_cluster.go
@@ -127,26 +127,14 @@ var ovhDeprovisionCmd = &cobra.Command{
 		}
 
 		if result.Success {
-			fmt.Println(text.FgGreen.Sprint("OVH cluster deprovisioned successfully!"))
+			fmt.Println(text.FgGreen.Sprint("OVH cluster deprovision initiated!"))
 		} else {
-			fmt.Println("Cluster deprovisioned with issues.")
+			fmt.Println("Cluster deprovision requested with issues.")
 		}
 
 		fmt.Printf("  Cluster ID: %s\n", result.ClusterID)
-		if len(result.DeletedServers) > 0 {
-			fmt.Printf("  Deleted servers: %d\n", len(result.DeletedServers))
-		}
-		if len(result.DeletedNetworks) > 0 {
-			fmt.Printf("  Deleted networks: %d\n", len(result.DeletedNetworks))
-		}
-		if len(result.DeletedSSHKeys) > 0 {
-			fmt.Printf("  Deleted SSH keys: %d\n", len(result.DeletedSSHKeys))
-		}
-		if len(result.Errors) > 0 {
-			fmt.Println(text.FgYellow.Sprint("  Warnings:"))
-			for _, e := range result.Errors {
-				fmt.Printf("    - %s\n", e)
-			}
+		if result.OperationID != nil {
+			fmt.Printf("  Operation ID: %s\n", *result.OperationID)
 		}
 		return nil
 	},

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -78,6 +78,7 @@ type APIClient interface {
 	DeleteStack(ctx context.Context, clusterID, stackName string) (*client.DeleteStackResult, error)
 	RenameStack(ctx context.Context, clusterID, stackName, newName string) (*client.RenameStackResult, error)
 	GetStackHistory(clusterID, stackName string) (*client.GetStackHistoryResponse, error)
+	GetStackAddonResourceID(clusterID, stackName, addonName string) (string, error)
 	CloneStackToCluster(ctx context.Context, targetClusterID string, cloneReq client.CloneStackToClusterRequest) (*client.CloneStackToClusterResult, error)
 
 	ListStackProfiles(page, pageSize int, search string, category string) (*client.StackProfileListResponse, error)

--- a/cmd/upcloud_cluster.go
+++ b/cmd/upcloud_cluster.go
@@ -129,15 +129,6 @@ var upcloudDeprovisionCmd = &cobra.Command{
 		if result.OperationID != nil {
 			fmt.Printf("  Operation ID: %s\n", *result.OperationID)
 		}
-		if result.ResourcesMarked > 0 {
-			fmt.Printf("  Resources queued for deletion: %d\n", result.ResourcesMarked)
-		}
-		if len(result.Errors) > 0 {
-			fmt.Println(text.FgYellow.Sprint("  Warnings:"))
-			for _, e := range result.Errors {
-				fmt.Printf("    - %s\n", e)
-			}
-		}
 		return nil
 	},
 }

--- a/internal/client/addons.go
+++ b/internal/client/addons.go
@@ -17,18 +17,24 @@ import (
 // it as a not-found condition (exit code 3) rather than a generic failure.
 var ErrAddonNotFound = errors.New("addon not found")
 
+// ClusterAddonListItem mirrors the backend's importedread
+// ClusterAddonListItem. The listing carries no resource id — uninstall
+// resolves it through the stack history (GetStackAddonResourceID) — and the
+// chart repository arrives as registry_url.
 type ClusterAddonListItem struct {
-	ID            string    `json:"id"`
-	Name          string    `json:"name"`
-	ChartName     string    `json:"chart_name"`
-	ChartVersion  string    `json:"chart_version"`
-	RepositoryURL string    `json:"repository_url"`
-	Namespace     string    `json:"namespace"`
-	Health        *string   `json:"health,omitempty"`
-	CreatedAt     time.Time `json:"created_at"`
-	UpdatedAt     time.Time `json:"updated_at"`
-	State         *string   `json:"state,omitempty"`
-	ThroughAnkra  bool      `json:"through_ankra"`
+	Name               string     `json:"name"`
+	ChartName          string     `json:"chart_name"`
+	ChartVersion       string     `json:"chart_version"`
+	RegistryURL        string     `json:"registry_url"`
+	RegistryName       *string    `json:"registry_name"`
+	Namespace          string     `json:"namespace"`
+	StackName          *string    `json:"stack_name"`
+	Health             *string    `json:"health,omitempty"`
+	CreatedAt          *time.Time `json:"created_at"`
+	UpdatedAt          *time.Time `json:"updated_at"`
+	State              *string    `json:"state,omitempty"`
+	ThroughAnkra       bool       `json:"through_ankra"`
+	LatestChartVersion *string    `json:"latest_chart_version"`
 }
 
 type ListClusterAddonsResponse struct {
@@ -83,13 +89,23 @@ type ListAvailableAddonsResponse struct {
 	Result []AvailableAddon `json:"result"`
 }
 
+// ListClusterAddons pages through the full addon listing (the backend
+// serves 25 per page by default and clamps page_size at 100).
 func (c *Client) ListClusterAddons(clusterID string) ([]ClusterAddonListItem, error) {
-	url := fmt.Sprintf("%s/api/v1/clusters/%s/addons", c.BaseURL, neturl.PathEscape(clusterID))
-	var resp ListClusterAddonsResponse
-	if err := c.getJSON(url, &resp); err != nil {
-		return nil, fmt.Errorf("failed to get cluster addons: %w", err)
+	var addons []ClusterAddonListItem
+	for page := 1; ; page++ {
+		url := fmt.Sprintf("%s/api/v1/clusters/%s/addons?page=%d&page_size=100",
+			c.BaseURL, neturl.PathEscape(clusterID), page)
+		var resp ListClusterAddonsResponse
+		if err := c.getJSON(url, &resp); err != nil {
+			return nil, fmt.Errorf("failed to get cluster addons: %w", err)
+		}
+		addons = append(addons, resp.Result...)
+		if page >= resp.Pagination.TotalPages || len(resp.Result) == 0 {
+			break
+		}
 	}
-	return resp.Result, nil
+	return addons, nil
 }
 
 func (c *Client) ListAvailableAddons(clusterID string) ([]AvailableAddon, error) {

--- a/internal/client/addons_test.go
+++ b/internal/client/addons_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestListClusterAddons(t *testing.T) {
+	now := time.Now()
 	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.URL.Path, "/addons") {
 			w.WriteHeader(http.StatusNotFound)
@@ -16,7 +17,7 @@ func TestListClusterAddons(t *testing.T) {
 		}
 		jsonResponse(t, w, http.StatusOK, ListClusterAddonsResponse{
 			Result: []ClusterAddonListItem{
-				{ID: "addon1", Name: "ingress", ChartName: "ingress-nginx", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+				{Name: "ingress", ChartName: "ingress-nginx", RegistryURL: "https://charts.example.com", CreatedAt: &now, UpdatedAt: &now},
 			},
 			Pagination: Pagination{TotalCount: 1, Page: 1, PageSize: 25, TotalPages: 1},
 		})
@@ -107,6 +108,7 @@ func TestUninstallAddon(t *testing.T) {
 }
 
 func TestGetAddonByName(t *testing.T) {
+	now := time.Now()
 	tests := []struct {
 		name    string
 		handler http.HandlerFunc
@@ -117,7 +119,7 @@ func TestGetAddonByName(t *testing.T) {
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				jsonResponse(t, w, http.StatusOK, ListClusterAddonsResponse{
 					Result: []ClusterAddonListItem{
-						{ID: "addon1", Name: "ingress", ChartName: "ingress-nginx", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+						{Name: "ingress", ChartName: "ingress-nginx", RegistryURL: "https://charts.example.com", CreatedAt: &now, UpdatedAt: &now},
 					},
 					Pagination: Pagination{TotalCount: 1, Page: 1, PageSize: 25, TotalPages: 1},
 				})

--- a/internal/client/chat.go
+++ b/internal/client/chat.go
@@ -45,12 +45,43 @@ type DeleteConversationResponse struct {
 	Message string `json:"message"`
 }
 
+// ClusterHealthIssue mirrors the backend's ClusterIssueWire (the members
+// the CLI renders).
+type ClusterHealthIssue struct {
+	Title            string   `json:"title"`
+	Severity         string   `json:"severity"`
+	Description      string   `json:"description"`
+	Namespace        *string  `json:"namespace"`
+	SuggestedActions []string `json:"suggested_actions"`
+}
+
+// ClusterHealthReport mirrors the backend's ClusterHealthReportWire.
+type ClusterHealthReport struct {
+	Status      string               `json:"status"`
+	Score       int                  `json:"score"`
+	Issues      []ClusterHealthIssue `json:"issues"`
+	PodStats    map[string]int       `json:"pod_stats"`
+	NodeStats   map[string]int       `json:"node_stats"`
+	EvaluatedAt string               `json:"evaluated_at"`
+}
+
+// ClusterHealthAIInsight mirrors the backend's AIInsightWire (the members
+// the CLI renders).
+type ClusterHealthAIInsight struct {
+	Title             string `json:"title"`
+	RootCauseAnalysis string `json:"root_cause_analysis"`
+	Severity          string `json:"severity"`
+	ImpactAssessment  string `json:"impact_assessment"`
+}
+
+// ClusterHealth mirrors the backend's ProactiveInsightWire: the health
+// report is nested, not flat.
 type ClusterHealth struct {
-	OverallHealth   string   `json:"overall_health"`
-	Score           int      `json:"score"`
-	Issues          []string `json:"issues,omitempty"`
-	Recommendations []string `json:"recommendations,omitempty"`
-	LastUpdated     string   `json:"last_updated"`
+	ClusterID    string                   `json:"cluster_id"`
+	HealthReport ClusterHealthReport      `json:"health_report"`
+	AIInsights   []ClusterHealthAIInsight `json:"ai_insights"`
+	Summary      string                   `json:"summary"`
+	GeneratedAt  string                   `json:"generated_at"`
 }
 
 type ChatStreamEvent struct {

--- a/internal/client/chat_test.go
+++ b/internal/client/chat_test.go
@@ -212,9 +212,13 @@ func TestGetClusterHealth_Success(t *testing.T) {
 			t.Errorf("include_ai_analysis = %s, want true", r.URL.Query().Get("include_ai_analysis"))
 		}
 		jsonResponse(t, w, http.StatusOK, ClusterHealth{
-			OverallHealth: "healthy",
-			Score:         95,
-			LastUpdated:   "2025-06-01T00:00:00Z",
+			ClusterID: "cluster-123",
+			HealthReport: ClusterHealthReport{
+				Status:      "healthy",
+				Score:       95,
+				EvaluatedAt: "2025-06-01T00:00:00Z",
+			},
+			Summary: "All good",
 		})
 	}
 	testClient := newTestClient(t, handler)
@@ -222,7 +226,7 @@ func TestGetClusterHealth_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetClusterHealth() error = %v", err)
 	}
-	if got.OverallHealth != "healthy" || got.Score != 95 {
+	if got.HealthReport.Status != "healthy" || got.HealthReport.Score != 95 {
 		t.Errorf("GetClusterHealth() got = %v", got)
 	}
 }

--- a/internal/client/digitalocean_clusters.go
+++ b/internal/client/digitalocean_clusters.go
@@ -50,12 +50,12 @@ type StartDigitaloceanClusterResult struct {
 	CreatedOperations int    `json:"created_operations"`
 }
 
+// DeprovisionDigitaloceanClusterResponse mirrors the backend's shared
+// DeprovisionClusterResponse.
 type DeprovisionDigitaloceanClusterResponse struct {
-	Success         bool     `json:"success"`
-	ClusterID       string   `json:"cluster_id"`
-	OperationID     *string  `json:"operation_id,omitempty"`
-	ResourcesMarked int      `json:"resources_marked"`
-	Errors          []string `json:"errors"`
+	Success     bool    `json:"success"`
+	ClusterID   string  `json:"cluster_id"`
+	OperationID *string `json:"operation_id,omitempty"`
 }
 
 func (c *Client) CreateDigitaloceanCluster(req CreateDigitaloceanClusterRequest) (*CreateDigitaloceanClusterResponse, error) {

--- a/internal/client/iac.go
+++ b/internal/client/iac.go
@@ -101,13 +101,19 @@ type PatchStackRequest struct {
 	PartialStack bool             `json:"partial_stack"`
 }
 
-// PatchStackResourceError mirrors the backend ResourceError shape returned in
-// UpdateClusterStackResult.errors when validation fails per-resource.
-type PatchStackResourceError struct {
-	Name    string `json:"name"`
-	Kind    string `json:"kind"`
+// PatchStackErrorDetail is one key/message pair inside a resource error.
+type PatchStackErrorDetail struct {
 	Key     string `json:"key"`
 	Message string `json:"message"`
+}
+
+// PatchStackResourceError mirrors the backend ResourceError shape returned in
+// UpdateClusterStackResult.errors when validation fails per-resource: the
+// key/message pairs are nested one level down.
+type PatchStackResourceError struct {
+	Name   string                  `json:"name"`
+	Kind   string                  `json:"kind"`
+	Errors []PatchStackErrorDetail `json:"errors"`
 }
 
 // PatchStackResult mirrors UpdateClusterStackResult on the backend.

--- a/internal/client/manifests.go
+++ b/internal/client/manifests.go
@@ -6,19 +6,26 @@ import (
 	"fmt"
 	"net/http"
 	neturl "net/url"
+	"time"
 )
 
+// ClusterManifestListItem mirrors the backend's cliread ManifestItem: the
+// listing carries no namespace or parents — the stack a manifest belongs to
+// arrives as stack_name (nil for standalone manifests).
 type ClusterManifestListItem struct {
-	Name              string   `json:"name"`
-	ManifestBase64    string   `json:"manifest_base64"`
-	Namespace         string   `json:"namespace"`
-	Parents           []Parent `json:"parents"`
-	DeletePermanently bool     `json:"delete_permanently"`
-	State             string   `json:"state"`
+	Name              string     `json:"name"`
+	ManifestBase64    string     `json:"manifest_base64"`
+	State             string     `json:"state"`
+	DeletePermanently bool       `json:"delete_permanently"`
+	CreatedAt         *time.Time `json:"created_at"`
+	StackName         *string    `json:"stack_name"`
 }
 
+// ListClusterManifestsResponse mirrors ListClusterManifestsResult: the
+// backend wraps the page in a result/pagination envelope.
 type ListClusterManifestsResponse struct {
-	Manifests []ClusterManifestListItem `json:"manifests"`
+	Result     []ClusterManifestListItem `json:"result"`
+	Pagination Pagination                `json:"pagination"`
 }
 
 func (c *Client) ListClusterManifests(clusterID string) ([]ClusterManifestListItem, error) {
@@ -29,7 +36,7 @@ func (c *Client) ListClusterManifests(clusterID string) ([]ClusterManifestListIt
 		return nil, fmt.Errorf("failed to list cluster manifests: %w", err)
 	}
 
-	return response.Manifests, nil
+	return response.Result, nil
 }
 
 // getClusterManifestResponse mirrors GetClusterManifestResult from the

--- a/internal/client/manifests_test.go
+++ b/internal/client/manifests_test.go
@@ -12,10 +12,12 @@ func TestListClusterManifests(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
+		stackName := "core"
 		jsonResponse(t, w, http.StatusOK, ListClusterManifestsResponse{
-			Manifests: []ClusterManifestListItem{
-				{Name: "manifest1", Namespace: "default", State: "synced"},
+			Result: []ClusterManifestListItem{
+				{Name: "manifest1", State: "synced", StackName: &stackName},
 			},
+			Pagination: Pagination{TotalCount: 1, Page: 1, PageSize: 1000, TotalPages: 1},
 		})
 	})
 	got, err := testClient.ListClusterManifests("cluster-id")

--- a/internal/client/organisations.go
+++ b/internal/client/organisations.go
@@ -16,21 +16,24 @@ type OrganisationSummary struct {
 	Role           *string `json:"role"`
 }
 
+// OrganisationMember mirrors the backend's OrganisationUser: every field is
+// nullable (pending invites have an invite_id but no user id).
 type OrganisationMember struct {
-	UserID    string  `json:"user_id"`
-	Email     string  `json:"email"`
-	Name      *string `json:"name"`
-	Role      string  `json:"role"`
-	JoinedAt  string  `json:"joined_at"`
-	AvatarURL *string `json:"avatar_url"`
+	ID          *string `json:"id"`
+	InviteID    *string `json:"invite_id"`
+	Email       *string `json:"email"`
+	Status      *string `json:"status"`
+	Role        *string `json:"role"`
+	UserCurrent *bool   `json:"user_current"`
 }
 
+// OrganisationFull mirrors the backend's OrganisationFull: the member list
+// arrives under the users key.
 type OrganisationFull struct {
 	OrganisationID string               `json:"organisation_id"`
 	Name           *string              `json:"name"`
 	Slug           *string              `json:"slug"`
-	Status         *string              `json:"status"`
-	Members        []OrganisationMember `json:"members"`
+	Members        []OrganisationMember `json:"users"`
 	CreatedAt      string               `json:"created_at"`
 }
 

--- a/internal/client/organisations_test.go
+++ b/internal/client/organisations_test.go
@@ -67,6 +67,9 @@ func TestSwitchOrganisation(t *testing.T) {
 
 func TestGetOrganisation(t *testing.T) {
 	orgName := "Test Org"
+	memberID := "user-1"
+	memberEmail := "admin@test.com"
+	memberRole := "admin"
 	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/org/organisation/org-123" {
 			w.WriteHeader(http.StatusNotFound)
@@ -77,7 +80,7 @@ func TestGetOrganisation(t *testing.T) {
 			Name:           &orgName,
 			CreatedAt:      "2025-01-01T00:00:00Z",
 			Members: []OrganisationMember{
-				{UserID: "user-1", Email: "admin@test.com", Role: "admin", JoinedAt: "2025-01-01T00:00:00Z"},
+				{ID: &memberID, Email: &memberEmail, Role: &memberRole},
 			},
 		})
 	})

--- a/internal/client/ovh_clusters.go
+++ b/internal/client/ovh_clusters.go
@@ -45,13 +45,13 @@ type CreateOvhClusterResponse struct {
 	Name      string `json:"name"`
 }
 
+// DeprovisionOvhClusterResponse mirrors the backend's shared
+// DeprovisionClusterResponse: deprovisioning is asynchronous, so the
+// response carries the created operation id rather than deleted resources.
 type DeprovisionOvhClusterResponse struct {
-	Success         bool     `json:"success"`
-	ClusterID       string   `json:"cluster_id"`
-	DeletedServers  []string `json:"deleted_servers"`
-	DeletedNetworks []string `json:"deleted_networks"`
-	DeletedSSHKeys  []string `json:"deleted_ssh_keys"`
-	Errors          []string `json:"errors"`
+	Success     bool    `json:"success"`
+	ClusterID   string  `json:"cluster_id"`
+	OperationID *string `json:"operation_id,omitempty"`
 }
 
 type StopOvhClusterResponse struct {

--- a/internal/client/stacks.go
+++ b/internal/client/stacks.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	neturl "net/url"
+	"time"
 )
 
 type ClusterStackListItem struct {
@@ -47,21 +48,34 @@ type StackAddonConfig struct {
 }
 
 type ListClusterStacksResponse struct {
-	Stacks []ClusterStackListItem `json:"stacks"`
+	Stacks     []ClusterStackListItem `json:"stacks"`
+	Pagination Pagination             `json:"pagination"`
 }
 
-type StackHistoryEntry struct {
-	ID          string  `json:"id"`
-	Version     int     `json:"version"`
-	Description *string `json:"description,omitempty"`
-	CreatedAt   string  `json:"created_at"`
-	CreatedBy   *string `json:"created_by,omitempty"`
-	ChangeType  string  `json:"change_type"`
+// StackVersionHistoryEntry mirrors the backend's VersionHistoryEntry: one
+// stored version of a stack member resource.
+type StackVersionHistoryEntry struct {
+	VersionID    string           `json:"version_id"`
+	CreatedAt    *time.Time       `json:"created_at"`
+	Delta        []map[string]any `json:"delta"`
+	UserID       string           `json:"user_id"`
+	UserName     *string          `json:"user_name"`
+	ExternalUser *string          `json:"external_user"`
+	ChangeType   *string          `json:"change_type"`
 }
 
+// StackHistoryItem mirrors the backend's StackHistoryItem: the history is
+// grouped per stack member (addon or manifest), newest version first.
+type StackHistoryItem struct {
+	ResourceName   string                     `json:"resource_name"`
+	ResourceType   string                     `json:"resource_type"`
+	ResourceID     string                     `json:"resource_id"`
+	VersionHistory []StackVersionHistoryEntry `json:"version_history"`
+}
+
+// GetStackHistoryResponse mirrors GetClusterStackHistoryResult.
 type GetStackHistoryResponse struct {
-	StackName string              `json:"stack_name"`
-	History   []StackHistoryEntry `json:"history"`
+	History []StackHistoryItem `json:"history"`
 }
 
 type DeleteStackResult struct {
@@ -78,15 +92,25 @@ type RenameStackResult struct {
 	Message string `json:"message"`
 }
 
+// ListClusterStacks pages through the full stack listing. The
+// /api/v1/clusters/{id}/stacks twin always serves page 1 of 25, so this
+// uses the imported-cluster route, which accepts paging (page_size max 100)
+// and renders the identical stack items.
 func (c *Client) ListClusterStacks(clusterID string) ([]ClusterStackListItem, error) {
-	url := fmt.Sprintf("%s/api/v1/clusters/%s/stacks", c.BaseURL, neturl.PathEscape(clusterID))
-
-	var response ListClusterStacksResponse
-	if err := c.getJSON(url, &response); err != nil {
-		return nil, fmt.Errorf("failed to list cluster stacks: %w", err)
+	var stacks []ClusterStackListItem
+	for page := 1; ; page++ {
+		url := fmt.Sprintf("%s/api/v1/org/clusters/imported/%s/stacks?page=%d&page_size=100",
+			c.BaseURL, neturl.PathEscape(clusterID), page)
+		var response ListClusterStacksResponse
+		if err := c.getJSON(url, &response); err != nil {
+			return nil, fmt.Errorf("failed to list cluster stacks: %w", err)
+		}
+		stacks = append(stacks, response.Stacks...)
+		if page >= response.Pagination.TotalPages || len(response.Stacks) == 0 {
+			break
+		}
 	}
-
-	return response.Stacks, nil
+	return stacks, nil
 }
 
 func (c *Client) GetStackHistory(clusterID, stackName string) (*GetStackHistoryResponse, error) {
@@ -97,6 +121,25 @@ func (c *Client) GetStackHistory(clusterID, stackName string) (*GetStackHistoryR
 		return nil, fmt.Errorf("failed to get stack history: %w", err)
 	}
 	return &resp, nil
+}
+
+// GetStackAddonResourceID resolves an addon's resource id through the stack
+// history endpoint — the addon listing carries no id, and the uninstall
+// endpoint takes only the resource UUID. max_versions=1 keeps the response
+// minimal; the resource ids arrive regardless of version depth.
+func (c *Client) GetStackAddonResourceID(clusterID, stackName, addonName string) (string, error) {
+	url := fmt.Sprintf("%s/api/v1/org/clusters/imported/%s/stacks/%s/history?resource_type=addon&max_versions=1",
+		c.BaseURL, neturl.PathEscape(clusterID), neturl.PathEscape(stackName))
+	var resp GetStackHistoryResponse
+	if err := c.getJSON(url, &resp); err != nil {
+		return "", fmt.Errorf("failed to resolve addon resource id: %w", err)
+	}
+	for _, item := range resp.History {
+		if item.ResourceType == "addon" && item.ResourceName == addonName {
+			return item.ResourceID, nil
+		}
+	}
+	return "", fmt.Errorf("addon %q: %w", addonName, ErrAddonNotFound)
 }
 
 func (c *Client) DeleteStack(ctx context.Context, clusterID, stackName string) (*DeleteStackResult, error) {

--- a/internal/client/stacks_test.go
+++ b/internal/client/stacks_test.go
@@ -17,6 +17,7 @@ func TestListClusterStacks(t *testing.T) {
 			Stacks: []ClusterStackListItem{
 				{Name: "stack1", Description: "desc", State: "synced"},
 			},
+			Pagination: Pagination{TotalCount: 1, Page: 1, PageSize: 100, TotalPages: 1},
 		})
 	})
 	got, err := testClient.ListClusterStacks("cluster-id")
@@ -28,16 +29,43 @@ func TestListClusterStacks(t *testing.T) {
 	}
 }
 
+// TestListClusterStacks_Paginates verifies the client walks every page
+// instead of silently truncating at the backend's default page size.
+func TestListClusterStacks_Paginates(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		stacks := []ClusterStackListItem{{Name: "stack-page-" + page}}
+		jsonResponse(t, w, http.StatusOK, ListClusterStacksResponse{
+			Stacks:     stacks,
+			Pagination: Pagination{TotalCount: 2, Page: 1, PageSize: 100, TotalPages: 2},
+		})
+	})
+	got, err := testClient.ListClusterStacks("cluster-id")
+	if err != nil {
+		t.Fatalf("ListClusterStacks() error = %v", err)
+	}
+	if len(got) != 2 || got[0].Name != "stack-page-1" || got[1].Name != "stack-page-2" {
+		t.Errorf("ListClusterStacks() got = %v, want stacks from pages 1 and 2", got)
+	}
+}
+
 func TestGetStackHistory(t *testing.T) {
+	changeType := "create"
 	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.URL.Path, "/stacks/stack1/history") {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 		jsonResponse(t, w, http.StatusOK, GetStackHistoryResponse{
-			StackName: "stack1",
-			History: []StackHistoryEntry{
-				{ID: "v1", Version: 1, CreatedAt: "2025-01-01", ChangeType: "create"},
+			History: []StackHistoryItem{
+				{
+					ResourceName: "ingress",
+					ResourceType: "addon",
+					ResourceID:   "res-1",
+					VersionHistory: []StackVersionHistoryEntry{
+						{VersionID: "v1", ChangeType: &changeType},
+					},
+				},
 			},
 		})
 	})
@@ -45,8 +73,37 @@ func TestGetStackHistory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetStackHistory() error = %v", err)
 	}
-	if got.StackName != "stack1" || len(got.History) != 1 {
+	if len(got.History) != 1 || got.History[0].ResourceName != "ingress" {
 		t.Errorf("GetStackHistory() got = %v", got)
+	}
+}
+
+func TestGetStackAddonResourceID(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/stacks/core/history") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if r.URL.Query().Get("resource_type") != "addon" {
+			t.Errorf("resource_type = %s, want addon", r.URL.Query().Get("resource_type"))
+		}
+		jsonResponse(t, w, http.StatusOK, GetStackHistoryResponse{
+			History: []StackHistoryItem{
+				{ResourceName: "other", ResourceType: "addon", ResourceID: "res-0"},
+				{ResourceName: "ingress", ResourceType: "addon", ResourceID: "res-1"},
+			},
+		})
+	})
+	got, err := testClient.GetStackAddonResourceID("cluster-id", "core", "ingress")
+	if err != nil {
+		t.Fatalf("GetStackAddonResourceID() error = %v", err)
+	}
+	if got != "res-1" {
+		t.Errorf("GetStackAddonResourceID() = %q, want res-1", got)
+	}
+
+	if _, err := testClient.GetStackAddonResourceID("cluster-id", "core", "absent"); err == nil {
+		t.Error("GetStackAddonResourceID() expected error for absent addon, got nil")
 	}
 }
 

--- a/internal/client/upcloud_clusters.go
+++ b/internal/client/upcloud_clusters.go
@@ -50,12 +50,12 @@ type StartUpcloudClusterResult struct {
 	CreatedOperations int    `json:"created_operations"`
 }
 
+// DeprovisionUpcloudClusterResponse mirrors the backend's shared
+// DeprovisionClusterResponse.
 type DeprovisionUpcloudClusterResponse struct {
-	Success         bool     `json:"success"`
-	ClusterID       string   `json:"cluster_id"`
-	OperationID     *string  `json:"operation_id,omitempty"`
-	ResourcesMarked int      `json:"resources_marked"`
-	Errors          []string `json:"errors"`
+	Success     bool    `json:"success"`
+	ClusterID   string  `json:"cluster_id"`
+	OperationID *string `json:"operation_id,omitempty"`
 }
 
 func (c *Client) CreateUpcloudCluster(req CreateUpcloudClusterRequest) (*CreateUpcloudClusterResponse, error) {


### PR DESCRIPTION
Fixes `ankra-y9k4` — eight response-decode mismatches, verified against the backend wire structs at cluster `origin/main`, that made commands render empty or garbage output:

- **`cluster manifests list` was always empty**: the CLI decoded `{"manifests":[…]}` but the backend sends `{"result":[…],"pagination":{…}}`. The item shape now matches too (`stack_name`/`created_at` instead of the never-sent `namespace`/`parents`; the namespace column is extracted from the manifest YAML).
- **`cluster addons uninstall` could never succeed**: it deleted by the `id` field of the listing, which the backend never sends, producing `DELETE …/addons/` → 404. The resource UUID is now resolved through `GET /stacks/{stack}/history?resource_type=addon`, which exposes `resource_id` per stack member. Addons outside an Ankra-managed stack get a clear refusal instead.
- **`addons get`/`list` printed an empty ID and Repository**: no id exists on the wire, and the repository arrives as `registry_url`, not `repository_url`. The decode now mirrors the backend item (including nullable timestamps, which previously would have failed the whole decode).
- **`org members` always said "No members found"**: the CLI decoded `members`; the backend sends `users` (with nullable id/email/role/status). The table now shows email, role, invite status, and the current-user marker.
- **`chat health` printed an all-zero report**: the CLI expected a flat `{overall_health,score,…}`; the backend returns `ProactiveInsightWire` with the report nested under `health_report`. The renderer now shows the scored report, issues with suggested actions, and AI insights.
- **`cluster stacks history` rendered blank rows**: the CLI shape bore no relation to the backend's `{history:[{resource_name,version_history:[…]}]}`. The table now lists each version of each stack member with change type, timestamp, and author.
- **PATCH-stack validation errors printed empty**: the backend nests `errors[].errors[]{key,message}`; the CLI read flat `key`/`message`. All four render sites (manifests/addon upgrade, encrypt ×2) share a new unpacking helper.
- **`cluster stacks` and `cluster addons list` were silently capped at 25**: both listings now page through (`page_size=100` per request until `total_pages`); stacks moved to the imported-cluster route, which accepts paging and renders identical items.
- **OVH/UpCloud/DigitalOcean deprovision decoded dead fields**: `deleted_servers`/`deleted_networks`/`deleted_ssh_keys`/`resources_marked` are never sent; the shared backend response is `{success, cluster_id, operation_id}`. The commands now print the operation id.

No backend changes required — every fix targets an endpoint and shape that already exists on the bearer-token lane.

Tests: fixtures updated to the real wire shapes; new coverage for stack-list pagination and the history-based addon resource-id resolution. `go test -race ./…` green, `golangci-lint run` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
