### PR TITLE
feat(nodes): add the Scaleway node list/get/restart commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,16 @@
 
 ### Added
 
+- **Scaleway clusters now have the same `nodes` commands as every other
+  Ankra-provisioned provider.** `ankra cluster scaleway nodes list`, `nodes
+  get`, and `nodes restart` were the only provider node surface missing from
+  the CLI, even though the platform has served the Scaleway node routes and
+  the `scaleway_restart_server` restart lane all along — so a Scaleway node
+  could be restarted from the portal or the AI chat, but not from the
+  terminal. `nodes restart` schedules a native reboot (falling back to a
+  power cycle) as a tracked operation for any node the cluster reports,
+  including the bastion/gateway. HPE Morpheus still has no `nodes restart`,
+  matching the platform, which has no Morpheus restart lane.
 - **A kube-gateway access denial now suggests the command that fixes it.**
   When `ankra cluster kubeconfig add` or `ankra cluster kube-token` is
   rejected with a 403 because the caller has no access grant on the cluster,

--- a/cmd/cluster_nodes.go
+++ b/cmd/cluster_nodes.go
@@ -53,6 +53,15 @@ func digitaloceanNodesOps() clusterNodesOps {
 	}
 }
 
+func scalewayNodesOps() clusterNodesOps {
+	return clusterNodesOps{
+		provider: "scaleway",
+		list:     apiClient.ListScalewayClusterNodes,
+		get:      apiClient.GetScalewayClusterNode,
+		restart:  apiClient.RestartScalewayClusterNode,
+	}
+}
+
 func proxmoxNodesOps() clusterNodesOps {
 	return clusterNodesOps{
 		provider: "proxmox",
@@ -299,6 +308,7 @@ func init() {
 	ovhCmd.AddCommand(newNodesCmd(ovhNodesOps, "OVH", true))
 	upcloudCmd.AddCommand(newNodesCmd(upcloudNodesOps, "UpCloud", true))
 	digitaloceanCmd.AddCommand(newNodesCmd(digitaloceanNodesOps, "DigitalOcean", true))
+	scalewayCmd.AddCommand(newNodesCmd(scalewayNodesOps, "Scaleway", true))
 	proxmoxCmd.AddCommand(newNodesCmd(proxmoxNodesOps, "Proxmox VE", true))
 	morpheusCmd.AddCommand(newNodesCmd(morpheusNodesOps, "HPE Morpheus", false))
 }

--- a/cmd/cluster_nodes_test.go
+++ b/cmd/cluster_nodes_test.go
@@ -74,12 +74,70 @@ func TestClusterNodesRestartCommandRequiresBothArgs(t *testing.T) {
 	}
 }
 
+type scalewayNodesMock struct {
+	baseMock
+
+	restartResult *client.RestartNodeResult
+	restartCalls  []string
+	listResult    *client.NodeListResult
+	listCalls     []string
+}
+
+func (m *scalewayNodesMock) RestartScalewayClusterNode(clusterID, nodeID string) (*client.RestartNodeResult, error) {
+	m.restartCalls = append(m.restartCalls, clusterID+":"+nodeID)
+	return m.restartResult, nil
+}
+
+func (m *scalewayNodesMock) ListScalewayClusterNodes(clusterID string) (*client.NodeListResult, error) {
+	m.listCalls = append(m.listCalls, clusterID)
+	return m.listResult, nil
+}
+
+func TestClusterNodesRestartCommandDispatchesScaleway(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	mock := &scalewayNodesMock{
+		restartResult: &client.RestartNodeResult{OperationID: "op-9", NodeID: "node-9", JobName: "scaleway_restart_server"},
+	}
+	setMockClient(t, mock)
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("cluster", "scaleway", "nodes", "restart", "cluster-9", "node-9")
+	})
+
+	if len(mock.restartCalls) != 1 || mock.restartCalls[0] != "cluster-9:node-9" {
+		t.Fatalf("expected one Scaleway restart call for cluster-9:node-9, got %v", mock.restartCalls)
+	}
+	if !strings.Contains(stdoutOutput, "scaleway_restart_server") {
+		t.Errorf("expected the Scaleway job name in output, got: %s", stdoutOutput)
+	}
+}
+
+func TestClusterNodesListCommandDispatchesScaleway(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	mock := &scalewayNodesMock{
+		listResult: &client.NodeListResult{Nodes: []client.NodeSummary{{ID: "node-9", Name: "worker-1", State: "up"}}},
+	}
+	setMockClient(t, mock)
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("cluster", "scaleway", "nodes", "list", "cluster-9")
+	})
+
+	if len(mock.listCalls) != 1 || mock.listCalls[0] != "cluster-9" {
+		t.Fatalf("expected one Scaleway list call for cluster-9, got %v", mock.listCalls)
+	}
+	if !strings.Contains(stdoutOutput, "worker-1") {
+		t.Errorf("expected the node name in output, got: %s", stdoutOutput)
+	}
+}
+
 func TestClusterNodesRestartSurfaceMatchesProviderSupport(t *testing.T) {
 	expectations := map[string]bool{
 		"hetzner":      true,
 		"ovh":          true,
 		"upcloud":      true,
 		"digitalocean": true,
+		"scaleway":     true,
 		"proxmox":      true,
 		"morpheus":     false,
 	}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1223,6 +1223,18 @@ func (m baseMock) StartScalewayCluster(clusterID, scope string) (*client.Provide
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) ListScalewayClusterNodes(clusterID string) (*client.NodeListResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetScalewayClusterNode(clusterID, nodeID string) (*client.NodeDetail, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) RestartScalewayClusterNode(clusterID, nodeID string) (*client.RestartNodeResult, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) CreateProxmoxCluster(request client.CreateProxmoxClusterRequest) (*client.CreateProxmoxClusterResponse, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -349,6 +349,9 @@ type APIClient interface {
 
 	StopScalewayCluster(clusterID string) (*client.ProviderStopClusterResponse, error)
 	StartScalewayCluster(clusterID, scope string) (*client.ProviderStartClusterResult, error)
+	ListScalewayClusterNodes(clusterID string) (*client.NodeListResult, error)
+	GetScalewayClusterNode(clusterID, nodeID string) (*client.NodeDetail, error)
+	RestartScalewayClusterNode(clusterID, nodeID string) (*client.RestartNodeResult, error)
 	CreateProxmoxCluster(request client.CreateProxmoxClusterRequest) (*client.CreateProxmoxClusterResponse, error)
 	DeprovisionProxmoxCluster(clusterID string) (*client.ProviderDeprovisionClusterResponse, error)
 	StopProxmoxCluster(clusterID string) (*client.ProviderStopClusterResponse, error)

--- a/internal/client/cluster_nodes_test.go
+++ b/internal/client/cluster_nodes_test.go
@@ -72,6 +72,60 @@ func TestRestartDigitaloceanClusterNode_Success(t *testing.T) {
 	}
 }
 
+func TestRestartScalewayClusterNode_Success(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/clusters/scaleway/cluster-1/nodes/node-1/restart" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		jsonResponse(t, w, http.StatusOK, RestartNodeResult{OperationID: "op-1", NodeID: "node-1", JobName: "scaleway_restart_server"})
+	}
+	testClient := newTestClient(t, handler)
+	result, err := testClient.RestartScalewayClusterNode("cluster-1", "node-1")
+	if err != nil {
+		t.Fatalf("RestartScalewayClusterNode: %v", err)
+	}
+	if result.JobName != "scaleway_restart_server" {
+		t.Errorf("JobName = %s, want scaleway_restart_server", result.JobName)
+	}
+}
+
+func TestListScalewayClusterNodes_Success(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/clusters/scaleway/cluster-1/nodes" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		jsonResponse(t, w, http.StatusOK, NodeListResult{Nodes: []NodeSummary{{ID: "node-1", Name: "worker-1"}}})
+	}
+	testClient := newTestClient(t, handler)
+	result, err := testClient.ListScalewayClusterNodes("cluster-1")
+	if err != nil {
+		t.Fatalf("ListScalewayClusterNodes: %v", err)
+	}
+	if len(result.Nodes) != 1 || result.Nodes[0].Name != "worker-1" {
+		t.Errorf("Nodes = %+v, want one node named worker-1", result.Nodes)
+	}
+}
+
+func TestGetScalewayClusterNode_Success(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/clusters/scaleway/cluster-1/nodes/node-1" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		jsonResponse(t, w, http.StatusOK, NodeDetail{ID: "node-1", Name: "worker-1", State: "up"})
+	}
+	testClient := newTestClient(t, handler)
+	result, err := testClient.GetScalewayClusterNode("cluster-1", "node-1")
+	if err != nil {
+		t.Fatalf("GetScalewayClusterNode: %v", err)
+	}
+	if result.Name != "worker-1" {
+		t.Errorf("Name = %s, want worker-1", result.Name)
+	}
+}
+
 func TestRestartHetznerClusterNode_ConflictSurfacesDetail(t *testing.T) {
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		jsonResponse(t, w, http.StatusConflict, map[string]string{

--- a/internal/client/scaleway_clusters.go
+++ b/internal/client/scaleway_clusters.go
@@ -1,9 +1,23 @@
 package client
 
+const scalewayKind = "scaleway"
+
 func (c *Client) StopScalewayCluster(clusterID string) (*ProviderStopClusterResponse, error) {
-	return c.stopProviderCluster("scaleway", clusterID)
+	return c.stopProviderCluster(scalewayKind, clusterID)
 }
 
 func (c *Client) StartScalewayCluster(clusterID, scope string) (*ProviderStartClusterResult, error) {
-	return c.startProviderCluster("scaleway", clusterID, scope)
+	return c.startProviderCluster(scalewayKind, clusterID, scope)
+}
+
+func (c *Client) ListScalewayClusterNodes(clusterID string) (*NodeListResult, error) {
+	return c.listClusterNodes(scalewayKind, clusterID)
+}
+
+func (c *Client) GetScalewayClusterNode(clusterID, nodeID string) (*NodeDetail, error) {
+	return c.getClusterNode(scalewayKind, clusterID, nodeID)
+}
+
+func (c *Client) RestartScalewayClusterNode(clusterID, nodeID string) (*RestartNodeResult, error) {
+	return c.restartClusterNode(scalewayKind, clusterID, nodeID)
 }


### PR DESCRIPTION
## What & why

Scaleway was the only Ankra-provisioned provider without a `nodes` command surface in the CLI.

The platform has always mounted the full node routes for Scaleway (`/api/v1/clusters/scaleway/{cluster_id}/nodes`, `/nodes/{node_id}`, `/nodes/{node_id}/restart`) and ships a `scaleway_restart_server` restart lane in `restartJobNamesByProvider`. So a Scaleway node could already be listed and restarted from the portal Nodes page and from the `restart_node` Ankra AI chat tool — just not from the terminal.

This wires Scaleway into the existing shared plumbing:

- `internal/client/scaleway_clusters.go` — `ListScalewayClusterNodes`, `GetScalewayClusterNode`, `RestartScalewayClusterNode` onto the provider-agnostic `listClusterNodes` / `getClusterNode` / `restartClusterNode` helpers, plus a `scalewayKind` constant replacing the two existing string literals.
- `cmd/cluster_nodes.go` — `scalewayNodesOps()` and registration through the shared `newNodesCmd` factory with `supportsRestart=true`.
- `cmd/services.go` + `cmd/e2e_test.go` — the three methods on the `APIClient` interface and the `baseMock` stub set, as the repo's build contract requires.

No new command code paths: output formatting, `-o json|yaml` structured output, exit codes, and error surfacing all come from the factory every other provider already uses.

**HPE Morpheus deliberately stays `supportsRestart=false`** — the platform has no Morpheus restart lane, so offering the command would only ever produce a 409.

### Provider coverage after this change

| Provider | list | get | restart |
|---|---|---|---|
| Hetzner, OVH, UpCloud, DigitalOcean, Proxmox | ✅ | ✅ | ✅ |
| **Scaleway** | **✅ new** | **✅ new** | **✅ new** |
| HPE Morpheus | ✅ | ✅ | — (no platform lane) |

## Test plan

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -race -count=1 ./...` — all packages pass
- `golangci-lint run` — 0 issues
- Verified on the built binary: `ankra cluster scaleway nodes --help` now lists `get`, `list`, and `restart`

New tests:

- `internal/client`: `TestRestartScalewayClusterNode_Success`, `TestListScalewayClusterNodes_Success`, `TestGetScalewayClusterNode_Success` — assert the exact request method and URL path for each route
- `cmd`: `TestClusterNodesRestartCommandDispatchesScaleway`, `TestClusterNodesListCommandDispatchesScaleway` — assert the command dispatches to the Scaleway client method with the right arguments
- `TestClusterNodesRestartSurfaceMatchesProviderSupport` gains Scaleway, so this parity guard now pins all seven providers — a provider that gains a restart lane server-side will fail this test until the CLI is wired too

`gofmt -l` reports several files in this repo, all of them pre-existing on `master` and none touched here; deliberately not reformatted to keep the diff reviewable.

## Docs checklist

- [x] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); `Short`/`Long` come from the shared `newNodesCmd` factory and already read for docs users
- CHANGELOG.md updated under Unreleased → Added

🤖 Generated with [Claude Code](https://claude.com/claude-code)
