### PR TITLE
feat(chat): let agent-mode writes be confirmed from the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,20 @@
 
 ### Added
 
+- **Agent-mode chat writes can now be approved from the terminal.** In agent
+  mode every mutating tool halts the turn and emits an `action_proposal`
+  frame, and the write only runs once that proposal is confirmed. The CLI
+  parsed the chat stream but silently dropped that frame and had no way to
+  answer it, so `ankra chat --mode agent "restart node worker-1"` appeared to
+  do nothing — the proposal existed server-side but was invisible and
+  unreachable. The stream now renders every proposal (tool, description, risk,
+  whether it is reversible, parameters, expiry, and the action id), an
+  interactive session prompts to run or discard each one, and
+  `ankra chat actions confirm|reject|list` drives the same decision from a
+  script. A confirmation refused because the cluster drifted since the
+  proposal reports what happened and prints the ready-to-run `--force`
+  invocation; a superseded action does not offer force, because forcing one
+  cannot work.
 - **A kube-gateway access denial now suggests the command that fixes it.**
   When `ankra cluster kubeconfig add` or `ankra cluster kube-token` is
   rejected with a 403 because the caller has no access grant on the cluster,

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -108,6 +108,16 @@ func runChatMessage(clusterID *string, query string, interactionMode string) err
 					hadStatus = true
 				}
 			}
+		case "action_proposal":
+			proposal, decodeError := decodeActionProposal(event.Data)
+			if decodeError != nil {
+				fmt.Printf("\nAn action is awaiting confirmation but could not be read: %v\n", decodeError)
+				continue
+			}
+			renderActionProposal(proposal)
+			fmt.Println("This write has NOT run. Confirm it to proceed:")
+			fmt.Printf("  ankra chat actions confirm %s\n", proposal.ActionID)
+			fmt.Printf("  ankra chat actions reject %s\n\n", proposal.ActionID)
 		case "error":
 			fmt.Printf("\nError: %s\n", event.Error)
 		case "done", "complete":
@@ -180,6 +190,7 @@ func runInteractiveChat(clusterID *string, interactionMode string) error {
 		var response strings.Builder
 		var hasStartedContent bool
 		var hadStatus bool
+		var pendingProposals []*client.ChatActionProposal
 		for event := range events {
 			switch event.Type {
 			case "content":
@@ -213,6 +224,13 @@ func runInteractiveChat(clusterID *string, interactionMode string) error {
 						hadStatus = true
 					}
 				}
+			case "action_proposal":
+				proposal, decodeError := decodeActionProposal(event.Data)
+				if decodeError != nil {
+					fmt.Printf("\nAn action is awaiting confirmation but could not be read: %v\n", decodeError)
+					continue
+				}
+				pendingProposals = append(pendingProposals, proposal)
 			case "error":
 				fmt.Printf("\nError: %s\n", event.Error)
 			case "done", "complete":
@@ -225,6 +243,7 @@ func runInteractiveChat(clusterID *string, interactionMode string) error {
 			}
 		}
 		fmt.Print("\n\n")
+		resolvePendingProposals(reader, pendingProposals)
 	}
 }
 

