### PR TITLE
Add `ankra cluster playground` (ankra-yqop)

### DIFF
--- a/cmd/cluster_playground.go
+++ b/cmd/cluster_playground.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var clusterPlaygroundCmd = &cobra.Command{
+	Use:   "playground",
+	Short: "Create and inspect your organisation's playground",
+	Long: "The playground is a real, writable Kubernetes environment Ankra provisions for you - " +
+		"a virtual cluster on Ankra's own infrastructure, with the agent already installed. " +
+		"Every organisation may hold one; it expires after a period of inactivity.",
+}
+
+var clusterPlaygroundCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create your organisation's playground",
+	Long: "Create the organisation's playground. Provisioning runs in the background: poll " +
+		"`ankra cluster playground status <cluster_id>` until the phase reaches ready.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		result, err := apiClient.CreatePlayground()
+		if err != nil {
+			return fmt.Errorf("creating the playground: %w", err)
+		}
+		fmt.Printf("Playground created.\n")
+		fmt.Printf("  Cluster ID: %s\n", result.ClusterID)
+		fmt.Printf("\nProvisioning takes a couple of minutes. Follow it with:\n")
+		fmt.Printf("  ankra cluster playground status %s\n", result.ClusterID)
+		return nil
+	},
+}
+
+var clusterPlaygroundStatusCmd = &cobra.Command{
+	Use:   "status <cluster_id>",
+	Short: "Show the provisioning phase of a playground",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		status, err := apiClient.GetPlaygroundStatus(args[0])
+		if err != nil {
+			return fmt.Errorf("reading the playground status: %w", err)
+		}
+		fmt.Printf("Cluster ID: %s\n", status.ClusterID)
+		fmt.Printf("Phase:      %s\n", status.Phase)
+		fmt.Printf("Expires at: %s\n", status.ExpiresAt)
+		if status.StatusMessage != nil && *status.StatusMessage != "" {
+			fmt.Printf("Message:    %s\n", *status.StatusMessage)
+		}
+		return nil
+	},
+}
+
+func init() {
+	clusterPlaygroundCmd.AddCommand(clusterPlaygroundCreateCmd)
+	clusterPlaygroundCmd.AddCommand(clusterPlaygroundStatusCmd)
+	clusterCmd.AddCommand(clusterPlaygroundCmd)
+}

