### PR TITLE
feat(cluster): add power-schedules commands (ankra-a0f1)

### DIFF
--- a/cmd/cluster_power_schedule.go
+++ b/cmd/cluster_power_schedule.go
@@ -1,0 +1,291 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"ankra/internal/client"
+)
+
+// powerScheduleFlags carries the shared create/update inputs. Exactly one
+// of at (a one-off RFC 3339 fire time) or cron (a repeated 5-field
+// expression, evaluated in timezone) must be set; the backend validates the
+// values themselves (future run_at, parseable cron, IANA timezone).
+type powerScheduleFlags struct {
+	action   string
+	at       string
+	cron     string
+	timezone string
+	enabled  bool
+}
+
+// registerPowerScheduleSpecFlags declares the shared create/update flag set.
+func registerPowerScheduleSpecFlags(cmd *cobra.Command) {
+	cmd.Flags().String("action", "", "What the schedule does when it fires: stop or start (required)")
+	cmd.Flags().String("at", "", "Fire once at this RFC 3339 time, e.g. 2026-01-02T19:00:00Z (mutually exclusive with --cron)")
+	cmd.Flags().String("cron", "", "Fire repeatedly per this 5-field cron expression, e.g. '0 19 * * 1-5' (mutually exclusive with --at)")
+	cmd.Flags().String("timezone", "", "IANA timezone the cron expression is evaluated in, e.g. Europe/Stockholm (default UTC)")
+	cmd.Flags().Bool("enabled", true, "Whether the schedule is armed; --enabled=false creates or leaves it paused")
+	_ = cmd.MarkFlagRequired("action")
+}
+
+// powerScheduleFlagsFromCommand reads and cross-validates the shared flags.
+func powerScheduleFlagsFromCommand(cmd *cobra.Command) (powerScheduleFlags, error) {
+	var flags powerScheduleFlags
+	flags.action, _ = cmd.Flags().GetString("action")
+	flags.at, _ = cmd.Flags().GetString("at")
+	flags.cron, _ = cmd.Flags().GetString("cron")
+	flags.timezone, _ = cmd.Flags().GetString("timezone")
+	flags.enabled, _ = cmd.Flags().GetBool("enabled")
+
+	flags.action = strings.ToLower(strings.TrimSpace(flags.action))
+	if flags.action != "stop" && flags.action != "start" {
+		return flags, withExitCode(exitUsage, fmt.Errorf("--action must be stop or start"))
+	}
+	flags.at = strings.TrimSpace(flags.at)
+	flags.cron = strings.TrimSpace(flags.cron)
+	flags.timezone = strings.TrimSpace(flags.timezone)
+	if (flags.at == "") == (flags.cron == "") {
+		return flags, withExitCode(exitUsage, fmt.Errorf("exactly one of --at (one-off) or --cron (repeated) must be provided"))
+	}
+	if flags.at != "" && flags.timezone != "" {
+		return flags, withExitCode(exitUsage, fmt.Errorf("--timezone only applies to --cron schedules; encode the offset in the --at timestamp instead"))
+	}
+	return flags, nil
+}
+
+// request maps the validated flags onto the API body. The backend treats
+// updates as full replaces, so enabled always rides along, and a cron
+// schedule always restates its timezone (defaulting to UTC explicitly,
+// matching the create-time default).
+func (flags powerScheduleFlags) request() client.PowerScheduleRequest {
+	request := client.PowerScheduleRequest{
+		Action:  flags.action,
+		Enabled: flags.enabled,
+	}
+	if flags.at != "" {
+		request.ScheduleKind = "once"
+		runAt := flags.at
+		request.RunAt = &runAt
+	} else {
+		request.ScheduleKind = "cron"
+		cronExpression := flags.cron
+		request.CronExpression = &cronExpression
+		timezone := flags.timezone
+		if timezone == "" {
+			timezone = "UTC"
+		}
+		request.Timezone = &timezone
+	}
+	return request
+}
+
+var clusterPowerSchedulesCmd = &cobra.Command{
+	Use:     "power-schedules",
+	Aliases: []string{"power-schedule"},
+	Short:   "Manage scheduled stop/start (power schedules) for the active cluster",
+	Long: `Manage the cluster's power schedules: scheduled stop or start actions that
+fire once at a chosen time or repeatedly on a cron expression, so a
+development cluster can park itself outside working hours.
+
+Power schedules are available for self-managed Hetzner, OVHcloud, UpCloud,
+DigitalOcean, Scaleway, Proxmox VE, and HPE Morpheus clusters - the same
+clusters that support manual stop and start. A scheduled stop behaves
+exactly like stopping the cluster yourself: the provider VMs are
+terminated and only the cluster's configuration is preserved for the next
+start.
+
+Examples:
+  # Park a development cluster on weekday evenings, back before morning
+  ankra cluster power-schedules create --action stop --cron '0 19 * * 1-5' --timezone Europe/Stockholm
+  ankra cluster power-schedules create --action start --cron '0 7 * * 1-5' --timezone Europe/Stockholm
+
+  # One-off stop before the weekend
+  ankra cluster power-schedules create --action stop --at 2026-01-02T19:00:00Z`,
+}
+
+var clusterPowerSchedulesListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List the active cluster's power schedules",
+	Args:    cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cluster, err := resolveActiveCluster(cmd)
+		if err != nil {
+			return err
+		}
+		result, err := apiClient.ListPowerSchedules(cluster.ID)
+		if err != nil {
+			return fmt.Errorf("listing power schedules: %w", err)
+		}
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
+		}
+		printPowerScheduleTable(result.Schedules)
+		return nil
+	},
+}
+
+var clusterPowerSchedulesCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a power schedule on the active cluster",
+	Long: `Create a scheduled stop or start on the active cluster. The schedule fires
+once at --at, or repeatedly per --cron evaluated in --timezone (UTC when
+omitted). A cluster can hold up to 20 schedules.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		flags, err := powerScheduleFlagsFromCommand(cmd)
+		if err != nil {
+			return err
+		}
+		cluster, err := resolveActiveCluster(cmd)
+		if err != nil {
+			return err
+		}
+		result, err := apiClient.CreatePowerSchedule(cluster.ID, flags.request())
+		if err != nil {
+			return fmt.Errorf("creating power schedule: %w", err)
+		}
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
+		}
+		fmt.Printf("Power schedule created on cluster %s.\n\n", cluster.Name)
+		printPowerScheduleTable(result.Schedules)
+		return nil
+	},
+}
+
+var clusterPowerSchedulesUpdateCmd = &cobra.Command{
+	Use:   "update <schedule_id>",
+	Short: "Replace a power schedule's action, timing, and enabled flag",
+	Long: `Replace a power schedule. This is a full replace, not a patch: pass the
+complete schedule as it should be afterwards - --action plus one of --at or
+--cron (with --timezone for cron schedules), and --enabled=false to leave it
+paused. Use 'ankra cluster power-schedules list' for the schedule ID and the
+current values.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		flags, err := powerScheduleFlagsFromCommand(cmd)
+		if err != nil {
+			return err
+		}
+		cluster, err := resolveActiveCluster(cmd)
+		if err != nil {
+			return err
+		}
+		result, err := apiClient.UpdatePowerSchedule(cluster.ID, strings.TrimSpace(args[0]), flags.request())
+		if err != nil {
+			return fmt.Errorf("updating power schedule: %w", err)
+		}
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
+		}
+		fmt.Printf("Power schedule updated on cluster %s.\n\n", cluster.Name)
+		printPowerScheduleTable(result.Schedules)
+		return nil
+	},
+}
+
+var clusterPowerSchedulesDeleteCmd = &cobra.Command{
+	Use:     "delete <schedule_id>",
+	Aliases: []string{"rm"},
+	Short:   "Delete a power schedule",
+	Long: `Delete a power schedule: it stops firing immediately and disappears from
+the cluster's schedule list. The cluster itself is not touched. To pause a
+schedule while keeping its configuration, use
+'ankra cluster power-schedules update <schedule_id> ... --enabled=false'.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cluster, err := resolveActiveCluster(cmd)
+		if err != nil {
+			return err
+		}
+		scheduleID := strings.TrimSpace(args[0])
+		yes, _ := cmd.Flags().GetBool("yes")
+		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Delete power schedule %s from cluster %s? [y/N]: ", scheduleID, cluster.Name), yes); err != nil {
+			return err
+		}
+		result, err := apiClient.DeletePowerSchedule(cluster.ID, scheduleID)
+		if err != nil {
+			return fmt.Errorf("deleting power schedule: %w", err)
+		}
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
+		}
+		fmt.Printf("Power schedule %s deleted.\n", scheduleID)
+		return nil
+	},
+}
+
+// printPowerScheduleTable renders the schedule listing in the shared
+// column style.
+func printPowerScheduleTable(schedules []client.PowerSchedule) {
+	if len(schedules) == 0 {
+		fmt.Println("No power schedules found.")
+		return
+	}
+	fmt.Printf("%-36s  %-6s  %-5s  %-28s  %-8s  %-14s  %-14s  %-10s\n",
+		"ID", "ACTION", "KIND", "SCHEDULE", "ENABLED", "NEXT_RUN", "LAST_RUN", "LAST_STATUS")
+	for _, schedule := range schedules {
+		fmt.Printf("%-36s  %-6s  %-5s  %-28s  %-8t  %-14s  %-14s  %-10s\n",
+			schedule.ID,
+			schedule.Action,
+			schedule.ScheduleKind,
+			truncate(powerScheduleCadence(schedule), 28),
+			schedule.Enabled,
+			powerScheduleTimeAgo(schedule.NextRunAt),
+			powerScheduleTimeAgo(schedule.LastRunAt),
+			truncate(stringValue(schedule.LastRunStatus), 10),
+		)
+		if detail := stringValue(schedule.LastRunDetail); detail != "" {
+			fmt.Printf("%-36s    last run: %s\n", "", truncate(detail, 100))
+		}
+	}
+}
+
+// powerScheduleCadence phrases a schedule's timing for the table.
+func powerScheduleCadence(schedule client.PowerSchedule) string {
+	if schedule.ScheduleKind == "once" {
+		return "at " + stringValue(schedule.RunAt)
+	}
+	return stringValue(schedule.CronExpression) + " (" + schedule.Timezone + ")"
+}
+
+// powerScheduleTimeAgo renders a nullable RFC 3339 timestamp as a relative
+// time; future times read "in N", past times "N ago".
+func powerScheduleTimeAgo(timestamp *string) string {
+	if timestamp == nil || *timestamp == "" {
+		return "-"
+	}
+	if _, err := time.Parse(time.RFC3339, *timestamp); err != nil {
+		return *timestamp
+	}
+	return formatTimeAgo(*timestamp)
+}
+
+func init() {
+	registerStructuredOutputFlags(clusterPowerSchedulesListCmd,
+		clusterPowerSchedulesCreateCmd, clusterPowerSchedulesUpdateCmd,
+		clusterPowerSchedulesDeleteCmd)
+	registerPowerScheduleSpecFlags(clusterPowerSchedulesCreateCmd)
+	registerPowerScheduleSpecFlags(clusterPowerSchedulesUpdateCmd)
+	clusterPowerSchedulesDeleteCmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
+
+	clusterPowerSchedulesCmd.AddCommand(clusterPowerSchedulesListCmd)
+	clusterPowerSchedulesCmd.AddCommand(clusterPowerSchedulesCreateCmd)
+	clusterPowerSchedulesCmd.AddCommand(clusterPowerSchedulesUpdateCmd)
+	clusterPowerSchedulesCmd.AddCommand(clusterPowerSchedulesDeleteCmd)
+	clusterCmd.AddCommand(clusterPowerSchedulesCmd)
+}

--- a/cmd/cluster_power_schedule_test.go
+++ b/cmd/cluster_power_schedule_test.go
@@ -1,0 +1,214 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+
+	"ankra/internal/client"
+)
+
+type powerScheduleCall struct {
+	ClusterID  string
+	ScheduleID string
+	Request    client.PowerScheduleRequest
+}
+
+type powerScheduleMock struct {
+	baseMock
+
+	lists   []string
+	creates []powerScheduleCall
+	updates []powerScheduleCall
+	deletes []powerScheduleCall
+}
+
+func (m *powerScheduleMock) GetCluster(name string) (client.ClusterListItem, error) {
+	return client.ClusterListItem{ID: "cluster-1", Name: name, Kind: "hetzner"}, nil
+}
+
+func (m *powerScheduleMock) listing() *client.PowerScheduleListResult {
+	cronExpression := "0 19 * * 1-5"
+	return &client.PowerScheduleListResult{Schedules: []client.PowerSchedule{
+		{ID: "sched-1", Action: "stop", ScheduleKind: "cron",
+			CronExpression: &cronExpression, Timezone: "Europe/Stockholm", Enabled: true},
+	}}
+}
+
+func (m *powerScheduleMock) ListPowerSchedules(clusterID string) (*client.PowerScheduleListResult, error) {
+	m.lists = append(m.lists, clusterID)
+	return m.listing(), nil
+}
+
+func (m *powerScheduleMock) CreatePowerSchedule(clusterID string, request client.PowerScheduleRequest) (*client.PowerScheduleListResult, error) {
+	m.creates = append(m.creates, powerScheduleCall{ClusterID: clusterID, Request: request})
+	return m.listing(), nil
+}
+
+func (m *powerScheduleMock) UpdatePowerSchedule(clusterID, scheduleID string, request client.PowerScheduleRequest) (*client.PowerScheduleListResult, error) {
+	m.updates = append(m.updates, powerScheduleCall{ClusterID: clusterID, ScheduleID: scheduleID, Request: request})
+	return m.listing(), nil
+}
+
+func (m *powerScheduleMock) DeletePowerSchedule(clusterID, scheduleID string) (*client.DeletePowerScheduleResult, error) {
+	m.deletes = append(m.deletes, powerScheduleCall{ClusterID: clusterID, ScheduleID: scheduleID})
+	return &client.DeletePowerScheduleResult{Deleted: true}, nil
+}
+
+// executePowerScheduleCommand runs args against rootCmd with stdin wired for
+// the delete [y/N] prompt, resetting the family's flag state around the run
+// (rootCmd is a process global).
+func executePowerScheduleCommand(t *testing.T, stdinContent string, args ...string) error {
+	t.Helper()
+	resetPowerScheduleFlags()
+	t.Cleanup(func() {
+		rootCmd.SetIn(nil)
+		resetPowerScheduleFlags()
+	})
+	rootCmd.SetOut(new(strings.Builder))
+	rootCmd.SetErr(new(strings.Builder))
+	rootCmd.SetIn(strings.NewReader(stdinContent))
+	rootCmd.SetArgs(args)
+	return rootCmd.Execute()
+}
+
+func resetPowerScheduleFlags() {
+	reset := func(fs *pflag.FlagSet) {
+		fs.VisitAll(func(f *pflag.Flag) {
+			_ = f.Value.Set(f.DefValue)
+			f.Changed = false
+		})
+	}
+	reset(clusterPowerSchedulesListCmd.Flags())
+	reset(clusterPowerSchedulesCreateCmd.Flags())
+	reset(clusterPowerSchedulesUpdateCmd.Flags())
+	reset(clusterPowerSchedulesDeleteCmd.Flags())
+	reset(clusterCmd.PersistentFlags())
+}
+
+func TestClusterPowerSchedulesList_UsesResolvedCluster(t *testing.T) {
+	mock := &powerScheduleMock{}
+	setMockClient(t, mock)
+
+	if err := executePowerScheduleCommand(t, "", "cluster", "power-schedules", "list",
+		"--cluster", "my-cluster"); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(mock.lists) != 1 || mock.lists[0] != "cluster-1" {
+		t.Fatalf("expected one list call for cluster-1, got %+v", mock.lists)
+	}
+}
+
+func TestClusterPowerSchedulesCreate_CronSendsTimezoneAndEnabled(t *testing.T) {
+	mock := &powerScheduleMock{}
+	setMockClient(t, mock)
+
+	if err := executePowerScheduleCommand(t, "", "cluster", "power-schedules", "create",
+		"--cluster", "my-cluster", "--action", "stop",
+		"--cron", "0 19 * * 1-5", "--timezone", "Europe/Stockholm"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if len(mock.creates) != 1 {
+		t.Fatalf("expected one create call, got %d", len(mock.creates))
+	}
+	request := mock.creates[0].Request
+	if request.Action != "stop" || request.ScheduleKind != "cron" ||
+		request.CronExpression == nil || *request.CronExpression != "0 19 * * 1-5" ||
+		request.Timezone == nil || *request.Timezone != "Europe/Stockholm" ||
+		!request.Enabled || request.RunAt != nil {
+		t.Fatalf("unexpected request: %+v", request)
+	}
+}
+
+func TestClusterPowerSchedulesCreate_CronDefaultsTimezoneUTC(t *testing.T) {
+	mock := &powerScheduleMock{}
+	setMockClient(t, mock)
+
+	if err := executePowerScheduleCommand(t, "", "cluster", "power-schedules", "create",
+		"--cluster", "my-cluster", "--action", "start", "--cron", "0 7 * * 1-5"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	request := mock.creates[0].Request
+	if request.Timezone == nil || *request.Timezone != "UTC" {
+		t.Fatalf("cron schedules must restate an explicit timezone (UTC default), got %+v", request.Timezone)
+	}
+}
+
+func TestClusterPowerSchedulesCreate_RequiresExactlyOneCadence(t *testing.T) {
+	mock := &powerScheduleMock{}
+	setMockClient(t, mock)
+
+	err := executePowerScheduleCommand(t, "", "cluster", "power-schedules", "create",
+		"--cluster", "my-cluster", "--action", "stop")
+	if err == nil || !strings.Contains(err.Error(), "exactly one of --at") {
+		t.Fatalf("expected the cadence requirement, got %v", err)
+	}
+
+	err = executePowerScheduleCommand(t, "", "cluster", "power-schedules", "create",
+		"--cluster", "my-cluster", "--action", "stop",
+		"--at", "2030-01-01T00:00:00Z", "--cron", "0 19 * * 1-5")
+	if err == nil || !strings.Contains(err.Error(), "exactly one of --at") {
+		t.Fatalf("expected the cadence exclusivity refusal, got %v", err)
+	}
+	if len(mock.creates) != 0 {
+		t.Fatalf("invalid flag combinations must not reach the API, got %+v", mock.creates)
+	}
+}
+
+func TestClusterPowerSchedulesCreate_RejectsTimezoneWithAt(t *testing.T) {
+	mock := &powerScheduleMock{}
+	setMockClient(t, mock)
+
+	err := executePowerScheduleCommand(t, "", "cluster", "power-schedules", "create",
+		"--cluster", "my-cluster", "--action", "stop",
+		"--at", "2030-01-01T00:00:00Z", "--timezone", "Europe/Stockholm")
+	if err == nil || !strings.Contains(err.Error(), "--timezone only applies to --cron") {
+		t.Fatalf("expected the timezone/at refusal, got %v", err)
+	}
+}
+
+func TestClusterPowerSchedulesUpdate_SendsPausedFullReplace(t *testing.T) {
+	mock := &powerScheduleMock{}
+	setMockClient(t, mock)
+
+	if err := executePowerScheduleCommand(t, "", "cluster", "power-schedules", "update", "sched-1",
+		"--cluster", "my-cluster", "--action", "stop",
+		"--cron", "0 19 * * 1-5", "--timezone", "Europe/Stockholm", "--enabled=false"); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if len(mock.updates) != 1 {
+		t.Fatalf("expected one update call, got %d", len(mock.updates))
+	}
+	call := mock.updates[0]
+	if call.ScheduleID != "sched-1" || call.ClusterID != "cluster-1" || call.Request.Enabled {
+		t.Fatalf("unexpected update call: %+v", call)
+	}
+}
+
+func TestClusterPowerSchedulesDelete_PromptDeclineSkipsAPI(t *testing.T) {
+	mock := &powerScheduleMock{}
+	setMockClient(t, mock)
+
+	err := executePowerScheduleCommand(t, "n\n", "cluster", "power-schedules", "delete", "sched-1",
+		"--cluster", "my-cluster")
+	if err == nil {
+		t.Fatal("expected the cancelled error when declining the prompt")
+	}
+	if len(mock.deletes) != 0 {
+		t.Fatalf("a declined prompt must not reach the API, got %+v", mock.deletes)
+	}
+}
+
+func TestClusterPowerSchedulesDelete_YesSkipsPrompt(t *testing.T) {
+	mock := &powerScheduleMock{}
+	setMockClient(t, mock)
+
+	if err := executePowerScheduleCommand(t, "", "cluster", "power-schedules", "delete", "sched-1",
+		"--cluster", "my-cluster", "--yes"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if len(mock.deletes) != 1 || mock.deletes[0].ScheduleID != "sched-1" {
+		t.Fatalf("expected one delete call for sched-1, got %+v", mock.deletes)
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -239,6 +239,22 @@ func (m baseMock) UninstallAddon(ctx context.Context, clusterID, addonResourceID
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) ListPowerSchedules(clusterID string) (*client.PowerScheduleListResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) CreatePowerSchedule(clusterID string, request client.PowerScheduleRequest) (*client.PowerScheduleListResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) UpdatePowerSchedule(clusterID, scheduleID string, request client.PowerScheduleRequest) (*client.PowerScheduleListResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) DeletePowerSchedule(clusterID, scheduleID string) (*client.DeletePowerScheduleResult, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) ListExecutions(opts client.ListExecutionsOptions) (client.ExecutionListResponse, error) {
 	return client.ExecutionListResponse{}, errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -37,6 +37,11 @@ type APIClient interface {
 	GetClusterAddonValues(ctx context.Context, clusterID, addonName string) (string, error)
 	UninstallAddon(ctx context.Context, clusterID, addonResourceID string, deletePermanently bool) (*client.UninstallAddonResult, error)
 
+	ListPowerSchedules(clusterID string) (*client.PowerScheduleListResult, error)
+	CreatePowerSchedule(clusterID string, request client.PowerScheduleRequest) (*client.PowerScheduleListResult, error)
+	UpdatePowerSchedule(clusterID, scheduleID string, request client.PowerScheduleRequest) (*client.PowerScheduleListResult, error)
+	DeletePowerSchedule(clusterID, scheduleID string) (*client.DeletePowerScheduleResult, error)
+
 	ListExecutions(opts client.ListExecutionsOptions) (client.ExecutionListResponse, error)
 	GetExecution(executionID string) (client.ExecutionDetail, error)
 	EnrichExecutionDetailWithDrift(detail *client.ExecutionDetail) error

--- a/internal/client/power_schedules.go
+++ b/internal/client/power_schedules.go
@@ -1,0 +1,104 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+	neturl "net/url"
+)
+
+// PowerSchedule is one scheduled stop/start entry on a cluster, as returned
+// by the power-schedule routes. A "once" schedule fires a single time at
+// RunAt; a "cron" schedule fires repeatedly per CronExpression evaluated in
+// Timezone. NextRunAt is the armed next fire (nil while disabled), and the
+// LastRun fields report the most recent outcome (completed, skipped,
+// deferred, or failed, with detail).
+type PowerSchedule struct {
+	ID             string  `json:"id"`
+	Action         string  `json:"action"`
+	ScheduleKind   string  `json:"schedule_kind"`
+	RunAt          *string `json:"run_at"`
+	CronExpression *string `json:"cron_expression"`
+	Timezone       string  `json:"timezone"`
+	Enabled        bool    `json:"enabled"`
+	NextRunAt      *string `json:"next_run_at"`
+	LastRunAt      *string `json:"last_run_at"`
+	LastRunStatus  *string `json:"last_run_status"`
+	LastRunDetail  *string `json:"last_run_detail"`
+	CreatedAt      string  `json:"created_at"`
+	UpdatedAt      string  `json:"updated_at"`
+}
+
+// PowerScheduleListResult wraps the cluster's schedule listing. Create and
+// update answer the same refreshed listing, so callers always render the
+// full post-write state.
+type PowerScheduleListResult struct {
+	Schedules []PowerSchedule `json:"schedules"`
+}
+
+// PowerScheduleRequest is the shared create/update body. Exactly one of
+// RunAt (schedule kind "once") or CronExpression (+ Timezone, schedule kind
+// "cron") applies. Updates are full replaces on the backend: Enabled must
+// always be sent, and Timezone must be restated for "cron" schedules.
+type PowerScheduleRequest struct {
+	Action         string  `json:"action"`
+	ScheduleKind   string  `json:"schedule_kind"`
+	RunAt          *string `json:"run_at,omitempty"`
+	CronExpression *string `json:"cron_expression,omitempty"`
+	Timezone       *string `json:"timezone,omitempty"`
+	Enabled        bool    `json:"enabled"`
+}
+
+// DeletePowerScheduleResult reports a schedule deletion.
+type DeletePowerScheduleResult struct {
+	Deleted bool `json:"deleted"`
+}
+
+// ListPowerSchedules returns the cluster's power schedules, newest first.
+// GET /api/v1/org/clusters/imported/{cluster_id}/power-schedules
+func (c *Client) ListPowerSchedules(clusterID string) (*PowerScheduleListResult, error) {
+	url := fmt.Sprintf("%s/api/v1/org/clusters/imported/%s/power-schedules",
+		c.BaseURL, neturl.PathEscape(clusterID))
+	var result PowerScheduleListResult
+	if err := c.getJSON(url, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// CreatePowerSchedule creates one schedule and returns the cluster's
+// refreshed schedule listing.
+// POST /api/v1/org/clusters/imported/{cluster_id}/power-schedules
+func (c *Client) CreatePowerSchedule(clusterID string, request PowerScheduleRequest) (*PowerScheduleListResult, error) {
+	url := fmt.Sprintf("%s/api/v1/org/clusters/imported/%s/power-schedules",
+		c.BaseURL, neturl.PathEscape(clusterID))
+	var result PowerScheduleListResult
+	if err := c.sendJSON(http.MethodPost, url, request, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// UpdatePowerSchedule replaces a schedule's action, timing, and enabled
+// flag (a full replace, not a patch) and returns the refreshed listing.
+// PUT /api/v1/org/clusters/imported/{cluster_id}/power-schedules/{schedule_id}
+func (c *Client) UpdatePowerSchedule(clusterID, scheduleID string, request PowerScheduleRequest) (*PowerScheduleListResult, error) {
+	url := fmt.Sprintf("%s/api/v1/org/clusters/imported/%s/power-schedules/%s",
+		c.BaseURL, neturl.PathEscape(clusterID), neturl.PathEscape(scheduleID))
+	var result PowerScheduleListResult
+	if err := c.sendJSON(http.MethodPut, url, request, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeletePowerSchedule soft-deletes one schedule.
+// DELETE /api/v1/org/clusters/imported/{cluster_id}/power-schedules/{schedule_id}
+func (c *Client) DeletePowerSchedule(clusterID, scheduleID string) (*DeletePowerScheduleResult, error) {
+	url := fmt.Sprintf("%s/api/v1/org/clusters/imported/%s/power-schedules/%s",
+		c.BaseURL, neturl.PathEscape(clusterID), neturl.PathEscape(scheduleID))
+	var result DeletePowerScheduleResult
+	if err := c.sendJSON(http.MethodDelete, url, nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/internal/client/power_schedules_test.go
+++ b/internal/client/power_schedules_test.go
@@ -1,0 +1,142 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestListPowerSchedules_Success(t *testing.T) {
+	nextRun := "2026-01-05T19:00:00Z"
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/org/clusters/imported/cluster-123/power-schedules" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		jsonResponse(t, w, http.StatusOK, PowerScheduleListResult{Schedules: []PowerSchedule{
+			{ID: "sched-1", Action: "stop", ScheduleKind: "cron", Timezone: "Europe/Stockholm",
+				Enabled: true, NextRunAt: &nextRun},
+		}})
+	}
+	testClient := newTestClient(t, handler)
+	result, err := testClient.ListPowerSchedules("cluster-123")
+	if err != nil {
+		t.Fatalf("ListPowerSchedules: %v", err)
+	}
+	if len(result.Schedules) != 1 || result.Schedules[0].ID != "sched-1" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if result.Schedules[0].NextRunAt == nil || *result.Schedules[0].NextRunAt != nextRun {
+		t.Errorf("NextRunAt = %v, want %s", result.Schedules[0].NextRunAt, nextRun)
+	}
+}
+
+func TestCreatePowerSchedule_SendsBodyAndDecodesListing(t *testing.T) {
+	cronExpression := "0 19 * * 1-5"
+	timezone := "Europe/Stockholm"
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/org/clusters/imported/cluster-123/power-schedules" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decoding body: %v", err)
+		}
+		if body["action"] != "stop" || body["schedule_kind"] != "cron" ||
+			body["cron_expression"] != cronExpression || body["timezone"] != timezone ||
+			body["enabled"] != true {
+			t.Errorf("unexpected body: %+v", body)
+		}
+		if _, hasRunAt := body["run_at"]; hasRunAt {
+			t.Errorf("run_at must be omitted for cron schedules, body: %+v", body)
+		}
+		jsonResponse(t, w, http.StatusOK, PowerScheduleListResult{Schedules: []PowerSchedule{
+			{ID: "sched-new", Action: "stop", ScheduleKind: "cron"},
+		}})
+	}
+	testClient := newTestClient(t, handler)
+	result, err := testClient.CreatePowerSchedule("cluster-123", PowerScheduleRequest{
+		Action: "stop", ScheduleKind: "cron",
+		CronExpression: &cronExpression, Timezone: &timezone, Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("CreatePowerSchedule: %v", err)
+	}
+	if len(result.Schedules) != 1 || result.Schedules[0].ID != "sched-new" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestUpdatePowerSchedule_PutsFullReplace(t *testing.T) {
+	runAt := "2026-02-01T07:00:00Z"
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("method = %s, want PUT", r.Method)
+		}
+		if r.URL.Path != "/api/v1/org/clusters/imported/cluster-123/power-schedules/sched-1" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decoding body: %v", err)
+		}
+		// enabled is not omitempty: a paused (false) update must still
+		// serialize, because the backend refuses a body without it.
+		if body["enabled"] != false || body["run_at"] != runAt {
+			t.Errorf("unexpected body: %+v", body)
+		}
+		jsonResponse(t, w, http.StatusOK, PowerScheduleListResult{Schedules: []PowerSchedule{
+			{ID: "sched-1", Action: "start", ScheduleKind: "once", Enabled: false},
+		}})
+	}
+	testClient := newTestClient(t, handler)
+	result, err := testClient.UpdatePowerSchedule("cluster-123", "sched-1", PowerScheduleRequest{
+		Action: "start", ScheduleKind: "once", RunAt: &runAt, Enabled: false,
+	})
+	if err != nil {
+		t.Fatalf("UpdatePowerSchedule: %v", err)
+	}
+	if len(result.Schedules) != 1 || result.Schedules[0].Enabled {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestDeletePowerSchedule_Success(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("method = %s, want DELETE", r.Method)
+		}
+		if r.URL.Path != "/api/v1/org/clusters/imported/cluster-123/power-schedules/sched-1" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		jsonResponse(t, w, http.StatusOK, DeletePowerScheduleResult{Deleted: true})
+	}
+	testClient := newTestClient(t, handler)
+	result, err := testClient.DeletePowerSchedule("cluster-123", "sched-1")
+	if err != nil {
+		t.Fatalf("DeletePowerSchedule: %v", err)
+	}
+	if !result.Deleted {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestPowerSchedules_BackendDetailSurfaces(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(t, w, http.StatusConflict, map[string]string{
+			"detail": "At most 20 power schedules are allowed per cluster"})
+	}
+	testClient := newTestClient(t, handler)
+	_, err := testClient.CreatePowerSchedule("cluster-123", PowerScheduleRequest{
+		Action: "stop", ScheduleKind: "once", Enabled: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "At most 20 power schedules") {
+		t.Fatalf("expected the backend detail to surface, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the CLI slice of **ankra-a0f1** (power schedules follow-ups): first-class commands for the shipped cluster power-schedule feature (cluster#802 API + scheduler loop, portal#1070 UI).

```
ankra cluster power-schedules list
ankra cluster power-schedules create --action stop --cron '0 19 * * 1-5' --timezone Europe/Stockholm
ankra cluster power-schedules create --action stop --at 2026-01-02T19:00:00Z
ankra cluster power-schedules update <schedule_id> --action stop --cron '0 19 * * 1-5' --timezone Europe/Stockholm --enabled=false
ankra cluster power-schedules delete <schedule_id> [--yes]
```

## Changes

- `internal/client/power_schedules.go`: client over `GET/POST /api/v1/org/clusters/imported/{cluster_id}/power-schedules` and `PUT/DELETE .../power-schedules/{schedule_id}`. Create/update decode the backend's refreshed full listing; delete decodes `{"deleted": true}`.
- `cmd/cluster_power_schedule.go`: the `power-schedules` family on the active cluster (`--cluster` override inherited from `clusterCmd`), with the shared `-o json|yaml` structured output. Flag cross-validation happens client-side (exactly one of `--at`/`--cron`; `--timezone` only with `--cron`); the backend stays the authority on value validation (future `run_at`, parseable cron, IANA timezone) and on which cluster kinds support schedules. Two backend contract details are encoded deliberately: cron requests always send an explicit timezone (`UTC` when omitted, matching the create-time default) and every request sends `enabled`, because updates are full replaces that refuse an omitted `enabled`/`timezone` rather than silently re-arming or shifting to UTC. Delete uses the shared `[y/N]` prompt with `--yes` to skip.
- `cmd/services.go` + `cmd/e2e_test.go`: the four methods on the `APIClient` interface and the `baseMock` stubs.
- Tests: httptest client coverage (paths, methods, body shape incl. `enabled: false` serialization, backend detail surfacing) and command coverage through `rootCmd` (cluster resolution, request mapping, cadence-flag refusals, prompt decline vs `--yes`).

No client-side kind gate: unlike `cluster scale` (which must pick provider-specific endpoints), this endpoint is kind-agnostic, so unsupported kinds surface the backend's own 409 detail.

## Validation

- `go build ./...`: pass
- `go test ./internal/client/... ./cmd/...`: pass
- `gofmt -l` clean on all added files

Bead: ankra-a0f1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
