### PR TITLE
fix(chat): surface backend errors with non-zero exit, object statuses, clean Ctrl-D, idle watchdog (ankra-mjpc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+### Fixed
+
+- **`ankra chat` now surfaces server errors instead of printing a blank
+  `Error:` line and exiting 0.** The backend sends its message inside the
+  error frame's `data` member (rate limits, spend caps, busy conversations);
+  the CLI now reads it from there, prints it to stderr, and one-shot chat
+  exits non-zero so scripts can detect the failure.
+
+- **Chat progress is visible again.** Status frames became structured
+  objects on newer backends and the CLI silently dropped them; it now
+  renders the intent (and mechanism) as the familiar `[...]` progress line.
+
+- **Ctrl-D leaves interactive chat cleanly** like `exit`, instead of failing
+  with `reading input: EOF` and exit code 1.
+
+- **A stalled chat stream no longer hangs the CLI forever.** A watchdog
+  ends the stream with a clear `stream idle timeout` error when the
+  connection goes silent for 3 minutes (the backend heartbeats every few
+  seconds while working).
+
 ## v0.9.0-rc5 — 2026-07-30
 
 ### Deprecated

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -12,6 +14,37 @@ import (
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/spf13/cobra"
 )
+
+// chatStatusText renders a status frame's progress line. Newer backends
+// send an object ({intent, mechanism, ...}); older ones sent a plain
+// string. Empty means nothing worth showing.
+func chatStatusText(data any) string {
+	switch typed := data.(type) {
+	case string:
+		return typed
+	case map[string]any:
+		intent, _ := typed["intent"].(string)
+		mechanism, _ := typed["mechanism"].(string)
+		switch {
+		case intent != "" && mechanism != "":
+			return intent + " · " + mechanism
+		case intent != "":
+			return intent
+		case mechanism != "":
+			return mechanism
+		}
+	}
+	return ""
+}
+
+// chatErrorMessage never returns empty: an error frame without a readable
+// message still has to fail the command with something actionable.
+func chatErrorMessage(event client.ChatStreamEvent) string {
+	if message := event.ErrorMessage(); message != "" {
+		return message
+	}
+	return "the server reported an error without details"
+}
 
 var chatCmd = &cobra.Command{
 	Use:   "chat [message]",
@@ -77,6 +110,7 @@ func runChatMessage(clusterID *string, query string, interactionMode string) err
 	fmt.Print("\n")
 	var hasStartedContent bool
 	var hadStatus bool
+	var streamErrorMessage string
 	for event := range events {
 		switch event.Type {
 		case "content":
@@ -99,12 +133,11 @@ func runChatMessage(clusterID *string, query string, interactionMode string) err
 				fmt.Print(event.Content)
 			}
 		case "status":
-			// Show status
-			if str, ok := event.Data.(string); ok {
+			if status := chatStatusText(event.Data); status != "" {
 				if hasStartedContent {
-					fmt.Printf("\n\n[%s]\n\n", str)
+					fmt.Printf("\n\n[%s]\n\n", status)
 				} else {
-					fmt.Printf("[%s]", str)
+					fmt.Printf("[%s]", status)
 					hadStatus = true
 				}
 			}
@@ -119,12 +152,22 @@ func runChatMessage(clusterID *string, query string, interactionMode string) err
 			fmt.Printf("  ankra chat actions confirm %s\n", proposal.ActionID)
 			fmt.Printf("  ankra chat actions reject %s\n\n", proposal.ActionID)
 		case "error":
-			fmt.Printf("\nError: %s\n", event.Error)
+			// Fail the command once the stream drains: errors belong on
+			// stderr with a non-zero exit, not lost in the transcript.
+			if streamErrorMessage == "" {
+				streamErrorMessage = chatErrorMessage(event)
+			}
 		case "done", "complete":
 			fmt.Print("\n\n")
 		default:
 			// Ignore triage, context and other metadata events
 		}
+	}
+	if streamErrorMessage != "" {
+		if hasStartedContent {
+			fmt.Print("\n")
+		}
+		return errors.New(streamErrorMessage)
 	}
 	return nil
 }
@@ -153,6 +196,11 @@ func runInteractiveChat(clusterID *string, interactionMode string) error {
 		fmt.Print(text.FgCyan.Sprint("You: "))
 		input, err := reader.ReadString('\n')
 		if err != nil {
+			// Ctrl-D ends the session like 'exit', not like a failure.
+			if errors.Is(err, io.EOF) {
+				fmt.Println("\nGoodbye!")
+				return nil
+			}
 			return fmt.Errorf("reading input: %w", err)
 		}
 
@@ -216,11 +264,11 @@ func runInteractiveChat(clusterID *string, interactionMode string) error {
 				}
 			case "status":
 				// Show status, don't add to response
-				if str, ok := event.Data.(string); ok {
+				if status := chatStatusText(event.Data); status != "" {
 					if hasStartedContent {
-						fmt.Printf("\n\n[%s]\n\n", str)
+						fmt.Printf("\n\n[%s]\n\n", status)
 					} else {
-						fmt.Printf("[%s]", str)
+						fmt.Printf("[%s]", status)
 						hadStatus = true
 					}
 				}
@@ -232,7 +280,7 @@ func runInteractiveChat(clusterID *string, interactionMode string) error {
 				}
 				pendingProposals = append(pendingProposals, proposal)
 			case "error":
-				fmt.Printf("\nError: %s\n", event.Error)
+				fmt.Fprintf(os.Stderr, "\nError: %s\n", chatErrorMessage(event))
 			case "done", "complete":
 				// Add assistant response to history
 				if response.Len() > 0 {

--- a/cmd/chat_test.go
+++ b/cmd/chat_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"ankra/internal/client"
@@ -43,5 +44,81 @@ func TestChatDelete_YesProceeds(t *testing.T) {
 	}
 	if mock.gotConversationID != "conv-1" {
 		t.Errorf("conversation id = %q, want conv-1", mock.gotConversationID)
+	}
+}
+
+func TestChatStatusText(t *testing.T) {
+	testCases := []struct {
+		name string
+		data any
+		want string
+	}{
+		{"legacy string status", "Analyzing cluster", "Analyzing cluster"},
+		{"object with intent and mechanism", map[string]any{"intent": "Processing...", "mechanism": "tool_use"}, "Processing... · tool_use"},
+		{"object with intent only", map[string]any{"intent": "Processing...", "mechanism": nil}, "Processing..."},
+		{"object with nothing renderable", map[string]any{"elapsed_ms": float64(12)}, ""},
+		{"nil data", nil, ""},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := chatStatusText(testCase.data); got != testCase.want {
+				t.Errorf("chatStatusText(%v) = %q, want %q", testCase.data, got, testCase.want)
+			}
+		})
+	}
+}
+
+type chatStreamMock struct {
+	baseMock
+	events []client.ChatStreamEvent
+}
+
+func (m *chatStreamMock) StreamChat(clusterID *string, chatReq client.ChatRequest) (<-chan client.ChatStreamEvent, error) {
+	stream := make(chan client.ChatStreamEvent, len(m.events))
+	for _, event := range m.events {
+		stream <- event
+	}
+	close(stream)
+	return stream, nil
+}
+
+func TestChat_BackendErrorFrameFailsWithMessage(t *testing.T) {
+	mock := &chatStreamMock{events: []client.ChatStreamEvent{
+		{Type: "error", Data: map[string]any{
+			"message": "You've sent too many messages this hour. Please wait a while and try again.",
+			"is_rate_limited": true,
+		}},
+	}}
+	_, err := runWithInput(t, mock, "", "chat", "hello")
+	if err == nil {
+		t.Fatal("expected the command to fail on a backend error frame, got nil (exit 0)")
+	}
+	if !strings.Contains(err.Error(), "too many messages this hour") {
+		t.Errorf("error %q does not carry the backend message", err.Error())
+	}
+}
+
+func TestChat_ErrorFrameWithoutDetailsStillFails(t *testing.T) {
+	mock := &chatStreamMock{events: []client.ChatStreamEvent{
+		{Type: "error"},
+	}}
+	_, err := runWithInput(t, mock, "", "chat", "hello")
+	if err == nil {
+		t.Fatal("expected the command to fail, got nil")
+	}
+	if !strings.Contains(err.Error(), "error without details") {
+		t.Errorf("error %q should carry the fallback message", err.Error())
+	}
+}
+
+func TestChat_CleanStreamExitsZero(t *testing.T) {
+	mock := &chatStreamMock{events: []client.ChatStreamEvent{
+		{Type: "status", Data: map[string]any{"intent": "Processing...", "mechanism": nil}},
+		{Type: "content", Content: "All good."},
+		{Type: "complete"},
+	}}
+	_, err := runWithInput(t, mock, "", "chat", "hello")
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
 	}
 }

