### PR TITLE
fix(login): insecure-HTTP guard at login; redact echoed bodies in all error paths (ankra-dfq9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@
   connection goes silent for 3 minutes (the backend heartbeats every few
   seconds while working).
 
+- **`ankra login` now runs the same insecure-HTTP guard as every other
+  command.** The login flow sends the PKCE verifier and receives the minted
+  token; a plaintext `http://` base URL to a non-loopback host is refused
+  (loopback development and `ANKRA_ALLOW_INSECURE_HTTP=1` still work).
+
+- **Error messages that echo API response bodies now redact likely secret
+  material everywhere.** Several error paths (stack patch 422 echoes,
+  variable requests, manifest and add-on configuration reads, support
+  uploads) rendered raw response bodies to the terminal; they now pass
+  through the same redaction the other error paths already used.
+
 ## v0.9.0-rc5 — 2026-07-30
 
 ### Deprecated

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -239,6 +239,13 @@ func runLogin() error {
 	if loginURL == "" {
 		loginURL = "https://platform.ankra.app"
 	}
+	// The same insecure-HTTP guard every API command runs (root.go): the
+	// poll below sends the PKCE verifier and receives the minted token,
+	// which must never travel plaintext to a non-loopback host.
+	loginURL, err = client.NormalizeBaseURL(loginURL, os.Getenv(envAllowInsecureHTTP) == "1")
+	if err != nil {
+		return fmt.Errorf("invalid base URL: %w", err)
+	}
 
 	machineID := getOrCreateMachineID()
 	machineName, err := os.Hostname()

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -443,3 +443,32 @@ func TestLogoutWithoutTokenIDWarnsAndClears(t *testing.T) {
 		t.Errorf("expected warning about non-revocable token, got:\n%s", output)
 	}
 }
+
+func TestRunLoginRefusesPlaintextHTTPBaseURL(t *testing.T) {
+	// login POSTs the PKCE verifier and receives the minted token; it must
+	// run the same insecure-HTTP guard as every other command (ankra-dfq9).
+	previousBaseURL := viper.GetString("base-url")
+	viper.Set("base-url", "http://api.example.com")
+	t.Cleanup(func() { viper.Set("base-url", previousBaseURL) })
+
+	err := runLogin()
+	if err == nil || !strings.Contains(err.Error(), "plaintext http") {
+		t.Fatalf("login must refuse a non-loopback http:// base URL, got %v", err)
+	}
+}
+
+func TestRunLoginAllowsLoopbackHTTPBaseURL(t *testing.T) {
+	previousBaseURL := viper.GetString("base-url")
+	viper.Set("base-url", "http://127.0.0.1:1")
+	t.Cleanup(func() { viper.Set("base-url", previousBaseURL) })
+
+	// The guard lets loopback through; the loopback port is closed, so the
+	// failure must be the connection, never the plaintext refusal.
+	err := runLogin()
+	if err == nil {
+		t.Fatal("expected the unreachable loopback to fail the login")
+	}
+	if strings.Contains(err.Error(), "plaintext http") {
+		t.Fatalf("loopback http:// must pass the guard, got %v", err)
+	}
+}

--- a/internal/client/addons.go
+++ b/internal/client/addons.go
@@ -228,7 +228,7 @@ func (c *Client) GetClusterAddonValues(ctx context.Context, clusterID, addonName
 		return "", ErrUnauthorized
 	}
 	if resp.StatusCode != http.StatusOK {
-		return "", newUnexpectedResponseError("get addon configuration failed", resp.StatusCode, truncateForError(body, 500))
+		return "", newUnexpectedResponseError("get addon configuration failed", resp.StatusCode, redactedBodyForError(body, 500))
 	}
 
 	var parsed addonConfigurationV2Response

--- a/internal/client/iac.go
+++ b/internal/client/iac.go
@@ -142,7 +142,7 @@ func (e *PatchStackError) Error() string {
 	if e.Err != nil {
 		return e.Err.Error()
 	}
-	return fmt.Sprintf("patch stack failed: status %d, body: %s", e.StatusCode, truncateForError(e.Body, 500))
+	return fmt.Sprintf("patch stack failed: status %d, body: %s", e.StatusCode, redactedBodyForError(e.Body, 500))
 }
 
 func (e *PatchStackError) Unwrap() error {
@@ -202,13 +202,13 @@ func (c *Client) GetClusterIaC(ctx context.Context, clusterID string) (string, e
 		if parsedErr.Detail != "" {
 			return "", fmt.Errorf("get IaC failed: %s", parsedErr.Detail)
 		}
-		return "", fmt.Errorf("get IaC failed: status 404, body: %s", truncateForError(body, 500))
+		return "", fmt.Errorf("get IaC failed: status 404, body: %s", redactedBodyForError(body, 500))
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
 		return "", ErrUnauthorized
 	}
 	if resp.StatusCode != http.StatusOK {
-		return "", newUnexpectedResponseErrorWithMessage(resp.StatusCode, fmt.Sprintf("get IaC failed: status %d, body: %s", resp.StatusCode, truncateForError(body, 500)))
+		return "", newUnexpectedResponseErrorWithMessage(resp.StatusCode, fmt.Sprintf("get IaC failed: status %d, body: %s", resp.StatusCode, redactedBodyForError(body, 500)))
 	}
 
 	var parsed IacResponse

--- a/internal/client/manifests.go
+++ b/internal/client/manifests.go
@@ -75,7 +75,7 @@ func (c *Client) GetClusterManifestConfiguration(ctx context.Context, clusterID,
 		return "", ErrUnauthorized
 	}
 	if resp.StatusCode != http.StatusOK {
-		return "", newUnexpectedResponseError("get manifest configuration failed", resp.StatusCode, truncateForError(body, 500))
+		return "", newUnexpectedResponseError("get manifest configuration failed", resp.StatusCode, redactedBodyForError(body, 500))
 	}
 
 	var parsed getClusterManifestResponse
@@ -118,7 +118,7 @@ func (c *Client) DisconnectManifest(ctx context.Context, clusterID, stackName, m
 		return nil, ErrUnauthorized
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, newUnexpectedResponseError("disconnect manifest failed", resp.StatusCode, truncateForError(body, 500))
+		return nil, newUnexpectedResponseError("disconnect manifest failed", resp.StatusCode, redactedBodyForError(body, 500))
 	}
 
 	var parsed DisconnectManifestResult

--- a/internal/client/redact_test.go
+++ b/internal/client/redact_test.go
@@ -114,3 +114,19 @@ func TestKeyLooksSensitive(t *testing.T) {
 		})
 	}
 }
