### PR TITLE
feat(cluster): --allow-repoint flags for changing a cluster's GitOps source (ankra-po6d)

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -25,6 +25,13 @@ var clusterApplyCmd = &cobra.Command{
 func init() {
 	clusterApplyCmd.Flags().StringP("file", "f", "", "Path to the ImportCluster YAML file to apply")
 	clusterApplyCmd.Flags().Bool("dry-run", false, "Validate the ImportCluster YAML locally without calling the API")
+	// Repointing a cluster's GitOps source removes whatever the new source does
+	// not define. The server refuses it without these, so they are the CLI half
+	// of that gate rather than a local check (ankra-po6d).
+	clusterApplyCmd.Flags().Bool("allow-repoint", false,
+		"Allow this apply to change the cluster's GitOps repository or branch. Resources the new source does not define are pruned")
+	clusterApplyCmd.Flags().Bool("allow-repoint-destroying-data", false,
+		"Additionally allow a repoint on a cluster holding PersistentVolumeClaims, whose data the prune destroys. Requires --allow-repoint")
 	registerAsyncWriteFlags(clusterApplyCmd)
 	// The shared wording ("wait for the operation to finish") is true of the
 	// node-group and bastion writes, but on apply it promises more than it
@@ -61,6 +68,20 @@ func runApply(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("invalid ImportCluster in %q:\n  %w", filePath, err)
 	}
+
+	allowRepoint, err := cmd.Flags().GetBool("allow-repoint")
+	if err != nil {
+		return fmt.Errorf("reading --allow-repoint: %w", err)
+	}
+	allowRepointDestroyingData, err := cmd.Flags().GetBool("allow-repoint-destroying-data")
+	if err != nil {
+		return fmt.Errorf("reading --allow-repoint-destroying-data: %w", err)
+	}
+	if allowRepointDestroyingData && !allowRepoint {
+		return errors.New("--allow-repoint-destroying-data requires --allow-repoint")
+	}
+	importRequest.AllowRepoint = allowRepoint
+	importRequest.AllowRepointDestroyingData = allowRepointDestroyingData
 
 	if err := validateResourceGraph(importRequest); err != nil {
 		return fmt.Errorf("invalid ImportCluster in %q:\n  %w", filePath, err)

--- a/cmd/apply_repoint_test.go
+++ b/cmd/apply_repoint_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeMinimalImportCluster(t *testing.T) string {
+	t.Helper()
+	yamlPath := filepath.Join(t.TempDir(), "cluster.yaml")
+	contents := `kind: ImportCluster
+metadata:
+  name: repoint-guard-cluster
+spec:
+  stacks: []
+`
+	if writeError := os.WriteFile(yamlPath, []byte(contents), 0o644); writeError != nil {
+		t.Fatal(writeError)
+	}
+	return yamlPath
+}
+
+// TestApplyRepointFlagsDefaultToOff pins that an ordinary apply asks for
+// neither acknowledgement. Every apply carries git_repository, so a flag that
+// defaulted on would silently re-enable the destructive path the server guard
+// exists to stop (ankra-po6d).
+func TestApplyRepointFlagsDefaultToOff(t *testing.T) {
+	for _, flagName := range []string{"allow-repoint", "allow-repoint-destroying-data"} {
+		flag := clusterApplyCmd.Flags().Lookup(flagName)
+		if flag == nil {
+			t.Fatalf("--%s is not registered on cluster apply", flagName)
+		}
+		if flag.DefValue != "false" {
+			t.Fatalf("--%s defaults to %q, want false", flagName, flag.DefValue)
+		}
+	}
+}
+
+// TestApplyRepointFlagsExplainThePrune pins that the help text says what the
+// flag permits. "allow-repoint" on its own reads like a permission toggle
+// rather than a delete.
+func TestApplyRepointFlagsExplainThePrune(t *testing.T) {
+	repointUsage := clusterApplyCmd.Flags().Lookup("allow-repoint").Usage
+	if !strings.Contains(repointUsage, "pruned") {
+		t.Fatalf("--allow-repoint usage does not mention pruning: %q", repointUsage)
+	}
+	dataUsage := clusterApplyCmd.Flags().Lookup("allow-repoint-destroying-data").Usage
+	if !strings.Contains(dataUsage, "PersistentVolumeClaims") || !strings.Contains(dataUsage, "--allow-repoint") {
+		t.Fatalf("--allow-repoint-destroying-data usage is incomplete: %q", dataUsage)
+	}
+}
+
+// TestApplyDataFlagRequiresRepointFlag pins the dependency between the two.
+// Accepting the data acknowledgement alone would let a caller believe they had
+// confirmed the repoint when the server had not been told.
+func TestApplyDataFlagRequiresRepointFlag(t *testing.T) {
+	t.Cleanup(func() {
+		_ = clusterApplyCmd.Flags().Set("allow-repoint", "false")
+		_ = clusterApplyCmd.Flags().Set("allow-repoint-destroying-data", "false")
+		_ = clusterApplyCmd.Flags().Set("file", "")
+	})
+	if setError := clusterApplyCmd.Flags().Set("allow-repoint-destroying-data", "true"); setError != nil {
+		t.Fatalf("setting flag: %v", setError)
+	}
+	if setError := clusterApplyCmd.Flags().Set("file", writeMinimalImportCluster(t)); setError != nil {
+		t.Fatalf("setting flag: %v", setError)
+	}
+
+	runError := runApply(clusterApplyCmd, nil)
+	if runError == nil || !strings.Contains(runError.Error(), "requires --allow-repoint") {
+		t.Fatalf("error = %v, want the dependency between the two flags to be reported", runError)
+	}
+}

--- a/internal/client/clusters.go
+++ b/internal/client/clusters.go
@@ -334,6 +334,13 @@ type CreateImportClusterRequest struct {
 	Name        string             `json:"name"`
 	Description string             `json:"description,omitempty"`
 	Spec        CreateResourceSpec `json:"spec"`
+	// AllowRepoint acknowledges that moving the cluster to a different GitOps
+	// repository or branch prunes whatever the new source does not define.
+	// Omitted unless asked for, so an ordinary apply carries neither flag.
+	AllowRepoint bool `json:"allow_repoint,omitempty"`
+	// AllowRepointDestroyingData is the separate acknowledgement the server
+	// requires when the cluster holds PersistentVolumeClaims.
+	AllowRepointDestroyingData bool `json:"allow_repoint_destroying_data,omitempty"`
 }
 
 type ImportResponseErrorItem struct {


### PR DESCRIPTION
Bead: ankra-po6d · CLI half of ankraio/cluster#1026 · from PLA-749 / Ankra #1060

The server now refuses an apply that would change a cluster's GitOps repository or branch unless the caller acknowledges the prune. These are the flags its refusal message tells you to pass.

`--allow-repoint` permits the change.

`--allow-repoint-destroying-data` is the separate acknowledgement the server requires when the cluster holds PersistentVolumeClaims. It is rejected locally without `--allow-repoint`, so a caller cannot walk away believing they confirmed a repoint the server was never told about.

Both default to off and are omitted from the request body entirely unless set, so an ordinary apply carries neither and nothing changes for existing callers.

The help text names the consequence rather than reading as a permission toggle:

> Allow this apply to change the cluster's GitOps repository or branch. Resources the new source does not define are pruned

## Why two flags

Losing a redeployable workload and losing data are different decisions. The reporter's intended repoint would have pruned roughly 180Gi of live PostgreSQL and Typesense volumes; a single confirmation would have covered both cases equally, and the destructive one deserves its own.

## Verification

`cmd/apply_repoint_test.go`: both flags default to off (a flag defaulting on would silently re-enable the path the guard exists to stop); the help text names pruning and the PVC case; and `--allow-repoint-destroying-data` alone is rejected with the dependency spelled out.

`go build`, `go vet`, `go test ./...` all clean.

Note on the diff: `gofmt -w` over `cmd/` and `internal/client/` initially reformatted several files that are unformatted on `master` and unrelated to this change. Those were reverted, so the commit is exactly `cmd/apply.go`, `cmd/apply_repoint_test.go` and `internal/client/clusters.go`.