--- a/cmd/chat_actions.go
+++ b/cmd/chat_actions.go
@@ -1,0 +1,282 @@
+package cmd
+
+// `ankra chat actions ...`: the terminal half of agent-mode write approval.
+// In agent mode every tool flagged requires_confirmation halts the turn and
+// emits an `action_proposal` frame; the write only runs once the proposal is
+// confirmed. These commands are how that confirmation is given without a
+// browser.
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"ankra/internal/client"
+)
+
+var chatActionsCmd = &cobra.Command{
+	Use:   "actions",
+	Short: "Review and confirm AI actions awaiting approval",
+	Long: `Agent-mode chat halts before every write and proposes it as a pending
+action. Confirm the action to run it, or reject it to discard it.
+
+Pending actions expire, so confirm promptly. If the cluster changed since the
+action was proposed, confirming answers a drift conflict; re-run with --force
+to apply it against the changed state anyway.`,
+}
+
+var chatActionsConfirmCmd = &cobra.Command{
+	Use:   "confirm <action_id>",
+	Short: "Confirm a pending AI action so it runs",
+	Long: `Confirm a pending action proposed by agent-mode chat.
+
+The platform re-checks the action against live cluster state before running
+it. If the state drifted since the proposal, the command reports the drift and
+exits without running anything; pass --force to run it anyway.`,
+	Example: `  # Confirm the action id printed by the chat stream
+  ankra chat actions confirm 6f1c2f9e-6d5a-4a1e-9f0b-6d4c2b8a1e77
+
+  # Apply it even though the cluster drifted since it was proposed
+  ankra chat actions confirm 6f1c2f9e-6d5a-4a1e-9f0b-6d4c2b8a1e77 --force \
+    --force-reason "drift is an unrelated label change"`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		force, _ := cmd.Flags().GetBool("force")
+		forceReason, _ := cmd.Flags().GetString("force-reason")
+		return runChatActionDecision(cmd, args[0], true, force, forceReason, "")
+	},
+}
+
+var chatActionsRejectCmd = &cobra.Command{
+	Use:   "reject <action_id>",
+	Short: "Reject a pending AI action so it never runs",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		reason, _ := cmd.Flags().GetString("reason")
+		return runChatActionDecision(cmd, args[0], false, false, "", reason)
+	},
+}
+
+var chatActionsListCmd = &cobra.Command{
+	Use:   "list <conversation_id>",
+	Short: "List the actions awaiting confirmation in a conversation",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		result, listError := apiClient.ListPendingChatActions(args[0])
+		if listError != nil {
+			return listError
+		}
+		if handled, renderError := renderStructured(cmd, result); renderError != nil {
+			return renderError
+		} else if handled {
+			return nil
+		}
+		if result.Count == 0 {
+			fmt.Println("No actions awaiting confirmation.")
+			return nil
+		}
+		for _, action := range result.Actions {
+			fmt.Printf("%-38s %-28s %s\n",
+				mapString(action, "action_id"),
+				mapString(action, "tool_name"),
+				mapString(action, "description"))
+		}
+		fmt.Printf("\n%d action(s) awaiting confirmation.\n", result.Count)
+		return nil
+	},
+}
+
+// runChatActionDecision performs the confirm/reject call and renders the
+// answer, translating a drift conflict into the --force hint.
+func runChatActionDecision(cmd *cobra.Command, actionID string, confirmed, force bool,
+	forceReason, reason string) error {
+	request := client.ConfirmChatActionRequest{ActionID: actionID, Confirmed: confirmed}
+	if force {
+		request.Force = &force
+	}
+	if forceReason != "" {
+		request.ForceReason = &forceReason
+	}
+	if reason != "" {
+		request.Reason = &reason
+	}
+
+	result, confirmError := apiClient.ConfirmChatAction(request)
+	if confirmError != nil {
+		var conflict *client.ActionConflictError
+		if errors.As(confirmError, &conflict) {
+			return chatActionConflictError(conflict, actionID)
+		}
+		return confirmError
+	}
+
+	if handled, renderError := renderStructured(cmd, result); renderError != nil {
+		return renderError
+	} else if handled {
+		return nil
+	}
+
+	if !confirmed {
+		fmt.Printf("Action %s rejected; it will not run.\n", actionID)
+		return nil
+	}
+	fmt.Printf("Action %s confirmed.\n", actionID)
+	if result.Message != "" {
+		fmt.Println(result.Message)
+	}
+	if result.Status != "" {
+		fmt.Printf("Status: %s\n", result.Status)
+	}
+	return nil
+}
+
+// chatActionConflictError renders a 409 as a usable next step: drift is
+// recoverable with --force, a supersede never is.
+func chatActionConflictError(conflict *client.ActionConflictError, actionID string) error {
+	if conflict.IsDrift() {
+		return fmt.Errorf(
+			"%s\n\nThe cluster changed since this action was proposed, so it was not run.\n"+
+				"Review the change, then re-run with --force to apply it anyway:\n"+
+				"  ankra chat actions confirm %s --force",
+			conflict.Error(), actionID)
+	}
+	return fmt.Errorf(
+		"%s\n\nA newer action replaced this one, so it can no longer be confirmed.\n"+
+			"Ask the assistant again to get a fresh proposal", conflict.Error())
+}
+
+// renderActionProposal prints an `action_proposal` frame. Agent-mode writes
+// halt on this frame, so it must always be shown - a dropped proposal looks
+// like the assistant silently ignored the request.
+func renderActionProposal(proposal *client.ChatActionProposal) {
+	fmt.Println()
+	fmt.Println("── Action awaiting confirmation ──────────────────────────────")
+	fmt.Printf("  Tool:        %s\n", proposal.ToolName)
+	if proposal.Description != "" {
+		fmt.Printf("  Description: %s\n", proposal.Description)
+	}
+	fmt.Printf("  Risk:        %s", proposal.RiskLevel)
+	if proposal.Reversible {
+		fmt.Print(" (reversible)")
+	} else {
+		fmt.Print(" (NOT reversible)")
+	}
+	fmt.Println()
+	if parameters := formatProposalParameters(proposal.Parameters); parameters != "" {
+		fmt.Printf("  Parameters:  %s\n", parameters)
+	}
+	if proposal.ExpiresInSeconds > 0 {
+		fmt.Printf("  Expires in:  %ds\n", proposal.ExpiresInSeconds)
+	}
+	fmt.Printf("  Action ID:   %s\n", proposal.ActionID)
+	fmt.Println("──────────────────────────────────────────────────────────────")
+}
+
+// formatProposalParameters renders the tool arguments on one line, keeping
+// the server's key order.
+func formatProposalParameters(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var decoded map[string]any
+	if unmarshalError := json.Unmarshal(raw, &decoded); unmarshalError != nil {
+		return strings.TrimSpace(string(raw))
+	}
+	if len(decoded) == 0 {
+		return ""
+	}
+	compact, marshalError := json.Marshal(decoded)
+	if marshalError != nil {
+		return strings.TrimSpace(string(raw))
+	}
+	return string(compact)
+}
+
+// decodeActionProposal converts the SSE frame's `data` member into the typed
+// proposal. The stream decodes frames into `any`, so this round-trips.
+func decodeActionProposal(data any) (*client.ChatActionProposal, error) {
+	encoded, marshalError := json.Marshal(data)
+	if marshalError != nil {
+		return nil, marshalError
+	}
+	var proposal client.ChatActionProposal
+	if unmarshalError := json.Unmarshal(encoded, &proposal); unmarshalError != nil {
+		return nil, unmarshalError
+	}
+	if proposal.ActionID == "" {
+		return nil, errors.New("action proposal carried no action_id")
+	}
+	return &proposal, nil
+}
+
+// resolvePendingProposals walks the proposals a turn halted on and asks the
+// user to decide each one, so an interactive session never has to leave the
+// prompt to approve a write. Answering anything but yes rejects the action,
+// which is the safe default for a mutation.
+func resolvePendingProposals(reader *bufio.Reader, proposals []*client.ChatActionProposal) {
+	for _, proposal := range proposals {
+		renderActionProposal(proposal)
+		fmt.Print("Run this action? [y/N]: ")
+		answer, readError := reader.ReadString('\n')
+		if readError != nil && readError != io.EOF {
+			fmt.Printf("Could not read your answer (%v); leaving the action pending.\n", readError)
+			fmt.Printf("Confirm it later with: ankra chat actions confirm %s\n", proposal.ActionID)
+			return
+		}
+		confirmed := isAffirmative(answer)
+
+		result, confirmError := apiClient.ConfirmChatAction(client.ConfirmChatActionRequest{
+			ActionID:  proposal.ActionID,
+			Confirmed: confirmed,
+		})
+		if confirmError != nil {
+			var conflict *client.ActionConflictError
+			if errors.As(confirmError, &conflict) {
+				fmt.Printf("%v\n", chatActionConflictError(conflict, proposal.ActionID))
+				continue
+			}
+			fmt.Printf("Could not resolve the action: %v\n", confirmError)
+			continue
+		}
+		if !confirmed {
+			fmt.Printf("Rejected; %s will not run.\n\n", proposal.ToolName)
+			continue
+		}
+		fmt.Printf("Confirmed; %s is running.\n", proposal.ToolName)
+		if result != nil && result.Message != "" {
+			fmt.Println(result.Message)
+		}
+		fmt.Println()
+	}
+}
+
+func isAffirmative(answer string) bool {
+	normalised := strings.ToLower(strings.TrimSpace(answer))
+	return normalised == "y" || normalised == "yes"
+}
+
+func mapString(source map[string]any, key string) string {
+	if value, present := source[key]; present {
+		if text, isText := value.(string); isText {
+			return text
+		}
+	}
+	return "-"
+}
+
+func init() {
+	chatActionsConfirmCmd.Flags().Bool("force", false,
+		"Confirm even though cluster state drifted since the action was proposed")
+	chatActionsConfirmCmd.Flags().String("force-reason", "",
+		"Why the drift is acceptable (recorded in the audit trail, max 280 characters)")
+	chatActionsRejectCmd.Flags().String("reason", "", "Why the action was rejected")
+
+	registerStructuredOutputFlags(chatActionsConfirmCmd, chatActionsRejectCmd, chatActionsListCmd)
+	chatActionsCmd.AddCommand(chatActionsConfirmCmd, chatActionsRejectCmd, chatActionsListCmd)
+	chatCmd.AddCommand(chatActionsCmd)
+}

