### PR TITLE
feat(cluster): add ankra cluster gitops status (ankra-5h4e.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Ankra CLI Changelog
 
+## Unreleased
+
+### Added
+
+- **`ankra cluster gitops status` shows which GitOps repository a cluster
+  actually syncs from.** Previously this was only visible in the browser: the
+  new command prints the repository (owner/name and web URL), branch, stored
+  Git credential, and provider, plus the last synced commit and time, the
+  sync status and phase, and any pending commit or sync error. Supports
+  `-o json|yaml` for scripting.
+
 ## v0.10.0-rc1 — 2026-08-11
 
 First release candidate for v0.10.0. Multi-key and whole-Secret encryption

--- a/cmd/cluster_gitops.go
+++ b/cmd/cluster_gitops.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"fmt"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// clusterGitopsCmd groups the GitOps repository visibility commands under
+// `ankra cluster gitops`.
+var clusterGitopsCmd = &cobra.Command{
+	Use:   "gitops",
+	Short: "Inspect the GitOps repository wiring of a cluster",
+	Long:  `Commands for inspecting which GitOps repository a cluster syncs from.`,
+}
+
+var clusterGitopsStatusCmd = &cobra.Command{
+	Use:   "status [cluster_name]",
+	Short: "Show which GitOps repository a cluster syncs from",
+	Long: `Show the GitOps sync status of a cluster: the repository, branch, and
+credential it syncs from, the last synced commit, and any pending commit or
+sync error.
+
+If no cluster name is provided, uses the currently selected cluster.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		clusterID, clusterName, err := resolveClusterFromArgs(cmd, args)
+		if err != nil {
+			return err
+		}
+		status, err := apiClient.GetClusterGitopsStatus(clusterID)
+		if err != nil {
+			return fmt.Errorf("fetching gitops status for %s: %w", clusterName, err)
+		}
+		if rendered, err := renderStructured(cmd, status); rendered || err != nil {
+			return err
+		}
+		printClusterGitopsStatus(clusterName, status)
+		return nil
+	},
+}
+
+// gitopsRepositoryLabel builds the provider-shaped owner/name label of the
+// repository: repo_owner/repo_name for GitHub, workspace/repo_slug for
+// Bitbucket Cloud, project_key/repo_slug for Bitbucket Data Center.
+func gitopsRepositoryLabel(repo *client.ClusterGitopsRepo) string {
+	pair := func(left, right *string) string {
+		if left == nil || right == nil {
+			return ""
+		}
+		return *left + "/" + *right
+	}
+	if label := pair(repo.RepoOwner, repo.RepoName); label != "" {
+		return label
+	}
+	if label := pair(repo.Workspace, repo.RepoSlug); label != "" {
+		return label
+	}
+	if label := pair(repo.ProjectKey, repo.RepoSlug); label != "" {
+		return label
+	}
+	return repo.WebURL
+}
+
+// gitopsErrorSummary flattens the backend's error info object (general,
+// validation, or multiple-validation shape) into one human-readable line.
+func gitopsErrorSummary(errorInfo map[string]interface{}) string {
+	if message, ok := errorInfo["message"].(string); ok && message != "" {
+		return message
+	}
+	if nested, ok := errorInfo["errors"].([]interface{}); ok {
+		summary := ""
+		for _, entry := range nested {
+			entryObject, ok := entry.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			message, ok := entryObject["message"].(string)
+			if !ok || message == "" {
+				continue
+			}
+			if summary != "" {
+				summary += "; "
+			}
+			summary += message
+		}
+		if summary != "" {
+			return summary
+		}
+	}
+	if errorType, ok := errorInfo["error_type"].(string); ok && errorType != "" {
+		return errorType
+	}
+	return fmt.Sprintf("%v", errorInfo)
+}
+
+// printClusterGitopsStatus renders the human-readable status: repository,
+// branch, credential, and provider first, then the sync outcome, with the
+// pending commit and error lines only when present.
+func printClusterGitopsStatus(clusterName string, status *client.ClusterGitopsStatus) {
+	valueOrDash := func(value *string) string {
+		if value == nil || *value == "" {
+			return "-"
+		}
+		return *value
+	}
+
+	fmt.Printf("GitOps Status for %s:\n", clusterName)
+	if repo := status.GitRepo; repo != nil {
+		fmt.Printf("  Repository: %s (%s)\n", gitopsRepositoryLabel(repo), repo.WebURL)
+		fmt.Printf("  Branch: %s\n", repo.Branch)
+		fmt.Printf("  Credential: %s\n", valueOrDash(repo.CredentialName))
+		fmt.Printf("  Provider: %s\n", repo.Provider)
+	} else {
+		fmt.Println("  Repository: not configured")
+	}
+	fmt.Printf("  Sync Status: %s\n", valueOrDash(status.SyncStatus))
+	if status.SyncPhase != nil && *status.SyncPhase != "" {
+		fmt.Printf("  Sync Phase: %s\n", *status.SyncPhase)
+	}
+	if status.SyncProgressMessage != nil && *status.SyncProgressMessage != "" {
+		fmt.Printf("  Progress: %s\n", *status.SyncProgressMessage)
+	}
+	if status.LastCommitSHA != nil {
+		fmt.Printf("  Last Synced Commit: %s\n", *status.LastCommitSHA)
+	}
+	if status.LastSyncedAt != nil {
+		syncedLine := fmt.Sprintf("%s (%s)", *status.LastSyncedAt, formatTimeAgo(*status.LastSyncedAt))
+		if status.LastSyncedFrom != nil && *status.LastSyncedFrom != "" {
+			syncedLine += " via " + *status.LastSyncedFrom
+		}
+		fmt.Printf("  Last Synced: %s\n", syncedLine)
+	}
+	if status.PendingCommitSHA != nil && *status.PendingCommitSHA != "" {
+		fmt.Printf("  Pending Commit: %s\n", *status.PendingCommitSHA)
+	}
+	if status.AppliedWithFailedMembers {
+		fmt.Println("  Warning: applied, but member deployments are failing")
+	}
+	if status.Error != nil {
+		fmt.Printf("  Error: %s\n", gitopsErrorSummary(status.Error))
+	}
+}
+
+func init() {
+	registerStructuredOutputFlags(clusterGitopsStatusCmd)
+	clusterGitopsCmd.AddCommand(clusterGitopsStatusCmd)
+	clusterCmd.AddCommand(clusterGitopsCmd)
+}

--- a/cmd/cluster_gitops_test.go
+++ b/cmd/cluster_gitops_test.go
@@ -1,0 +1,236 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type gitopsStatusMock struct {
+	baseMock
+	status             *client.ClusterGitopsStatus
+	statusError        error
+	requestedClusterID string
+}
+
+func (m *gitopsStatusMock) GetCluster(name string) (client.ClusterListItem, error) {
+	return client.ClusterListItem{ID: "gitops-cluster-id", Name: name}, nil
+}
+
+func (m *gitopsStatusMock) GetClusterGitopsStatus(clusterID string) (*client.ClusterGitopsStatus, error) {
+	m.requestedClusterID = clusterID
+	if m.statusError != nil {
+		return nil, m.statusError
+	}
+	return m.status, nil
+}
+
+func syncedGitopsStatus() *client.ClusterGitopsStatus {
+	return &client.ClusterGitopsStatus{
+		SyncStatus:          strPtrCmd("synced"),
+		LastSyncedAt:        strPtrCmd("2026-07-02T09:05:00Z"),
+		LastSyncedFrom:      strPtrCmd("webhook"),
+		LastCommitSHA:       strPtrCmd("abc123"),
+		LastCommitTimestamp: strPtrCmd("2026-07-02T09:05:00Z"),
+		ClusterName:         strPtrCmd("my-cluster"),
+		ClusterShortID:      strPtrCmd("shortid1"),
+		GitRepo: &client.ClusterGitopsRepo{
+			Provider:       "github",
+			Branch:         "develop",
+			WebURL:         "https://github.com/ankra/gitops",
+			RepoOwner:      strPtrCmd("ankra"),
+			RepoName:       strPtrCmd("gitops"),
+			CredentialName: strPtrCmd("github-creds"),
+		},
+	}
+}
+
+func TestClusterGitopsStatusCommand(t *testing.T) {
+	mock := &gitopsStatusMock{status: syncedGitopsStatus()}
+	setMockClient(t, mock)
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("cluster", "gitops", "status", "my-cluster")
+	})
+
+	if mock.requestedClusterID != "gitops-cluster-id" {
+		t.Errorf("expected status request for the resolved cluster id, got %q", mock.requestedClusterID)
+	}
+	for _, fragment := range []string{
+		"GitOps Status for my-cluster",
+		"Repository: ankra/gitops (https://github.com/ankra/gitops)",
+		"Branch: develop",
+		"Credential: github-creds",
+		"Provider: github",
+		"Sync Status: synced",
+		"Last Synced Commit: abc123",
+		"via webhook",
+	} {
+		if !strings.Contains(stdoutOutput, fragment) {
+			t.Errorf("expected output to contain %q, got: %s", fragment, stdoutOutput)
+		}
+	}
+	for _, absent := range []string{"Pending Commit", "Error:", "Warning:"} {
+		if strings.Contains(stdoutOutput, absent) {
+			t.Errorf("expected output without %q, got: %s", absent, stdoutOutput)
+		}
+	}
+}
+
+func TestClusterGitopsStatusShowsPendingCommitAndError(t *testing.T) {
+	status := syncedGitopsStatus()
+	status.SyncStatus = strPtrCmd("error")
+	status.SyncPhase = strPtrCmd("pushing")
+	status.PendingCommitSHA = strPtrCmd("def456")
+	status.Error = map[string]interface{}{
+		"error_type": "general",
+		"message":    "push rejected by remote",
+	}
+	mock := &gitopsStatusMock{status: status}
+	setMockClient(t, mock)
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("cluster", "gitops", "status", "my-cluster")
+	})
+
+	for _, fragment := range []string{
+		"Sync Status: error",
+		"Sync Phase: pushing",
+		"Pending Commit: def456",
+		"Error: push rejected by remote",
+	} {
+		if !strings.Contains(stdoutOutput, fragment) {
+			t.Errorf("expected output to contain %q, got: %s", fragment, stdoutOutput)
+		}
+	}
+}
+
+func TestClusterGitopsStatusNotConfigured(t *testing.T) {
+	mock := &gitopsStatusMock{status: &client.ClusterGitopsStatus{
+		SyncStatus: strPtrCmd("not_configured"),
+	}}
+	setMockClient(t, mock)
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("cluster", "gitops", "status", "my-cluster")
+	})
+
+	if !strings.Contains(stdoutOutput, "Repository: not configured") {
+		t.Errorf("expected not-configured repository line, got: %s", stdoutOutput)
+	}
+	if !strings.Contains(stdoutOutput, "Sync Status: not_configured") {
+		t.Errorf("expected not_configured sync status, got: %s", stdoutOutput)
+	}
+}
+
+func TestClusterGitopsStatusJSONOutput(t *testing.T) {
+	mock := &gitopsStatusMock{status: syncedGitopsStatus()}
+	setMockClient(t, mock)
+
+	output, err := executeCommand("cluster", "gitops", "status", "my-cluster", "-o", "json")
+	if err != nil {
+		t.Fatalf("command failed: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if unmarshalErr := json.Unmarshal([]byte(output), &decoded); unmarshalErr != nil {
+		t.Fatalf("expected parseable JSON on stdout, got %v: %s", unmarshalErr, output)
+	}
+	if decoded["sync_status"] != "synced" {
+		t.Errorf("sync_status = %v, want synced", decoded["sync_status"])
+	}
+	gitRepo, ok := decoded["git_repo"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("git_repo missing from JSON output: %s", output)
+	}
+	if gitRepo["credential_name"] != "github-creds" {
+		t.Errorf("git_repo.credential_name = %v, want github-creds", gitRepo["credential_name"])
+	}
+}
+
+func TestGitopsRepositoryLabelProviderShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		repo client.ClusterGitopsRepo
+		want string
+	}{
+		{
+			name: "github owner and name",
+			repo: client.ClusterGitopsRepo{
+				WebURL:    "https://github.com/ankra/gitops",
+				RepoOwner: strPtrCmd("ankra"),
+				RepoName:  strPtrCmd("gitops"),
+			},
+			want: "ankra/gitops",
+		},
+		{
+			name: "bitbucket cloud workspace and slug",
+			repo: client.ClusterGitopsRepo{
+				WebURL:    "https://bitbucket.org/ankra/gitops",
+				Workspace: strPtrCmd("ankra"),
+				RepoSlug:  strPtrCmd("gitops"),
+			},
+			want: "ankra/gitops",
+		},
+		{
+			name: "bitbucket data center project and slug",
+			repo: client.ClusterGitopsRepo{
+				WebURL:     "https://bitbucket.internal/projects/ANK/repos/gitops",
+				ProjectKey: strPtrCmd("ANK"),
+				RepoSlug:   strPtrCmd("gitops"),
+			},
+			want: "ANK/gitops",
+		},
+		{
+			name: "no pair falls back to the web url",
+			repo: client.ClusterGitopsRepo{WebURL: "https://github.com/ankra/gitops"},
+			want: "https://github.com/ankra/gitops",
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := gitopsRepositoryLabel(&testCase.repo); got != testCase.want {
+				t.Errorf("gitopsRepositoryLabel() = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestGitopsErrorSummaryShapes(t *testing.T) {
+	tests := []struct {
+		name      string
+		errorInfo map[string]interface{}
+		want      string
+	}{
+		{
+			name:      "general message",
+			errorInfo: map[string]interface{}{"error_type": "general", "message": "boom"},
+			want:      "boom",
+		},
+		{
+			name: "multiple validation errors joined",
+			errorInfo: map[string]interface{}{
+				"error_type": "multiple_validation_errors",
+				"errors": []interface{}{
+					map[string]interface{}{"message": "first"},
+					map[string]interface{}{"message": "second"},
+				},
+			},
+			want: "first; second",
+		},
+		{
+			name:      "error type fallback",
+			errorInfo: map[string]interface{}{"error_type": "validation_error"},
+			want:      "validation_error",
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := gitopsErrorSummary(testCase.errorInfo); got != testCase.want {
+				t.Errorf("gitopsErrorSummary() = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -35,6 +35,10 @@ func (m baseMock) GetClusterByID(clusterID string) (client.ClusterListItem, erro
 	return client.ClusterListItem{}, errors.New("not implemented")
 }
 
+func (m baseMock) GetClusterGitopsStatus(clusterID string) (*client.ClusterGitopsStatus, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) DeleteCluster(ctx context.Context, name string) error {
 	return errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -15,6 +15,7 @@ type APIClient interface {
 	ListClusters(page int, pageSize int) (*client.ClusterListResponse, error)
 	GetCluster(name string) (client.ClusterListItem, error)
 	GetClusterByID(clusterID string) (client.ClusterListItem, error)
+	GetClusterGitopsStatus(clusterID string) (*client.ClusterGitopsStatus, error)
 	DeleteCluster(ctx context.Context, name string) error
 	TriggerReconcile(ctx context.Context, clusterID string) (*client.TriggerReconcileResult, error)
 	ProvisionCluster(ctx context.Context, clusterID string) (*client.ProvisionClusterResult, error)

--- a/internal/client/gitops.go
+++ b/internal/client/gitops.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"fmt"
+	neturl "net/url"
+)
+
+// ClusterGitopsStatus mirrors the backend's GitOpsStatusResponse for
+// GET /api/v1/clusters/{cluster_id}/gitops/status: which repository, branch,
+// and credential a cluster syncs from, plus the latest sync outcome. A cluster
+// without GitOps history answers the same shape with null fields, and a
+// missing cluster row answers sync_status "not_configured".
+type ClusterGitopsStatus struct {
+	SyncStatus          *string `json:"sync_status" yaml:"sync_status"`
+	LastSyncedAt        *string `json:"last_synced_at" yaml:"last_synced_at"`
+	LastSyncedFrom      *string `json:"last_synced_from" yaml:"last_synced_from"`
+	LastCommitSHA       *string `json:"last_commit_sha" yaml:"last_commit_sha"`
+	LastCommitTimestamp *string `json:"last_commit_timestamp" yaml:"last_commit_timestamp"`
+	PendingCommitSHA    *string `json:"pending_commit_sha" yaml:"pending_commit_sha"`
+	SyncPhase           *string `json:"sync_phase" yaml:"sync_phase"`
+	SyncProgressMessage *string `json:"sync_progress_message" yaml:"sync_progress_message"`
+	// AppliedWithFailedMembers marks a "synced" answer whose member deploy
+	// jobs are failing, so "synced" alone does not over-promise.
+	AppliedWithFailedMembers bool `json:"applied_with_failed_members" yaml:"applied_with_failed_members"`
+	// Error is one of the backend's error info objects (general, validation,
+	// or multiple-validation), kept schemaless so every arm round-trips
+	// through -o json|yaml unchanged.
+	Error          map[string]interface{} `json:"error" yaml:"error"`
+	RetryCount     int                    `json:"retry_count" yaml:"retry_count"`
+	ClusterName    *string                `json:"cluster_name" yaml:"cluster_name"`
+	ClusterShortID *string                `json:"cluster_short_id" yaml:"cluster_short_id"`
+	GitRepo        *ClusterGitopsRepo     `json:"git_repo" yaml:"git_repo"`
+}
+
+// ClusterGitopsRepo mirrors the git_repo member of the GitOps status payload.
+// The owner/name pair is provider-shaped: repo_owner/repo_name for GitHub,
+// workspace/repo_slug for Bitbucket Cloud, project_key/repo_slug (plus
+// instance_url) for Bitbucket Data Center.
+type ClusterGitopsRepo struct {
+	Provider       string  `json:"provider" yaml:"provider"`
+	Branch         string  `json:"branch" yaml:"branch"`
+	WebURL         string  `json:"web_url" yaml:"web_url"`
+	RepoOwner      *string `json:"repo_owner" yaml:"repo_owner"`
+	RepoName       *string `json:"repo_name" yaml:"repo_name"`
+	Workspace      *string `json:"workspace" yaml:"workspace"`
+	RepoSlug       *string `json:"repo_slug" yaml:"repo_slug"`
+	ProjectKey     *string `json:"project_key" yaml:"project_key"`
+	InstanceURL    *string `json:"instance_url" yaml:"instance_url"`
+	CredentialName *string `json:"credential_name" yaml:"credential_name"`
+}
+
+// GetClusterGitopsStatus fetches the GitOps sync snapshot for a cluster.
+func (c *Client) GetClusterGitopsStatus(clusterID string) (*ClusterGitopsStatus, error) {
+	url := fmt.Sprintf("%s/api/v1/clusters/%s/gitops/status", c.BaseURL, neturl.PathEscape(clusterID))
+	var status ClusterGitopsStatus
+	if err := c.getJSON(url, &status); err != nil {
+		return nil, err
+	}
+	return &status, nil
+}


### PR DESCRIPTION
## What & why

PLA-738 (#1051), bead ankra-5h4e.3. Operators could only see which GitOps repository a cluster syncs from in the browser. `ankra cluster gitops status [cluster_name]` asks the new token-authenticated `GET /api/v1/clusters/{cluster_id}/gitops/status` endpoint (ankraio/cluster#919) and prints:

- repository (owner/name, provider-shaped for GitHub / Bitbucket Cloud / Bitbucket DC) and web URL
- branch, stored Git credential name, provider
- last synced commit and time (with source), sync status and phase
- pending commit and sync error, only when present

`-o json|yaml` (via the shared `registerStructuredOutputFlags`) emits the bare status object for scripting, like `cluster info`. The command honours the positional name, the inherited `--cluster` override, and the selected cluster.

Client method `GetClusterGitopsStatus` added to `internal/client` with the mandatory triple-edit (`APIClient` in `cmd/services.go`, `baseMock` in `cmd/e2e_test.go`), plus a `CHANGELOG.md` Unreleased entry.

## Test plan

- e2e mock-style tests: human rendering (happy path, pending-commit/error lines only when present, not-configured), `-o json` stays parseable and carries `git_repo.credential_name`, resolved-cluster-id plumbing.
- Unit tests for the provider-shaped repository label and the error-summary flattening across all three backend error shapes.
- `gofmt` clean on touched files, `go build ./...`, `go test ./...` and `golangci-lint run` (0 issues) all green; pre-commit hook ran the same on commit.

## Docs checklist

- [x] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); `Short`/`Long` on the new commands are written for docs readers
- [ ] No user-facing command/flag changes — no docs needed
- [ ] Broader behaviour changes — docs updated in [ankra-docs](https://github.com/ankraio/ankra-docs) (link the PR): n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JxoL8uwy4FG3QLWd1xXup
