### PR TITLE
feat(cluster): repeatable --key and --all-data for cluster encrypt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Added
+
+- **`ankra cluster encrypt` can encrypt several keys in one run.** `--key`
+  is now repeatable on both `encrypt manifest` and `encrypt addon`, in file
+  mode and cluster mode alike, so encrypting a Secret with a dozen entries
+  no longer takes a dozen invocations: all keys go through a single SOPS
+  pass and a single write (one commit in cluster mode), every key is
+  verified to be real ENC[...] ciphertext, and each one is recorded in
+  `encrypted_paths`. `encrypt manifest` additionally gains `--all-data`,
+  which selects every key under a Secret's `data` and `stringData`
+  automatically - values that are already encrypted are skipped with a
+  notice, and pointing it at anything other than a Secret fails naming the
+  actual kind.
+
 ### Removed
 
 - **The MFA management and organisation RBAC commands are gone — none of

--- a/cmd/cluster_encrypt.go
+++ b/cmd/cluster_encrypt.go
@@ -47,7 +47,8 @@ var clusterSopsConfigCmd = &cobra.Command{
 
 var (
 	encryptClusterFile string
-	encryptKey         string
+	encryptKeys        []string
+	encryptAllData     bool
 	encryptAddonName   string
 	encryptClusterFlag string
 	encryptStackFlag   string
@@ -62,15 +63,22 @@ var clusterEncryptCmd = &cobra.Command{
 
 var clusterEncryptManifestCmd = &cobra.Command{
 	Use:   "manifest <manifest_name>",
-	Short: "Encrypt a key in a manifest",
-	Long: `Encrypt a specific key in a manifest using SOPS.
+	Short: "Encrypt one or more keys in a manifest",
+	Long: `Encrypt one or more keys in a manifest using SOPS.
 
 --key takes the YAML key name whose values should be encrypted (for a Secret's
-data.password, that is "password"). SOPS matches key names anywhere in the
-document, not dotted paths; a dotted --key is normalised to its last segment.
-A key whose own name starts with a dot (such as ".dockerconfigjson" in a
-kubernetes.io/dockerconfigjson Secret) is kept literally. After encrypting, the
-CLI verifies the value is actually ENC[...] ciphertext and fails if it is not.
+data.password, that is "password"). Repeat --key to encrypt several keys in a
+single run; all keys are encrypted in one SOPS pass and one write. SOPS matches
+key names anywhere in the document, not dotted paths; a dotted --key is
+normalised to its last segment. A key whose own name starts with a dot (such as
+".dockerconfigjson" in a kubernetes.io/dockerconfigjson Secret) is kept
+literally. After encrypting, the CLI verifies every value is actually ENC[...]
+ciphertext and fails if any is not.
+
+--all-data selects every key under data and stringData of a Kubernetes Secret
+manifest instead of naming keys individually; keys whose values are already
+encrypted are skipped. The manifest must be a Secret. --all-data and --key are
+mutually exclusive.
 
 Two modes:
   Cluster mode (default): fetch the manifest from a live cluster, encrypt the
@@ -103,6 +111,12 @@ Examples:
   ankra cluster encrypt manifest db-secret --key password \
     --set 'data.password=bmV3LXNlY3JldA==' --cluster prod
 
+  # Encrypt several keys in one run
+  ankra cluster encrypt manifest db-secret --key password --key api-token
+
+  # Encrypt every data/stringData key of a Secret manifest
+  ankra cluster encrypt manifest db-secret --all-data --cluster prod
+
   # File mode
   ankra cluster encrypt manifest db-secret --key password -f cluster.yaml`,
 	Args: cobra.ExactArgs(1),
@@ -111,14 +125,16 @@ Examples:
 
 var clusterEncryptAddonCmd = &cobra.Command{
 	Use:   "addon",
-	Short: "Encrypt a key in an addon's values",
-	Long: `Encrypt a specific key in an addon's Helm values using SOPS.
+	Short: "Encrypt one or more keys in an addon's values",
+	Long: `Encrypt one or more keys in an addon's Helm values using SOPS.
 
---key takes the YAML key name whose values should be encrypted. SOPS matches
-key names anywhere in the document, not dotted paths; a dotted --key is
-normalised to its last segment. A key whose own name starts with a dot (such
-as ".dockerconfigjson") is kept literally. After encrypting, the CLI verifies
-the value is actually ENC[...] ciphertext and fails if it is not.
+--key takes the YAML key name whose values should be encrypted. Repeat --key to
+encrypt several keys in a single run; all keys are encrypted in one SOPS pass
+and one write. SOPS matches key names anywhere in the document, not dotted
+paths; a dotted --key is normalised to its last segment. A key whose own name
+starts with a dot (such as ".dockerconfigjson") is kept literally. After
+encrypting, the CLI verifies every value is actually ENC[...] ciphertext and
+fails if any is not.
 
 Two modes:
   Cluster mode (default): fetch the addon's values from a live cluster,
@@ -135,6 +151,9 @@ Examples:
   # Cluster mode against a specific cluster, disambiguating stack
   ankra cluster encrypt addon --name grafana --key adminPassword --cluster prod --stack monitoring
 
+  # Encrypt several keys in one run
+  ankra cluster encrypt addon --name grafana --key adminPassword --key smtpPassword
+
   # File mode
   ankra cluster encrypt addon --name grafana --key adminPassword -f cluster.yaml`,
 	RunE: runEncryptAddon,
@@ -142,15 +161,17 @@ Examples:
 
 func init() {
 	clusterEncryptManifestCmd.Flags().StringVarP(&encryptClusterFile, "file", "f", "", "Path to a local cluster YAML (enables file mode)")
-	clusterEncryptManifestCmd.Flags().StringVar(&encryptKey, "key", "", "YAML key name to encrypt (required); dotted paths are normalised to the last segment, a leading-dot key like .dockerconfigjson is kept literally")
+	clusterEncryptManifestCmd.Flags().StringArrayVar(&encryptKeys, "key", nil, "YAML key name to encrypt (repeatable); dotted paths are normalised to the last segment, a leading-dot key like .dockerconfigjson is kept literally")
+	clusterEncryptManifestCmd.Flags().BoolVar(&encryptAllData, "all-data", false, "Encrypt every key under data and stringData of a Secret manifest, skipping values that are already encrypted")
 	clusterEncryptManifestCmd.Flags().StringVar(&encryptClusterFlag, "cluster", "", "Target cluster (name or ID); defaults to the active selection (cluster mode)")
 	clusterEncryptManifestCmd.Flags().StringArrayVar(&encryptSetEntries, "set", nil, "Apply value edits in-memory before encrypting (same syntax as manifests upgrade --set, e.g. --set 'data.password=bmV3'); the plaintext value never reaches git (cluster mode only; repeatable)")
-	_ = clusterEncryptManifestCmd.MarkFlagRequired("key")
+	clusterEncryptManifestCmd.MarkFlagsOneRequired("key", "all-data")
+	clusterEncryptManifestCmd.MarkFlagsMutuallyExclusive("key", "all-data")
 	clusterEncryptManifestCmd.MarkFlagsMutuallyExclusive("file", "cluster")
 	clusterEncryptManifestCmd.MarkFlagsMutuallyExclusive("file", "set")
 
 	clusterEncryptAddonCmd.Flags().StringVarP(&encryptClusterFile, "file", "f", "", "Path to a local cluster YAML (enables file mode)")
-	clusterEncryptAddonCmd.Flags().StringVar(&encryptKey, "key", "", "YAML key name to encrypt (required); dotted paths are normalised to the last segment, a leading-dot key like .dockerconfigjson is kept literally")
+	clusterEncryptAddonCmd.Flags().StringArrayVar(&encryptKeys, "key", nil, "YAML key name to encrypt (required; repeatable); dotted paths are normalised to the last segment, a leading-dot key like .dockerconfigjson is kept literally")
 	clusterEncryptAddonCmd.Flags().StringVar(&encryptAddonName, "name", "", "Name of the addon (required)")
 	clusterEncryptAddonCmd.Flags().StringVar(&encryptClusterFlag, "cluster", "", "Target cluster (name or ID); defaults to the active selection (cluster mode)")
 	clusterEncryptAddonCmd.Flags().StringVar(&encryptStackFlag, "stack", "", "Stack name (cluster mode; required when the addon exists in multiple stacks)")
@@ -200,6 +221,128 @@ func announceEncryptKeyNormalization(cmd *cobra.Command, rawKey, leafKey string)
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(),
 		"Note: SOPS matches YAML key names, not dotted paths; encrypting key %q (derived from --key %q).\n",
 		leafKey, rawKey)
+}
+
+// normalizeAndAnnounceEncryptKeys runs every --key value through
+// normalizeEncryptKey, announces each normalisation, and drops duplicates after
+// normalisation while preserving first-seen order.
+func normalizeAndAnnounceEncryptKeys(cmd *cobra.Command, rawKeys []string) ([]string, error) {
+	if len(rawKeys) == 0 {
+		return nil, fmt.Errorf("at least one --key is required")
+	}
+	seenLeafKeys := map[string]bool{}
+	leafKeys := make([]string, 0, len(rawKeys))
+	for _, rawKey := range rawKeys {
+		leafKey, err := normalizeEncryptKey(rawKey)
+		if err != nil {
+			return nil, err
+		}
+		announceEncryptKeyNormalization(cmd, rawKey, leafKey)
+		if seenLeafKeys[leafKey] {
+			continue
+		}
+		seenLeafKeys[leafKey] = true
+		leafKeys = append(leafKeys, leafKey)
+	}
+	return leafKeys, nil
+}
+
+// describeEncryptKeys renders leaf keys for progress messages: `key "a"` for a
+// single key, `keys "a", "b"` for several.
+func describeEncryptKeys(leafKeys []string) string {
+	quotedKeys := make([]string, len(leafKeys))
+	for keyIndex, leafKey := range leafKeys {
+		quotedKeys[keyIndex] = fmt.Sprintf("%q", leafKey)
+	}
+	if len(quotedKeys) == 1 {
+		return "key " + quotedKeys[0]
+	}
+	return "keys " + strings.Join(quotedKeys, ", ")
+}
+
+// describeEncryptKeysCapitalised is describeEncryptKeys for sentence starts.
+func describeEncryptKeysCapitalised(leafKeys []string) string {
+	described := describeEncryptKeys(leafKeys)
+	return strings.ToUpper(described[:1]) + described[1:]
+}
+
+// selectSecretDataKeys implements --all-data key selection: it parses manifest
+// YAML, requires every document to be a Kubernetes Secret, and returns the
+// keys under data and stringData. Keys whose value is already ENC[...]
+// ciphertext are returned separately so callers can skip re-encrypting them.
+func selectSecretDataKeys(manifestYAML []byte) (plaintextKeys, alreadyEncryptedKeys []string, err error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(manifestYAML))
+	seenPlaintextKeys := map[string]bool{}
+	seenEncryptedKeys := map[string]bool{}
+	secretDocumentCount := 0
+	for {
+		var document yaml.Node
+		decodeErr := decoder.Decode(&document)
+		if errors.Is(decodeErr, io.EOF) {
+			break
+		}
+		if decodeErr != nil {
+			return nil, nil, fmt.Errorf("parse manifest YAML: %w", decodeErr)
+		}
+		rootNode := &document
+		if rootNode.Kind == yaml.DocumentNode && len(rootNode.Content) > 0 {
+			rootNode = resolveYAMLAlias(rootNode.Content[0])
+		}
+		if rootNode == nil || rootNode.Kind != yaml.MappingNode {
+			continue
+		}
+		manifestKind := yamlMapString(rootNode, "kind")
+		if manifestKind != "Secret" {
+			if manifestKind == "" {
+				return nil, nil, fmt.Errorf("--all-data requires a Secret manifest, but the manifest has no kind field")
+			}
+			return nil, nil, fmt.Errorf("--all-data requires a Secret manifest, but the manifest is a %s", manifestKind)
+		}
+		secretDocumentCount++
+		for _, sectionKey := range []string{"data", "stringData"} {
+			section := yamlMapValue(rootNode, sectionKey)
+			if section == nil || section.Kind != yaml.MappingNode {
+				continue
+			}
+			for entryIndex := 0; entryIndex+1 < len(section.Content); entryIndex += 2 {
+				dataKey := section.Content[entryIndex].Value
+				valueNode := resolveYAMLAlias(section.Content[entryIndex+1])
+				if valueNode != nil && valueNode.Kind == yaml.ScalarNode && strings.HasPrefix(valueNode.Value, sopsEncryptedValuePrefix) {
+					if !seenEncryptedKeys[dataKey] {
+						seenEncryptedKeys[dataKey] = true
+						alreadyEncryptedKeys = append(alreadyEncryptedKeys, dataKey)
+					}
+					continue
+				}
+				if !seenPlaintextKeys[dataKey] {
+					seenPlaintextKeys[dataKey] = true
+					plaintextKeys = append(plaintextKeys, dataKey)
+				}
+			}
+		}
+	}
+	if secretDocumentCount == 0 {
+		return nil, nil, fmt.Errorf("--all-data requires a Secret manifest, but the manifest contains no YAML documents")
+	}
+	if len(plaintextKeys) == 0 && len(alreadyEncryptedKeys) == 0 {
+		return nil, nil, fmt.Errorf("the Secret manifest has no data or stringData keys to encrypt")
+	}
+	skippedKeys := make([]string, 0, len(alreadyEncryptedKeys))
+	for _, dataKey := range alreadyEncryptedKeys {
+		if !seenPlaintextKeys[dataKey] {
+			skippedKeys = append(skippedKeys, dataKey)
+		}
+	}
+	return plaintextKeys, skippedKeys, nil
+}
+
+// announceSkippedEncryptedKeys reports --all-data keys left untouched because
+// their values are already ENC[...] ciphertext.
+func announceSkippedEncryptedKeys(out io.Writer, alreadyEncryptedKeys []string) {
+	if len(alreadyEncryptedKeys) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(out, "Skipping already-encrypted %s.\n", describeEncryptKeys(alreadyEncryptedKeys))
 }
 
 // verifyKeyEncrypted guards against SOPS "succeeding" without encrypting
@@ -298,18 +441,21 @@ func isSubtreeEncrypted(node *yaml.Node) bool {
 
 func runEncryptManifest(cmd *cobra.Command, args []string) error {
 	manifestName := args[0]
-	leafKey, err := normalizeEncryptKey(encryptKey)
-	if err != nil {
-		return err
+	var leafKeys []string
+	if !encryptAllData {
+		normalizedKeys, err := normalizeAndAnnounceEncryptKeys(cmd, encryptKeys)
+		if err != nil {
+			return err
+		}
+		leafKeys = normalizedKeys
 	}
-	announceEncryptKeyNormalization(cmd, encryptKey, leafKey)
 	if encryptClusterFile == "" {
-		return runEncryptManifestCluster(cmd, manifestName, leafKey)
+		return runEncryptManifestCluster(cmd, manifestName, leafKeys)
 	}
-	return runEncryptManifestFile(cmd, manifestName, leafKey)
+	return runEncryptManifestFile(cmd, manifestName, leafKeys)
 }
 
-func runEncryptManifestFile(cmd *cobra.Command, manifestName, leafKey string) error {
+func runEncryptManifestFile(cmd *cobra.Command, manifestName string, leafKeys []string) error {
 	clusterData, err := os.ReadFile(encryptClusterFile)
 	if err != nil {
 		return fmt.Errorf("failed to read cluster file %q: %w", encryptClusterFile, err)
@@ -359,15 +505,30 @@ func runEncryptManifestFile(cmd *cobra.Command, manifestName, leafKey string) er
 		return fmt.Errorf("failed to read manifest file %q: %w", manifestFilePath, err)
 	}
 
-	fmt.Printf("Encrypting key %q in manifest %q...\n", leafKey, manifestName)
+	if encryptAllData {
+		plaintextKeys, alreadyEncryptedKeys, selectErr := selectSecretDataKeys(manifestContent)
+		if selectErr != nil {
+			return selectErr
+		}
+		announceSkippedEncryptedKeys(os.Stdout, alreadyEncryptedKeys)
+		if len(plaintextKeys) == 0 {
+			fmt.Printf("All data keys in manifest %q are already encrypted; nothing to encrypt.\n", manifestName)
+			return nil
+		}
+		leafKeys = plaintextKeys
+	}
 
-	encryptedContent, err := apiClient.EncryptYAML(string(manifestContent), []string{leafKey})
+	fmt.Printf("Encrypting %s in manifest %q...\n", describeEncryptKeys(leafKeys), manifestName)
+
+	encryptedContent, err := apiClient.EncryptYAML(string(manifestContent), leafKeys)
 	if err != nil {
 		return fmt.Errorf("encryption failed: %w", err)
 	}
 
-	if err := verifyKeyEncrypted(encryptedContent, leafKey); err != nil {
-		return fmt.Errorf("encryption verification failed: %w", err)
+	for _, leafKey := range leafKeys {
+		if err := verifyKeyEncrypted(encryptedContent, leafKey); err != nil {
+			return fmt.Errorf("encryption verification failed: %w", err)
+		}
 	}
 
 	if err := os.WriteFile(manifestFilePath, []byte(encryptedContent), 0o644); err != nil {
@@ -380,13 +541,21 @@ func runEncryptManifestFile(cmd *cobra.Command, manifestName, leafKey string) er
 	// the yaml.Node level so fields the CLI structs do not model
 	// (deploy_wave, prometheus_metrics, future keys), comments, and ordering
 	// survive the rewrite of this GitOps source of truth.
-	if !containsString(foundManifest.EncryptedPaths, leafKey) {
+	missingKeys := make([]string, 0, len(leafKeys))
+	for _, leafKey := range leafKeys {
+		if !containsString(foundManifest.EncryptedPaths, leafKey) {
+			missingKeys = append(missingKeys, leafKey)
+		}
+	}
+	if len(missingKeys) > 0 {
 		clusterDoc, err := parseClusterYAMLDoc(clusterData)
 		if err != nil {
 			return fmt.Errorf("failed to update cluster file: %w", err)
 		}
-		if err := appendManifestEncryptedPath(clusterDoc, manifestName, leafKey); err != nil {
-			return fmt.Errorf("failed to update cluster file: %w", err)
+		for _, leafKey := range missingKeys {
+			if err := appendManifestEncryptedPath(clusterDoc, manifestName, leafKey); err != nil {
+				return fmt.Errorf("failed to update cluster file: %w", err)
+			}
 		}
 		if err := writeClusterFile(encryptClusterFile, clusterDoc); err != nil {
 			return fmt.Errorf("failed to update cluster file: %w", err)
@@ -394,7 +563,7 @@ func runEncryptManifestFile(cmd *cobra.Command, manifestName, leafKey string) er
 
 		fmt.Printf("Updated cluster file with encrypted_paths: %s\n", encryptClusterFile)
 	} else {
-		fmt.Printf("Key %q already in encrypted_paths, cluster file unchanged\n", leafKey)
+		fmt.Printf("%s already in encrypted_paths, cluster file unchanged\n", describeEncryptKeysCapitalised(leafKeys))
 	}
 
 	fmt.Println("Encryption complete!")
@@ -402,18 +571,17 @@ func runEncryptManifestFile(cmd *cobra.Command, manifestName, leafKey string) er
 }
 
 func runEncryptAddon(cmd *cobra.Command, args []string) error {
-	leafKey, err := normalizeEncryptKey(encryptKey)
+	leafKeys, err := normalizeAndAnnounceEncryptKeys(cmd, encryptKeys)
 	if err != nil {
 		return err
 	}
-	announceEncryptKeyNormalization(cmd, encryptKey, leafKey)
 	if encryptClusterFile == "" {
-		return runEncryptAddonCluster(cmd, encryptAddonName, leafKey)
+		return runEncryptAddonCluster(cmd, encryptAddonName, leafKeys)
 	}
-	return runEncryptAddonFile(cmd, leafKey)
+	return runEncryptAddonFile(cmd, leafKeys)
 }
 
-func runEncryptAddonFile(cmd *cobra.Command, leafKey string) error {
+func runEncryptAddonFile(cmd *cobra.Command, leafKeys []string) error {
 	clusterData, err := os.ReadFile(encryptClusterFile)
 	if err != nil {
 		return fmt.Errorf("failed to read cluster file %q: %w", encryptClusterFile, err)
@@ -469,15 +637,17 @@ func runEncryptAddonFile(cmd *cobra.Command, leafKey string) error {
 		return fmt.Errorf("failed to read addon configuration file %q: %w", addonFilePath, err)
 	}
 
-	fmt.Printf("Encrypting key %q in addon %q...\n", leafKey, encryptAddonName)
+	fmt.Printf("Encrypting %s in addon %q...\n", describeEncryptKeys(leafKeys), encryptAddonName)
 
-	encryptedContent, err := apiClient.EncryptYAML(string(addonContent), []string{leafKey})
+	encryptedContent, err := apiClient.EncryptYAML(string(addonContent), leafKeys)
 	if err != nil {
 		return fmt.Errorf("encryption failed: %w", err)
 	}
 
-	if err := verifyKeyEncrypted(encryptedContent, leafKey); err != nil {
-		return fmt.Errorf("encryption verification failed: %w", err)
+	for _, leafKey := range leafKeys {
+		if err := verifyKeyEncrypted(encryptedContent, leafKey); err != nil {
+			return fmt.Errorf("encryption verification failed: %w", err)
+		}
 	}
 
 	if err := os.WriteFile(addonFilePath, []byte(encryptedContent), 0o644); err != nil {
@@ -491,13 +661,21 @@ func runEncryptAddonFile(cmd *cobra.Command, leafKey string) error {
 	// model (deploy_wave, prometheus_metrics, future keys), comments, and
 	// ordering survive the rewrite of this GitOps source of truth.
 	encryptedPaths := getEncryptedPathsFromConfig(foundAddon.Configuration)
-	if !containsString(encryptedPaths, leafKey) {
+	missingKeys := make([]string, 0, len(leafKeys))
+	for _, leafKey := range leafKeys {
+		if !containsString(encryptedPaths, leafKey) {
+			missingKeys = append(missingKeys, leafKey)
+		}
+	}
+	if len(missingKeys) > 0 {
 		clusterDoc, err := parseClusterYAMLDoc(clusterData)
 		if err != nil {
 			return fmt.Errorf("failed to update cluster file: %w", err)
 		}
-		if err := appendAddonEncryptedPath(clusterDoc, encryptAddonName, leafKey); err != nil {
-			return fmt.Errorf("failed to update cluster file: %w", err)
+		for _, leafKey := range missingKeys {
+			if err := appendAddonEncryptedPath(clusterDoc, encryptAddonName, leafKey); err != nil {
+				return fmt.Errorf("failed to update cluster file: %w", err)
+			}
 		}
 		if err := writeClusterFile(encryptClusterFile, clusterDoc); err != nil {
 			return fmt.Errorf("failed to update cluster file: %w", err)
@@ -505,7 +683,7 @@ func runEncryptAddonFile(cmd *cobra.Command, leafKey string) error {
 
 		fmt.Printf("Updated cluster file with encrypted_paths: %s\n", encryptClusterFile)
 	} else {
-		fmt.Printf("Key %q already in encrypted_paths, cluster file unchanged\n", leafKey)
+		fmt.Printf("%s already in encrypted_paths, cluster file unchanged\n", describeEncryptKeysCapitalised(leafKeys))
 	}
 
 	fmt.Println("Encryption complete!")
@@ -654,7 +832,7 @@ func fetchClusterIaCDoc(ctx context.Context, clusterFlag string) (clusterID, clu
 	return clusterID, clusterName, doc, nil
 }
 
-func runEncryptManifestCluster(cmd *cobra.Command, manifestName, leafKey string) error {
+func runEncryptManifestCluster(cmd *cobra.Command, manifestName string, leafKeys []string) error {
 	// The command ends in a partial-stack PATCH, which the backend serves
 	// synchronously (DB transaction + a full GitOps commit/push when the
 	// cluster has a linked repo) rather than enqueuing it - that can
@@ -695,19 +873,36 @@ func runEncryptManifestCluster(cmd *cobra.Command, manifestName, leafKey string)
 		return fmt.Errorf("base64-decode manifest content: %w", err)
 	}
 
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Encrypting key %q in manifest %q (stack %q)...\n", leafKey, manifestName, stack.Name)
-	encryptedYAML, err := apiClient.EncryptYAML(string(decoded), []string{leafKey})
+	if encryptAllData {
+		plaintextKeys, alreadyEncryptedKeys, selectErr := selectSecretDataKeys(decoded)
+		if selectErr != nil {
+			return selectErr
+		}
+		announceSkippedEncryptedKeys(cmd.OutOrStdout(), alreadyEncryptedKeys)
+		if len(plaintextKeys) == 0 {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "All data keys in manifest %q are already encrypted; nothing to encrypt.\n", manifestName)
+			return nil
+		}
+		leafKeys = plaintextKeys
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Encrypting %s in manifest %q (stack %q)...\n", describeEncryptKeys(leafKeys), manifestName, stack.Name)
+	encryptedYAML, err := apiClient.EncryptYAML(string(decoded), leafKeys)
 	if err != nil {
 		return fmt.Errorf("encryption failed: %w", err)
 	}
 
-	if err := verifyKeyEncrypted(encryptedYAML, leafKey); err != nil {
-		return fmt.Errorf("encryption verification failed: %w", err)
+	for _, leafKey := range leafKeys {
+		if err := verifyKeyEncrypted(encryptedYAML, leafKey); err != nil {
+			return fmt.Errorf("encryption verification failed: %w", err)
+		}
 	}
 
 	newPaths := append([]string{}, manifest.EncryptedPaths...)
-	if !containsString(newPaths, leafKey) {
-		newPaths = append(newPaths, leafKey)
+	for _, leafKey := range leafKeys {
+		if !containsString(newPaths, leafKey) {
+			newPaths = append(newPaths, leafKey)
+		}
 	}
 
 	mutated := *manifest
@@ -736,7 +931,7 @@ func runEncryptManifestCluster(cmd *cobra.Command, manifestName, leafKey string)
 	return nil
 }
 
-func runEncryptAddonCluster(cmd *cobra.Command, addonName, leafKey string) error {
+func runEncryptAddonCluster(cmd *cobra.Command, addonName string, leafKeys []string) error {
 	// The command ends in a partial-stack PATCH, which the backend serves
 	// synchronously (DB transaction + a full GitOps commit/push when the
 	// cluster has a linked repo) rather than enqueuing it - that can
@@ -759,14 +954,16 @@ func runEncryptAddonCluster(cmd *cobra.Command, addonName, leafKey string) error
 		return fmt.Errorf("fetch current addon values: %w", err)
 	}
 
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Encrypting key %q in addon %q (stack %q)...\n", leafKey, addonName, stack.Name)
-	encryptedYAML, err := apiClient.EncryptYAML(currentValues, []string{leafKey})
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Encrypting %s in addon %q (stack %q)...\n", describeEncryptKeys(leafKeys), addonName, stack.Name)
+	encryptedYAML, err := apiClient.EncryptYAML(currentValues, leafKeys)
 	if err != nil {
 		return fmt.Errorf("encryption failed: %w", err)
 	}
 
-	if err := verifyKeyEncrypted(encryptedYAML, leafKey); err != nil {
-		return fmt.Errorf("encryption verification failed: %w", err)
+	for _, leafKey := range leafKeys {
+		if err := verifyKeyEncrypted(encryptedYAML, leafKey); err != nil {
+			return fmt.Errorf("encryption verification failed: %w", err)
+		}
 	}
 
 	existingPaths := []string{}
@@ -774,8 +971,10 @@ func runEncryptAddonCluster(cmd *cobra.Command, addonName, leafKey string) error
 		existingPaths = addon.Configuration.EncryptedPaths
 	}
 	newPaths := append([]string{}, existingPaths...)
-	if !containsString(newPaths, leafKey) {
-		newPaths = append(newPaths, leafKey)
+	for _, leafKey := range leafKeys {
+		if !containsString(newPaths, leafKey) {
+			newPaths = append(newPaths, leafKey)
+		}
 	}
 
 	mutatedAddon := *addon

--- a/cmd/cluster_encrypt_test.go
+++ b/cmd/cluster_encrypt_test.go
@@ -1,0 +1,621 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Tests for repeatable --key and --all-data on `cluster encrypt` (bead
+// ankra-5h4e.6, PLA-741 / customer ticket #1054): encrypting many keys used to
+// take one invocation per key, and there was no way to encrypt every data key
+// of a Secret at once.
+
+const bothKeysEncryptedSecretManifestYAML = `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: web
+type: Opaque
+data:
+  username: ENC[AES256_GCM,data:usr,iv:abc,tag:def,type:str]
+  password: ENC[AES256_GCM,data:pwd,iv:abc,tag:def,type:str]
+sops:
+  mac: ENC[AES256_GCM,data:mac]
+  encrypted_regex: ^(password|username)$
+`
+
+const allDataPlainSecretManifestYAML = `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: web
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: aHVudGVyMg==
+stringData:
+  api-token: hunter2
+`
+
+const allDataEncryptedSecretManifestYAML = `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: web
+type: Opaque
+data:
+  username: ENC[AES256_GCM,data:usr,iv:abc,tag:def,type:str]
+  password: ENC[AES256_GCM,data:pwd,iv:abc,tag:def,type:str]
+stringData:
+  api-token: ENC[AES256_GCM,data:tok,iv:abc,tag:def,type:str]
+sops:
+  mac: ENC[AES256_GCM,data:mac]
+`
+
+const partiallyEncryptedSecretManifestYAML = `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: web
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: ENC[AES256_GCM,data:pwd,iv:abc,tag:def,type:str]
+stringData:
+  api-token: hunter2
+sops:
+  mac: ENC[AES256_GCM,data:mac]
+`
+
+const configMapManifestYAML = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-config
+data:
+  setting: enabled
+`
+
+func TestRunEncryptManifest_FileModeMultipleKeysSingleEncryptCall(t *testing.T) {
+	clusterPath, manifestPath := writeEncryptFileModeFixture(t, plainSecretManifestYAML)
+
+	mock := &upgradeMock{encryptResult: bothKeysEncryptedSecretManifestYAML}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "my-secret",
+		"--key", "password",
+		"--key", "data.username",
+		"-f", clusterPath,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+
+	if len(mock.encryptCalls) != 1 {
+		t.Fatalf("expected exactly one EncryptYAML call for two keys, got %d", len(mock.encryptCalls))
+	}
+	paths := mock.encryptCalls[0].EncryptedPaths
+	if len(paths) != 2 || paths[0] != "password" || paths[1] != "username" {
+		t.Errorf("encrypted paths = %v, want [password username]", paths)
+	}
+
+	writtenManifest, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read written manifest: %v", err)
+	}
+	if string(writtenManifest) != bothKeysEncryptedSecretManifestYAML {
+		t.Errorf("manifest file = %q, want the encrypted content", writtenManifest)
+	}
+
+	writtenCluster, err := os.ReadFile(clusterPath)
+	if err != nil {
+		t.Fatalf("read written cluster file: %v", err)
+	}
+	assertContainsAll(t, string(writtenCluster), []string{"- password", "- username"})
+}
+
+func TestRunEncryptManifest_ClusterModeMultipleKeysPatchesAllPaths(t *testing.T) {
+	mock := &upgradeMock{
+		iac:           sampleIaCYAMLForCmd,
+		manifestB64:   base64.StdEncoding.EncodeToString([]byte(plainSecretManifestYAML)),
+		encryptResult: bothKeysEncryptedSecretManifestYAML,
+	}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "demo-namespace",
+		"--key", "password",
+		"--key", "username",
+		"--cluster", fakeClusterUUID,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+
+	if len(mock.encryptCalls) != 1 {
+		t.Fatalf("expected exactly one EncryptYAML call for two keys, got %d", len(mock.encryptCalls))
+	}
+	callPaths := mock.encryptCalls[0].EncryptedPaths
+	if len(callPaths) != 2 || callPaths[0] != "password" || callPaths[1] != "username" {
+		t.Errorf("encrypted paths = %v, want [password username]", callPaths)
+	}
+	if len(mock.capturedRequests) != 1 {
+		t.Fatalf("expected one PATCH, got %d", len(mock.capturedRequests))
+	}
+	manifest := mock.capturedRequests[0].Body.Spec.Stacks[0].Manifests[0]
+	if len(manifest.EncryptedPaths) != 2 || manifest.EncryptedPaths[0] != "password" || manifest.EncryptedPaths[1] != "username" {
+		t.Errorf("manifest.encrypted_paths = %v, want [password username]", manifest.EncryptedPaths)
+	}
+}
+
+func TestRunEncryptManifest_DuplicateKeysDeduplicatedAfterNormalisation(t *testing.T) {
+	mock := &upgradeMock{
+		iac:           sampleIaCYAMLForCmd,
+		manifestB64:   base64.StdEncoding.EncodeToString([]byte(plainSecretManifestYAML)),
+		encryptResult: encryptedSecretManifestYAML,
+	}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "demo-namespace",
+		"--key", "data.password",
+		"--key", "password",
+		"--cluster", fakeClusterUUID,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+
+	if len(mock.encryptCalls) != 1 {
+		t.Fatalf("expected one EncryptYAML call, got %d", len(mock.encryptCalls))
+	}
+	callPaths := mock.encryptCalls[0].EncryptedPaths
+	if len(callPaths) != 1 || callPaths[0] != "password" {
+		t.Errorf("encrypted paths = %v, want the deduplicated [password]", callPaths)
+	}
+	manifest := mock.capturedRequests[0].Body.Spec.Stacks[0].Manifests[0]
+	if len(manifest.EncryptedPaths) != 1 || manifest.EncryptedPaths[0] != "password" {
+		t.Errorf("manifest.encrypted_paths = %v, want [password]", manifest.EncryptedPaths)
+	}
+}
+
+func TestRunEncryptManifest_AllDataFileModeEncryptsEveryDataKey(t *testing.T) {
+	clusterPath, manifestPath := writeEncryptFileModeFixture(t, allDataPlainSecretManifestYAML)
+
+	mock := &upgradeMock{encryptResult: allDataEncryptedSecretManifestYAML}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "my-secret",
+		"--all-data",
+		"-f", clusterPath,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+
+	if len(mock.encryptCalls) != 1 {
+		t.Fatalf("expected exactly one EncryptYAML call, got %d", len(mock.encryptCalls))
+	}
+	callPaths := mock.encryptCalls[0].EncryptedPaths
+	if len(callPaths) != 3 || callPaths[0] != "username" || callPaths[1] != "password" || callPaths[2] != "api-token" {
+		t.Errorf("encrypted paths = %v, want [username password api-token]", callPaths)
+	}
+
+	writtenManifest, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read written manifest: %v", err)
+	}
+	if string(writtenManifest) != allDataEncryptedSecretManifestYAML {
+		t.Errorf("manifest file = %q, want the encrypted content", writtenManifest)
+	}
+
+	writtenCluster, err := os.ReadFile(clusterPath)
+	if err != nil {
+		t.Fatalf("read written cluster file: %v", err)
+	}
+	assertContainsAll(t, string(writtenCluster), []string{"- username", "- password", "- api-token"})
+}
+
+func TestRunEncryptManifest_AllDataClusterModeSkipsAlreadyEncrypted(t *testing.T) {
+	mock := &upgradeMock{
+		iac:           sampleIaCYAMLForCmd,
+		manifestB64:   base64.StdEncoding.EncodeToString([]byte(partiallyEncryptedSecretManifestYAML)),
+		encryptResult: allDataEncryptedSecretManifestYAML,
+	}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "demo-namespace",
+		"--all-data",
+		"--cluster", fakeClusterUUID,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+
+	if len(mock.encryptCalls) != 1 {
+		t.Fatalf("expected one EncryptYAML call, got %d", len(mock.encryptCalls))
+	}
+	callPaths := mock.encryptCalls[0].EncryptedPaths
+	if len(callPaths) != 2 || callPaths[0] != "username" || callPaths[1] != "api-token" {
+		t.Errorf("encrypted paths = %v, want [username api-token] (password already encrypted)", callPaths)
+	}
+	if !strings.Contains(out.String(), `Skipping already-encrypted key "password"`) {
+		t.Errorf("expected a skip notice for the already-encrypted key, got:\n%s", out.String())
+	}
+	manifest := mock.capturedRequests[0].Body.Spec.Stacks[0].Manifests[0]
+	if len(manifest.EncryptedPaths) != 2 || manifest.EncryptedPaths[0] != "username" || manifest.EncryptedPaths[1] != "api-token" {
+		t.Errorf("manifest.encrypted_paths = %v, want [username api-token]", manifest.EncryptedPaths)
+	}
+}
+
+func TestRunEncryptManifest_AllDataNothingLeftToEncrypt(t *testing.T) {
+	mock := &upgradeMock{
+		iac:         sampleIaCYAMLForCmd,
+		manifestB64: base64.StdEncoding.EncodeToString([]byte(allDataEncryptedSecretManifestYAML)),
+	}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "demo-namespace",
+		"--all-data",
+		"--cluster", fakeClusterUUID,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+
+	if len(mock.encryptCalls) != 0 {
+		t.Errorf("expected no EncryptYAML call when every key is encrypted, got %d", len(mock.encryptCalls))
+	}
+	if len(mock.capturedRequests) != 0 {
+		t.Errorf("expected no PATCH when every key is encrypted, got %d", len(mock.capturedRequests))
+	}
+	if !strings.Contains(out.String(), "already encrypted; nothing to encrypt") {
+		t.Errorf("expected a nothing-to-encrypt notice, got:\n%s", out.String())
+	}
+}
+
+func TestRunEncryptManifest_AllDataRejectsNonSecret(t *testing.T) {
+	clusterPath, manifestPath := writeEncryptFileModeFixture(t, configMapManifestYAML)
+
+	mock := &upgradeMock{}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "my-secret",
+		"--all-data",
+		"-f", clusterPath,
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected an error for a non-Secret manifest")
+	}
+	if !strings.Contains(err.Error(), "ConfigMap") {
+		t.Errorf("expected the error to name the actual kind, got: %v", err)
+	}
+	if len(mock.encryptCalls) != 0 {
+		t.Errorf("must not call EncryptYAML for a non-Secret manifest, got %d calls", len(mock.encryptCalls))
+	}
+
+	manifestAfter, readErr := os.ReadFile(manifestPath)
+	if readErr != nil {
+		t.Fatalf("read manifest after failed run: %v", readErr)
+	}
+	if string(manifestAfter) != configMapManifestYAML {
+		t.Errorf("manifest file must be untouched on rejection, got:\n%s", manifestAfter)
+	}
+}
+
+func TestRunEncryptManifest_AllDataAndKeyMutuallyExclusive(t *testing.T) {
+	mock := &upgradeMock{}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "any",
+		"--key", "password",
+		"--all-data",
+		"-f", "/tmp/x.yaml",
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected mutual-exclusion error for --key with --all-data")
+	}
+	if !strings.Contains(err.Error(), "none of the others can be") {
+		t.Errorf("expected the flag-group exclusion error, got: %v", err)
+	}
+}
+
+func TestRunEncryptManifest_RequiresKeyOrAllData(t *testing.T) {
+	mock := &upgradeMock{}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "any",
+		"-f", "/tmp/x.yaml",
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected an error when neither --key nor --all-data is given")
+	}
+	if !strings.Contains(err.Error(), "at least one of the flags") {
+		t.Errorf("expected the one-required flag-group error, got: %v", err)
+	}
+}
+
+func TestRunEncryptAddon_ClusterModeMultipleKeys(t *testing.T) {
+	mock := &upgradeMock{
+		iac:           sampleIaCYAMLForCmd,
+		addonValues:   "adminPassword: hunter2\nsmtpPassword: hunter3\n",
+		encryptResult: "adminPassword: ENC[AES256_GCM,data:a]\nsmtpPassword: ENC[AES256_GCM,data:b]\n",
+	}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "addon",
+		"--name", "website",
+		"--key", "adminPassword",
+		"--key", "smtpPassword",
+		"--cluster", fakeClusterUUID,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+
+	if len(mock.encryptCalls) != 1 {
+		t.Fatalf("expected exactly one EncryptYAML call for two keys, got %d", len(mock.encryptCalls))
+	}
+	callPaths := mock.encryptCalls[0].EncryptedPaths
+	if len(callPaths) != 2 || callPaths[0] != "adminPassword" || callPaths[1] != "smtpPassword" {
+		t.Errorf("encrypted paths = %v, want [adminPassword smtpPassword]", callPaths)
+	}
+	addon := mock.capturedRequests[0].Body.Spec.Stacks[0].Addons[0]
+	if addon.Configuration == nil {
+		t.Fatal("expected configuration in PATCH")
+	}
+	if len(addon.Configuration.EncryptedPaths) != 2 ||
+		addon.Configuration.EncryptedPaths[0] != "adminPassword" ||
+		addon.Configuration.EncryptedPaths[1] != "smtpPassword" {
+		t.Errorf("addon.encrypted_paths = %v, want [adminPassword smtpPassword]", addon.Configuration.EncryptedPaths)
+	}
+}
+
+func writeEncryptAddonFileModeFixture(t *testing.T, valuesYAML string) (clusterPath, valuesPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	valuesPath = filepath.Join(dir, "values", "grafana.yaml")
+	if err := os.MkdirAll(filepath.Dir(valuesPath), 0o755); err != nil {
+		t.Fatalf("create values dir: %v", err)
+	}
+	if err := os.WriteFile(valuesPath, []byte(valuesYAML), 0o644); err != nil {
+		t.Fatalf("write values fixture: %v", err)
+	}
+	clusterPath = filepath.Join(dir, "cluster.yaml")
+	clusterYAML := `apiVersion: v1
+kind: ImportCluster
+metadata:
+  name: file-mode-test
+spec:
+  stacks:
+    - name: web
+      addons:
+        - name: grafana
+          chart_name: grafana
+          chart_version: "7.0.0"
+          configuration:
+            from_file: values/grafana.yaml
+`
+	if err := os.WriteFile(clusterPath, []byte(clusterYAML), 0o644); err != nil {
+		t.Fatalf("write cluster fixture: %v", err)
+	}
+	return clusterPath, valuesPath
+}
+
+func TestRunEncryptAddon_FileModeMultipleKeys(t *testing.T) {
+	clusterPath, valuesPath := writeEncryptAddonFileModeFixture(t, "adminPassword: hunter2\nsmtpPassword: hunter3\n")
+
+	encryptedValues := "adminPassword: ENC[AES256_GCM,data:a]\nsmtpPassword: ENC[AES256_GCM,data:b]\n"
+	mock := &upgradeMock{encryptResult: encryptedValues}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "addon",
+		"--name", "grafana",
+		"--key", "adminPassword",
+		"--key", "smtpPassword",
+		"-f", clusterPath,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+
+	if len(mock.encryptCalls) != 1 {
+		t.Fatalf("expected exactly one EncryptYAML call for two keys, got %d", len(mock.encryptCalls))
+	}
+	callPaths := mock.encryptCalls[0].EncryptedPaths
+	if len(callPaths) != 2 || callPaths[0] != "adminPassword" || callPaths[1] != "smtpPassword" {
+		t.Errorf("encrypted paths = %v, want [adminPassword smtpPassword]", callPaths)
+	}
+
+	writtenValues, err := os.ReadFile(valuesPath)
+	if err != nil {
+		t.Fatalf("read written values file: %v", err)
+	}
+	if string(writtenValues) != encryptedValues {
+		t.Errorf("values file = %q, want the encrypted content", writtenValues)
+	}
+
+	writtenCluster, err := os.ReadFile(clusterPath)
+	if err != nil {
+		t.Fatalf("read written cluster file: %v", err)
+	}
+	assertContainsAll(t, string(writtenCluster), []string{"encrypted_paths:", "- adminPassword", "- smtpPassword"})
+}
+
+// formattingFixtureClusterYAML exercises everything the yaml.Node round-trip
+// editor must preserve: a head comment, line comments, a deliberate key order
+// (addons before name), an anchor/alias pair, and fields the CLI structs do
+// not model (prometheus_metrics, deploy_wave, future_field).
+const formattingFixtureClusterYAML = `# GitOps source of truth for prod - hand-maintained ordering.
+apiVersion: v1
+kind: ImportCluster
+metadata:
+  name: prod
+spec:
+  prometheus_metrics:
+    endpoint: https://prom.example.com # scraped by victoria
+    flavor: victoriametrics
+  stacks:
+    - addons:
+        - name: grafana
+          chart_name: grafana
+          chart_version: "7.0.0"
+          configuration:
+            from_file: values/grafana.yaml
+      name: core # addons deliberately listed before name
+      deploy_wave: 2 # after networking
+      namespace: &web-ns web
+      manifests:
+        - name: db-secret
+          namespace: *web-ns
+          from_file: manifests/secret.yaml
+      future_field: keep-me
+`
+
+func TestRunEncryptManifest_FileModePreservesUntouchedLinesByteForByte(t *testing.T) {
+	dir := t.TempDir()
+	clusterPath := filepath.Join(dir, "cluster.yaml")
+	if err := os.WriteFile(clusterPath, []byte(formattingFixtureClusterYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(dir, "manifests", "secret.yaml")
+	if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifestPath, []byte(plainSecretManifestYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &upgradeMock{encryptResult: encryptedSecretManifestYAML}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "db-secret",
+		"--key", "password",
+		"-f", clusterPath,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+
+	written, err := os.ReadFile(clusterPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The only permitted change to cluster.yaml is the encrypted_paths entry
+	// appended to the db-secret manifest; every other line must survive the
+	// rewrite byte-identically (the referenced manifest file changes in its
+	// own file, not here).
+	expected := strings.Replace(formattingFixtureClusterYAML,
+		"          from_file: manifests/secret.yaml\n",
+		"          from_file: manifests/secret.yaml\n          encrypted_paths:\n            - password\n",
+		1)
+	if string(written) != expected {
+		t.Errorf("cluster file changed beyond the encrypted_paths append.\n--- got ---\n%s\n--- want ---\n%s", written, expected)
+	}
+}
+
+func TestSelectSecretDataKeys_MultiDocumentSecrets(t *testing.T) {
+	manifestYAML := []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  name: first
+data:
+  password: aHVudGVyMg==
+  token: ENC[AES256_GCM,data:tok]
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: second
+stringData:
+  password: hunter2
+  extra: value
+`)
+	plaintextKeys, alreadyEncryptedKeys, err := selectSecretDataKeys(manifestYAML)
+	if err != nil {
+		t.Fatalf("selectSecretDataKeys failed: %v", err)
+	}
+	if len(plaintextKeys) != 2 || plaintextKeys[0] != "password" || plaintextKeys[1] != "extra" {
+		t.Errorf("plaintext keys = %v, want [password extra]", plaintextKeys)
+	}
+	if len(alreadyEncryptedKeys) != 1 || alreadyEncryptedKeys[0] != "token" {
+		t.Errorf("already-encrypted keys = %v, want [token]", alreadyEncryptedKeys)
+	}
+}
+
+func TestSelectSecretDataKeys_NoDataKeys(t *testing.T) {
+	manifestYAML := []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  name: empty
+type: Opaque
+`)
+	if _, _, err := selectSecretDataKeys(manifestYAML); err == nil {
+		t.Error("expected an error for a Secret without data or stringData keys")
+	}
+}

--- a/cmd/cluster_yaml_edit_test.go
+++ b/cmd/cluster_yaml_edit_test.go
@@ -363,7 +363,7 @@ func TestRunEncryptManifestFile_PreservesUnmodeledFields(t *testing.T) {
 	encryptClusterFile = clusterPath
 	t.Cleanup(func() { encryptClusterFile = previousFile })
 
-	if err := runEncryptManifestFile(nil, "db-secret", "password"); err != nil {
+	if err := runEncryptManifestFile(nil, "db-secret", []string{"password"}); err != nil {
 		t.Fatalf("runEncryptManifestFile failed: %v", err)
 	}
 


### PR DESCRIPTION
## What

`ankra cluster encrypt manifest|addon` can now encrypt several keys in one run, and `encrypt manifest` can encrypt every data key of a Secret at once:

- **`--key` is repeatable** on both `encrypt manifest` and `encrypt addon`, in file mode and cluster mode. All keys are normalised (dotted paths to leaf keys, leading-dot keys kept literally) and deduplicated after normalisation, encrypted in a **single SOPS pass and a single write** (one commit in cluster mode), verified per key to be real `ENC[...]` ciphertext, and each recorded in `encrypted_paths`. Single `--key` behaviour is byte-identical to before.
- **New `--all-data` flag** on `encrypt manifest` (file + cluster mode): selects every key under a Secret's `data` and `stringData`. Values that are already encrypted are skipped with a notice; if nothing is left to encrypt the command succeeds without touching anything; pointing it at a non-Secret fails naming the actual kind (e.g. `the manifest is a ConfigMap`). Mutually exclusive with `--key`, and one of the two is required.

## Why

PLA-741 (#1054): the customer had to run the CLI **twelve times** to encrypt 12 keys across 5 Secret manifests, since `--key` accepted exactly one value per invocation, and asked for a way to encrypt all data keys of a Secret in one go. Their other complaint from the same ticket - whole-file reformatting of `cluster.yaml` - was already fixed on master by the yaml.Node round-trip editor; this PR adds a regression test pinning that behaviour: a file-mode encrypt over a fixture with comments, an anchor/alias, deliberate key order (`addons` before `name`), and unmodeled fields must leave every untouched line **byte-identical**, with the `encrypted_paths` append as the only change.

Bead: ankra-5h4e.6

## Tests

- Multi-key: file + cluster mode single-`EncryptYAML`-call assertions, dedupe after normalisation, addon file + cluster mode.
- `--all-data`: happy path (data + stringData), mixed already-encrypted skip, nothing-left-to-encrypt no-op, non-Secret rejection naming the kind, flag-group exclusivity/one-required.
- Formatting: byte-for-byte cluster.yaml preservation regression test (mocked `EncryptYAML`, no real SOPS call).
- Full suite: `go test -race -count=1 ./...` green, `golangci-lint run` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
