### PR TITLE
fix(ai): name the current Expert model in the --model-id examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Ankra CLI Changelog
 
+## Unreleased
+
+### Fixed
+
+- **`ankra ai models create|update` help now names the current Expert
+  model.** The `--model-id` examples still said `claude-opus-4-8` after the
+  platform's Expert tier moved to Claude Opus 5, so the help text suggested
+  a superseded model id. Because the hosted CLI reference is regenerated
+  from this help text on every release, the stale example also kept
+  reverting the corrected model id in `reference/cli/ai.mdx`.
+
 ## v0.9.0 — 2026-08-07
 
 The stable v0.9.0 release promotes the v0.9.0 release candidates out of

--- a/cmd/ai.go
+++ b/cmd/ai.go
@@ -139,7 +139,7 @@ var aiModelsCreateCmd = &cobra.Command{
 	Short: "Add a model to the catalog",
 	Long: `Add a model to the catalog.
 
-For an Ankra-managed Claude model pass --model-id (e.g. claude-opus-4-8). For a
+For an Ankra-managed Claude model pass --model-id (e.g. claude-opus-5). For a
 model served by a custom OpenAI-compatible endpoint, also pass --endpoint with
 the endpoint id (see 'ankra ai endpoints list').`,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -587,7 +587,7 @@ func modelRequestFromExisting(model client.AICatalogModel) client.AIModelRequest
 func addModelWriteFlags(cmd *cobra.Command) {
 	cmd.Flags().String("key", "", "Catalog key (lowercase slug; the model_mode value)")
 	cmd.Flags().String("name", "", "Display name shown in the picker")
-	cmd.Flags().String("model-id", "", "Provider model id (e.g. claude-opus-4-8 or gpt-4o)")
+	cmd.Flags().String("model-id", "", "Provider model id (e.g. claude-opus-5 or gpt-4o)")
 	cmd.Flags().String("description", "", "Short description")
 	cmd.Flags().String("tier", "", "Auto-routing tier: expert, think, quick, or empty")
 	cmd.Flags().String("endpoint", "", "OpenAI-compatible endpoint id (omit for Ankra-managed Claude)")


### PR DESCRIPTION
Found while reviewing the v0.9.0 CLI-reference regeneration (ankra-docs#87).

`ankra ai models create|update` still offered `claude-opus-4-8` as the Ankra-managed `--model-id` example, though the platform's Expert tier moved to Claude Opus 5 (see the July changelog entry "Ankra AI now runs on Claude Opus 5").

This matters beyond the help text: the hosted CLI reference is generated from these strings on every release, so the stale example silently reverted the corrected model id in `reference/cli/ai.mdx` — the docs were hand-fixed on 2026-07-25 and the v0.9.0 regeneration changed them straight back. Fixing the source stops that loop.

Test fixtures that use `claude-opus-4-8` as arbitrary catalog data are left alone — they assert plumbing, not the advertised model.

`make build` green.