### PR TITLE
feat(charts): ankra charts template + ankra charts values (ankra-5h4e.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Ankra CLI Changelog
 
+## Unreleased
+
+### Added
+
+- **`ankra charts template` renders a chart's manifests without deploying
+  anything.** The `helm template` equivalent for the Ankra catalog: the
+  chart version is rendered server-side (no cluster connection) and printed
+  to stdout as a `---`-separated multi-doc YAML stream with a `# Source:`
+  header per document, ready to pipe into `kubectl diff` or kubeconform.
+  `-f values.yaml` overrides the chart's defaults, `--release-name` and
+  `--namespace` control the render context, and values problems (bad YAML,
+  schema violations, template errors) fail with the exact Helm error a
+  deploy would have produced — so broken values are caught before they
+  reach a cluster. Chart NOTES.txt output goes to stderr, keeping stdout
+  parseable.
+- **`ankra charts values` prints a chart version's default values.** The
+  `helm show values` equivalent: the decoded YAML lands on stdout, ready to
+  redirect to a file, edit, and feed back to `ankra charts template -f`
+  (`-o raw` prints the base64-encoded form). For both new commands the
+  repository is resolved automatically when the chart name is unambiguous;
+  `--repository` pins it.
+
 ## v0.10.0-rc1 — 2026-08-11
 
 First release candidate for v0.10.0. Multi-key and whole-Secret encryption

--- a/cmd/charts_template.go
+++ b/cmd/charts_template.go
@@ -89,13 +89,13 @@ reach production:
 			if !strings.HasSuffix(text, "\n") {
 				text += "\n"
 			}
-			fmt.Fprintf(out, "---\n# Source: %s\n%s", manifest.Path, text)
+			_, _ = fmt.Fprintf(out, "---\n# Source: %s\n%s", manifest.Path, text)
 		}
 		if len(result.Rendered) == 0 {
-			fmt.Fprintln(cmd.ErrOrStderr(), "The chart rendered no manifests.")
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "The chart rendered no manifests.")
 		}
 		if result.Notes != nil && strings.TrimSpace(*result.Notes) != "" {
-			fmt.Fprintf(cmd.ErrOrStderr(), "\nNOTES:\n%s", *result.Notes)
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "\nNOTES:\n%s", *result.Notes)
 		}
 		return nil
 	},

