### PR TITLE
fix(cli): complete paginated listings and keep structured output consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### Added
+
+- **`ankra helm registries list --all` fetches every page.** The listing is
+  paginated server-side (20 per page), and the CLI only ever showed the
+  requested page — an organisation with 121 registries saw 20 rows with no
+  sign that more existed. `--all` walks every page client-side and prints
+  the complete set (mutually exclusive with `--page`).
+- **`ankra helm registries get` can page through a registry's charts.** The
+  chart listing attached to a registry only ever returned the first page;
+  the new `--page`/`--page-size` flags select which chart page the response
+  (and the `Charts: N (showing M on this page)` footer) reflects.
+- **`ankra cluster get storageclasses` lists StorageClasses directly.**
+  StorageClass was previously only reachable through `cluster get resources
+  StorageClass --group storage.k8s.io`, and nothing told you the `--group`
+  value it needed.
+
 ### Removed
 
 - **The MFA management and organisation RBAC commands are gone — none of
@@ -21,6 +37,28 @@
 
 ### Fixed
 
+- **`ankra cluster manifests list` no longer silently truncates.** The
+  client decoded the response's pagination envelope but never sent paging
+  parameters, so clusters with more manifests than the backend's first page
+  quietly lost the rest. The listing now walks every page.
+- **`ankra cluster get <kind> -o json` stays parseable when nothing is
+  found.** An empty listing printed `No <kind> found.` to stdout even in
+  JSON/YAML mode, breaking `jq` pipelines; empty results now render as the
+  structured envelope, and the human message is table-mode only.
+- **`ankra cluster get pods -o json` emits one consistent shape.** Clusters
+  that fit in one page got the full response envelope while clusters over
+  100 pods got a bare pod array, so scripts saw a different document
+  depending on cluster size. JSON output is now always the envelope, with
+  every page's pods merged and the pagination describing the merged result.
+- **`ankra cluster get resources <Kind>` now explains `--group`.** When a
+  lookup finds nothing, the kind is outside the core API group, and
+  `--group` was left unset, the empty message adds a hint naming the flag
+  (e.g. `--group storage.k8s.io` for StorageClass), instead of an
+  indistinguishable `No StorageClass found.`
+- **Structured chart and registry listings carry complete metadata.**
+  `ankra charts list -o json` pagination now includes `total_count`, and
+  `ankra helm registries list -o json` rows now include the `kind` field
+  the table always showed.
 - **`ankra ai models create|update` help now names the current Expert
   model.** The `--model-id` examples still said `claude-opus-4-8` after the
   platform's Expert tier moved to Claude Opus 5, so the help text suggested

--- a/cmd/cluster_k8s.go
+++ b/cmd/cluster_k8s.go
@@ -91,6 +91,10 @@ type kindConfig struct {
 	short         string
 	headers       table.Row
 	formatRow     func(obj map[string]interface{}) table.Row
+	// emptyHint, when set, is printed after the table-mode "No X found."
+	// message. The generic resources command uses it to point at --group
+	// for kinds that live outside the core API group.
+	emptyHint string
 }
 
 var kindConfigs = []kindConfig{
@@ -398,6 +402,20 @@ var kindConfigs = []kindConfig{
 			}
 		},
 	},
+	{
+		commandName: "storageclasses", kind: "StorageClass", group: "storage.k8s.io", version: "v1", clusterScoped: true,
+		short:   "List storage classes in the cluster",
+		headers: table.Row{"Name", "Provisioner", "Reclaim Policy", "Binding Mode", "Age"},
+		formatRow: func(obj map[string]interface{}) table.Row {
+			return table.Row{
+				getNestedString(obj, "metadata", "name"),
+				getNestedString(obj, "provisioner"),
+				getNestedString(obj, "reclaimPolicy"),
+				getNestedString(obj, "volumeBindingMode"),
+				formatK8sAge(getNestedString(obj, "metadata", "creationTimestamp")),
+			}
+		},
+	},
 }
 
 // validateK8sOutputFormat guards the kubernetes command family's -o flag, which
@@ -456,18 +474,19 @@ func fetchAndRenderResources(clusterID, namespace, nameFilter, labelSelector, ou
 		return err
 	}
 
