### PR TITLE
feat(ai): add openrouter set/remove key commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Added
+
+- **`ankra ai openrouter set|remove` makes OpenRouter bring-your-own-key
+  scriptable.** `set` stores the organisation's OpenRouter API key — pass it
+  with `--api-key`, pipe it on stdin, or omit both and a masked interactive
+  prompt asks for it; the key itself is never echoed. `remove` deletes the
+  stored key (confirming first, `--yes` to skip) and, when OpenRouter was
+  the active provider, the organisation falls back to the Ankra-managed
+  default. `ankra ai provider openrouter` activates a stored key and
+  `ankra ai status` now shows the OpenRouter block alongside Anthropic and
+  the legacy OpenAI-compatible endpoint.
+
 ### Removed
 
 - **The MFA management and organisation RBAC commands are gone — none of

--- a/cmd/ai.go
+++ b/cmd/ai.go
@@ -1,14 +1,19 @@
 package cmd
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
 	"ankra/internal/client"
 
+	"github.com/chzyer/readline"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 )
 
@@ -60,6 +65,15 @@ var aiStatusCmd = &cobra.Command{
 		} else {
 			fmt.Printf("  configured: %s\n", "no")
 		}
+		fmt.Println("\nOpenRouter (custom key):")
+		if status.OpenRouter.Configured {
+			fmt.Printf("  configured: %s\n", text.FgGreen.Sprint("yes"))
+			if status.OpenRouter.KeyPreview != nil {
+				fmt.Printf("  key:        %s\n", *status.OpenRouter.KeyPreview)
+			}
+		} else {
+			fmt.Printf("  configured: %s\n", "no")
+		}
 		return nil
 	},
 }