--- a/cmd/charts_template.go
+++ b/cmd/charts_template.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+var chartsTemplateCmd = &cobra.Command{
+	Use:   "template <chart_name>",
+	Short: "Render a chart's Kubernetes manifests (helm template)",
+	Long: `Render a chart version's Kubernetes manifests server-side, without
+deploying anything - the 'helm template' equivalent for the Ankra catalog.
+
+The manifests are printed to stdout as a '---' separated multi-doc YAML
+stream with a '# Source:' header per document, so the output pipes straight
+into kubectl diff, kubeconform, or a file. Chart NOTES.txt output goes to
+stderr.
+
+Values problems (bad YAML, schema violations, template errors) fail with the
+exact Helm error a deploy would have produced - validate values before they
+reach production:
+
+  ankra charts template nginx --version 1.2.3
+  ankra charts template nginx --version 1.2.3 -f values.yaml
+  ankra charts template nginx --version 1.2.3 --release-name web --namespace edge`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		chartName := args[0]
+		chartVersion, _ := cmd.Flags().GetString("version")
+		repositoryName, _ := cmd.Flags().GetString("repository")
+		valuesFile, _ := cmd.Flags().GetString("values")
+		releaseName, _ := cmd.Flags().GetString("release-name")
+		namespace, _ := cmd.Flags().GetString("namespace")
+
+		if repositoryName == "" {
+			resolved, err := resolveChartRepositoryName(chartName)
+			if err != nil {
+				return err
+			}
+			repositoryName = resolved
+		}
+
+		request := client.TemplateChartRequest{
+			RepositoryName: repositoryName,
+			ChartName:      chartName,
+			ChartVersion:   chartVersion,
+		}
+		if valuesFile != "" {
+			content, readErr := os.ReadFile(valuesFile)
+			if readErr != nil {
+				return fmt.Errorf("reading values file: %w", readErr)
+			}
+			encoded := base64.StdEncoding.EncodeToString(content)
+			request.ValuesBase64 = &encoded
+		}
+		if releaseName != "" {
+			request.ReleaseName = &releaseName
+		}
+		if namespace != "" {
+			request.Namespace = &namespace
+		}
+
+		result, err := apiClient.TemplateChart(request)
+		if err != nil {
+			var templateErr *client.ChartTemplateError
+			if errors.As(err, &templateErr) {
+				return fmt.Errorf("chart rendering failed:\n%s", templateErr.Message)
+			}
+			if errors.Is(err, client.ErrChartNotFound) {
+				return withExitCode(exitNotFound, err)
+			}
+			return fmt.Errorf("rendering chart: %w", err)
+		}
+
+		out := cmd.OutOrStdout()
+		for _, manifest := range result.Rendered {
+			decoded, decodeErr := base64.StdEncoding.DecodeString(manifest.ContentBase64)
+			if decodeErr != nil {
+				return fmt.Errorf("base64-decode manifest %s: %w", manifest.Path, decodeErr)
+			}
+			text := string(decoded)
+			if !strings.HasSuffix(text, "\n") {
+				text += "\n"
+			}
+			fmt.Fprintf(out, "---\n# Source: %s\n%s", manifest.Path, text)
+		}
+		if len(result.Rendered) == 0 {
+			fmt.Fprintln(cmd.ErrOrStderr(), "The chart rendered no manifests.")
+		}
+		if result.Notes != nil && strings.TrimSpace(*result.Notes) != "" {
+			fmt.Fprintf(cmd.ErrOrStderr(), "\nNOTES:\n%s", *result.Notes)
+		}
+		return nil
+	},
+}
+
+func init() {
+	chartsTemplateCmd.Flags().String("version", "", "Chart version (required)")
+	chartsTemplateCmd.Flags().String("repository", "", "Repository name for the chart")
+	chartsTemplateCmd.Flags().StringP("values", "f", "", "YAML file overriding the chart's default values")
+	chartsTemplateCmd.Flags().String("release-name", "", "Release name for the render (default: the chart name)")
+	chartsTemplateCmd.Flags().String("namespace", "", "Release namespace for the render (default: \"default\")")
+	_ = chartsTemplateCmd.MarkFlagRequired("version")
+
+	chartsCmd.AddCommand(chartsTemplateCmd)
+}

