### PR TITLE
release: prepare v0.9.0-rc5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.9.0-rc5 — 2026-07-30
+
 ### Deprecated
 
 - **`ankra cluster deprovision --auto-delete` is deprecated — it never did


### PR DESCRIPTION
Cuts the Unreleased changelog section into a `v0.9.0-rc5` heading (dated 2026-07-30) so the tag-triggered release workflow extracts the right notes — same pattern as rc4 (#34).

Ships in this RC: the Scaleway `nodes list|get|restart` surface (#53), agent-mode chat action confirmation (#54), plus the already-merged deprovision-flag honesty pass, encrypt/clone YAML preservation, and response-decode fixes.

Verified the workflow's awk extraction against this file: 169 lines of notes for `0.9.0-rc5`, section boundaries correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)