+
+func TestPatchStackErrorRedactsEchoedSecrets(t *testing.T) {
+	// The 422 echo can carry manifest and variable secret values verbatim;
+	// the rendered error reaches terminals and CI logs (ankra-dfq9).
+	patchError := &PatchStackError{
+		StatusCode: 422,
+		Body:       []byte(`{"detail":"invalid manifest","password":"hunter2","token":"ankra_pat_secret"}`),
+	}
+	rendered := patchError.Error()
+	if strings.Contains(rendered, "hunter2") || strings.Contains(rendered, "ankra_pat_secret") {
+		t.Fatalf("patch-stack error leaked a secret: %q", rendered)
+	}
+	if !strings.Contains(rendered, "<redacted>") || !strings.Contains(rendered, "invalid manifest") {
+		t.Fatalf("patch-stack error must keep the detail and mark redactions: %q", rendered)
+	}
+}

--- a/internal/client/support.go
+++ b/internal/client/support.go
@@ -294,7 +294,7 @@ func (c *Client) UploadSupportAttachment(ctx context.Context, ticketID, filePath
 	case http.StatusNotFound:
 		return nil, ErrSupportTicketNotFound
 	default:
-		return nil, newUnexpectedResponseError("attachment upload failed", resp.StatusCode, truncateForError(respBody, 500))
+		return nil, newUnexpectedResponseError("attachment upload failed", resp.StatusCode, redactedBodyForError(respBody, 500))
 	}
 }
 
@@ -351,7 +351,7 @@ func (c *Client) doSupportRequest(ctx context.Context, method, url string, body 
 	case http.StatusConflict:
 		return nil, fmt.Errorf("%w: %s", ErrSupportReviewRequired, extractDetail(respBody))
 	default:
-		return nil, newUnexpectedResponseError("support request failed", resp.StatusCode, truncateForError(respBody, 500))
+		return nil, newUnexpectedResponseError("support request failed", resp.StatusCode, redactedBodyForError(respBody, 500))
 	}
 }
 
@@ -362,5 +362,5 @@ func extractDetail(body []byte) string {
 	if err := json.Unmarshal(body, &parsed); err == nil && parsed.Detail != "" {
 		return parsed.Detail
 	}
-	return truncateForError(body, 300)
+	return redactedBodyForError(body, 300)
 }

--- a/internal/client/variables.go
+++ b/internal/client/variables.go
@@ -234,6 +234,6 @@ func (c *Client) doVariableRequest(ctx context.Context, method, url string, body
 	case http.StatusConflict:
 		return nil, ErrVariableDuplicate
 	default:
-		return nil, newUnexpectedResponseError("variable request failed", resp.StatusCode, truncateForError(respBody, 500))
+		return nil, newUnexpectedResponseError("variable request failed", resp.StatusCode, redactedBodyForError(respBody, 500))
 	}
 }


### PR DESCRIPTION
Fixes bead **ankra-dfq9** (CLI/backend deep review 2026-07-27).

**1. `ankra login` bypassed the insecure-HTTP token guard.** `runLogin` read `base-url` raw from viper; `pollForToken` then POSTs the PKCE verifier and receives the minted PAT over it — plaintext `http://` to any host was accepted at login while every other command refuses it via `client.NormalizeBaseURL` (root.go). The login URL now runs the same guard, with the same escape hatches: loopback hosts and `ANKRA_ALLOW_INSECURE_HTTP=1`. (The logout/revoke path already normalized.)

**2. Ten error paths bypassed secret redaction.** `helpers.go` says terminal-rendered bodies use `redactedBodyForError`; these still used raw `truncateForError`: `iac.go` (the `PatchStackError` 422 echo — carries manifest/variable secret values — plus the two get-IaC paths), `variables.go` (secret variable values), `manifests.go` ×2, `addons.go`, `support.go` ×3 (incl. the `extractDetail` fallback). All swept to the redacting helper; `truncateForError` remains only as the internal truncation primitive.

Tests: `TestRunLoginRefusesPlaintextHTTPBaseURL` + `TestRunLoginAllowsLoopbackHTTPBaseURL` pin the guard both ways; `TestPatchStackErrorRedactsEchoedSecrets` pins the representative 422-echo redaction (the shared redactor already has its own suite). CHANGELOG updated.

Validation: full `go build ./...` + `go test ./...` green; pre-commit hook (go test + golangci-lint) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
