### PR TITLE
Keep the addon configuration block through an upgrade (ankra-u8ho)

### DIFF
--- a/cmd/cluster_addon.go
+++ b/cmd/cluster_addon.go
@@ -498,8 +498,12 @@ func runAddonsUpgrade(cmd *cobra.Command, args []string) error {
 	}
 
 	mutatedAddon := applyAddonMutations(*addon, flags, newValuesB64)
-	if mutatedAddon.Configuration != nil && len(encryptedPaths) > 0 {
-		mutatedAddon.Configuration.EncryptedPaths = encryptedPaths
+	// Replacing the values inlines them, so the GitOps pointer they came
+	// from goes away: say so rather than letting it vanish from the diff
+	// unremarked. A non-values change keeps the pointer (ankra-u8ho).
+	if newValuesB64 != nil && addon.Configuration != nil && addon.Configuration.FromFile != "" {
+		notices = append(notices, fmt.Sprintf(
+			"values are sent inline, replacing the configuration.from_file reference %q", addon.Configuration.FromFile))
 	}
 	if flags.HasParentEdit() {
 		parents, pErr := mergeParents(addon.Parents, flags.AddParents, flags.RemoveParents, flags.SetParents)

--- a/cmd/cluster_partial.go
+++ b/cmd/cluster_partial.go
@@ -544,12 +544,35 @@ func applyAddonMutations(orig client.AddonSpec, flags addonsUpgradeFlags, newVal
 	if flags.RegistryCredentialName != "" {
 		out.RegistryCredentialName = flags.RegistryCredentialName
 	}
+	// The configuration block is carried over, not rebuilt: it holds the
+	// GitOps values reference (from_file) and the encrypted_paths list, and
+	// dropping either would re-deploy the addon with default/empty values
+	// or with its SOPS paths unmarked (ankra-u8ho). A values replacement
+	// overwrites only values_base64 - and clears from_file, because the new
+	// values are inline and a stale pointer would contradict them.
+	out.Configuration = copyAddonConfiguration(orig.Configuration)
 	if newValuesB64 != nil {
-		out.Configuration = &client.AddonConfigurationSpec{
-			ValuesBase64: *newValuesB64,
+		if out.Configuration == nil {
+			out.Configuration = &client.AddonConfigurationSpec{}
 		}
+		out.Configuration.ValuesBase64 = *newValuesB64
+		out.Configuration.FromFile = ""
 	}
 	return out
+}
+
+// copyAddonConfiguration deep-copies the configuration block so a mutation
+// on the patch can never write through to the parsed IaC document the
+// dry-run preview renders as "before".
+func copyAddonConfiguration(original *client.AddonConfigurationSpec) *client.AddonConfigurationSpec {
+	if original == nil {
+		return nil
+	}
+	copied := *original
+	if original.EncryptedPaths != nil {
+		copied.EncryptedPaths = append([]string(nil), original.EncryptedPaths...)
+	}
+	return &copied
 }
 
 // manifestsUpgradeFlags is the parsed view of the flag set for

--- a/cmd/cluster_partial_test.go
+++ b/cmd/cluster_partial_test.go
@@ -567,3 +567,59 @@ func TestReadSource_StdinSentinel(t *testing.T) {
 		t.Error("expected error when no source provided")
 	}
 }
+
+// TestApplyAddonMutations_CarriesConfigurationBlock is the ankra-u8ho
+// repro: a same-version chart bump on an addon whose values live in the
+// GitOps repo used to propose a spec with no configuration block at all,
+// so applying it would re-deploy the addon with its values reference
+// stripped — default/empty values on a production logging stack.
+func TestApplyAddonMutations_CarriesConfigurationBlock(t *testing.T) {
+	orig := client.AddonSpec{
+		Name:         "fluent-bit",
+		ChartName:    "fluent-bit",
+		ChartVersion: "1.0.3",
+		Namespace:    "opensearch",
+		Configuration: &client.AddonConfigurationSpec{
+			FromFile:       "stacks/opensearch/add-ons/fluent-bit/values.yaml",
+			EncryptedPaths: []string{"secrets.password"},
+		},
+	}
+
+	out := applyAddonMutations(orig, addonsUpgradeFlags{ChartVersion: "1.0.3"}, nil)
+	if out.Configuration == nil {
+		t.Fatal("configuration block was dropped: applying this would wipe the addon's values reference")
+	}
+	if out.Configuration.FromFile != orig.Configuration.FromFile {
+		t.Errorf("from_file = %q, want %q", out.Configuration.FromFile, orig.Configuration.FromFile)
+	}
+	if len(out.Configuration.EncryptedPaths) != 1 || out.Configuration.EncryptedPaths[0] != "secrets.password" {
+		t.Errorf("encrypted_paths = %v, want the original list", out.Configuration.EncryptedPaths)
+	}
+
+	// A registry-only change keeps it too.
+	registryOut := applyAddonMutations(orig, addonsUpgradeFlags{RegistryName: "regB"}, nil)
+	if registryOut.Configuration == nil || registryOut.Configuration.FromFile != orig.Configuration.FromFile {
+		t.Errorf("registry-only change must keep the values reference, got %+v", registryOut.Configuration)
+	}
+
+	// Replacing the values inlines them, so the pointer is deliberately
+	// dropped (it would contradict the inline document) while the SOPS
+	// paths survive.
+	newB64 := "aGVsbG8="
+	replaced := applyAddonMutations(orig, addonsUpgradeFlags{}, &newB64)
+	if replaced.Configuration == nil || replaced.Configuration.ValuesBase64 != newB64 {
+		t.Fatalf("values replacement did not land: %+v", replaced.Configuration)
+	}
+	if replaced.Configuration.FromFile != "" {
+		t.Errorf("from_file = %q, want it cleared when values are sent inline", replaced.Configuration.FromFile)
+	}
+	if len(replaced.Configuration.EncryptedPaths) != 1 {
+		t.Errorf("encrypted_paths must survive a values replacement, got %v", replaced.Configuration.EncryptedPaths)
+	}
+
+	// The mutation never writes through to the parsed IaC document the
+	// dry-run renders as "before".
+	if orig.Configuration.FromFile == "" || len(orig.Configuration.EncryptedPaths) != 1 {
+		t.Errorf("the original spec was mutated: %+v", orig.Configuration)
+	}
+}


### PR DESCRIPTION
Fixes **ankra-u8ho**.

## The bug

Repro from the bead:

```
ankra cluster addons upgrade fluent-bit --chart-version 1.0.3 \
  --cluster ankra-infrastructure --dry-run
```

The **Before** spec carries `configuration: { from_file: stacks/opensearch/add-ons/fluent-bit/values.yaml }`. The proposed **After** spec omits the configuration block entirely. Applying it would re-deploy the addon with its GitOps values reference stripped — i.e. default/empty values on a production logging stack.

`applyAddonMutations` rebuilt the spec field by field and only attached a `Configuration` when new values were supplied — and even then it constructed a *fresh* `AddonConfigurationSpec` carrying only `values_base64`, so `from_file` and `encrypted_paths` were lost on that path too. Parents and the AGENTS.md fields were carried through explicitly, which is exactly what made the gap easy to miss in the diff.

## The fix

- The configuration block is carried over, deep-copied so a mutation on the patch can never write through to the parsed IaC document the dry-run renders as "before".
- A values replacement (`--values-from-file` / `--values -` / `--set*`) still overwrites `values_base64` and clears `from_file` — the values are inline now, and a stale pointer would contradict them — but it emits a dry-run notice naming the reference it replaces, instead of letting it vanish unremarked. This matches what `manifests upgrade` already does with its `from_file`.
- `encrypted_paths` survive either way, which makes the manual re-application in `runAddonsUpgrade` unnecessary; it's removed rather than left as a no-op.

## Verification

`go build`, `go vet`, and the full `go test ./...` suite green (pre-commit hook ran clean on push).

New regression test walks the exact repro: a same-version chart bump keeps `from_file` and `encrypted_paths`; a registry-only change keeps them; a values replacement lands the new values, clears `from_file`, and keeps `encrypted_paths`; and the original spec is never mutated.

## Not addressed here (noted in the bead)

The CLI still has no plain retry/re-apply verb — the only re-trigger is a mutating upgrade, which is how this was found — and `ankra cluster helm` still exposes only releases/uninstall with no rollback despite the agent having `rollback_helm_release`. Both are separate features rather than part of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