--- a/internal/client/chat.go
+++ b/internal/client/chat.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync/atomic"
+	"time"
 )
 
 type ChatMessage struct {
@@ -92,6 +94,32 @@ type ChatStreamEvent struct {
 	Done    bool   `json:"done,omitempty"`
 }
 
+// ErrorMessage extracts the human message from an error event. Backend
+// error frames carry {"type":"error","data":{"message":...}}; the Error
+// member is only set by this client for local stream failures. Returns ""
+// when the event carries no readable message.
+func (event ChatStreamEvent) ErrorMessage() string {
+	if event.Error != "" {
+		return event.Error
+	}
+	switch data := event.Data.(type) {
+	case string:
+		return data
+	case map[string]any:
+		if message, ok := data["message"].(string); ok {
+			return message
+		}
+	}
+	return ""
+}
+
+// chatStreamIdleTimeout bounds how long a chat stream read may sit with no
+// bytes at all. The backend heartbeats every few seconds while working, so
+// a silent stream this long is a dead connection, not a slow answer;
+// without the watchdog a stalled stream hung the command forever. A var so
+// tests can shorten it.
+var chatStreamIdleTimeout = 3 * time.Minute
+
 func (c *Client) StreamChat(clusterID *string, chatReq ChatRequest) (<-chan ChatStreamEvent, error) {
 	var url string
 	if clusterID != nil && *clusterID != "" {
@@ -142,11 +170,25 @@ func (c *Client) StreamChat(clusterID *string, chatReq ChatRequest) (<-chan Chat
 		defer closeBody(resp)
 		defer close(events)
 
+		// The watchdog closes the body when nothing arrives for the idle
+		// window, which unblocks the pending Read; heartbeat comment frames
+		// reset it, so only a genuinely dead connection trips it.
+		var idleTimedOut atomic.Bool
+		watchdog := time.AfterFunc(chatStreamIdleTimeout, func() {
+			idleTimedOut.Store(true)
+			closeBody(resp)
+		})
+		defer watchdog.Stop()
+
 		reader := bufio.NewReader(resp.Body)
 		for {
 			line, readErr := reader.ReadString('\n')
+			watchdog.Reset(chatStreamIdleTimeout)
 			if readErr != nil {
-				if readErr != io.EOF {
+				if idleTimedOut.Load() {
+					events <- ChatStreamEvent{Type: "error",
+						Error: fmt.Sprintf("stream idle timeout: no data received for %s", chatStreamIdleTimeout)}
+				} else if readErr != io.EOF {
 					events <- ChatStreamEvent{Type: "error", Error: readErr.Error()}
 				}
 				return

--- a/internal/client/chat_test.go
+++ b/internal/client/chat_test.go
@@ -3,7 +3,9 @@ package client
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestStreamChat_Success(t *testing.T) {
@@ -270,5 +272,98 @@ func TestDeleteChatConversation_Error(t *testing.T) {
 	_, err := testClient.DeleteChatConversation("conv-123")
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestChatStreamEvent_ErrorMessage(t *testing.T) {
+	testCases := []struct {
+		name  string
+		event ChatStreamEvent
+		want  string
+	}{
+		{"local stream failure", ChatStreamEvent{Type: "error", Error: "connection reset"}, "connection reset"},
+		{"backend error frame", ChatStreamEvent{Type: "error",
+			Data: map[string]any{"message": "Rate limited.", "is_rate_limited": true}}, "Rate limited."},
+		{"legacy string data", ChatStreamEvent{Type: "error", Data: "plain text"}, "plain text"},
+		{"message missing", ChatStreamEvent{Type: "error", Data: map[string]any{"code": float64(1)}}, ""},
+		{"no payload at all", ChatStreamEvent{Type: "error"}, ""},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := testCase.event.ErrorMessage(); got != testCase.want {
+				t.Errorf("ErrorMessage() = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestStreamChat_BackendErrorFrameCarriesMessage(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		_, _ = fmt.Fprint(w, "data: {\"type\":\"error\",\"schema_version\":2,\"data\":{\"message\":\"Your organisation's daily AI spend cap has been reached.\",\"is_spend_capped\":true}}\n\n")
+		flusher.Flush()
+	}
+	testClient := newTestClient(t, handler)
+	events, err := testClient.StreamChat(nil, ChatRequest{Query: "hi"})
+	if err != nil {
+		t.Fatalf("StreamChat: %v", err)
+	}
+	var received []ChatStreamEvent
+	for event := range events {
+		received = append(received, event)
+	}
+	if len(received) != 1 || received[0].Type != "error" {
+		t.Fatalf("expected one error event, got %v", received)
+	}
+	if got := received[0].ErrorMessage(); got != "Your organisation's daily AI spend cap has been reached." {
+		t.Errorf("ErrorMessage() = %q, want the backend message", got)
+	}
+}
+
+func TestStreamChat_IdleTimeoutEndsStalledStream(t *testing.T) {
+	previousTimeout := chatStreamIdleTimeout
+	chatStreamIdleTimeout = 150 * time.Millisecond
+	defer func() { chatStreamIdleTimeout = previousTimeout }()
+
+	handlerDone := make(chan struct{})
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		defer close(handlerDone)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		_, _ = fmt.Fprint(w, "data: {\"type\":\"content\",\"content\":\"partial\"}\n\n")
+		flusher.Flush()
+		// Stall without closing: the client must not hang forever.
+		select {
+		case <-r.Context().Done():
+		case <-time.After(5 * time.Second):
+		}
+	}
+	testClient := newTestClient(t, handler)
+	events, err := testClient.StreamChat(nil, ChatRequest{Query: "hi"})
+	if err != nil {
+		t.Fatalf("StreamChat: %v", err)
+	}
+	var received []ChatStreamEvent
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case event, open := <-events:
+			if !open {
+				if len(received) != 2 {
+					t.Fatalf("expected content + idle-timeout events, got %v", received)
+				}
+				if received[1].Type != "error" || !strings.Contains(received[1].Error, "stream idle timeout") {
+					t.Fatalf("expected an idle-timeout error event, got %+v", received[1])
+				}
+				<-handlerDone
+				return
+			}
+			received = append(received, event)
+		case <-deadline:
+			t.Fatal("stream never ended: idle watchdog did not fire")
+		}
 	}
 }


### PR DESCRIPTION
Fixes bead **ankra-mjpc** (CLI/backend deep review 2026-07-27) — the still-open items of the chat contract breakage. Item (4) of the bead (action_proposal/plan_proposal confirm client) already shipped separately in `cmd/chat_actions.go`; this PR closes the rest:

1. **Blank error frames** — backend error frames are `{type:"error","data":{"message":...}}` (rate limit, spend cap, busy conversation, org pause); the CLI read the never-present top-level `error` key and printed literally `Error: ` with no text. New `ChatStreamEvent.ErrorMessage()` reads the message from `data.message` (with string-data and local-failure fallbacks).
2. **Errors to stdout + exit 0** — one-shot `ankra chat "..."` now returns the backend message as the command error: cobra prints it to stderr and the process exits 1 (`exitError`), so scripts can finally detect failures. Interactive chat prints to stderr and keeps the session alive.
3. **Invisible progress** — status frames became `{intent, mechanism, ...}` objects and the CLI only rendered string data; `chatStatusText` renders both shapes as the `[...]` progress line.
4. **Ctrl-D** — ends interactive chat cleanly like `exit` (was: `reading input: EOF`, exit 1).
5. **Stalled stream hangs forever** — a 3-minute idle watchdog (reset by every read incl. heartbeat comments) closes the body and ends the stream with a clear `stream idle timeout` error.

Not in scope: the bead's P3 notes (`[DONE]` sentinel dead code, pod-log SSE end-frame leak in `client/kubernetes.go`) — left as-is to keep this reviewable.

Tests: table tests for `ErrorMessage`/`chatStatusText`; SSE-server tests for the backend-shaped error frame and the idle watchdog (150ms shortened timeout, asserts the stream ends instead of hanging); cmd-level tests via the mock harness pinning non-zero exit with the backend message, the no-details fallback, and clean exit 0 on a healthy stream. CHANGELOG updated.

Validation: `go build ./...` + full `go test` green; pre-commit hook (go test + golangci-lint) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