--- a/cmd/cluster_playground_test.go
+++ b/cmd/cluster_playground_test.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type playgroundMock struct {
+	baseMock
+
+	createResult    *client.CreatePlaygroundResult
+	createError     error
+	status          *client.PlaygroundStatus
+	statusError     error
+	statusRequested string
+}
+
+func (m *playgroundMock) CreatePlayground() (*client.CreatePlaygroundResult, error) {
+	return m.createResult, m.createError
+}
+
+func (m *playgroundMock) GetPlaygroundStatus(clusterID string) (*client.PlaygroundStatus, error) {
+	m.statusRequested = clusterID
+	return m.status, m.statusError
+}
+
+func withPlaygroundMock(t *testing.T, mock *playgroundMock) {
+	t.Helper()
+	previous := apiClient
+	apiClient = mock
+	t.Cleanup(func() { apiClient = previous })
+}
+
+func TestPlaygroundCreatePrintsTheClusterIDAndTheFollowUpCommand(t *testing.T) {
+	withPlaygroundMock(t, &playgroundMock{
+		createResult: &client.CreatePlaygroundResult{ClusterID: "cluster-42", Success: true},
+	})
+	output := captureStdout(t, func() {
+		if err := clusterPlaygroundCreateCmd.RunE(clusterPlaygroundCreateCmd, nil); err != nil {
+			t.Fatalf("create failed: %v", err)
+		}
+	})
+	if !strings.Contains(output, "cluster-42") {
+		t.Errorf("expected the cluster id in the output, got: %s", output)
+	}
+	// Provisioning is asynchronous, so the command has to tell the user how
+	// to follow it rather than implying the playground is ready.
+	if !strings.Contains(output, "ankra cluster playground status cluster-42") {
+		t.Errorf("expected the follow-up command in the output, got: %s", output)
+	}
+}
+
+func TestPlaygroundCreateSurfacesTheServerError(t *testing.T) {
+	withPlaygroundMock(t, &playgroundMock{createError: errors.New("A playground already exists for this organisation.")})
+	runError := clusterPlaygroundCreateCmd.RunE(clusterPlaygroundCreateCmd, nil)
+	if runError == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(runError.Error(), "already exists") {
+		t.Errorf("expected the server detail to survive, got: %v", runError)
+	}
+}
+
+func TestPlaygroundStatusPrintsThePhaseAndMessage(t *testing.T) {
+	message := "waiting for the agent"
+	mock := &playgroundMock{status: &client.PlaygroundStatus{
+		ClusterID:     "cluster-42",
+		Phase:         "provisioning",
+		StatusMessage: &message,
+		ExpiresAt:     "2026-08-14T09:00:00Z",
+	}}
+	withPlaygroundMock(t, mock)
+	output := captureStdout(t, func() {
+		if err := clusterPlaygroundStatusCmd.RunE(clusterPlaygroundStatusCmd, []string{"cluster-42"}); err != nil {
+			t.Fatalf("status failed: %v", err)
+		}
+	})
+	if mock.statusRequested != "cluster-42" {
+		t.Errorf("expected the cluster id to be passed through, got %q", mock.statusRequested)
+	}
+	for _, expected := range []string{"provisioning", "2026-08-14T09:00:00Z", "waiting for the agent"} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("expected %q in the output, got: %s", expected, output)
+		}
+	}
+}
+
+// An absent status_message must not print an empty Message line.
+func TestPlaygroundStatusOmitsAnAbsentMessage(t *testing.T) {
+	withPlaygroundMock(t, &playgroundMock{status: &client.PlaygroundStatus{
+		ClusterID: "cluster-42",
+		Phase:     "ready",
+		ExpiresAt: "2026-08-14T09:00:00Z",
+	}})
+	output := captureStdout(t, func() {
+		if err := clusterPlaygroundStatusCmd.RunE(clusterPlaygroundStatusCmd, []string{"cluster-42"}); err != nil {
+			t.Fatalf("status failed: %v", err)
+		}
+	})
+	if strings.Contains(output, "Message:") {
+		t.Errorf("expected no Message line, got: %s", output)
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -931,6 +931,14 @@ func (m baseMock) ListKubeadmVersions() (*client.ListVersionsResult, error) {
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) CreatePlayground() (*client.CreatePlaygroundResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetPlaygroundStatus(string) (*client.PlaygroundStatus, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) ListOvhNodeGroups(clusterID string) (*client.NodeGroupListResult, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -258,6 +258,8 @@ type APIClient interface {
 	ListHetznerServerTypes(credentialID, location string) ([]client.HetznerServerType, error)
 	ListK3sVersions() (*client.ListVersionsResult, error)
 	ListKubeadmVersions() (*client.ListVersionsResult, error)
+	CreatePlayground() (*client.CreatePlaygroundResult, error)
+	GetPlaygroundStatus(clusterID string) (*client.PlaygroundStatus, error)
 	ListOvhNodeGroups(clusterID string) (*client.NodeGroupListResult, error)
 	AddOvhNodeGroup(ctx context.Context, clusterID string, req client.AddNodeGroupRequest, wait bool) (*client.AddNodeGroupResult, bool, error)
 	ScaleOvhNodeGroup(ctx context.Context, clusterID, groupName string, count int, wait bool) (*client.ScaleNodeGroupResult, bool, error)

--- a/internal/client/playground.go
+++ b/internal/client/playground.go
@@ -1,0 +1,47 @@
+package client
+
+// Playground: a real, writable vcluster Ankra provisions for the
+// organisation on its shared playground host. Every organisation may hold
+// one.
+
+import (
+	"fmt"
+	neturl "net/url"
+)
+
+// CreatePlaygroundResult is the POST body.
+type CreatePlaygroundResult struct {
+	ClusterID string `json:"cluster_id"`
+	Success   bool   `json:"success"`
+}
+
+// PlaygroundStatus is the provisioning state machine's public shape.
+type PlaygroundStatus struct {
+	ClusterID     string  `json:"cluster_id"`
+	Phase         string  `json:"phase"`
+	StatusMessage *string `json:"status_message"`
+	ExpiresAt     string  `json:"expires_at"`
+}
+
+// CreatePlayground provisions the organisation's playground. A 409 means one
+// already exists; a 503 means the shared host is at capacity. Both surface as
+// the server's detail text through the shared unexpected-response error.
+func (c *Client) CreatePlayground() (*CreatePlaygroundResult, error) {
+	url := fmt.Sprintf("%s/api/v1/org/clusters/playground", c.BaseURL)
+	var result CreatePlaygroundResult
+	if err := c.postCSRFJSON(url, nil, &result, "create playground"); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetPlaygroundStatus reads the provisioning phase.
+func (c *Client) GetPlaygroundStatus(clusterID string) (*PlaygroundStatus, error) {
+	url := fmt.Sprintf("%s/api/v1/org/clusters/playground/%s/status",
+		c.BaseURL, neturl.PathEscape(clusterID))
+	var status PlaygroundStatus
+	if err := c.getJSON(url, &status); err != nil {
+		return nil, err
+	}
+	return &status, nil
+}


### PR DESCRIPTION
## Why

Third entry point for the playground lane, alongside the portal's create-cluster dialog and onboarding. Pairs with [cluster#1003](https://github.com/ankraio/cluster/pull/1003), which adds the `/api/v1` bearer-PAT twins this drives.

## What

```
ankra cluster playground create
ankra cluster playground status <cluster_id>
```

Provisioning is asynchronous, so `create` prints the follow-up status command rather than implying the playground is ready when it returns.

No change was needed to the upgrade and scale guards: both switch on a whitelist of cloud kinds, so `playground` already falls through to unsupported.

## Verification

`make build test lint` ✅ (golangci-lint: 0 issues). Tests cover the created / server-error / status-with-message / status-without-message paths. The CLI reference docs regenerate from `cmd/` on release tags, so no docs edit here.