--- a/cmd/charts_template_test.go
+++ b/cmd/charts_template_test.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type chartsTemplateMock struct {
+	baseMock
+	templateResult  *client.TemplateChartResult
+	templateError   error
+	capturedRequest client.TemplateChartRequest
+}
+
+func (m *chartsTemplateMock) TemplateChart(request client.TemplateChartRequest) (*client.TemplateChartResult, error) {
+	m.capturedRequest = request
+	if m.templateError != nil {
+		return nil, m.templateError
+	}
+	return m.templateResult, nil
+}
+
+func encodeManifest(content string) string {
+	return base64.StdEncoding.EncodeToString([]byte(content))
+}
+
+func TestChartsTemplatePrintsManifestStreamWithSourceHeaders(t *testing.T) {
+	resetCommandFlags(t, chartsTemplateCmd)
+	notes := "Deployed nginx.\n"
+	mock := &chartsTemplateMock{
+		templateResult: &client.TemplateChartResult{
+			Rendered: []client.RenderedChartManifest{
+				{Path: "nginx/templates/deployment.yaml", ContentBase64: encodeManifest("kind: Deployment\n")},
+				{Path: "nginx/templates/service.yaml", ContentBase64: encodeManifest("kind: Service")},
+			},
+			Notes: &notes,
+		},
+	}
+	setMockClient(t, mock)
+
+	output, err := executeCommand("charts", "template", "nginx", "--version", "1.2.3", "--repository", "repo-a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, expected := range []string{
+		"---\n# Source: nginx/templates/deployment.yaml\nkind: Deployment\n",
+		"---\n# Source: nginx/templates/service.yaml\nkind: Service\n",
+		"NOTES:\nDeployed nginx.\n",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("output missing %q:\n%s", expected, output)
+		}
+	}
+	if mock.capturedRequest.RepositoryName != "repo-a" || mock.capturedRequest.ChartName != "nginx" ||
+		mock.capturedRequest.ChartVersion != "1.2.3" {
+		t.Errorf("unexpected request: %+v", mock.capturedRequest)
+	}
+	if mock.capturedRequest.ValuesBase64 != nil || mock.capturedRequest.ReleaseName != nil ||
+		mock.capturedRequest.Namespace != nil {
+		t.Errorf("optional fields unexpectedly set: %+v", mock.capturedRequest)
+	}
+}
+
+func TestChartsTemplateSendsValuesFileAndRenderOptions(t *testing.T) {
+	resetCommandFlags(t, chartsTemplateCmd)
+	valuesContent := "replicaCount: 5\n"
+	valuesPath := filepath.Join(t.TempDir(), "values.yaml")
+	if writeError := os.WriteFile(valuesPath, []byte(valuesContent), 0o600); writeError != nil {
+		t.Fatal(writeError)
+	}
+	mock := &chartsTemplateMock{
+		templateResult: &client.TemplateChartResult{
+			Rendered: []client.RenderedChartManifest{
+				{Path: "nginx/templates/deployment.yaml", ContentBase64: encodeManifest("kind: Deployment\n")},
+			},
+		},
+	}
+	setMockClient(t, mock)
+
+	_, err := executeCommand("charts", "template", "nginx", "--version", "1.2.3", "--repository", "repo-a",
+		"-f", valuesPath, "--release-name", "preview", "--namespace", "staging")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.capturedRequest.ValuesBase64 == nil ||
+		*mock.capturedRequest.ValuesBase64 != base64.StdEncoding.EncodeToString([]byte(valuesContent)) {
+		t.Errorf("values not forwarded: %+v", mock.capturedRequest.ValuesBase64)
+	}
+	if mock.capturedRequest.ReleaseName == nil || *mock.capturedRequest.ReleaseName != "preview" {
+		t.Errorf("release name not forwarded: %+v", mock.capturedRequest.ReleaseName)
+	}
+	if mock.capturedRequest.Namespace == nil || *mock.capturedRequest.Namespace != "staging" {
+		t.Errorf("namespace not forwarded: %+v", mock.capturedRequest.Namespace)
+	}
+}
+
+func TestChartsTemplateSurfacesHelmErrorNonZero(t *testing.T) {
+	resetCommandFlags(t, chartsTemplateCmd)
+	mock := &chartsTemplateMock{
+		templateError: &client.ChartTemplateError{Message: "values don't meet the specifications of the schema(s): replicaCount must be integer"},
+	}
+	setMockClient(t, mock)
+
+	_, err := executeCommand("charts", "template", "nginx", "--version", "1.2.3", "--repository", "repo-a")
+	if err == nil || !strings.Contains(err.Error(), "replicaCount must be integer") {
+		t.Fatalf("expected the helm error text, got: %v", err)
+	}
+	if exitCodeFor(err) == exitOK {
+		t.Error("helm error must exit non-zero")
+	}
+}
+
+func TestChartsTemplateUnknownChartExitsNotFound(t *testing.T) {
+	resetCommandFlags(t, chartsTemplateCmd)
+	mock := &chartsTemplateMock{
+		templateError: fmt.Errorf("chart %q version %q in repository %q: %w",
+			"nginx", "9.9.9", "repo-a", client.ErrChartNotFound),
+	}
+	setMockClient(t, mock)
+
+	_, err := executeCommand("charts", "template", "nginx", "--version", "9.9.9", "--repository", "repo-a")
+	if err == nil || !errors.Is(err, client.ErrChartNotFound) {
+		t.Fatalf("expected a not-found error, got: %v", err)
+	}
+	if exitCodeFor(err) != exitNotFound {
+		t.Errorf("exit code = %d, want %d", exitCodeFor(err), exitNotFound)
+	}
+}

