### PR TITLE
feat(helm): YAML specs, flag-based creation, and scheme guard for registries create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Added
+
+- **`ankra helm registries create` accepts YAML spec files and pure flag
+  invocations.** `-f` now sniffs the file content, so the same command
+  takes a JSON or a YAML spec, and a registry can be created without a
+  file at all: `--name` plus `--url` (with optional `--credential-name`
+  and repeatable `--exclude-charts`) build the spec for you. Exactly one
+  of `-f` or `--name`/`--url` must be given. Flat specs with a URL scheme
+  other than `oci://`, `http://`, or `https://` are rejected client-side
+  as a usage error instead of being posted as an HTTP registry (the API
+  answers such specs with an unhelpful 500), and a successful create now
+  prints a reminder that `ankra helm registries sync <name>` triggers
+  indexing immediately.
+
 ### Removed
 
 - **The MFA management and organisation RBAC commands are gone — none of

--- a/cmd/helm.go
+++ b/cmd/helm.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 var helmCmd = &cobra.Command{
@@ -133,29 +134,49 @@ var helmRegistriesGetCmd = &cobra.Command{
 
 var helmRegistriesCreateCmd = &cobra.Command{
 	Use:   "create",
-	Short: "Create a Helm chart registry from a spec file",
-	Long: `Create a Helm chart registry by providing a JSON spec file.
+	Short: "Create a Helm chart registry from a spec file or flags",
+	Long: `Create a Helm chart registry from a spec file (-f, JSON or YAML) or
+directly from --name and --url.
 
-The registry must be nested under exactly one of "helm_oci_registry" or
-"helm_http_registry":
+In a spec file the registry must be nested under exactly one of
+"helm_oci_registry" or "helm_http_registry":
 
   {"spec": {"helm_oci_registry": {"name": "my-charts", "url": "oci://ghcr.io/acme/charts"}}}
   {"spec": {"helm_http_registry": {"name": "my-charts", "url": "https://charts.example.com"}}}
 
 A flat {"name": ..., "url": ...} file is accepted and nested automatically,
-inferring the registry type from the URL scheme (oci:// means OCI).
+inferring the registry type from the URL scheme: oci:// creates an OCI
+registry, http:// or https:// an HTTP chart repository. The flag form uses
+the same inference.
 
-Example:
-  ankra helm registries create -f registry-spec.json`,
+Examples:
+  ankra helm registries create -f registry-spec.json
+  ankra helm registries create -f registry-spec.yaml
+  ankra helm registries create --name my-charts --url oci://ghcr.io/acme/charts
+  ankra helm registries create --name my-charts --url https://charts.example.com \
+    --credential-name my-cred --exclude-charts legacy-chart`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		filePath, _ := cmd.Flags().GetString("file")
 
-		fileData, err := os.ReadFile(filePath)
-		if err != nil {
-			return fmt.Errorf("reading file: %w", err)
+		var rawSpec []byte
+		if filePath != "" {
+			fileData, err := os.ReadFile(filePath)
+			if err != nil {
+				return fmt.Errorf("reading file: %w", err)
+			}
+			rawSpec, err = helmRegistrySpecFileToJSON(fileData)
+			if err != nil {
+				return withExitCode(exitUsage, err)
+			}
+		} else {
+			var err error
+			rawSpec, err = helmRegistrySpecFromFlags(cmd)
+			if err != nil {
+				return err
+			}
 		}
 
-		specJSON, note, err := normalizeHelmRegistrySpec(fileData)
+		specJSON, note, err := normalizeHelmRegistrySpec(rawSpec)
 		if err != nil {
 			return withExitCode(exitUsage, err)
 		}
@@ -177,6 +198,9 @@ Example:
 		}
 
 		fmt.Println("Helm registry created successfully!")
+		if registryName := helmRegistryNameFromSpec(specJSON); registryName != "" {
+			fmt.Fprintf(os.Stderr, "Indexing runs in the background; trigger it now with: ankra helm registries sync %s\n", registryName)
+		}
 		return nil
 	},
 }
@@ -185,12 +209,75 @@ const helmRegistrySpecHint = `the registry must be nested under exactly one of "
   {"spec": {"helm_oci_registry": {"name": "my-charts", "url": "oci://ghcr.io/acme/charts"}}}
   {"spec": {"helm_http_registry": {"name": "my-charts", "url": "https://charts.example.com"}}}`
 
-// normalizeHelmRegistrySpec validates the spec file before it is POSTed. The
+// helmRegistrySpecFileToJSON accepts a spec file in JSON or YAML. JSON
+// content passes through untouched so existing spec files behave exactly as
+// before; anything else is parsed as YAML and re-encoded as JSON, so
+// normalizeHelmRegistrySpec only ever sees one format.
+func helmRegistrySpecFileToJSON(fileData []byte) ([]byte, error) {
+	if json.Valid(fileData) {
+		return fileData, nil
+	}
+	var document any
+	if err := yaml.Unmarshal(fileData, &document); err != nil {
+		return nil, fmt.Errorf("parsing spec file (JSON and YAML are accepted): %w", err)
+	}
+	specJSON, err := json.Marshal(document)
+	if err != nil {
+		return nil, fmt.Errorf("converting YAML spec to JSON: %w", err)
+	}
+	return specJSON, nil
+}
+
+// helmRegistrySpecFromFlags builds a flat registry spec from the create
+// command's flags. The result goes through normalizeHelmRegistrySpec like a
+// spec file would, so the nesting logic lives in exactly one place.
+func helmRegistrySpecFromFlags(cmd *cobra.Command) ([]byte, error) {
+	name, _ := cmd.Flags().GetString("name")
+	registryURL, _ := cmd.Flags().GetString("url")
+	credentialName, _ := cmd.Flags().GetString("credential-name")
+	excludeCharts, _ := cmd.Flags().GetStringArray("exclude-charts")
+
+	spec := map[string]any{
+		"name": name,
+		"url":  registryURL,
+	}
+	if credentialName != "" {
+		spec["credential_name"] = credentialName
+	}
+	if len(excludeCharts) > 0 {
+		spec["exclude_charts"] = excludeCharts
+	}
+	specJSON, err := json.Marshal(spec)
+	if err != nil {
+		return nil, fmt.Errorf("encoding spec: %w", err)
+	}
+	return specJSON, nil
+}
+
+// helmRegistryNameFromSpec extracts the registry name from a normalized spec
+// so the post-create hint can name the exact sync command to run.
+func helmRegistryNameFromSpec(specJSON json.RawMessage) string {
+	var spec map[string]struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(specJSON, &spec); err != nil {
+		return ""
+	}
+	for _, registry := range spec {
+		if registry.Name != "" {
+			return registry.Name
+		}
+	}
+	return ""
+}
+
+// normalizeHelmRegistrySpec validates the spec before it is POSTed. The
 // API requires the registry nested under exactly one of helm_oci_registry /
 // helm_http_registry and answers a bare 500 "No registry provided!" to any
 // other shape, so shape problems must be caught client-side. A flat
-// {name, url} spec is auto-nested, inferring OCI from an oci:// URL; the
-// returned note tells the user when that happened.
+// {name, url} spec is auto-nested by URL scheme — oci:// becomes an OCI
+// registry, http:// or https:// an HTTP one, anything else is rejected —
+// and the returned note tells the user what was inferred.
 func normalizeHelmRegistrySpec(fileData []byte) (json.RawMessage, string, error) {
 	var doc map[string]json.RawMessage
 	if err := json.Unmarshal(fileData, &doc); err != nil {
@@ -230,9 +317,15 @@ func normalizeHelmRegistrySpec(fileData []byte) (json.RawMessage, string, error)
 	if _, hasName := spec["name"]; !hasName || registryURL == "" {
 		return nil, "", fmt.Errorf("invalid registry spec: %s", helmRegistrySpecHint)
 	}
-	registryKey := "helm_http_registry"
-	if strings.HasPrefix(strings.ToLower(registryURL), "oci://") {
+	var registryKey string
+	lowercaseURL := strings.ToLower(registryURL)
+	switch {
+	case strings.HasPrefix(lowercaseURL, "oci://"):
 		registryKey = "helm_oci_registry"
+	case strings.HasPrefix(lowercaseURL, "http://"), strings.HasPrefix(lowercaseURL, "https://"):
+		registryKey = "helm_http_registry"
+	default:
+		return nil, "", fmt.Errorf("invalid registry url %q: the URL scheme must be oci:// (OCI registry) or http:// / https:// (HTTP chart repository)", registryURL)
 	}
 	specJSON, err := json.Marshal(map[string]map[string]json.RawMessage{registryKey: spec})
 	if err != nil {
@@ -538,8 +631,17 @@ func init() {
 	helmRegistriesListCmd.Flags().String("search", "", "Filter registries by name (case-insensitive substring)")
 	helmRegistriesListCmd.Flags().String("sort-by", "", "Sort column: name, url, created_at, updated_at, chart_count, last_indexed_at, is_global")
 	helmRegistriesListCmd.Flags().String("sort-order", "", "Sort order: asc or desc")
-	helmRegistriesCreateCmd.Flags().StringP("file", "f", "", "Path to registry spec JSON file (required)")
-	_ = helmRegistriesCreateCmd.MarkFlagRequired("file")
+	helmRegistriesCreateCmd.Flags().StringP("file", "f", "", "Path to a registry spec file, JSON or YAML")
+	helmRegistriesCreateCmd.Flags().String("name", "", "Registry name (with --url; alternative to --file)")
+	helmRegistriesCreateCmd.Flags().String("url", "", "Registry URL: oci:// for OCI registries, http:// or https:// for HTTP chart repositories")
+	helmRegistriesCreateCmd.Flags().String("credential-name", "", "Name of an existing Helm registry credential for private registries")
+	helmRegistriesCreateCmd.Flags().StringArray("exclude-charts", nil, "Chart name to exclude from indexing (repeatable)")
+	helmRegistriesCreateCmd.MarkFlagsOneRequired("file", "name")
+	helmRegistriesCreateCmd.MarkFlagsMutuallyExclusive("file", "name")
+	helmRegistriesCreateCmd.MarkFlagsMutuallyExclusive("file", "url")
+	helmRegistriesCreateCmd.MarkFlagsMutuallyExclusive("file", "credential-name")
+	helmRegistriesCreateCmd.MarkFlagsMutuallyExclusive("file", "exclude-charts")
+	helmRegistriesCreateCmd.MarkFlagsRequiredTogether("name", "url")
 	helmRegistriesDeleteCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
 	helmRegistriesUpdateCmd.Flags().Int("read-job-interval", 0, "Seconds between automatic background syncs (required)")
 	_ = helmRegistriesUpdateCmd.MarkFlagRequired("read-job-interval")

--- a/cmd/helm_registries_create_test.go
+++ b/cmd/helm_registries_create_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -8,6 +9,8 @@ import (
 	"testing"
 
 	"ankra/internal/client"
+
+	"github.com/spf13/pflag"
 )
 
 func TestNormalizeHelmRegistrySpec(t *testing.T) {
@@ -55,6 +58,16 @@ func TestNormalizeHelmRegistrySpec(t *testing.T) {
 			name:    "flat spec without url rejected",
 			file:    `{"name": "acme"}`,
 			wantErr: "helm_oci_registry",
+		},
+		{
+			name:    "flat spec with unknown url scheme rejected",
+			file:    `{"name": "acme", "url": "ftp://charts.example.com"}`,
+			wantErr: "URL scheme must be oci://",
+		},
+		{
+			name:    "flat spec with scheme-less url rejected",
+			file:    `{"name": "acme", "url": "charts.example.com"}`,
+			wantErr: "http:// / https://",
 		},
 		{
 			name:    "non-object file rejected",
@@ -124,12 +137,57 @@ func (m *helmRegistryCreateMock) CreateHelmRegistry(req client.CreateHelmRegistr
 }
 
 func writeHelmSpecFile(t *testing.T, content string) string {
+	return writeHelmSpecFileNamed(t, "registry-spec.json", content)
+}
+
+func writeHelmSpecFileNamed(t *testing.T, fileName, content string) string {
 	t.Helper()
-	path := filepath.Join(t.TempDir(), "registry-spec.json")
+	path := filepath.Join(t.TempDir(), fileName)
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("writing spec file: %v", err)
 	}
 	return path
+}
+
+// resetHelmRegistriesCreateFlags clears the create command's flag state so
+// the package-level command does not leak flag values (or their Changed
+// bits, which drive the exactly-one-of group validation) between tests.
+// Slice flags need Replace because pflag's Set appends to arrays.
+func resetHelmRegistriesCreateFlags() {
+	helmRegistriesCreateCmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		if sliceValue, ok := flag.Value.(pflag.SliceValue); ok {
+			_ = sliceValue.Replace(nil)
+		} else {
+			_ = flag.Value.Set(flag.DefValue)
+		}
+		flag.Changed = false
+	})
+}
+
+func runHelmRegistriesCreate(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	resetHelmRegistriesCreateFlags()
+	t.Cleanup(resetHelmRegistriesCreateFlags)
+	return executeCommand(append([]string{"helm", "registries", "create"}, args...)...)
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	originalStderr := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() failed: %v", err)
+	}
+	os.Stderr = writer
+
+	fn()
+
+	_ = writer.Close()
+	os.Stderr = originalStderr
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(reader)
+	return buf.String()
 }
 
 func TestHelmRegistriesCreateAutoNestsFlatSpec(t *testing.T) {
@@ -137,7 +195,7 @@ func TestHelmRegistriesCreateAutoNestsFlatSpec(t *testing.T) {
 	setMockClient(t, mock)
 	path := writeHelmSpecFile(t, `{"name": "acme", "url": "oci://ghcr.io/acme/charts"}`)
 
-	_, err := executeCommand("helm", "registries", "create", "-f", path)
+	_, err := runHelmRegistriesCreate(t, "-f", path)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -156,7 +214,7 @@ func TestHelmRegistriesCreateRejectsUnrecognizedSpecBeforePost(t *testing.T) {
 	setMockClient(t, mock)
 	path := writeHelmSpecFile(t, `{"registry": {"name": "acme", "url": "oci://x"}}`)
 
-	_, err := executeCommand("helm", "registries", "create", "-f", path)
+	_, err := runHelmRegistriesCreate(t, "-f", path)
 	if err == nil {
 		t.Fatal("expected an error for an unrecognized spec shape")
 	}
@@ -168,5 +226,184 @@ func TestHelmRegistriesCreateRejectsUnrecognizedSpecBeforePost(t *testing.T) {
 	}
 	if mock.lastReq != nil {
 		t.Error("expected no API call for an invalid spec file")
+	}
+}
+
+func TestHelmRegistriesCreateAcceptsNestedYAMLSpec(t *testing.T) {
+	mock := &helmRegistryCreateMock{}
+	setMockClient(t, mock)
+	path := writeHelmSpecFileNamed(t, "registry-spec.yaml", `spec:
+  helm_http_registry:
+    name: acme
+    url: https://charts.example.com
+    exclude_charts:
+      - legacy
+`)
+
+	_, err := runHelmRegistriesCreate(t, "-f", path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.lastReq == nil {
+		t.Fatal("expected CreateHelmRegistry to be called")
+	}
+	got := mustCanonicalJSON(t, mock.lastReq.Spec)
+	want := `{"helm_http_registry":{"exclude_charts":["legacy"],"name":"acme","url":"https://charts.example.com"}}`
+	if got != want {
+		t.Errorf("posted spec mismatch:\n  got:  %s\n  want: %s", got, want)
+	}
+}
+
+func TestHelmRegistriesCreateAutoNestsFlatYAMLSpec(t *testing.T) {
+	mock := &helmRegistryCreateMock{}
+	setMockClient(t, mock)
+	path := writeHelmSpecFileNamed(t, "registry-spec.yaml", "name: acme\nurl: oci://ghcr.io/acme/charts\n")
+
+	_, err := runHelmRegistriesCreate(t, "-f", path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.lastReq == nil {
+		t.Fatal("expected CreateHelmRegistry to be called")
+	}
+	got := mustCanonicalJSON(t, mock.lastReq.Spec)
+	want := `{"helm_oci_registry":{"name":"acme","url":"oci://ghcr.io/acme/charts"}}`
+	if got != want {
+		t.Errorf("posted spec mismatch:\n  got:  %s\n  want: %s", got, want)
+	}
+}
+
+func TestHelmRegistriesCreateRejectsMalformedSpecFile(t *testing.T) {
+	mock := &helmRegistryCreateMock{}
+	setMockClient(t, mock)
+	path := writeHelmSpecFile(t, `{"name": `)
+
+	_, err := runHelmRegistriesCreate(t, "-f", path)
+	if err == nil {
+		t.Fatal("expected an error for a file that is neither JSON nor YAML")
+	}
+	if !strings.Contains(err.Error(), "JSON and YAML are accepted") {
+		t.Errorf("expected error naming the accepted formats, got: %v", err)
+	}
+	if code := exitCodeFor(err); code != exitUsage {
+		t.Errorf("expected usage exit code %d, got %d", exitUsage, code)
+	}
+	if mock.lastReq != nil {
+		t.Error("expected no API call for a malformed spec file")
+	}
+}
+
+func TestHelmRegistriesCreateFromFlags(t *testing.T) {
+	mock := &helmRegistryCreateMock{}
+	setMockClient(t, mock)
+
+	var err error
+	stderrOutput := captureStderr(t, func() {
+		_, err = runHelmRegistriesCreate(t,
+			"--name", "acme",
+			"--url", "https://charts.example.com",
+			"--credential-name", "cred",
+			"--exclude-charts", "legacy",
+			"--exclude-charts", "internal")
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.lastReq == nil {
+		t.Fatal("expected CreateHelmRegistry to be called")
+	}
+	got := mustCanonicalJSON(t, mock.lastReq.Spec)
+	want := `{"helm_http_registry":{"credential_name":"cred","exclude_charts":["legacy","internal"],"name":"acme","url":"https://charts.example.com"}}`
+	if got != want {
+		t.Errorf("posted spec mismatch:\n  got:  %s\n  want: %s", got, want)
+	}
+	if !strings.Contains(stderrOutput, "helm registries sync acme") {
+		t.Errorf("expected a sync hint on stderr, got: %q", stderrOutput)
+	}
+}
+
+func TestHelmRegistriesCreateFromFlagsInfersOCI(t *testing.T) {
+	mock := &helmRegistryCreateMock{}
+	setMockClient(t, mock)
+
+	_, err := runHelmRegistriesCreate(t, "--name", "acme", "--url", "oci://ghcr.io/acme/charts")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.lastReq == nil {
+		t.Fatal("expected CreateHelmRegistry to be called")
+	}
+	got := mustCanonicalJSON(t, mock.lastReq.Spec)
+	want := `{"helm_oci_registry":{"name":"acme","url":"oci://ghcr.io/acme/charts"}}`
+	if got != want {
+		t.Errorf("posted spec mismatch:\n  got:  %s\n  want: %s", got, want)
+	}
+}
+
+func TestHelmRegistriesCreateRejectsFileAndFlagsTogether(t *testing.T) {
+	mock := &helmRegistryCreateMock{}
+	setMockClient(t, mock)
+	path := writeHelmSpecFile(t, `{"name": "acme", "url": "oci://ghcr.io/acme/charts"}`)
+
+	_, err := runHelmRegistriesCreate(t, "-f", path, "--name", "acme", "--url", "oci://ghcr.io/acme/charts")
+	if err == nil {
+		t.Fatal("expected an error when both --file and --name are set")
+	}
+	if code := exitCodeFor(err); code != exitUsage {
+		t.Errorf("expected usage exit code %d, got %d", exitUsage, code)
+	}
+	if mock.lastReq != nil {
+		t.Error("expected no API call when --file and --name conflict")
+	}
+}
+
+func TestHelmRegistriesCreateRequiresFileOrFlags(t *testing.T) {
+	mock := &helmRegistryCreateMock{}
+	setMockClient(t, mock)
+
+	_, err := runHelmRegistriesCreate(t)
+	if err == nil {
+		t.Fatal("expected an error when neither --file nor --name is set")
+	}
+	if code := exitCodeFor(err); code != exitUsage {
+		t.Errorf("expected usage exit code %d, got %d", exitUsage, code)
+	}
+	if mock.lastReq != nil {
+		t.Error("expected no API call without --file or --name")
+	}
+}
+
+func TestHelmRegistriesCreateRequiresURLWithName(t *testing.T) {
+	mock := &helmRegistryCreateMock{}
+	setMockClient(t, mock)
+
+	_, err := runHelmRegistriesCreate(t, "--name", "acme")
+	if err == nil {
+		t.Fatal("expected an error when --name is set without --url")
+	}
+	if code := exitCodeFor(err); code != exitUsage {
+		t.Errorf("expected usage exit code %d, got %d", exitUsage, code)
+	}
+	if mock.lastReq != nil {
+		t.Error("expected no API call when --url is missing")
+	}
+}
+
+func TestHelmRegistriesCreateRejectsUnknownURLScheme(t *testing.T) {
+	mock := &helmRegistryCreateMock{}
+	setMockClient(t, mock)
+
+	_, err := runHelmRegistriesCreate(t, "--name", "acme", "--url", "ftp://charts.example.com")
+	if err == nil {
+		t.Fatal("expected an error for an unsupported url scheme")
+	}
+	if !strings.Contains(err.Error(), "oci://") {
+		t.Errorf("expected error naming the accepted schemes, got: %v", err)
+	}
+	if code := exitCodeFor(err); code != exitUsage {
+		t.Errorf("expected usage exit code %d, got %d", exitUsage, code)
+	}
+	if mock.lastReq != nil {
+		t.Error("expected no API call for an unsupported url scheme")
 	}
 }


### PR DESCRIPTION
## What

`ankra helm registries create` grows three spec-shape safety nets plus a quality-of-life hint:

- **YAML spec files**: `-f` now sniffs the file content — JSON passes through untouched, anything else is parsed as YAML (`gopkg.in/yaml.v3`) and re-encoded as JSON before the shared normalisation, so the same command takes `registry-spec.json` or `registry-spec.yaml`.
- **Flag-based creation**: `--name` + `--url` (with optional `--credential-name` and repeatable `--exclude-charts`) build the spec without a file. Exactly one of `-f` or `--name`/`--url` must be given, enforced via cobra flag groups so violations exit with the usage code (2). The flag-built spec runs through the same `normalizeHelmRegistrySpec` path, keeping the nesting logic in one place.
- **URL scheme guard**: flat specs previously nested anything that was not `oci://` under `helm_http_registry`. Now `oci://` means OCI, `http://`/`https://` means HTTP, and any other scheme is a client-side usage error naming the accepted schemes. The stderr note about the inferred registry type stays.
- **Sync hint**: after a successful create, a stderr reminder points at `ankra helm registries sync <name>` to trigger indexing immediately (stdout stays clean).

## Why

The server (`POST /api/v1/org/helm/registries`) requires the registry nested under exactly one of `spec.helm_http_registry` / `spec.helm_oci_registry` and answers a frozen 500 "No registry provided!" to anything else. A customer hit exactly that with a flat spec — PLA-737 (#1050). This is the CLI half of bead ankra-5h4e.2; the server-side 422 for malformed specs lands separately in the cluster repo.

## Tests

- `TestNormalizeHelmRegistrySpec` extended with unknown-scheme and scheme-less URL rejections.
- New e2e tests: nested + flat YAML specs, flags path (credential + exclude-charts passthrough, sync hint on stderr), OCI inference from flags, `-f`/`--name` mutual exclusion, neither-form usage error, `--name` without `--url`, unknown scheme via flags — all asserting exit code 2 and that no API call is made on rejection.
- `go build ./...`, `go test -race -count=1 ./...`, `golangci-lint run` all green; usage exit codes smoke-tested against the built binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
