### PR TITLE
release: cut v0.10.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Ankra CLI Changelog
 
-## Unreleased
+## v0.10.0-rc1 — 2026-08-11
+
+First release candidate for v0.10.0. Multi-key and whole-Secret encryption
+for `cluster encrypt`, complete paginated listings (`--all`, no more silent
+truncation), a dedicated StorageClass listing, and structured-output
+consistency fixes.
 
 ### Added
 


### PR DESCRIPTION
Promotes the Unreleased changelog section to v0.10.0-rc1 ahead of tagging.

Carries ankra-cli #61 (encrypt: repeatable `--key`, `--all-data`, byte-for-byte file-mode regression test; PLA-741 / #1054, bead ankra-5h4e.6) and #62 (listing completeness: `--all`, manifests-list truncation fix, registry charts paging, StorageClass, group hints, JSON purity; PLA-743 / #1056, bead ankra-5h4e.8).

After merge: tag `v0.10.0-rc1` on the merge commit; the hyphen marks the release prerelease automatically, and the rc tag deliberately skips the Homebrew formula and docs regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JxoL8uwy4FG3QLWd1xXup