--- a/cmd/chat_actions_test.go
+++ b/cmd/chat_actions_test.go
@@ -1,0 +1,203 @@
+package cmd
+
+// Tests for the agent-mode approval surface: an `action_proposal` frame must
+// never be dropped (the write is halted behind it), and confirm/reject must
+// reach the API with the right body and translate a drift conflict into the
+// --force hint.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type chatActionMock struct {
+	baseMock
+
+	confirmRequests []client.ConfirmChatActionRequest
+	confirmResult   *client.ConfirmChatActionResult
+	confirmError    error
+
+	pendingResult *client.PendingChatActionsResult
+}
+
+func (m *chatActionMock) ConfirmChatAction(request client.ConfirmChatActionRequest) (*client.ConfirmChatActionResult, error) {
+	m.confirmRequests = append(m.confirmRequests, request)
+	if m.confirmError != nil {
+		return nil, m.confirmError
+	}
+	return m.confirmResult, nil
+}
+
+func (m *chatActionMock) ListPendingChatActions(conversationID string) (*client.PendingChatActionsResult, error) {
+	return m.pendingResult, nil
+}
+
+func TestChatActionsConfirmSendsConfirmedTrue(t *testing.T) {
+	mock := &chatActionMock{confirmResult: &client.ConfirmChatActionResult{Success: true, Status: "executing"}}
+	setMockClient(t, mock)
+
+	stdoutOutput := captureStdout(t, func() {
+		if _, commandError := executeCommand("chat", "actions", "confirm", "action-1"); commandError != nil {
+			t.Fatalf("confirm: %v", commandError)
+		}
+	})
+
+	if len(mock.confirmRequests) != 1 {
+		t.Fatalf("expected one confirm call, got %d", len(mock.confirmRequests))
+	}
+	request := mock.confirmRequests[0]
+	if request.ActionID != "action-1" || !request.Confirmed {
+		t.Errorf("request = %+v, want action-1 confirmed=true", request)
+	}
+	if request.Force != nil {
+		t.Errorf("Force = %v, want nil when --force is not passed", *request.Force)
+	}
+	if !strings.Contains(stdoutOutput, "confirmed") {
+		t.Errorf("expected a confirmation line, got: %s", stdoutOutput)
+	}
+}
+
+func TestChatActionsRejectSendsConfirmedFalse(t *testing.T) {
+	mock := &chatActionMock{confirmResult: &client.ConfirmChatActionResult{Success: true}}
+	setMockClient(t, mock)
+
+	stdoutOutput := captureStdout(t, func() {
+		if _, commandError := executeCommand("chat", "actions", "reject", "action-2", "--reason", "not now"); commandError != nil {
+			t.Fatalf("reject: %v", commandError)
+		}
+	})
+
+	request := mock.confirmRequests[0]
+	if request.Confirmed {
+		t.Error("Confirmed = true, want false for reject")
+	}
+	if request.Reason == nil || *request.Reason != "not now" {
+		t.Errorf("Reason = %v, want \"not now\"", request.Reason)
+	}
+	if !strings.Contains(stdoutOutput, "rejected") {
+		t.Errorf("expected a rejection line, got: %s", stdoutOutput)
+	}
+}
+
+func TestChatActionsConfirmForwardsForce(t *testing.T) {
+	mock := &chatActionMock{confirmResult: &client.ConfirmChatActionResult{Success: true}}
+	setMockClient(t, mock)
+
+	captureStdout(t, func() {
+		_, _ = executeCommand("chat", "actions", "confirm", "action-3",
+			"--force", "--force-reason", "unrelated label drift")
+	})
+
+	request := mock.confirmRequests[0]
+	if request.Force == nil || !*request.Force {
+		t.Error("expected Force=true to be forwarded")
+	}
+	if request.ForceReason == nil || *request.ForceReason != "unrelated label drift" {
+		t.Errorf("ForceReason = %v, want the supplied reason", request.ForceReason)
+	}
+}
+
+func TestChatActionsConfirmDriftSuggestsForce(t *testing.T) {
+	mock := &chatActionMock{confirmError: &client.ActionConflictError{
+		ErrorCode: client.ActionErrorCodeDrifted,
+		Detail:    "Cluster state changed since this action was proposed",
+	}}
+	setMockClient(t, mock)
+
+	_, commandError := executeCommand("chat", "actions", "confirm", "action-4")
+	if commandError == nil {
+		t.Fatal("expected the drift conflict to surface as an error")
+	}
+	if !strings.Contains(commandError.Error(), "--force") {
+		t.Errorf("expected the --force hint, got: %v", commandError)
+	}
+	if !strings.Contains(commandError.Error(), "action-4") {
+		t.Errorf("expected the ready-to-run command with the action id, got: %v", commandError)
+	}
+}
+
+func TestChatActionsConfirmSupersededDoesNotSuggestForce(t *testing.T) {
+	mock := &chatActionMock{confirmError: &client.ActionConflictError{
+		ErrorCode: client.ActionErrorCodeSuperseded,
+		Detail:    "A newer action replaced this one",
+	}}
+	setMockClient(t, mock)
+
+	_, commandError := executeCommand("chat", "actions", "confirm", "action-5")
+	if commandError == nil {
+		t.Fatal("expected the supersede conflict to surface as an error")
+	}
+	if strings.Contains(commandError.Error(), "--force") {
+		t.Errorf("a superseded action is not forceable, but the error offered --force: %v", commandError)
+	}
+}
+
+func TestDecodeActionProposalReadsTheSSEPayload(t *testing.T) {
+	var payload any
+	if unmarshalError := json.Unmarshal([]byte(`{
+		"action_id": "6f1c2f9e-6d5a-4a1e-9f0b-6d4c2b8a1e77",
+		"tool_name": "restart_node",
+		"description": "Restart worker-1",
+		"parameters": {"node_id": "node-1"},
+		"risk_level": "medium",
+		"reversible": true,
+		"expires_in_seconds": 300
+	}`), &payload); unmarshalError != nil {
+		t.Fatalf("seed payload: %v", unmarshalError)
+	}
+
+	proposal, decodeError := decodeActionProposal(payload)
+	if decodeError != nil {
+		t.Fatalf("decodeActionProposal: %v", decodeError)
+	}
+	if proposal.ActionID != "6f1c2f9e-6d5a-4a1e-9f0b-6d4c2b8a1e77" {
+		t.Errorf("ActionID = %s", proposal.ActionID)
+	}
+	if proposal.ToolName != "restart_node" || !proposal.Reversible || proposal.RiskLevel != "medium" {
+		t.Errorf("proposal = %+v", proposal)
+	}
+	if proposal.ExpiresInSeconds != 300 {
+		t.Errorf("ExpiresInSeconds = %d, want 300", proposal.ExpiresInSeconds)
+	}
+}
+
+func TestDecodeActionProposalRejectsPayloadWithoutActionID(t *testing.T) {
+	if _, decodeError := decodeActionProposal(map[string]any{"tool_name": "restart_node"}); decodeError == nil {
+		t.Fatal("expected an error when action_id is absent - it is the only handle for confirming")
+	}
+}
+
+func TestRenderActionProposalShowsIrreversibilityAndActionID(t *testing.T) {
+	stdoutOutput := captureStdout(t, func() {
+		renderActionProposal(&client.ChatActionProposal{
+			ActionID:    "action-9",
+			ToolName:    "delete_cluster",
+			Description: "Delete production",
+			RiskLevel:   "high",
+			Reversible:  false,
+		})
+	})
+
+	if !strings.Contains(stdoutOutput, "NOT reversible") {
+		t.Errorf("an irreversible action must say so, got: %s", stdoutOutput)
+	}
+	if !strings.Contains(stdoutOutput, "action-9") {
+		t.Errorf("the action id is needed to confirm, got: %s", stdoutOutput)
+	}
+}
+
+func TestIsAffirmativeDefaultsToRejecting(t *testing.T) {
+	for _, answer := range []string{"y", "Y", "yes", "YES", " yes \n"} {
+		if !isAffirmative(answer) {
+			t.Errorf("isAffirmative(%q) = false, want true", answer)
+		}
+	}
+	for _, answer := range []string{"", "\n", "n", "no", "sure", "later"} {
+		if isAffirmative(answer) {
+			t.Errorf("isAffirmative(%q) = true; anything but yes must reject a mutation", answer)
+		}
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -519,6 +519,14 @@ func (m baseMock) StreamChat(clusterID *string, chatReq client.ChatRequest) (<-c
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) ConfirmChatAction(request client.ConfirmChatActionRequest) (*client.ConfirmChatActionResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ListPendingChatActions(conversationID string) (*client.PendingChatActionsResult, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) ListChatHistory(clusterID *string, limit, offset int) (*client.ListConversationsResponse, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -151,6 +151,8 @@ type APIClient interface {
 	RemovePasskey(credentialID string) (*client.RemoveMFAResponse, error)
 
 	StreamChat(clusterID *string, chatReq client.ChatRequest) (<-chan client.ChatStreamEvent, error)
+	ConfirmChatAction(request client.ConfirmChatActionRequest) (*client.ConfirmChatActionResult, error)
+	ListPendingChatActions(conversationID string) (*client.PendingChatActionsResult, error)
 	ListChatHistory(clusterID *string, limit, offset int) (*client.ListConversationsResponse, error)
 	GetChatConversation(conversationID string) (*client.ChatConversation, error)
 	DeleteChatConversation(conversationID string) (*client.DeleteConversationResponse, error)

--- a/internal/client/chat_actions.go
+++ b/internal/client/chat_actions.go
@@ -1,0 +1,172 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Stable error codes the confirm endpoint answers 409 with. The CLI keys on
+// the code, not the message, so the wording can change server-side without
+// breaking the retry hint.
+const (
+	ActionErrorCodeDrifted    = "ACTION_DRIFTED"
+	ActionErrorCodeSuperseded = "ACTION_SUPERSEDED"
+)
+
+// ChatActionProposal is the payload of an `action_proposal` SSE frame: the
+// write the assistant wants to run, halted until it is confirmed. Emitted
+// only in agent mode - ask mode refuses mutating tools before proposing.
+type ChatActionProposal struct {
+	ActionID         string          `json:"action_id"`
+	ToolName         string          `json:"tool_name"`
+	Description      string          `json:"description"`
+	Parameters       json.RawMessage `json:"parameters,omitempty"`
+	RiskLevel        string          `json:"risk_level"`
+	Reversible       bool            `json:"reversible"`
+	CreatedAt        string          `json:"created_at"`
+	ExpiresInSeconds int             `json:"expires_in_seconds"`
+	PlanID           *string         `json:"plan_id,omitempty"`
+}
+
+// ActionConflictError is a 409 from the confirm endpoint: the live state no
+// longer matches the fingerprint taken when the action was proposed
+// (ACTION_DRIFTED), or a newer action replaced this one
+// (ACTION_SUPERSEDED). Drift is recoverable by confirming with force.
+type ActionConflictError struct {
+	ErrorCode string
+	Detail    string
+	Payload   json.RawMessage
+}
+
+func (conflictError *ActionConflictError) Error() string {
+	if conflictError.Detail != "" {
+		return conflictError.Detail
+	}
+	return conflictError.ErrorCode
+}
+
+// IsDrift reports whether the conflict is recoverable by re-confirming with
+// force, as opposed to a supersede, which never is.
+func (conflictError *ActionConflictError) IsDrift() bool {
+	return conflictError.ErrorCode == ActionErrorCodeDrifted
+}
+
+// ConfirmChatActionRequest is the confirm endpoint's body. Confirmed=false
+// rejects the action instead of running it.
+type ConfirmChatActionRequest struct {
+	ActionID    string  `json:"action_id"`
+	Confirmed   bool    `json:"confirmed"`
+	Reason      *string `json:"reason,omitempty"`
+	Force       *bool   `json:"force,omitempty"`
+	ForceReason *string `json:"force_reason,omitempty"`
+}
+
+// ConfirmChatActionResult is the confirm endpoint's 200 body. The envelope
+// varies by tool, so the decoded document is kept whole for `-o json` and
+// the well-known fields are lifted for the human rendering.
+type ConfirmChatActionResult struct {
+	Success  bool           `json:"success"`
+	Status   string         `json:"status,omitempty"`
+	Message  string         `json:"message,omitempty"`
+	ActionID string         `json:"action_id,omitempty"`
+	ToolName string         `json:"tool_name,omitempty"`
+	Document map[string]any `json:"-"`
+}
+
+// UnmarshalJSON keeps the whole document alongside the lifted fields.
+func (result *ConfirmChatActionResult) UnmarshalJSON(data []byte) error {
+	type plainResult ConfirmChatActionResult
+	var lifted plainResult
+	if unmarshalError := json.Unmarshal(data, &lifted); unmarshalError != nil {
+		return unmarshalError
+	}
+	*result = ConfirmChatActionResult(lifted)
+	return json.Unmarshal(data, &result.Document)
+}
+
+// ConfirmChatAction confirms or rejects a pending AI action.
+//
+// The endpoint is CSRF-protected (double-submit), so the request carries a
+// matching `X-Ankra-CSRF` header and `ankra_csrf` cookie the same way the
+// account MFA writes do.
+func (c *Client) ConfirmChatAction(request ConfirmChatActionRequest) (*ConfirmChatActionResult, error) {
+	requestURL := c.BaseURL + "/api/v1/chat/actions/confirm"
+	payload, marshalError := json.Marshal(request)
+	if marshalError != nil {
+		return nil, fmt.Errorf("marshal request: %w", marshalError)
+	}
+	httpRequest, requestError := http.NewRequest(http.MethodPost, requestURL, bytes.NewReader(payload))
+	if requestError != nil {
+		return nil, fmt.Errorf("create request: %w", requestError)
+	}
+	httpRequest.Header.Set("Content-Type", "application/json")
+	c.applyAuthAndCSRFHeaders(httpRequest)
+
+	response, doError := c.HTTP.Do(httpRequest)
+	if doError != nil {
+		return nil, fmt.Errorf("request failed: %w", doError)
+	}
+	defer closeBody(response)
+
+	body, readError := readResponseBody(response)
+	if readError != nil {
+		return nil, fmt.Errorf("read response: %w", readError)
+	}
+
+	if response.StatusCode == http.StatusConflict {
+		return nil, actionConflictFromBody(body)
+	}
+	if response.StatusCode != http.StatusOK {
+		detail := detailFromBody(body)
+		if detail != "" {
+			return nil, fmt.Errorf("%s", detail)
+		}
+		return nil, newUnexpectedResponseError("confirm action failed",
+			response.StatusCode, redactedBodyForError(body, 500))
+	}
+
+	var result ConfirmChatActionResult
+	if unmarshalError := json.Unmarshal(body, &result); unmarshalError != nil {
+		return nil, fmt.Errorf("decode response: %w", unmarshalError)
+	}
+	return &result, nil
+}
+
+// actionConflictFromBody decodes the 409 envelope
+// ({error_code, detail, payload}) into the typed conflict.
+func actionConflictFromBody(body []byte) error {
+	var envelope struct {
+		ErrorCode string          `json:"error_code"`
+		Detail    string          `json:"detail"`
+		Payload   json.RawMessage `json:"payload,omitempty"`
+	}
+	if unmarshalError := json.Unmarshal(body, &envelope); unmarshalError != nil {
+		return fmt.Errorf("%s", detailFromBody(body))
+	}
+	return &ActionConflictError{
+		ErrorCode: envelope.ErrorCode,
+		Detail:    envelope.Detail,
+		Payload:   envelope.Payload,
+	}
+}
+
+// PendingChatActionsResult is the pending-actions listing for one
+// conversation.
+type PendingChatActionsResult struct {
+	Actions []map[string]any `json:"actions"`
+	Count   int              `json:"count"`
+}
+
+// ListPendingChatActions lists the actions still awaiting confirmation in a
+// conversation. conversationID is required by the endpoint.
+func (c *Client) ListPendingChatActions(conversationID string) (*PendingChatActionsResult, error) {
+	requestURL := fmt.Sprintf("%s/api/v1/chat/actions/pending?conversation_id=%s",
+		c.BaseURL, conversationID)
+	var result PendingChatActionsResult
+	if getError := c.getJSON(requestURL, &result); getError != nil {
+		return nil, getError
+	}
+	return &result, nil
+}

--- a/internal/client/chat_actions_test.go
+++ b/internal/client/chat_actions_test.go
@@ -1,0 +1,167 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestConfirmChatActionSendsCSRFDoubleSubmit(t *testing.T) {
+	// The confirm endpoint enforces double-submit CSRF, so the CLI must send
+	// a cookie and a header carrying the same token or it gets a 403.
+	var headerToken string
+	var cookieToken string
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/chat/actions/confirm" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		headerToken = r.Header.Get("X-Ankra-CSRF")
+		if cookie, cookieError := r.Cookie("ankra_csrf"); cookieError == nil {
+			cookieToken = cookie.Value
+		}
+		jsonResponse(t, w, http.StatusOK, map[string]any{"success": true, "status": "executing"})
+	}
+	testClient := newTestClient(t, handler)
+
+	result, confirmError := testClient.ConfirmChatAction(ConfirmChatActionRequest{
+		ActionID: "action-1", Confirmed: true,
+	})
+	if confirmError != nil {
+		t.Fatalf("ConfirmChatAction: %v", confirmError)
+	}
+	if headerToken == "" {
+		t.Error("no X-Ankra-CSRF header sent; the server answers 403 without it")
+	}
+	if cookieToken == "" {
+		t.Error("no ankra_csrf cookie sent; the server answers 403 without it")
+	}
+	if headerToken != cookieToken {
+		t.Errorf("CSRF header %q != cookie %q; double-submit requires them to match", headerToken, cookieToken)
+	}
+	if !result.Success || result.Status != "executing" {
+		t.Errorf("result = %+v", result)
+	}
+}
+
+func TestConfirmChatActionSendsTheRequestBody(t *testing.T) {
+	var received ConfirmChatActionRequest
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if decodeError := json.NewDecoder(r.Body).Decode(&received); decodeError != nil {
+			t.Errorf("decode body: %v", decodeError)
+		}
+		jsonResponse(t, w, http.StatusOK, map[string]any{"success": true})
+	}
+	testClient := newTestClient(t, handler)
+
+	force := true
+	forceReason := "drift is unrelated"
+	if _, confirmError := testClient.ConfirmChatAction(ConfirmChatActionRequest{
+		ActionID:    "action-2",
+		Confirmed:   true,
+		Force:       &force,
+		ForceReason: &forceReason,
+	}); confirmError != nil {
+		t.Fatalf("ConfirmChatAction: %v", confirmError)
+	}
+
+	if received.ActionID != "action-2" || !received.Confirmed {
+		t.Errorf("received = %+v", received)
+	}
+	if received.Force == nil || !*received.Force {
+		t.Error("force was not sent")
+	}
+	if received.ForceReason == nil || *received.ForceReason != "drift is unrelated" {
+		t.Errorf("ForceReason = %v", received.ForceReason)
+	}
+}
+
+func TestConfirmChatActionDecodesDriftConflict(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(t, w, http.StatusConflict, map[string]any{
+			"error_code": "ACTION_DRIFTED",
+			"detail":     "Cluster state changed since this action was proposed",
+			"payload":    map[string]any{"changed": []string{"replicas"}},
+		})
+	}
+	testClient := newTestClient(t, handler)
+
+	_, confirmError := testClient.ConfirmChatAction(ConfirmChatActionRequest{ActionID: "action-3", Confirmed: true})
+	if confirmError == nil {
+		t.Fatal("expected an error for the 409")
+	}
+	var conflict *ActionConflictError
+	if !errors.As(confirmError, &conflict) {
+		t.Fatalf("error = %T, want *ActionConflictError", confirmError)
+	}
+	if !conflict.IsDrift() {
+		t.Errorf("IsDrift() = false for %s", conflict.ErrorCode)
+	}
+	if conflict.Detail != "Cluster state changed since this action was proposed" {
+		t.Errorf("Detail = %q", conflict.Detail)
+	}
+	if len(conflict.Payload) == 0 {
+		t.Error("the drift payload should be preserved for the caller to show")
+	}
+}
+
+func TestConfirmChatActionSupersededIsNotDrift(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(t, w, http.StatusConflict, map[string]any{
+			"error_code": "ACTION_SUPERSEDED",
+			"detail":     "A newer action replaced this one",
+		})
+	}
+	testClient := newTestClient(t, handler)
+
+	_, confirmError := testClient.ConfirmChatAction(ConfirmChatActionRequest{ActionID: "action-4", Confirmed: true})
+	var conflict *ActionConflictError
+	if !errors.As(confirmError, &conflict) {
+		t.Fatalf("error = %T, want *ActionConflictError", confirmError)
+	}
+	if conflict.IsDrift() {
+		t.Error("a superseded action must not be reported as forceable drift")
+	}
+}
+
+func TestConfirmChatActionSurfacesNotFoundDetail(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(t, w, http.StatusNotFound, map[string]string{"detail": "Action not found or has expired"})
+	}
+	testClient := newTestClient(t, handler)
+
+	_, confirmError := testClient.ConfirmChatAction(ConfirmChatActionRequest{ActionID: "gone", Confirmed: true})
+	if confirmError == nil || confirmError.Error() != "Action not found or has expired" {
+		t.Errorf("error = %v, want the backend detail", confirmError)
+	}
+}
+
+func TestListPendingChatActionsRequestsTheConversation(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/chat/actions/pending" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("conversation_id"); got != "conversation-1" {
+			t.Errorf("conversation_id = %q, want conversation-1", got)
+		}
+		jsonResponse(t, w, http.StatusOK, map[string]any{
+			"actions": []map[string]any{{"action_id": "action-1", "tool_name": "restart_node"}},
+			"count":   1,
+		})
+	}
+	testClient := newTestClient(t, handler)
+
+	result, listError := testClient.ListPendingChatActions("conversation-1")
+	if listError != nil {
+		t.Fatalf("ListPendingChatActions: %v", listError)
+	}
+	if result.Count != 1 || len(result.Actions) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	if result.Actions[0]["tool_name"] != "restart_node" {
+		t.Errorf("actions[0] = %+v", result.Actions[0])
+	}
+}


