### PR TITLE
release: cut v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Ankra CLI Changelog
 
-## Unreleased
+## v0.9.1 — 2026-08-10
+
+A patch release. `ankra helm registries create` gains YAML spec support and
+flag-based creation with a client-side URL scheme guard (closing the path to
+the API's bare 500 on malformed specs), the never-functional MFA and
+organisation RBAC command families are removed in favour of a browser
+hand-off, and the AI model help examples name the current Expert model.
 
 ### Added
 


### PR DESCRIPTION
Promotes the Unreleased changelog section to v0.9.1 ahead of tagging.

The patch carries:
- `ankra helm registries create` YAML specs, `--name`/`--url` flag creation, URL scheme guard, and the post-create sync hint (#60, PLA-737 / ticket #1050, bead ankra-5h4e.2)
- removal of the MFA and organisation RBAC command families that never worked (#49)
- corrected Expert model id in `ankra ai models` help (#59)

Note: DEPRECATIONS.md reserves removals for minor releases; the #49 families failed on every invocation since v0.6.0, so their removal changes no working behaviour and ships in this patch deliberately.

After merge: tag `v0.9.1` on the merge commit; release.yml builds the binaries and publishes the release, and docs-sync regenerates the CLI reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JxoL8uwy4FG3QLWd1xXup