### PR TITLE
release: cut v0.10.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Ankra CLI Changelog
 
-## Unreleased
+## v0.10.0-rc2 — 2026-08-11
+
+Second release candidate for v0.10.0. Two new command families: GitOps
+source visibility (`cluster gitops status`) and chart introspection
+(`charts template` and `charts values`), rendering a chart's manifests and
+default values server-side from the same package Ankra deploys.
 
 ### Added
 


### PR DESCRIPTION
Promotes the Unreleased changelog section to v0.10.0-rc2 ahead of tagging.

Carries #65 (`ankra cluster gitops status`; PLA-738 / #1051, bead ankra-5h4e.3) and #66 (`ankra charts template` + `charts values`; PLA-740 / #1053, bead ankra-5h4e.5), paired with cluster PRs #919 and #920 which are already merged and deployed.

After merge: tag `v0.10.0-rc2` on the merge commit (prerelease via the hyphen; rc tags skip Homebrew and docs regeneration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JxoL8uwy4FG3QLWd1xXup