-	if len(response.ResourceResponses) == 0 || len(response.ResourceResponses[0].Items) == 0 {
-		fmt.Printf("No %s found.\n", cfg.commandName)
-		return nil
+	var items []interface{}
+	if len(response.ResourceResponses) > 0 {
+		items = response.ResourceResponses[0].Items
 	}
-
-	items := response.ResourceResponses[0].Items
 
 	isSingleResourceLookup := nameFilter != "" && len(items) == 1
 	if isSingleResourceLookup {
 		return renderSingleResource(items[0], outputFormat)
 	}
 
+	// Structured output renders before the empty-list early return so that
+	// -o json/yaml stays parseable even when nothing was found; the human
+	// "No X found." message is table-mode only.
 	if outputFormat == "json" {
 		jsonData, err := json.MarshalIndent(response, "", "  ")
 		if err != nil {
@@ -482,6 +501,14 @@ func fetchAndRenderResources(clusterID, namespace, nameFilter, labelSelector, ou
 			return fmt.Errorf("marshalling to YAML: %w", err)
 		}
 		fmt.Print(string(yamlData))
+		return nil
+	}
+
+	if len(items) == 0 {
+		fmt.Printf("No %s found.\n", cfg.commandName)
+		if cfg.emptyHint != "" {
+			fmt.Println(cfg.emptyHint)
+		}
 		return nil
 	}
 
@@ -584,6 +611,7 @@ var clusterPodsCmd = &cobra.Command{
 		}
 
 		allPods := []client.PodSummary{}
+		var firstResponse *client.ListPodsResponse
 		page := 1
 		for {
 			opts := &client.ListPodsOptions{
@@ -598,14 +626,11 @@ var clusterPodsCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
+			if firstResponse == nil {
+				firstResponse = response
+			}
 
 			allPods = append(allPods, response.Pods...)
-
-			if outputFormat == "json" && page == 1 && response.TotalPages <= 1 {
-				jsonData, _ := json.MarshalIndent(response, "", "  ")
-				fmt.Println(string(jsonData))
-				return nil
-			}
 
 			if page >= response.TotalPages {
 				break
@@ -614,7 +639,18 @@ var clusterPodsCmd = &cobra.Command{
 		}
 
 		if outputFormat == "json" {
-			jsonData, err := json.MarshalIndent(allPods, "", "  ")
+			// One shape regardless of how many pages were walked: the
+			// ListPodsResponse envelope with every page's pods merged and
+			// the pagination describing the merged result. Multi-page
+			// listings used to fall back to a bare pod array, so scripts
+			// saw a different document above 100 pods.
+			merged := *firstResponse
+			merged.Pods = allPods
+			merged.TotalCount = len(allPods)
+			merged.Page = 1
+			merged.PageSize = len(allPods)
+			merged.TotalPages = 1
+			jsonData, err := json.MarshalIndent(merged, "", "  ")
 			if err != nil {
 				return fmt.Errorf("marshalling to JSON: %w", err)
 			}
@@ -716,14 +752,58 @@ Example:
 	},
 }
 
+// coreV1Kinds enumerates the kinds served by the core ("") v1 API group,
+// for which the generic resources command's default empty --group is
+// correct. The resources/get backend echoes the request group back and
+// reports only a generic success/error status — there is no distinct
+// not-found signal on the wire — so the CLI infers the likely mistake
+// from the requested kind instead.
+var coreV1Kinds = map[string]bool{
+	"binding":               true,
+	"componentstatus":       true,
+	"configmap":             true,
+	"endpoints":             true,
+	"event":                 true,
+	"limitrange":            true,
+	"namespace":             true,
+	"node":                  true,
+	"persistentvolume":      true,
+	"persistentvolumeclaim": true,
+	"pod":                   true,
+	"podtemplate":           true,
+	"replicationcontroller": true,
+	"resourcequota":         true,
+	"secret":                true,
+	"service":               true,
+	"serviceaccount":        true,
+}
+
+// genericResourcesEmptyHint returns the guidance appended to the empty
+// "No <Kind> found." message of `cluster get resources <Kind>`: when
+// --group was left at its default and the kind is not a core/v1 kind, an
+// empty result usually means the group was simply not specified.
+func genericResourcesEmptyHint(kind, apiGroup string) string {
+	if apiGroup != "" {
+		return ""
+	}
+	lowered := strings.ToLower(kind)
+	if coreV1Kinds[lowered] || coreV1Kinds[strings.TrimSuffix(lowered, "s")] {
+		return ""
+	}
+	return fmt.Sprintf("If %s lives outside the core API group, pass --group (e.g. --group storage.k8s.io for StorageClass, --group networking.k8s.io for NetworkPolicy).", kind)
+}
+
 var clusterGenericResourcesCmd = &cobra.Command{
 	Use:   "resources <kind>",
 	Short: "Get any Kubernetes resource by kind",
 	Long: `Fetch any Kubernetes resource type. Use for kinds not covered by dedicated commands.
 
+Kinds outside the core API group need --group (and sometimes --api-version).
+
 Example:
   ankra cluster resources PersistentVolumeClaim -n default
-  ankra cluster resources NetworkPolicy --all-namespaces`,
+  ankra cluster resources NetworkPolicy --group networking.k8s.io --all-namespaces
+  ankra cluster resources StorageClass --group storage.k8s.io`,
 	Args:        cobra.ExactArgs(1),
 	Annotations: map[string]string{"group": "kubernetes"},
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -753,6 +833,7 @@ Example:
 			kind:        kind,
 			group:       apiGroup,
 			version:     apiVersion,
+			emptyHint:   genericResourcesEmptyHint(kind, apiGroup),
 			headers:     table.Row{"Name", "Namespace", "Age"},
 			formatRow: func(obj map[string]interface{}) table.Row {
 				return table.Row{

--- a/cmd/cluster_k8s_test.go
+++ b/cmd/cluster_k8s_test.go
@@ -1,9 +1,13 @@
 package cmd
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
 )
 
 // k8sResourcesMock returns two same-named resources with no formatRow-friendly
@@ -103,5 +107,229 @@ func TestResourcesWideExitsUsage(t *testing.T) {
 	}
 	if mock.called {
 		t.Error("invalid output format should be rejected before any API call")
+	}
+}
+
+// findClusterGetSubcommand resolves a `cluster get` subcommand by name so
+// tests can reset its persisted flag values (the cobra tree is shared
+// across the test binary).
+func findClusterGetSubcommand(t *testing.T, name string) *cobra.Command {
+	t.Helper()
+	for _, subcommand := range clusterGetCmd.Commands() {
+		if subcommand.Name() == name {
+			return subcommand
+		}
+	}
+	t.Fatalf("cluster get %s command not registered", name)
+	return nil
+}
+
+// capturedResourcesMock records the resource request it received and serves
+// a canned response.
+type capturedResourcesMock struct {
+	baseMock
+	lastRequest client.GetResourcesRequest
+	response    *client.GetResourcesResponse
+}
+
+func (m *capturedResourcesMock) GetResources(clusterID string, req client.GetResourcesRequest) (*client.GetResourcesResponse, error) {
+	m.lastRequest = req
+	return m.response, nil
+}
+
+func emptyResourcesResponse(kind string) *client.GetResourcesResponse {
+	return &client.GetResourcesResponse{
+		ResourceResponses: []client.ResourceResponseItem{
+			{Status: "success", Kind: kind, Version: "v1", Items: []interface{}{}},
+		},
+	}
+}
+
+// TestGetDeploymentsEmptyJSONStaysParseable pins the reorder of the empty
+// early-return: -o json must emit the structured envelope even when the
+// listing is empty, never the human "No deployments found." line.
+func TestGetDeploymentsEmptyJSONStaysParseable(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	mock := &capturedResourcesMock{response: emptyResourcesResponse("Deployment")}
+	setMockClient(t, mock)
+	deploymentsCmd := findClusterGetSubcommand(t, "deployments")
+	t.Cleanup(func() { _ = deploymentsCmd.Flags().Set("output", "table") })
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("cluster", "get", "deployments", "-o", "json")
+	})
+
+	if strings.Contains(stdoutOutput, "No deployments found.") {
+		t.Errorf("human empty message leaked into -o json output: %s", stdoutOutput)
+	}
+	var decoded client.GetResourcesResponse
+	if err := json.Unmarshal([]byte(stdoutOutput), &decoded); err != nil {
+		t.Fatalf("expected parseable JSON for an empty listing, got error %v for output: %s", err, stdoutOutput)
+	}
+	if len(decoded.ResourceResponses) != 1 {
+		t.Errorf("expected the full envelope, got %+v", decoded)
+	}
+}
+
+// podsPagedMock serves the pod listing across a fixed number of pages.
+type podsPagedMock struct {
+	baseMock
+	pages      map[int][]client.PodSummary
+	totalPages int
+	totalCount int
+}
+
+func (m *podsPagedMock) ListPods(clusterID string, opts *client.ListPodsOptions) (*client.ListPodsResponse, error) {
+	return &client.ListPodsResponse{
+		Pods:       m.pages[opts.Page],
+		TotalCount: m.totalCount,
+		Page:       opts.Page,
+		PageSize:   opts.PageSize,
+		TotalPages: m.totalPages,
+	}, nil
+}
+
+// TestGetPodsJSONAlwaysEmitsEnvelope pins the consistent -o json shape:
+// the ListPodsResponse envelope with all pages merged, both when the
+// listing fits one page and when the CLI had to walk several.
+func TestGetPodsJSONAlwaysEmitsEnvelope(t *testing.T) {
+	cases := []struct {
+		name       string
+		pages      map[int][]client.PodSummary
+		totalPages int
+		wantPods   int
+	}{
+		{
+			name: "single_page",
+			pages: map[int][]client.PodSummary{
+				1: {{Name: "web-1", Phase: "Running"}, {Name: "web-2", Phase: "Running"}},
+			},
+			totalPages: 1,
+			wantPods:   2,
+		},
+		{
+			name: "multiple_pages",
+			pages: map[int][]client.PodSummary{
+				1: {{Name: "web-1", Phase: "Running"}, {Name: "web-2", Phase: "Running"}},
+				2: {{Name: "web-3", Phase: "Pending"}},
+			},
+			totalPages: 2,
+			wantPods:   3,
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			writeSelectedClusterJSON(t)
+			mock := &podsPagedMock{
+				pages:      testCase.pages,
+				totalPages: testCase.totalPages,
+				totalCount: testCase.wantPods,
+			}
+			setMockClient(t, mock)
+			t.Cleanup(func() { _ = clusterPodsCmd.Flags().Set("output", "table") })
+
+			stdoutOutput := captureStdout(t, func() {
+				_, _ = executeCommand("cluster", "get", "pods", "-o", "json")
+			})
+
+			if !strings.HasPrefix(strings.TrimSpace(stdoutOutput), "{") {
+				t.Fatalf("expected a JSON object envelope, got: %s", stdoutOutput)
+			}
+			var decoded client.ListPodsResponse
+			if err := json.Unmarshal([]byte(stdoutOutput), &decoded); err != nil {
+				t.Fatalf("expected the ListPodsResponse envelope, got error %v for output: %s", err, stdoutOutput)
+			}
+			if len(decoded.Pods) != testCase.wantPods {
+				t.Errorf("expected %d merged pods, got %d", testCase.wantPods, len(decoded.Pods))
+			}
+			if decoded.TotalCount != testCase.wantPods || decoded.Page != 1 || decoded.TotalPages != 1 {
+				t.Errorf("expected pagination to describe the merged result, got %+v", decoded)
+			}
+		})
+	}
+}
+
+// TestGetStorageClassesCommand covers the dedicated storageclasses entry:
+// cluster-scoped, group storage.k8s.io, provisioner column rendered.
+func TestGetStorageClassesCommand(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	mock := &capturedResourcesMock{
+		response: &client.GetResourcesResponse{
+			ResourceResponses: []client.ResourceResponseItem{
+				{Status: "success", Kind: "StorageClass", Version: "v1", Items: []interface{}{
+					map[string]interface{}{
+						"metadata":          map[string]interface{}{"name": "local-path"},
+						"provisioner":       "rancher.io/local-path",
+						"reclaimPolicy":     "Delete",
+						"volumeBindingMode": "WaitForFirstConsumer",
+					},
+				}},
+			},
+		},
+	}
+	setMockClient(t, mock)
+	storageClassesCmd := findClusterGetSubcommand(t, "storageclasses")
+	if storageClassesCmd.Flags().Lookup("namespace") != nil {
+		t.Error("storageclasses is cluster-scoped and must not register --namespace")
+	}
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("cluster", "get", "storageclasses")
+	})
+
+	if len(mock.lastRequest.ResourceRequests) != 1 {
+		t.Fatalf("expected one resource request, got %+v", mock.lastRequest)
+	}
+	requested := mock.lastRequest.ResourceRequests[0]
+	if requested.Kind != "StorageClass" || requested.Group != "storage.k8s.io" || requested.Version != "v1" {
+		t.Errorf("expected StorageClass storage.k8s.io/v1 request, got %+v", requested)
+	}
+	for _, expected := range []string{"local-path", "rancher.io/local-path", "Delete", "WaitForFirstConsumer"} {
+		if !strings.Contains(stdoutOutput, expected) {
+			t.Errorf("expected output to contain %q, got: %s", expected, stdoutOutput)
+		}
+	}
+}
+
+// TestResourcesGroupHint covers the empty-result guidance of `cluster get
+// resources <Kind>`: hint when --group defaulted and the kind is outside
+// core/v1, silence for core kinds and for an explicit --group.
+func TestResourcesGroupHint(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		wantHint bool
+	}{
+		{name: "non_core_kind_without_group", args: []string{"cluster", "get", "resources", "StorageClass"}, wantHint: true},
+		{name: "core_kind_without_group", args: []string{"cluster", "get", "resources", "ConfigMap"}, wantHint: false},
+		{name: "non_core_kind_with_group", args: []string{"cluster", "get", "resources", "StorageClass", "--group", "storage.k8s.io"}, wantHint: false},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			writeSelectedClusterJSON(t)
+			kind := testCase.args[3]
+			mock := &capturedResourcesMock{response: emptyResourcesResponse(kind)}
+			setMockClient(t, mock)
+			t.Cleanup(func() {
+				flags := clusterGenericResourcesCmd.Flags()
+				_ = flags.Set("group", "")
+				_ = flags.Set("output", "table")
+			})
+
+			stdoutOutput := captureStdout(t, func() {
+				_, _ = executeCommand(testCase.args...)
+			})
+
+			if !strings.Contains(stdoutOutput, "No "+kind+" found.") {
+				t.Errorf("expected the empty message for %s, got: %s", kind, stdoutOutput)
+			}
+			hasHint := strings.Contains(stdoutOutput, "pass --group")
+			if hasHint != testCase.wantHint {
+				t.Errorf("hint presence = %v, want %v; output: %s", hasHint, testCase.wantHint, stdoutOutput)
+			}
+			if testCase.wantHint && !strings.Contains(stdoutOutput, "storage.k8s.io") {
+				t.Errorf("expected the hint to name an example group, got: %s", stdoutOutput)
+			}
+		})
 	}
 }

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -603,7 +603,7 @@ func (m baseMock) ListHelmRegistries(opts *client.ListHelmRegistriesOptions) (*c
 	return nil, errors.New("not implemented")
 }
 
-func (m baseMock) GetHelmRegistry(registryName string) (*client.GetHelmRegistryResponse, error) {
+func (m baseMock) GetHelmRegistry(registryName string, page, pageSize int) (*client.GetHelmRegistryResponse, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -2263,7 +2263,8 @@ type chartsListMock struct {
 func (m *chartsListMock) ListCharts(page, pageSize int, onlySubscribed bool) (*client.ListChartsResponse, error) {
 	return &client.ListChartsResponse{
 		Charts: m.charts,
-		Pagination: client.ChartsPagination{
+		Pagination: client.Pagination{
+			TotalCount: len(m.charts),
 			Page:       1,
 			PageSize:   pageSize,
 			TotalPages: 1,

--- a/cmd/helm.go
+++ b/cmd/helm.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -30,11 +31,12 @@ var helmRegistriesListCmd = &cobra.Command{
 	Long: `List Helm chart registries.
 
 Results are paginated (20 per page by default). Use --search to filter
-by name and --page/--page-size to navigate.
+by name, --page/--page-size to navigate, or --all to fetch every page.
 
 Examples:
   ankra helm registries list --search bitnami
   ankra helm registries list --page 2 --page-size 100
+  ankra helm registries list --all
   ankra helm registries list --sort-by chart_count --sort-order desc`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		page, _ := cmd.Flags().GetInt("page")
@@ -42,14 +44,29 @@ Examples:
 		search, _ := cmd.Flags().GetString("search")
 		sortBy, _ := cmd.Flags().GetString("sort-by")
 		sortOrder, _ := cmd.Flags().GetString("sort-order")
+		allPages, _ := cmd.Flags().GetBool("all")
 
-		response, err := apiClient.ListHelmRegistries(&client.ListHelmRegistriesOptions{
-			Page:      page,
-			PageSize:  pageSize,
-			Search:    search,
-			SortBy:    sortBy,
-			SortOrder: sortOrder,
-		})
+		if allPages && cmd.Flags().Changed("page") {
+			return withExitCode(exitUsage, errors.New("--all and --page are mutually exclusive"))
+		}
+
+		var response *client.ListHelmRegistriesResponse
+		var err error
+		if allPages {
+			response, err = listAllHelmRegistries(client.ListHelmRegistriesOptions{
+				Search:    search,
+				SortBy:    sortBy,
+				SortOrder: sortOrder,
+			})
+		} else {
+			response, err = apiClient.ListHelmRegistries(&client.ListHelmRegistriesOptions{
+				Page:      page,
+				PageSize:  pageSize,
+				Search:    search,
+				SortBy:    sortBy,
+				SortOrder: sortOrder,
+			})
+		}
 		if err != nil {
 			return fmt.Errorf("listing registries: %w", err)
 		}
@@ -79,7 +96,7 @@ Examples:
 			}
 			t.AppendRow(table.Row{
 				reg.Name,
-				reg.Kind(),
+				reg.Kind,
 				reg.URL,
 				reg.ChartCount,
 				reg.Indexing,
@@ -94,14 +111,62 @@ Examples:
 	},
 }
 
+// listAllHelmRegistries pages through the registry list until the backend
+// reports no more pages and returns one merged response whose pagination
+// describes the merged result. The backend defaults to 20 per page and
+// clamps page_size at 100, so a plain list silently truncated organisations
+// with more registries than a single page. maxPages bounds the walk against
+// a backend that keeps reporting more pages.
+func listAllHelmRegistries(options client.ListHelmRegistriesOptions) (*client.ListHelmRegistriesResponse, error) {
+	const pageSize = 100
+	const maxPages = 100
+	var registries []client.HelmRegistryListItem
+	totalCount := 0
+	for page := 1; page <= maxPages; page++ {
+		options.Page = page
+		options.PageSize = pageSize
+		response, err := apiClient.ListHelmRegistries(&options)
+		if err != nil {
+			return nil, err
+		}
+		registries = append(registries, response.Result...)
+		totalCount = response.Pagination.TotalCount
+		if response.Pagination.TotalPages <= page || len(response.Result) == 0 {
+			break
+		}
+	}
+	if totalCount < len(registries) {
+		totalCount = len(registries)
+	}
+	return &client.ListHelmRegistriesResponse{
+		Result: registries,
+		Pagination: client.Pagination{
+			TotalCount: totalCount,
+			TotalPages: 1,
+			Page:       1,
+			PageSize:   len(registries),
+		},
+	}, nil
+}
+
 var helmRegistriesGetCmd = &cobra.Command{
 	Use:   "get <name>",
 	Short: "Get details of a Helm chart registry",
-	Args:  cobra.ExactArgs(1),
+	Long: `Get details of a Helm chart registry.
+
+The registry's chart listing is paginated; use --page/--page-size to select
+which chart page the response (and -o json/yaml output) carries.
+
+Examples:
+  ankra helm registries get bitnami
+  ankra helm registries get bitnami --page 2 --page-size 100 -o json`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		registryName := args[0]
+		page, _ := cmd.Flags().GetInt("page")
+		pageSize, _ := cmd.Flags().GetInt("page-size")
 
-		response, err := apiClient.GetHelmRegistry(registryName)
+		response, err := apiClient.GetHelmRegistry(registryName, page, pageSize)
 		if err != nil {
 			return fmt.Errorf("getting registry: %w", err)
 		}
@@ -535,9 +600,12 @@ var helmCredentialsDeleteCmd = &cobra.Command{
 func init() {
 	helmRegistriesListCmd.Flags().Int("page", 1, "Page number")
 	helmRegistriesListCmd.Flags().Int("page-size", 20, "Number of registries per page (max 100)")
+	helmRegistriesListCmd.Flags().Bool("all", false, "Fetch every page and list all registries (mutually exclusive with --page)")
 	helmRegistriesListCmd.Flags().String("search", "", "Filter registries by name (case-insensitive substring)")
 	helmRegistriesListCmd.Flags().String("sort-by", "", "Sort column: name, url, created_at, updated_at, chart_count, last_indexed_at, is_global")
 	helmRegistriesListCmd.Flags().String("sort-order", "", "Sort order: asc or desc")
+	helmRegistriesGetCmd.Flags().Int("page", 1, "Charts page number")
+	helmRegistriesGetCmd.Flags().Int("page-size", 20, "Number of charts per page (max 100)")
 	helmRegistriesCreateCmd.Flags().StringP("file", "f", "", "Path to registry spec JSON file (required)")
 	_ = helmRegistriesCreateCmd.MarkFlagRequired("file")
 	helmRegistriesDeleteCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")

--- a/cmd/helm_registries_get_test.go
+++ b/cmd/helm_registries_get_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type helmRegistryGetPagedMock struct {
+	baseMock
+	lastPage     int
+	lastPageSize int
+	charts       []client.HelmChartVersionSummary
+	totalCount   int
+}
+
+func (m *helmRegistryGetPagedMock) GetHelmRegistry(registryName string, page, pageSize int) (*client.GetHelmRegistryResponse, error) {
+	m.lastPage = page
+	m.lastPageSize = pageSize
+	return &client.GetHelmRegistryResponse{
+		Registry: client.HelmRegistryDetail{Name: registryName, URL: "https://charts.example.com"},
+		Charts:   m.charts,
+		Pagination: client.Pagination{
+			TotalCount: m.totalCount,
+			TotalPages: 3,
+			Page:       page,
+			PageSize:   pageSize,
+		},
+	}, nil
+}
+
+func TestHelmRegistriesGetForwardsChartPaging(t *testing.T) {
+	mock := &helmRegistryGetPagedMock{
+		charts: []client.HelmChartVersionSummary{
+			{Name: "nginx", Version: "1.0.0"},
+			{Name: "redis", Version: "2.0.0"},
+		},
+		totalCount: 120,
+	}
+	setMockClient(t, mock)
+	t.Cleanup(func() {
+		flags := helmRegistriesGetCmd.Flags()
+		_ = flags.Set("page", "1")
+		_ = flags.Set("page-size", "20")
+	})
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("helm", "registries", "get", "my-registry", "--page", "2", "--page-size", "50")
+	})
+
+	if mock.lastPage != 2 || mock.lastPageSize != 50 {
+		t.Errorf("expected page=2 page_size=50 forwarded to the client, got page=%d page_size=%d",
+			mock.lastPage, mock.lastPageSize)
+	}
+	if !strings.Contains(stdoutOutput, "120 (showing 2 on this page)") {
+		t.Errorf("expected the charts footer to reflect the fetched page, got: %s", stdoutOutput)
+	}
+}

--- a/cmd/helm_registries_list_test.go
+++ b/cmd/helm_registries_list_test.go
@@ -1,0 +1,149 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+// helmRegistriesPagedMock serves a fixed page layout so the --all loop can
+// be observed walking every page with the expected options.
+type helmRegistriesPagedMock struct {
+	baseMock
+	pages      map[int][]client.HelmRegistryListItem
+	totalCount int
+	totalPages int
+	calls      []client.ListHelmRegistriesOptions
+}
+
+func (m *helmRegistriesPagedMock) ListHelmRegistries(opts *client.ListHelmRegistriesOptions) (*client.ListHelmRegistriesResponse, error) {
+	m.calls = append(m.calls, *opts)
+	return &client.ListHelmRegistriesResponse{
+		Result: m.pages[opts.Page],
+		Pagination: client.Pagination{
+			TotalCount: m.totalCount,
+			TotalPages: m.totalPages,
+			Page:       opts.Page,
+			PageSize:   opts.PageSize,
+		},
+	}, nil
+}
+
+// resetHelmRegistriesListFlags restores the list command's flag values and
+// their Changed markers both before and after the test: the cobra tree is
+// shared across the test binary, and the --all/--page exclusivity check
+// reads Changed, which any earlier --page invocation would leave set.
+func resetHelmRegistriesListFlags(t *testing.T) {
+	t.Helper()
+	reset := func() {
+		flags := helmRegistriesListCmd.Flags()
+		for name, value := range map[string]string{
+			"page":       "1",
+			"page-size":  "20",
+			"all":        "false",
+			"search":     "",
+			"sort-by":    "",
+			"sort-order": "",
+			"output":     "",
+		} {
+			_ = flags.Set(name, value)
+			flags.Lookup(name).Changed = false
+		}
+	}
+	reset()
+	t.Cleanup(reset)
+}
+
+func TestHelmRegistriesListAllWalksEveryPage(t *testing.T) {
+	mock := &helmRegistriesPagedMock{
+		pages: map[int][]client.HelmRegistryListItem{
+			1: {
+				{Name: "registry-a", Kind: "http", URL: "https://a.example.com"},
+				{Name: "registry-b", Kind: "http", URL: "https://b.example.com"},
+			},
+			2: {
+				{Name: "registry-c", Kind: "oci", URL: "oci://c.example.com"},
+				{Name: "registry-d", Kind: "http", URL: "https://d.example.com"},
+			},
+			3: {
+				{Name: "registry-e", Kind: "http", URL: "https://e.example.com"},
+			},
+		},
+		totalCount: 5,
+		totalPages: 3,
+	}
+	setMockClient(t, mock)
+	resetHelmRegistriesListFlags(t)
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("helm", "registries", "list", "--all")
+	})
+
+	for _, expected := range []string{"registry-a", "registry-b", "registry-c", "registry-d", "registry-e"} {
+		if !strings.Contains(stdoutOutput, expected) {
+			t.Errorf("expected output to contain %q, got: %s", expected, stdoutOutput)
+		}
+	}
+	if !strings.Contains(stdoutOutput, "Page 1 of 1 (total 5)") {
+		t.Errorf("expected merged pagination footer, got: %s", stdoutOutput)
+	}
+	if len(mock.calls) != 3 {
+		t.Fatalf("expected 3 page fetches, got %d: %+v", len(mock.calls), mock.calls)
+	}
+	for index, call := range mock.calls {
+		if call.Page != index+1 || call.PageSize != 100 {
+			t.Errorf("call %d: expected page %d with page_size 100, got %+v", index, index+1, call)
+		}
+	}
+}
+
+func TestHelmRegistriesListAllRejectsExplicitPage(t *testing.T) {
+	mock := &helmRegistriesPagedMock{totalPages: 1}
+	setMockClient(t, mock)
+	resetHelmRegistriesListFlags(t)
+
+	_, err := executeCommand("helm", "registries", "list", "--all", "--page", "2")
+	if err == nil {
+		t.Fatal("expected an error for --all combined with --page")
+	}
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("--all with --page should exit %d, got %d", exitUsage, got)
+	}
+	if len(mock.calls) != 0 {
+		t.Errorf("expected no API calls for the rejected flag combination, got %d", len(mock.calls))
+	}
+}
+
+func TestHelmRegistriesListAllJSONEmitsMergedEnvelope(t *testing.T) {
+	mock := &helmRegistriesPagedMock{
+		pages: map[int][]client.HelmRegistryListItem{
+			1: {{Name: "registry-a", Kind: "http", URL: "https://a.example.com"}},
+			2: {{Name: "registry-b", Kind: "oci", URL: "oci://b.example.com"}},
+		},
+		totalCount: 2,
+		totalPages: 2,
+	}
+	setMockClient(t, mock)
+	resetHelmRegistriesListFlags(t)
+
+	output, err := executeCommand("helm", "registries", "list", "--all", "-o", "json")
+	if err != nil {
+		t.Fatalf("executeCommand() error = %v", err)
+	}
+
+	var decoded client.ListHelmRegistriesResponse
+	if err := json.Unmarshal([]byte(output), &decoded); err != nil {
+		t.Fatalf("expected valid JSON envelope, got error %v for output: %s", err, output)
+	}
+	if len(decoded.Result) != 2 {
+		t.Errorf("expected 2 merged registries, got %d", len(decoded.Result))
+	}
+	if decoded.Pagination.TotalCount != 2 || decoded.Pagination.TotalPages != 1 || decoded.Pagination.Page != 1 {
+		t.Errorf("expected merged pagination, got %+v", decoded.Pagination)
+	}
+	if decoded.Result[1].Kind != "oci" {
+		t.Errorf("expected the kind field to survive structured output, got %+v", decoded.Result[1])
+	}
+}

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -176,7 +176,7 @@ type APIClient interface {
 	QueryPrometheusRange(clusterID string, opts client.PrometheusRangeOptions) (*client.PrometheusQueryResult, error)
 
 	ListHelmRegistries(opts *client.ListHelmRegistriesOptions) (*client.ListHelmRegistriesResponse, error)
-	GetHelmRegistry(registryName string) (*client.GetHelmRegistryResponse, error)
+	GetHelmRegistry(registryName string, page, pageSize int) (*client.GetHelmRegistryResponse, error)
 	CreateHelmRegistry(req client.CreateHelmRegistryRequest) (*client.CreateHelmRegistryResponse, error)
 	UpdateHelmRegistry(registryName string, readJobInterval *int) error
 	DeleteHelmRegistry(registryName string) (*client.DeleteHelmRegistryResponse, error)

--- a/internal/client/charts.go
+++ b/internal/client/charts.go
@@ -20,15 +20,12 @@ type ChartItem struct {
 	RegistryCredentialName *string `json:"registry_credential_name,omitempty"`
 }
 
-type ChartsPagination struct {
-	Page       int `json:"page"`
-	PageSize   int `json:"page_size"`
-	TotalPages int `json:"total_pages"`
-}
-
+// ListChartsResponse carries the chart page and its pagination envelope.
+// The pagination reuses the shared Pagination struct so structured output
+// includes total_count alongside page/page_size/total_pages.
 type ListChartsResponse struct {
-	Charts     []ChartItem      `json:"charts"`
-	Pagination ChartsPagination `json:"pagination"`
+	Charts     []ChartItem `json:"charts"`
+	Pagination Pagination  `json:"pagination"`
 }
 
 type ChartProfile struct {

--- a/internal/client/charts_test.go
+++ b/internal/client/charts_test.go
@@ -16,7 +16,7 @@ func TestListCharts(t *testing.T) {
 			Charts: []ChartItem{
 				{ChartID: "chart1", Name: "nginx", Description: "Web server", Version: "1.0.0"},
 			},
-			Pagination: ChartsPagination{Page: 1, PageSize: 25, TotalPages: 1},
+			Pagination: Pagination{Page: 1, PageSize: 25, TotalPages: 1},
 		})
 	})
 	got, err := testClient.ListCharts(1, 25, false)
@@ -69,7 +69,7 @@ func TestSearchCharts(t *testing.T) {
 						{ChartID: "chart1", Name: "nginx", Description: "Web server", Version: "1.0.0"},
 						{ChartID: "chart2", Name: "nginx-ingress", Description: "Ingress", Version: "1.0.0"},
 					},
-					Pagination: ChartsPagination{Page: 1, PageSize: 100, TotalPages: 1},
+					Pagination: Pagination{Page: 1, PageSize: 100, TotalPages: 1},
 				})
 			},
 			wantCount: 2,
@@ -83,7 +83,7 @@ func TestSearchCharts(t *testing.T) {
 					Charts: []ChartItem{
 						{ChartID: "chart1", Name: "nginx", Description: "Web server", Version: "1.0.0"},
 					},
-					Pagination: ChartsPagination{Page: 1, PageSize: 100, TotalPages: 1},
+					Pagination: Pagination{Page: 1, PageSize: 100, TotalPages: 1},
 				})
 			},
 			wantCount: 0,

--- a/internal/client/helm.go
+++ b/internal/client/helm.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 // HelmRegistryListItem mirrors the backend's ExtendedOCIRegistry /
@@ -13,26 +14,27 @@ import (
 // usecase/helm/list_helm_chart_registries.py). The kind is inferred from
 // the URL prefix; the API does not include it as a discriminator field
 // because each row is already an instance of the correct Pydantic
-// subclass.
+// subclass, so ListHelmRegistries fills Kind in at decode time to keep
+// the table and structured output in agreement.
 type HelmRegistryListItem struct {
-	Name           string  `json:"name"`
-	URL            string  `json:"url"`
-	CredentialName *string `json:"credential_name,omitempty"`
-	CreatedAt      *string `json:"created_at,omitempty"`
-	UpdatedAt      *string `json:"updated_at,omitempty"`
+	Name           string   `json:"name"`
+	Kind           string   `json:"kind"`
+	URL            string   `json:"url"`
+	CredentialName *string  `json:"credential_name,omitempty"`
+	CreatedAt      *string  `json:"created_at,omitempty"`
+	UpdatedAt      *string  `json:"updated_at,omitempty"`
 	ExcludeCharts  []string `json:"exclude_charts,omitempty"`
-	Indexing       bool    `json:"indexing"`
-	LastIndexedAt  *string `json:"last_indexed_at,omitempty"`
-	NextSyncAt     *string `json:"next_sync_at,omitempty"`
-	ChartCount     int     `json:"chart_count"`
-	IsGlobal       bool    `json:"is_global"`
+	Indexing       bool     `json:"indexing"`
+	LastIndexedAt  *string  `json:"last_indexed_at,omitempty"`
+	NextSyncAt     *string  `json:"next_sync_at,omitempty"`
+	ChartCount     int      `json:"chart_count"`
+	IsGlobal       bool     `json:"is_global"`
 }
 
-// Kind returns "oci" if the URL has an oci:// scheme, otherwise "http".
-// The CLI used to show a kind column populated from an explicit field,
-// but the API does not surface one. URL scheme is the canonical signal.
-func (item HelmRegistryListItem) Kind() string {
-	if len(item.URL) >= 6 && item.URL[:6] == "oci://" {
+// helmRegistryKindFromURL returns "oci" for an oci:// URL and "http"
+// otherwise. URL scheme is the canonical kind signal on this API surface.
+func helmRegistryKindFromURL(registryURL string) string {
+	if strings.HasPrefix(registryURL, "oci://") {
 		return "oci"
 	}
 	return "http"
@@ -127,11 +129,30 @@ func (c *Client) ListHelmRegistries(opts *ListHelmRegistriesOptions) (*ListHelmR
 	if err := c.getJSON(endpoint, &response); err != nil {
 		return nil, err
 	}
+	for index := range response.Result {
+		if response.Result[index].Kind == "" {
+			response.Result[index].Kind = helmRegistryKindFromURL(response.Result[index].URL)
+		}
+	}
 	return &response, nil
 }
 
-func (c *Client) GetHelmRegistry(registryName string) (*GetHelmRegistryResponse, error) {
+// GetHelmRegistry fetches a registry's detail. page and pageSize select the
+// charts page returned alongside the registry (the endpoint paginates the
+// chart listing); zero values leave the backend defaults, which serve the
+// first page.
+func (c *Client) GetHelmRegistry(registryName string, page, pageSize int) (*GetHelmRegistryResponse, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/org/helm/registries/%s", c.BaseURL, url.PathEscape(registryName))
+	params := url.Values{}
+	if page > 0 {
+		params.Set("page", fmt.Sprintf("%d", page))
+	}
+	if pageSize > 0 {
+		params.Set("page_size", fmt.Sprintf("%d", pageSize))
+	}
+	if encoded := params.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
 	var response GetHelmRegistryResponse
 	if err := c.getJSON(endpoint, &response); err != nil {
 		return nil, err

--- a/internal/client/helm_test.go
+++ b/internal/client/helm_test.go
@@ -89,6 +89,28 @@ func TestListHelmRegistries(t *testing.T) {
 	}
 }
 
+func TestListHelmRegistriesPopulatesKind(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(t, w, http.StatusOK, ListHelmRegistriesResponse{
+			Result: []HelmRegistryListItem{
+				{Name: "oci-registry", URL: "oci://ghcr.io/acme/charts"},
+				{Name: "http-registry", URL: "https://charts.example.com"},
+			},
+			Pagination: Pagination{TotalCount: 2, Page: 1, PageSize: 20, TotalPages: 1},
+		})
+	})
+	got, err := testClient.ListHelmRegistries(nil)
+	if err != nil {
+		t.Fatalf("ListHelmRegistries() error = %v", err)
+	}
+	if got.Result[0].Kind != "oci" {
+		t.Errorf("expected oci:// URL to decode with kind %q, got %q", "oci", got.Result[0].Kind)
+	}
+	if got.Result[1].Kind != "http" {
+		t.Errorf("expected https:// URL to decode with kind %q, got %q", "http", got.Result[1].Kind)
+	}
+}
+
 func TestGetHelmRegistry(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -125,7 +147,7 @@ func TestGetHelmRegistry(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testClient := newTestClient(t, tt.handler)
-			got, err := testClient.GetHelmRegistry("my-registry")
+			got, err := testClient.GetHelmRegistry("my-registry", 0, 0)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetHelmRegistry() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -134,6 +156,29 @@ func TestGetHelmRegistry(t *testing.T) {
 				t.Errorf("GetHelmRegistry() got.Registry.Name = %v, want my-registry", got.Registry.Name)
 			}
 		})
+	}
+}
+
+func TestGetHelmRegistrySendsChartPagingParameters(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("page") != "2" || q.Get("page_size") != "50" {
+			t.Errorf("expected page=2&page_size=50, got %q", r.URL.RawQuery)
+		}
+		jsonResponse(t, w, http.StatusOK, GetHelmRegistryResponse{
+			Registry: HelmRegistryDetail{Name: "my-registry", URL: "oci://ghcr.io"},
+			Charts: []HelmChartVersionSummary{
+				{Name: "nginx", Version: "1.0.0"},
+			},
+			Pagination: Pagination{TotalCount: 120, Page: 2, PageSize: 50, TotalPages: 3},
+		})
+	})
+	got, err := testClient.GetHelmRegistry("my-registry", 2, 50)
+	if err != nil {
+		t.Fatalf("GetHelmRegistry() error = %v", err)
+	}
+	if got.Pagination.Page != 2 || got.Pagination.TotalCount != 120 {
+		t.Errorf("GetHelmRegistry() pagination = %+v, want page 2 of 120 charts", got.Pagination)
 	}
 }
 

--- a/internal/client/manifests.go
+++ b/internal/client/manifests.go
@@ -28,15 +28,25 @@ type ListClusterManifestsResponse struct {
 	Pagination Pagination                `json:"pagination"`
 }
 
+// ListClusterManifests pages through the full manifest listing (the backend
+// serves a default page size and clamps page_size at 100). The previous
+// implementation sent no paging parameters and returned only the first page,
+// silently truncating clusters with more manifests than one page.
 func (c *Client) ListClusterManifests(clusterID string) ([]ClusterManifestListItem, error) {
-	url := fmt.Sprintf("%s/api/v1/clusters/%s/manifests", c.BaseURL, clusterID)
-
-	var response ListClusterManifestsResponse
-	if err := c.getJSON(url, &response); err != nil {
-		return nil, fmt.Errorf("failed to list cluster manifests: %w", err)
+	var manifests []ClusterManifestListItem
+	for page := 1; ; page++ {
+		url := fmt.Sprintf("%s/api/v1/clusters/%s/manifests?page=%d&page_size=100",
+			c.BaseURL, neturl.PathEscape(clusterID), page)
+		var response ListClusterManifestsResponse
+		if err := c.getJSON(url, &response); err != nil {
+			return nil, fmt.Errorf("failed to list cluster manifests: %w", err)
+		}
+		manifests = append(manifests, response.Result...)
+		if page >= response.Pagination.TotalPages || len(response.Result) == 0 {
+			break
+		}
 	}
-
-	return response.Result, nil
+	return manifests, nil
 }
 
 // getClusterManifestResponse mirrors GetClusterManifestResult from the

--- a/internal/client/manifests_test.go
+++ b/internal/client/manifests_test.go
@@ -28,3 +28,44 @@ func TestListClusterManifests(t *testing.T) {
 		t.Errorf("ListClusterManifests() got = %v", got)
 	}
 }
+
+func TestListClusterManifestsWalksAllPages(t *testing.T) {
+	var requestedPages []string
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		requestedPages = append(requestedPages, page)
+		if pageSize := r.URL.Query().Get("page_size"); pageSize != "100" {
+			t.Errorf("expected page_size=100, got %q", pageSize)
+		}
+		switch page {
+		case "1":
+			jsonResponse(t, w, http.StatusOK, ListClusterManifestsResponse{
+				Result: []ClusterManifestListItem{
+					{Name: "manifest1", State: "synced"},
+					{Name: "manifest2", State: "synced"},
+				},
+				Pagination: Pagination{TotalCount: 3, Page: 1, PageSize: 100, TotalPages: 2},
+			})
+		default:
+			jsonResponse(t, w, http.StatusOK, ListClusterManifestsResponse{
+				Result: []ClusterManifestListItem{
+					{Name: "manifest3", State: "synced"},
+				},
+				Pagination: Pagination{TotalCount: 3, Page: 2, PageSize: 100, TotalPages: 2},
+			})
+		}
+	})
+	got, err := testClient.ListClusterManifests("cluster-id")
+	if err != nil {
+		t.Fatalf("ListClusterManifests() error = %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("ListClusterManifests() got %d manifests, want 3 (silent truncation regression)", len(got))
+	}
+	if got[0].Name != "manifest1" || got[2].Name != "manifest3" {
+		t.Errorf("ListClusterManifests() merged pages out of order: %v", got)
+	}
+	if len(requestedPages) != 2 || requestedPages[0] != "1" || requestedPages[1] != "2" {
+		t.Errorf("expected pages 1 and 2 to be requested, got %v", requestedPages)
+	}
+}