### PR DESCRIPTION
## What & why

In agent mode, every tool flagged `requires_confirmation` **halts the turn**, creates a pending action with a state fingerprint, and emits an `action_proposal` SSE frame. The write runs only once that proposal is confirmed via `POST /chat/actions/confirm`.

The CLI decoded the chat stream but its event switch handled only `content`, `status`, `error`, and `done` — everything else hit `default:` and was dropped. `action_proposal` was therefore **silently discarded**, and no command existed to answer it.

The user-visible effect: `ankra chat --mode agent "restart node worker-1"` looked like it did nothing. The pending action existed server-side, invisible and unreachable from the terminal, until it expired. Every mutating tool in agent mode was affected — this is why node restart worked from the portal and from chat in the browser, but not from the CLI.

### What this adds

- **Proposals are rendered, never dropped** — tool, description, risk level, whether it is reversible, parameters, expiry, and the action id. A halted write must not be invisible.
- **Interactive sessions prompt** to run or discard each proposal. Proposals are collected during the stream and resolved after it ends, so the prompt doesn't interleave with streaming output. Anything but an explicit `yes` rejects — the safe default for a mutation.
- **`ankra chat actions confirm|reject|list`** for one-shot and scripted use, all with `-o json|yaml`.

### Two details worth reviewing