--- a/cmd/charts_values.go
+++ b/cmd/charts_values.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+var chartsValuesCmd = &cobra.Command{
+	Use:   "values <chart_name>",
+	Short: "Print a chart's default values (helm show values)",
+	Long: `Print the default values document shipped inside a chart version.
+
+By default the decoded YAML is written to stdout, making it easy to pipe into
+a file, edit, and feed back to 'ankra charts template -f':
+
+  ankra charts values nginx --version 1.2.3 > values.yaml
+  ankra charts values nginx --version 1.2.3 -o raw   # base64-encoded form
+
+The repository is resolved automatically when the chart name is unambiguous;
+pass --repository to pin it.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		chartName := args[0]
+		chartVersion, _ := cmd.Flags().GetString("version")
+		repositoryName, _ := cmd.Flags().GetString("repository")
+		outRaw, _ := cmd.Flags().GetString("output")
+
+		if repositoryName == "" {
+			resolved, err := resolveChartRepositoryName(chartName)
+			if err != nil {
+				return err
+			}
+			repositoryName = resolved
+		}
+
+		result, err := apiClient.GetChartDefaultValues(repositoryName, chartName, chartVersion)
+		if err != nil {
+			if errors.Is(err, client.ErrChartNotFound) {
+				return withExitCode(exitNotFound, err)
+			}
+			return fmt.Errorf("fetching chart values: %w", err)
+		}
+		decoded, decodeErr := base64.StdEncoding.DecodeString(result.ValuesBase64)
+		if decodeErr != nil {
+			return fmt.Errorf("base64-decode chart values: %w", decodeErr)
+		}
+		return writeDecodedDoc(cmd.OutOrStdout(), string(decoded), outRaw)
+	},
+}
+
+// resolveChartRepositoryName finds the repository carrying a chart via the
+// catalog search, mirroring the lookup 'charts info' performs. Ambiguity or
+// a miss asks the user to pass --repository explicitly.
+func resolveChartRepositoryName(chartName string) (string, error) {
+	charts, err := apiClient.SearchCharts(chartName)
+	if err != nil {
+		return "", fmt.Errorf("finding chart: %w", err)
+	}
+	repositoryNames := make([]string, 0, 1)
+	for _, chart := range charts {
+		if !strings.EqualFold(chart.Name, chartName) {
+			continue
+		}
+		alreadyKnown := false
+		for _, knownName := range repositoryNames {
+			if knownName == chart.RepositoryName {
+				alreadyKnown = true
+				break
+			}
+		}
+		if !alreadyKnown {
+			repositoryNames = append(repositoryNames, chart.RepositoryName)
+		}
+	}
+	switch len(repositoryNames) {
+	case 0:
+		return "", withExitCode(exitNotFound,
+			fmt.Errorf("chart '%s' not found. Please specify --repository flag", chartName))
+	case 1:
+		return repositoryNames[0], nil
+	default:
+		return "", withExitCode(exitUsage, fmt.Errorf(
+			"chart '%s' exists in several repositories (%s); specify --repository",
+			chartName, strings.Join(repositoryNames, ", ")))
+	}
+}
+
+func init() {
+	chartsValuesCmd.Flags().String("version", "", "Chart version (required)")
+	chartsValuesCmd.Flags().String("repository", "", "Repository name for the chart")
+	chartsValuesCmd.Flags().StringP("output", "o", "", "Output format: yaml (decoded, default) or raw (base64)")
+	_ = chartsValuesCmd.MarkFlagRequired("version")
+
+	chartsCmd.AddCommand(chartsValuesCmd)
+}

--- a/cmd/charts_values_test.go
+++ b/cmd/charts_values_test.go
@@ -1,0 +1,145 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// resetCommandFlags restores a command's flags to their defaults so tests do
+// not inherit flag values from earlier executions of the shared cobra tree.
+func resetCommandFlags(t *testing.T, command *cobra.Command) {
+	t.Helper()
+	command.Flags().VisitAll(func(flag *pflag.Flag) {
+		_ = flag.Value.Set(flag.DefValue)
+		flag.Changed = false
+	})
+}
+
+type chartsValuesMock struct {
+	baseMock
+	searchResults       []client.ChartItem
+	valuesResult        *client.GetChartDefaultValuesResult
+	valuesError         error
+	requestedRepository string
+	requestedChart      string
+	requestedVersion    string
+}
+
+func (m *chartsValuesMock) SearchCharts(query string) ([]client.ChartItem, error) {
+	return m.searchResults, nil
+}
+
+func (m *chartsValuesMock) GetChartDefaultValues(repositoryName, chartName, chartVersion string) (*client.GetChartDefaultValuesResult, error) {
+	m.requestedRepository = repositoryName
+	m.requestedChart = chartName
+	m.requestedVersion = chartVersion
+	if m.valuesError != nil {
+		return nil, m.valuesError
+	}
+	return m.valuesResult, nil
+}
+
+func TestChartsValuesPrintsDecodedDefaultValues(t *testing.T) {
+	resetCommandFlags(t, chartsValuesCmd)
+	defaultValuesYAML := "replicaCount: 1\nimage: nginx\n"
+	mock := &chartsValuesMock{
+		valuesResult: &client.GetChartDefaultValuesResult{
+			ValuesBase64: base64.StdEncoding.EncodeToString([]byte(defaultValuesYAML)),
+		},
+	}
+	setMockClient(t, mock)
+
+	output, err := executeCommand("charts", "values", "nginx", "--version", "1.2.3", "--repository", "repo-a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(output, defaultValuesYAML) {
+		t.Errorf("expected decoded values in output, got: %s", output)
+	}
+	if mock.requestedRepository != "repo-a" || mock.requestedChart != "nginx" || mock.requestedVersion != "1.2.3" {
+		t.Errorf("unexpected request: %s/%s@%s",
+			mock.requestedRepository, mock.requestedChart, mock.requestedVersion)
+	}
+}
+
+func TestChartsValuesRawOutputPrintsBase64(t *testing.T) {
+	resetCommandFlags(t, chartsValuesCmd)
+	encoded := base64.StdEncoding.EncodeToString([]byte("replicaCount: 1\n"))
+	mock := &chartsValuesMock{
+		valuesResult: &client.GetChartDefaultValuesResult{ValuesBase64: encoded},
+	}
+	setMockClient(t, mock)
+
+	output, err := executeCommand("charts", "values", "nginx", "--version", "1.2.3", "--repository", "repo-a", "-o", "raw")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(output, encoded) {
+		t.Errorf("expected base64 form in output, got: %s", output)
+	}
+}
+
+func TestChartsValuesResolvesRepositoryViaSearch(t *testing.T) {
+	resetCommandFlags(t, chartsValuesCmd)
+	mock := &chartsValuesMock{
+		searchResults: []client.ChartItem{
+			{Name: "nginx", Version: "1.2.3", RepositoryName: "repo-a"},
+			{Name: "nginx-extras", Version: "0.1.0", RepositoryName: "repo-b"},
+		},
+		valuesResult: &client.GetChartDefaultValuesResult{
+			ValuesBase64: base64.StdEncoding.EncodeToString([]byte("a: 1\n")),
+		},
+	}
+	setMockClient(t, mock)
+
+	if _, err := executeCommand("charts", "values", "nginx", "--version", "1.2.3"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.requestedRepository != "repo-a" {
+		t.Errorf("repository = %q, want repo-a", mock.requestedRepository)
+	}
+}
+
+func TestChartsValuesAmbiguousRepositoryExitsUsage(t *testing.T) {
+	resetCommandFlags(t, chartsValuesCmd)
+	mock := &chartsValuesMock{
+		searchResults: []client.ChartItem{
+			{Name: "nginx", Version: "1.2.3", RepositoryName: "repo-a"},
+			{Name: "nginx", Version: "1.2.3", RepositoryName: "repo-b"},
+		},
+	}
+	setMockClient(t, mock)
+
+	_, err := executeCommand("charts", "values", "nginx", "--version", "1.2.3")
+	if err == nil || !strings.Contains(err.Error(), "several repositories") {
+		t.Fatalf("expected ambiguity error, got: %v", err)
+	}
+	if exitCodeFor(err) != exitUsage {
+		t.Errorf("exit code = %d, want %d", exitCodeFor(err), exitUsage)
+	}
+}
+
+func TestChartsValuesUnknownChartExitsNotFound(t *testing.T) {
+	resetCommandFlags(t, chartsValuesCmd)
+	mock := &chartsValuesMock{
+		valuesError: fmt.Errorf("chart %q version %q in repository %q: %w",
+			"nginx", "9.9.9", "repo-a", client.ErrChartNotFound),
+	}
+	setMockClient(t, mock)
+
+	_, err := executeCommand("charts", "values", "nginx", "--version", "9.9.9", "--repository", "repo-a")
+	if err == nil || !errors.Is(err, client.ErrChartNotFound) {
+		t.Fatalf("expected a not-found error, got: %v", err)
+	}
+	if exitCodeFor(err) != exitNotFound {
+		t.Errorf("exit code = %d, want %d", exitCodeFor(err), exitNotFound)
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -571,6 +571,14 @@ func (m baseMock) GetChartDetails(chartName, repositoryURL string) (*client.Char
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) GetChartDefaultValues(repositoryName, chartName, chartVersion string) (*client.GetChartDefaultValuesResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) TemplateChart(request client.TemplateChartRequest) (*client.TemplateChartResult, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) ListPods(clusterID string, opts *client.ListPodsOptions) (*client.ListPodsResponse, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -166,6 +166,8 @@ type APIClient interface {
 	ListCharts(page, pageSize int, onlySubscribed bool) (*client.ListChartsResponse, error)
 	SearchCharts(query string) ([]client.ChartItem, error)
 	GetChartDetails(chartName, repositoryURL string) (*client.ChartDetails, error)
+	GetChartDefaultValues(repositoryName, chartName, chartVersion string) (*client.GetChartDefaultValuesResult, error)
+	TemplateChart(request client.TemplateChartRequest) (*client.TemplateChartResult, error)
 
 	ListPods(clusterID string, opts *client.ListPodsOptions) (*client.ListPodsResponse, error)
 	GetResources(clusterID string, req client.GetResourcesRequest) (*client.GetResourcesResponse, error)

--- a/internal/client/chart_template.go
+++ b/internal/client/chart_template.go
@@ -1,0 +1,158 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ErrChartNotFound is returned (wrapped) by GetChartDefaultValues and
+// TemplateChart when the chart version is unknown to the organisation or its
+// documents have not been indexed yet.
+var ErrChartNotFound = errors.New("chart not found")
+
+// ChartTemplateError carries the server-side Helm error a template request
+// failed with (bad values YAML, schema violations, template execution
+// errors) - the exact text a failed deploy would have produced.
+type ChartTemplateError struct {
+	Message string
+}
+
+func (e *ChartTemplateError) Error() string { return e.Message }
+
+// GetChartDefaultValuesResult mirrors the backend's
+// GetHelmChartDefaultValuesResult payload.
+type GetChartDefaultValuesResult struct {
+	ValuesBase64 string `json:"values_base64"`
+}
+
+// TemplateChartRequest mirrors the backend's TemplateHelmChartRequest body.
+type TemplateChartRequest struct {
+	RepositoryName string  `json:"repository_name"`
+	ChartName      string  `json:"chart_name"`
+	ChartVersion   string  `json:"chart_version"`
+	ValuesBase64   *string `json:"values_base64,omitempty"`
+	ReleaseName    *string `json:"release_name,omitempty"`
+	Namespace      *string `json:"namespace,omitempty"`
+}
+
+// RenderedChartManifest is one rendered template file, identified by its
+// path inside the chart archive.
+type RenderedChartManifest struct {
+	Path          string `json:"path"`
+	ContentBase64 string `json:"content_base64"`
+}
+
+// TemplateChartResult mirrors the backend's TemplateHelmChartResult payload.
+type TemplateChartResult struct {
+	Rendered []RenderedChartManifest `json:"rendered"`
+	Notes    *string                 `json:"notes"`
+}
+
+// GetChartDefaultValues fetches a chart version's default values document
+// (the `helm show values` equivalent) from the catalog.
+func (c *Client) GetChartDefaultValues(repositoryName, chartName, chartVersion string) (*GetChartDefaultValuesResult, error) {
+	requestURL := fmt.Sprintf("%s/api/v1/org/helm/charts/chart/%s/%s/%s/values",
+		c.BaseURL, url.PathEscape(repositoryName), url.PathEscape(chartName), url.PathEscape(chartVersion))
+	req, err := http.NewRequest("GET", requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+	body, readErr := readResponseBody(resp)
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	switch {
+	case resp.StatusCode == http.StatusOK:
+	case resp.StatusCode == http.StatusUnauthorized:
+		return nil, ErrUnauthorized
+	case resp.StatusCode == http.StatusNotFound:
+		return nil, fmt.Errorf("chart %q version %q in repository %q: %w",
+			chartName, chartVersion, repositoryName, ErrChartNotFound)
+	default:
+		if denied := PermissionDeniedFromResponse(resp.StatusCode, body); denied != nil {
+			return nil, denied
+		}
+		return nil, newUnexpectedResponseError("fetch chart values", resp.StatusCode, redactedBodyForError(body, 500))
+	}
+	var result GetChartDefaultValuesResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &result, nil
+}
+
+// TemplateChart renders a chart version's manifests server-side (the `helm
+// template` equivalent, no cluster connection). A 422 surfaces as a
+// *ChartTemplateError carrying the Helm error text verbatim.
+func (c *Client) TemplateChart(request TemplateChartRequest) (*TemplateChartResult, error) {
+	requestURL := c.BaseURL + "/api/v1/org/helm/charts/template"
+	encoded, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	req, err := http.NewRequest("POST", requestURL, strings.NewReader(string(encoded)))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+	body, readErr := readResponseBody(resp)
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	switch {
+	case resp.StatusCode == http.StatusOK:
+	case resp.StatusCode == http.StatusUnauthorized:
+		return nil, ErrUnauthorized
+	case resp.StatusCode == http.StatusNotFound:
+		return nil, fmt.Errorf("chart %q version %q in repository %q: %w",
+			request.ChartName, request.ChartVersion, request.RepositoryName, ErrChartNotFound)
+	case resp.StatusCode == http.StatusUnprocessableEntity:
+		return nil, &ChartTemplateError{Message: helmErrorFromValidationBody(body)}
+	default:
+		if denied := PermissionDeniedFromResponse(resp.StatusCode, body); denied != nil {
+			return nil, denied
+		}
+		return nil, newUnexpectedResponseError("template chart", resp.StatusCode, redactedBodyForError(body, 500))
+	}
+	var result TemplateChartResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &result, nil
+}
+
+// helmErrorFromValidationBody extracts the human-readable messages from a
+// FastAPI-style 422 body ({"detail": [{"msg": "Value error, ..."}, ...]}),
+// stripping pydantic's "Value error, " prefix so the user sees the Helm
+// error exactly as a failed deploy would have reported it.
+func helmErrorFromValidationBody(body []byte) string {
+	var parsed struct {
+		Detail []struct {
+			Message string `json:"msg"`
+		} `json:"detail"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil || len(parsed.Detail) == 0 {
+		return truncateForError(body, 500)
+	}
+	messages := make([]string, 0, len(parsed.Detail))
+	for _, entry := range parsed.Detail {
+		messages = append(messages, strings.TrimPrefix(entry.Message, "Value error, "))
+	}
+	return strings.Join(messages, "\n")
+}

--- a/internal/client/chart_template.go
+++ b/internal/client/chart_template.go
@@ -71,11 +71,11 @@ func (c *Client) GetChartDefaultValues(repositoryName, chartName, chartVersion s
 	if readErr != nil {
 		return nil, fmt.Errorf("read response: %w", readErr)
 	}
-	switch {
-	case resp.StatusCode == http.StatusOK:
-	case resp.StatusCode == http.StatusUnauthorized:
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusUnauthorized:
 		return nil, ErrUnauthorized
-	case resp.StatusCode == http.StatusNotFound:
+	case http.StatusNotFound:
 		return nil, fmt.Errorf("chart %q version %q in repository %q: %w",
 			chartName, chartVersion, repositoryName, ErrChartNotFound)
 	default:
@@ -115,14 +115,14 @@ func (c *Client) TemplateChart(request TemplateChartRequest) (*TemplateChartResu
 	if readErr != nil {
 		return nil, fmt.Errorf("read response: %w", readErr)
 	}
-	switch {
-	case resp.StatusCode == http.StatusOK:
-	case resp.StatusCode == http.StatusUnauthorized:
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusUnauthorized:
 		return nil, ErrUnauthorized
-	case resp.StatusCode == http.StatusNotFound:
+	case http.StatusNotFound:
 		return nil, fmt.Errorf("chart %q version %q in repository %q: %w",
 			request.ChartName, request.ChartVersion, request.RepositoryName, ErrChartNotFound)
-	case resp.StatusCode == http.StatusUnprocessableEntity:
+	case http.StatusUnprocessableEntity:
 		return nil, &ChartTemplateError{Message: helmErrorFromValidationBody(body)}
 	default:
 		if denied := PermissionDeniedFromResponse(resp.StatusCode, body); denied != nil {


### PR DESCRIPTION
CLI side of PLA-740 (#1053), bead **ankra-5h4e.5** — pairs with the cluster API PR ankraio/cluster#920, which adds the two endpoints these commands consume.

## Commands

- **`ankra charts values <chart> --version <v> [--repository <r>]`** — prints the chart version's default values YAML to stdout (the `helm show values` equivalent); `-o raw` prints the base64-encoded form. Redirect to a file, edit, and feed back to `template -f`.
- **`ankra charts template <chart> --version <v> [--repository <r>] [-f values.yaml] [--release-name X] [--namespace ns]`** — renders the chart's manifests server-side (no cluster connection, nothing deployed) and prints a `---`-separated multi-doc YAML stream with a `# Source: <path>` header per document, ready to pipe into `kubectl diff` or kubeconform. Chart NOTES.txt goes to stderr so stdout stays parseable.

For both, the repository is resolved via catalog search when the chart name is unambiguous; ambiguity or a miss asks for `--repository` (exit 2 / 3).

## Error contract

A server 422 (bad values YAML, schema violation, template execution failure) surfaces the Helm error text verbatim on stderr and exits non-zero — exactly what a failed deploy would have said, caught before it reaches a cluster. Unknown chart/version exits 3 (`exitNotFound`).

## Plumbing

- `internal/client/chart_template.go`: `GetChartDefaultValues` + `TemplateChart`, with the 422 body unwrapped into a typed `ChartTemplateError` (pydantic's `Value error, ` prefix stripped).
- Triple-edit honoured: `APIClient` interface in `cmd/services.go` + `baseMock` stubs in `cmd/e2e_test.go`.
- CHANGELOG: entries under a new `## Unreleased` heading (on top of the v0.10.0-rc1 section).

## Tests

Nine command tests covering: decoded values output, `-o raw`, repository resolution via search, ambiguous-repository exit 2, not-found exit 3 (both commands), manifest stream shape with `# Source:` headers and NOTES on stderr, values-file/release-name/namespace forwarding, and the 422 Helm-error non-zero exit. `gofmt`, `go build ./...`, `go test -race ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)