### PR DESCRIPTION
## What & why

Customer ticket PLA-743 (#1056): `ankra helm registries list` showed 20 of their 121 registries with no sign more existed, and an audit of the list surfaces found the same silent-truncation and JSON-shape bugs elsewhere. Bead: ankra-5h4e.8.

**Pagination / truncation**

- `helm registries list --all` walks every page client-side (page_size 100, bounded like `listAllClusters`) and prints the complete set. Mutually exclusive with `--page`; `-o json` emits one merged envelope whose pagination describes the merged result.
- `cluster manifests list` decoded the response's pagination envelope but never sent paging parameters, so everything past the backend's first page was silently dropped. The client now auto-paginates (same pattern as `ListClusterAddons`).
- `helm registries get <name>` only ever returned page 1 of the registry's charts. New `--page`/`--page-size` flags are wired through to the endpoint; the `Charts: N (showing M on this page)` footer stays accurate.

**JSON purity / envelope consistency**

- `cluster get <kind> -o json|yaml` printed `No <kind> found.` to stdout on empty results, breaking `jq` pipelines. Structured output now renders before the empty-list early return (the human message is table-mode only).
- `cluster get pods -o json` emitted the `ListPodsResponse` envelope for clusters that fit one page but a bare `[]PodSummary` once it had to walk pages. It now always emits the envelope, with all pages merged and pagination reflecting the merged result. (YAML keeps its historical bare-list shape — flipping it would break scripts that are consistent today.)
- `ChartsPagination` is replaced by the shared `Pagination` struct, so `charts list -o json` now carries `total_count` (additive; field names unchanged).
- The registries table's "Kind" column came from a Go method and was absent from `-o json`; it is now a `kind` field populated at decode time, so table and JSON agree.

**Discoverability**

- New `cluster get storageclasses` command (cluster-scoped, `storage.k8s.io/v1`, name/provisioner/reclaim-policy/binding-mode columns).
- `cluster get resources <Kind>` with zero results, a defaulted `--group`, and a non-core kind now appends a hint: "If <Kind> lives outside the core API group, pass --group (e.g. --group storage.k8s.io for StorageClass, ...)". The backend's `resource_responses[].status`/`group` were checked for a not-found signal — the group is just an echo of the request and status is a generic success/error, so the hint is inferred client-side from the requested kind (documented on `coreV1Kinds`).

## Test plan

- New unit tests: `--all` page walk + `--page` exclusivity + merged JSON envelope; `helm registries get` paging forwarding + footer; empty-listing `-o json` parseability; pods envelope (single- and multi-page); the storageclasses kind entry (request shape + cluster-scoped, no `--namespace`); the group hint (non-core kind, core kind, explicit `--group`); client-level pagination walks for manifests; `kind` population and chart-paging query params for the helm client.
- `go build ./...`, `go vet ./...`, `go test -race -count=1 ./...`, `golangci-lint run` (0 issues), gofmt clean on all changed files.

## Docs checklist

- [x] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); `Short`/`Long`/`Example` on the new command and flags are written for docs readers
- [ ] No user-facing command/flag changes — no docs needed
- [ ] Broader behaviour changes — docs updated in [ankra-docs](https://github.com/ankraio/ankra-docs) (link the PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