**CSRF.** The confirm endpoint enforces double-submit CSRF (`requireCSRFHeader`), which has no bearer-token bypass. The client sends a matching `X-Ankra-CSRF` header and `ankra_csrf` cookie, reusing the `applyAuthAndCSRFHeaders` helper the account-MFA writes already use. A test asserts the header and cookie are both present and equal.

**409 handling.** Decoded into a typed `ActionConflictError`:

| Code | Meaning | CLI behaviour |
|---|---|---|
| `ACTION_DRIFTED` | Cluster changed since the proposal | Reports the drift, prints the ready-to-run `--force` invocation |
| `ACTION_SUPERSEDED` | A newer action replaced this one | Does **not** offer `--force` — forcing cannot succeed |

## Test plan

- `go build ./...`, `go vet ./...` — clean
- `go test -race -count=1 ./...` — all packages pass
- `golangci-lint run` — 0 issues
- Verified on the built binary: `ankra chat actions --help` lists confirm/reject/list, and `confirm --help` shows `--force` / `--force-reason`

15 new tests:

- `internal/client` (6) — CSRF double-submit is sent and matches; request body incl. force/force-reason; `ACTION_DRIFTED` decodes to a drift conflict with payload preserved; `ACTION_SUPERSEDED` is not reported as drift; 404 detail surfaces; pending-list sends `conversation_id`
- `cmd` (9) — confirm sends `confirmed=true`; reject sends `confirmed=false` with reason; `--force`/`--force-reason` forwarded; drift error contains the `--force` hint and the action id; superseded error does **not** offer force; proposal decoding from the SSE payload; decoding rejects a payload with no `action_id`; irreversible actions are rendered as such; `isAffirmative` defaults to rejecting

## Docs checklist

- [x] Command/flag changes — the CLI reference regenerates on release (`tools/gendocs`); `Short`/`Long`/`Example` are written for docs readers
- CHANGELOG.md updated under Unreleased → Added

> Note: this is a CLI-only change. No server change was needed — the confirm, reject, and pending-list endpoints all already exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
