### PR TITLE
fix(cluster): stop apply implying it waited for the deploys (ankra-6j2w)

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -26,6 +26,18 @@ func init() {
 	clusterApplyCmd.Flags().StringP("file", "f", "", "Path to the ImportCluster YAML file to apply")
 	clusterApplyCmd.Flags().Bool("dry-run", false, "Validate the ImportCluster YAML locally without calling the API")
 	registerAsyncWriteFlags(clusterApplyCmd)
+	// The shared wording ("wait for the operation to finish") is true of the
+	// node-group and bastion writes, but on apply it promises more than it
+	// delivers: the server commits the configuration, pushes to Git and
+	// returns, and the reconciler dispatches the add-on deploys afterwards.
+	// A reporter read the old text as a rollout gate and took a clean exit 0
+	// as proof the deploy had succeeded while three add-ons crash-looped
+	// (ankra-6j2w / PLA-748, from Ankra #1059).
+	if waitFlag := clusterApplyCmd.Flags().Lookup("wait"); waitFlag != nil {
+		waitFlag.Usage = "Wait for the configuration write to be applied and report its result. " +
+			"Add-on deploys are dispatched afterwards and are NOT covered by this flag - " +
+			"watch them with 'ankra cluster operations list'"
+	}
 	registerStructuredOutputFlags(clusterApplyCmd)
 	setDryRunOffline(clusterApplyCmd)
 	_ = clusterApplyCmd.MarkFlagRequired("file")
@@ -104,7 +116,9 @@ func runApply(cmd *cobra.Command, _ []string) error {
 	}
 
 	if importResponse.ImportCommand == "" {
-		fmt.Printf("Cluster '%s' has been updated!\n\n", importResponse.Name)
+		fmt.Printf("Cluster '%s' configuration applied.\n\n", importResponse.Name)
+		fmt.Println("Add-on and manifest deploys run in the background from here.")
+		fmt.Println("Track them with 'ankra cluster operations list' before treating this as deployed.")
 	} else {
 		fmt.Printf("Cluster '%s' imported!\n\n", importResponse.Name)
 		fmt.Println("To install the Ankra agent, run:")


### PR DESCRIPTION
Bead: ankra-6j2w · Linear: PLA-748 (partial — the honesty half) · from Ankra #1059 (Smartoptics)

## What this fixes

`ankra cluster apply --wait` blocks on the **configuration write** — the server commits the transaction, pushes to Git, and returns — and the reconciler dispatches the add-on deploys *afterwards*. Two strings implied otherwise:

- the flag help, *"Wait for the operation to finish and report success or failure"*, reads as a rollout gate
- the success line, *"Cluster 'X' has been updated!"*, reads as a finished deploy

The reporter took a clean `exit 0` as proof the deploy had succeeded while three add-ons crash-looped. The grading bugs behind that symptom already shipped under PLA-747 (agent#57, cluster#977); this closes the part where the CLI itself misrepresents what it waited for.

## Scope

The shared `--wait` text is **honest** for the node-group and bastion writes that also use `registerAsyncWriteFlags` — those really do wait for the operation. So only apply's copy of the usage string is overridden, rather than changing the shared wording for every command.

apply's `--wait` now reads:

> Wait for the configuration write to be applied and report its result. Add-on deploys are dispatched afterwards and are NOT covered by this flag - watch them with 'ankra cluster operations list'

and the success output becomes:

```
Cluster 'so-development' configuration applied.

Add-on and manifest deploys run in the background from here.
Track them with 'ankra cluster operations list' before treating this as deployed.
```

## Deliberately not in this PR

PLA-748 carries a product decision this PR does not make: **does `--wait` change meaning to block on rollout** — breaking the current contract for every caller and slowing every apply to the rollout duration — **or does a new flag do that** while `--wait` keeps its meaning? Until that is decided, the honest thing is to stop the current flag over-promising, which is what this does.

Also untouched: the pre-deploy config smoke step (the reporter's ask b). It is a cross-repo feature — roughly nine server touchpoints including the `gitopsengine` normalizer twin and the chatpipeline stack-profile twin, a new job name in *both* job tables, and an agent-side handler — and it is scoped in the bead rather than started here.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` all clean. `gofmt` clean on the changed file (`cmd/chat_test.go` and `cmd/digitalocean_cluster.go` are unformatted on `master` already and are left alone).