@@ -67,13 +81,14 @@ var aiStatusCmd = &cobra.Command{
 // --- provider ---
 
 var aiProviderCmd = &cobra.Command{
-	Use:   "provider <ankra|anthropic|openai_compatible>",
+	Use:   "provider <ankra|anthropic|openai_compatible|openrouter>",
 	Short: "Set the active AI provider",
 	Long: `Set the active AI provider for the organisation.
 
   ankra              Ankra-managed Claude models (the default).
   anthropic          Your own Anthropic API key (set it first with 'ankra ai anthropic set').
-  openai_compatible  Your OpenAI-compatible endpoint (set it first with 'ankra ai openai set').`,
+  openai_compatible  Your OpenAI-compatible endpoint (set it first with 'ankra ai openai set').
+  openrouter         Your own OpenRouter API key (set it first with 'ankra ai openrouter set').`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		status, err := apiClient.SetAIProvider(args[0])
@@ -466,6 +481,99 @@ var aiAnthropicDeleteCmd = &cobra.Command{
 	},
 }
 
+// --- openrouter credentials ---
+
+var aiOpenRouterCmd = &cobra.Command{
+	Use:   "openrouter",
+	Short: "Manage the OpenRouter API key",
+	Long: `Manage the organisation's OpenRouter API key (bring your own key).
+
+Store a key with 'set', then activate it with 'ankra ai provider openrouter'.
+Removing the key while OpenRouter is the active provider resets the
+organisation to the Ankra-managed default.`,
+}
+
+var aiOpenRouterSetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Store an OpenRouter API key",
+	Long: `Store and validate an OpenRouter API key (must start with sk-or-).
+
+Pass the key with --api-key, pipe it on stdin, or omit both to be prompted
+interactively. The interactive prompt masks the input; the key is never
+echoed or logged.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		apiKey, err := resolveSecretInput(cmd, "api-key", "OpenRouter API key")
+		if err != nil {
+			return err
+		}
+		status, err := apiClient.SaveOpenRouterKey(apiKey)
+		if err != nil {
+			return fmt.Errorf("saving OpenRouter key: %w", err)
+		}
+		if rendered, err := renderStructured(cmd, status); rendered || err != nil {
+			return err
+		}
+		fmt.Println("OpenRouter API key saved. Activate it with: ankra ai provider openrouter")
+		return nil
+	},
+}
+
+var aiOpenRouterRemoveCmd = &cobra.Command{
+	Use:     "remove",
+	Aliases: []string{"delete"},
+	Short:   "Remove the OpenRouter API key",
+	Long: `Remove the organisation's OpenRouter API key. When OpenRouter is the
+active provider the organisation falls back to the Ankra-managed default.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		yes, _ := cmd.Flags().GetBool("yes")
+		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			"Remove the OpenRouter API key? [y/N]: ", yes); err != nil {
+			return err
+		}
+		if _, err := apiClient.DeleteOpenRouterKey(); err != nil {
+			return fmt.Errorf("deleting OpenRouter key: %w", err)
+		}
+		fmt.Println("OpenRouter API key removed.")
+		return nil
+	},
+}
+
+// resolveSecretInput returns the secret from the named flag when set, and
+// otherwise reads it from stdin: piped or redirected input is read as a
+// single line, while an interactive terminal gets a masked prompt. The
+// secret value itself is never printed back in either path.
+func resolveSecretInput(cmd *cobra.Command, flagName, label string) (string, error) {
+	if value := mustFlagString(cmd, flagName); value != "" {
+		return value, nil
+	}
+	in := cmd.InOrStdin()
+	if file, ok := in.(*os.File); ok && readline.IsTerminal(int(file.Fd())) {
+		prompt := promptui.Prompt{Label: label, Mask: '*', Stdin: file}
+		value, promptError := prompt.Run()
+		if promptError != nil {
+			if isPromptCancellation(promptError) {
+				return "", errCancelled
+			}
+			return "", fmt.Errorf("reading %s: %w", label, promptError)
+		}
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return "", withExitCode(exitUsage, fmt.Errorf("%s is required", label))
+		}
+		return value, nil
+	}
+	line, readError := bufio.NewReader(in).ReadString('\n')
+	if readError != nil && !errors.Is(readError, io.EOF) {
+		return "", fmt.Errorf("reading %s from stdin: %w", label, readError)
+	}
+	value := strings.TrimSpace(line)
+	if value == "" {
+		return "", withExitCode(exitUsage,
+			fmt.Errorf("%s is required: pass --%s, pipe it on stdin, or run interactively to be prompted", label, flagName))
+	}
+	return value, nil
+}
+
 // --- openai-compatible (legacy single endpoint) credentials ---
 
 var aiOpenAICmd = &cobra.Command{
@@ -624,6 +732,9 @@ func init() {
 	_ = aiAnthropicSetCmd.MarkFlagRequired("api-key")
 	aiAnthropicDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
+	aiOpenRouterSetCmd.Flags().String("api-key", "", "OpenRouter API key (starts with sk-or-; omit to read stdin or be prompted)")
+	aiOpenRouterRemoveCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
+
 	aiOpenAISetCmd.Flags().String("base-url", "", "OpenAI-compatible base URL")
 	aiOpenAISetCmd.Flags().String("api-key", "", "API key for the endpoint")
 	aiOpenAISetCmd.Flags().String("model", "", "Model id to use")
@@ -635,13 +746,14 @@ func init() {
 	registerStructuredOutputFlags(aiStatusCmd, aiProviderCmd,
 		aiModelsListCmd, aiModelsCreateCmd, aiModelsUpdateCmd, aiModelsResetCmd,
 		aiEndpointsListCmd, aiEndpointsCreateCmd, aiEndpointsUpdateCmd, aiEndpointsDiscoverCmd,
-		aiAnthropicSetCmd, aiOpenAISetCmd)
+		aiAnthropicSetCmd, aiOpenRouterSetCmd, aiOpenAISetCmd)
 
 	aiModelsCmd.AddCommand(aiModelsListCmd, aiModelsCreateCmd, aiModelsUpdateCmd, aiModelsDeleteCmd, aiModelsResetCmd)
 	aiEndpointsCmd.AddCommand(aiEndpointsListCmd, aiEndpointsCreateCmd, aiEndpointsUpdateCmd, aiEndpointsDeleteCmd, aiEndpointsDiscoverCmd)
 	aiAnthropicCmd.AddCommand(aiAnthropicSetCmd, aiAnthropicDeleteCmd)
+	aiOpenRouterCmd.AddCommand(aiOpenRouterSetCmd, aiOpenRouterRemoveCmd)
 	aiOpenAICmd.AddCommand(aiOpenAISetCmd, aiOpenAIDeleteCmd)
 
-	aiCmd.AddCommand(aiStatusCmd, aiProviderCmd, aiModelsCmd, aiEndpointsCmd, aiAnthropicCmd, aiOpenAICmd)
+	aiCmd.AddCommand(aiStatusCmd, aiProviderCmd, aiModelsCmd, aiEndpointsCmd, aiAnthropicCmd, aiOpenRouterCmd, aiOpenAICmd)
 	rootCmd.AddCommand(aiCmd)
 }

--- a/cmd/ai_test.go
+++ b/cmd/ai_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -9,16 +10,19 @@ import (
 
 type aiSettingsMock struct {
 	baseMock
-	status          *client.AIProviderStatus
-	models          []client.AICatalogModel
-	endpoints       []client.AIEndpoint
-	discovered      []string
-	createdModel    *client.AIModelRequest
-	updatedModelRef string
-	updatedModel    *client.AIModelRequest
-	deletedModelRef string
-	setProvider     string
-	resetCalled     bool
+	status             *client.AIProviderStatus
+	models             []client.AICatalogModel
+	endpoints          []client.AIEndpoint
+	discovered         []string
+	createdModel       *client.AIModelRequest
+	updatedModelRef    string
+	updatedModel       *client.AIModelRequest
+	deletedModelRef    string
+	setProvider        string
+	resetCalled        bool
+	savedOpenRouterKey string
+	openRouterSaveErr  error
+	openRouterDeleted  bool
 }
 
 func (m *aiSettingsMock) GetAIProviderStatus() (*client.AIProviderStatus, error) {
@@ -53,6 +57,20 @@ func (m *aiSettingsMock) DeleteAIModel(reference string) error {
 func (m *aiSettingsMock) ResetAIModels() ([]client.AICatalogModel, error) {
 	m.resetCalled = true
 	return m.models, nil
+}
+
+func (m *aiSettingsMock) SaveOpenRouterKey(apiKey string) (*client.AIAnthropicStatus, error) {
+	if m.openRouterSaveErr != nil {
+		return nil, m.openRouterSaveErr
+	}
+	m.savedOpenRouterKey = apiKey
+	preview := "sk-or-...cdef"
+	return &client.AIAnthropicStatus{Configured: true, KeyPreview: &preview}, nil
+}
+
+func (m *aiSettingsMock) DeleteOpenRouterKey() (*client.AIAnthropicStatus, error) {
+	m.openRouterDeleted = true
+	return &client.AIAnthropicStatus{Configured: false}, nil
 }
 
 func (m *aiSettingsMock) ListAIEndpoints() ([]client.AIEndpoint, error) {
@@ -217,5 +235,164 @@ func TestAIEndpointsDiscoverCommand(t *testing.T) {
 
 	if !strings.Contains(stdoutOutput, "gpt-4o-mini") {
 		t.Errorf("expected discovered model in output, got: %s", stdoutOutput)
+	}
+}
+
+func TestAIStatusShowsOpenRouter(t *testing.T) {
+	openRouterPreview := "sk-or-...wxyz"
+	mock := &aiSettingsMock{
+		status: &client.AIProviderStatus{
+			Provider:   "openrouter",
+			OpenRouter: client.AIAnthropicStatus{Configured: true, KeyPreview: &openRouterPreview},
+		},
+	}
+	setMockClient(t, mock)
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("ai", "status")
+	})
+
+	if !strings.Contains(stdoutOutput, "OpenRouter (custom key):") {
+		t.Errorf("expected OpenRouter block in output, got: %s", stdoutOutput)
+	}
+	if !strings.Contains(stdoutOutput, openRouterPreview) {
+		t.Errorf("expected key preview in output, got: %s", stdoutOutput)
+	}
+}
+
+func TestAIOpenRouterSetWithFlag(t *testing.T) {
+	const rawKey = "sk-or-v1-flag-secret-000"
+	mock := &aiSettingsMock{}
+	setMockClient(t, mock)
+	t.Cleanup(func() { _ = aiOpenRouterSetCmd.Flags().Set("api-key", "") })
+
+	var commandOutput string
+	stdoutOutput := captureStdout(t, func() {
+		commandOutput, _ = executeCommand("ai", "openrouter", "set", "--api-key", rawKey)
+	})
+
+	if mock.savedOpenRouterKey != rawKey {
+		t.Errorf("expected SaveOpenRouterKey with the flag value, got: %q", mock.savedOpenRouterKey)
+	}
+	if !strings.Contains(stdoutOutput, "OpenRouter API key saved") {
+		t.Errorf("expected save confirmation, got: %s", stdoutOutput)
+	}
+	if strings.Contains(stdoutOutput, rawKey) || strings.Contains(commandOutput, rawKey) {
+		t.Errorf("the raw API key must never be echoed, got stdout %q and command output %q",
+			stdoutOutput, commandOutput)
+	}
+}
+
+func TestAIOpenRouterSetFromStdin(t *testing.T) {
+	const rawKey = "sk-or-v1-stdin-secret-111"
+	mock := &aiSettingsMock{}
+	setMockClient(t, mock)
+	rootCmd.SetIn(strings.NewReader(rawKey + "\n"))
+	t.Cleanup(func() { rootCmd.SetIn(nil) })
+
+	var commandOutput string
+	stdoutOutput := captureStdout(t, func() {
+		commandOutput, _ = executeCommand("ai", "openrouter", "set")
+	})
+
+	if mock.savedOpenRouterKey != rawKey {
+		t.Errorf("expected SaveOpenRouterKey with the stdin value, got: %q", mock.savedOpenRouterKey)
+	}
+	if strings.Contains(stdoutOutput, rawKey) || strings.Contains(commandOutput, rawKey) {
+		t.Errorf("the raw API key must never be echoed, got stdout %q and command output %q",
+			stdoutOutput, commandOutput)
+	}
+}
+
+func TestAIOpenRouterSetMissingKey(t *testing.T) {
+	mock := &aiSettingsMock{}
+	setMockClient(t, mock)
+	rootCmd.SetIn(strings.NewReader("\n"))
+	t.Cleanup(func() { rootCmd.SetIn(nil) })
+
+	var executeError error
+	_ = captureStdout(t, func() {
+		_, executeError = executeCommand("ai", "openrouter", "set")
+	})
+
+	if executeError == nil {
+		t.Fatalf("expected an error when no key is provided")
+	}
+	if mock.savedOpenRouterKey != "" {
+		t.Errorf("expected no save call, got: %q", mock.savedOpenRouterKey)
+	}
+	if exitCodeFor(executeError) != exitUsage {
+		t.Errorf("expected usage exit code, got: %d", exitCodeFor(executeError))
+	}
+}
+
+func TestAIOpenRouterSetPlatformRejects(t *testing.T) {
+	mock := &aiSettingsMock{
+		openRouterSaveErr: client.NewUnexpectedResponseError(400,
+			"Invalid OpenRouter API key format (must start with sk-or-)"),
+	}
+	setMockClient(t, mock)
+	t.Cleanup(func() { _ = aiOpenRouterSetCmd.Flags().Set("api-key", "") })
+
+	var executeError error
+	_ = captureStdout(t, func() {
+		_, executeError = executeCommand("ai", "openrouter", "set", "--api-key", "sk-bad-key")
+	})
+
+	if executeError == nil {
+		t.Fatalf("expected the platform rejection to surface as an error")
+	}
+	if !strings.Contains(executeError.Error(), "Invalid OpenRouter API key format") {
+		t.Errorf("expected the platform detail in the error, got: %v", executeError)
+	}
+}
+
+func TestAIOpenRouterRemoveCommand(t *testing.T) {
+	mock := &aiSettingsMock{}
+	setMockClient(t, mock)
+	t.Cleanup(func() { _ = aiOpenRouterRemoveCmd.Flags().Set("yes", "false") })
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("ai", "openrouter", "remove", "--yes")
+	})
+
+	if !mock.openRouterDeleted {
+		t.Errorf("expected DeleteOpenRouterKey to be called")
+	}
+	if !strings.Contains(stdoutOutput, "OpenRouter API key removed") {
+		t.Errorf("expected removal confirmation, got: %s", stdoutOutput)
+	}
+}
+
+func TestAIOpenRouterRemoveDeleteAlias(t *testing.T) {
+	mock := &aiSettingsMock{}
+	setMockClient(t, mock)
+	t.Cleanup(func() { _ = aiOpenRouterRemoveCmd.Flags().Set("yes", "false") })
+
+	_ = captureStdout(t, func() {
+		_, _ = executeCommand("ai", "openrouter", "delete", "--yes")
+	})
+
+	if !mock.openRouterDeleted {
+		t.Errorf("expected DeleteOpenRouterKey via the delete alias")
+	}
+}
+
+func TestAIOpenRouterRemoveDeclined(t *testing.T) {
+	mock := &aiSettingsMock{}
+	setMockClient(t, mock)
+	rootCmd.SetIn(strings.NewReader("n\n"))
+	t.Cleanup(func() { rootCmd.SetIn(nil) })
+
+	var executeError error
+	_ = captureStdout(t, func() {
+		_, executeError = executeCommand("ai", "openrouter", "remove")
+	})
+
+	if mock.openRouterDeleted {
+		t.Errorf("expected no delete call after a declined prompt")
+	}
+	if !errors.Is(executeError, errCancelled) {
+		t.Errorf("expected errCancelled, got: %v", executeError)
 	}
 }

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -511,6 +511,14 @@ func (m baseMock) DeleteAnthropicKey() (*client.AIAnthropicStatus, error) {
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) SaveOpenRouterKey(apiKey string) (*client.AIAnthropicStatus, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) DeleteOpenRouterKey() (*client.AIAnthropicStatus, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) SaveOpenAICompatible(baseURL, apiKey, model string) (*client.AIOpenAICompatibleStatus, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -150,6 +150,8 @@ type APIClient interface {
 	SetAIProvider(provider string) (*client.AIProviderStatus, error)
 	SaveAnthropicKey(apiKey string) (*client.AIAnthropicStatus, error)
 	DeleteAnthropicKey() (*client.AIAnthropicStatus, error)
+	SaveOpenRouterKey(apiKey string) (*client.AIAnthropicStatus, error)
+	DeleteOpenRouterKey() (*client.AIAnthropicStatus, error)
 	SaveOpenAICompatible(baseURL, apiKey, model string) (*client.AIOpenAICompatibleStatus, error)
 	DeleteOpenAICompatible() (*client.AIOpenAICompatibleStatus, error)
 	ListAIModels() ([]client.AICatalogModel, error)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 toolchain go1.26.5
 
 require (
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/dustin/go-humanize v1.0.1
 	github.com/jedib0t/go-pretty/v6 v6.6.7
 	github.com/manifoldco/promptui v0.9.0
@@ -15,7 +16,6 @@ require (
 )
 
 require (
-	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/internal/client/aisettings.go
+++ b/internal/client/aisettings.go
@@ -30,6 +30,7 @@ type AIProviderStatus struct {
 	Provider         string                   `json:"provider"`
 	Anthropic        AIAnthropicStatus        `json:"anthropic"`
 	OpenAICompatible AIOpenAICompatibleStatus `json:"openai_compatible"`
+	OpenRouter       AIAnthropicStatus        `json:"openrouter"`
 }
 
 // AICatalogModel is one entry in the organisation model catalog. ID is null
@@ -118,6 +119,29 @@ func (c *Client) SaveAnthropicKey(apiKey string) (*AIAnthropicStatus, error) {
 func (c *Client) DeleteAnthropicKey() (*AIAnthropicStatus, error) {
 	var status AIAnthropicStatus
 	if err := c.sendJSON(http.MethodDelete, c.BaseURL+aiSettingsBasePath+"/anthropic", nil, &status); err != nil {
+		return nil, err
+	}
+	return &status, nil
+}
+
+// SaveOpenRouterKey stores the organisation's OpenRouter API key (BYOK).
+// The raw key never comes back; the returned status carries only the masked
+// preview the server derives.
+func (c *Client) SaveOpenRouterKey(apiKey string) (*AIAnthropicStatus, error) {
+	var status AIAnthropicStatus
+	payload := map[string]string{"api_key": apiKey}
+	if err := c.sendJSON(http.MethodPost, c.BaseURL+aiSettingsBasePath+"/openrouter", payload, &status); err != nil {
+		return nil, err
+	}
+	return &status, nil
+}
+
+// DeleteOpenRouterKey removes the organisation's OpenRouter API key. When
+// OpenRouter was the active provider the server resets the organisation to
+// the Ankra-managed default.
+func (c *Client) DeleteOpenRouterKey() (*AIAnthropicStatus, error) {
+	var status AIAnthropicStatus
+	if err := c.sendJSON(http.MethodDelete, c.BaseURL+aiSettingsBasePath+"/openrouter", nil, &status); err != nil {
 		return nil, err
 	}
 	return &status, nil


### PR DESCRIPTION
## Summary

Closes the CLI half of the OpenRouter BYOK story (bead `ankra-7qa7`): cluster#822 shipped the platform surface, and the bearer-PAT (token-lane) `POST`/`DELETE /api/v1/org/ai-settings/openrouter` routes already exist on cluster `main` (`go/internal/cliapi/aisettings.go`, gated on `ai.manage` exactly like the browser twins), so no platform change is needed — this PR adds the missing command family.

- **`ankra ai openrouter set`** stores the organisation's OpenRouter API key. The key comes from `--api-key`, a line piped on stdin, or a masked interactive prompt when neither is given. The raw key is never echoed, logged, or printed back; success output is a plain confirmation and structured output (`-o json`) only ever contains the server-side masked preview.
- **`ankra ai openrouter remove`** (alias `delete`, matching the sibling families) deletes the stored key after the standard `[y/N]` confirmation (`--yes` to skip; declining exits 4 via `errCancelled`). When OpenRouter was the active provider the platform falls back to the Ankra-managed default.
- **`ankra ai status`** now renders the OpenRouter block (configured + masked preview) and **`ankra ai provider`** documents the `openrouter` value it already accepted server-side.
- Platform rejections surface their detail message directly, e.g. `saving OpenRouter key: Invalid OpenRouter API key format (must start with sk-or-)`; missing input is a usage error (exit 2).

## Implementation notes

- `internal/client/aisettings.go`: `SaveOpenRouterKey`/`DeleteOpenRouterKey` plus the `openrouter` block on `AIProviderStatus`, mirroring the wire shape of the cliapi twin.
- `cmd/services.go` + `cmd/e2e_test.go`: `APIClient` interface and `baseMock` kept in lockstep per the repo invariant.
- `cmd/ai.go`: new `resolveSecretInput` helper — flag first, single stdin line when input is piped/redirected, `promptui` masked prompt only on a real terminal (`readline.IsTerminal`; `readline` was already in the module graph via promptui and just moves to a direct require).
- `CHANGELOG.md`: Unreleased entry.

## Testing

- `go build ./...`
- `go test -race -count=1 ./cmd/ ./internal/client/` — all green, including new tests for: set via flag, set via stdin, missing-key usage error, platform-rejection error surfacing, remove, the `delete` alias, declined confirmation, and assertions that the raw key never appears in any output.

Refs `ankra-7qa7`, cluster#822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
