### PR TITLE
feat(ovh): --availability-zones, --availability-zone and zone discovery (ankra-0enj)

### DIFF
--- a/cmd/cluster_node_group.go
+++ b/cmd/cluster_node_group.go
@@ -257,11 +257,13 @@ var clusterNodeGroupAddCmd = &cobra.Command{
 		name, _ := cmd.Flags().GetString("name")
 		instanceType, _ := cmd.Flags().GetString("instance-type")
 		count, _ := cmd.Flags().GetInt("count")
+		availabilityZone, _ := cmd.Flags().GetString("availability-zone")
 
 		req := client.AddNodeGroupRequest{
-			Name:         name,
-			InstanceType: instanceType,
-			Count:        count,
+			Name:             name,
+			InstanceType:     instanceType,
+			Count:            count,
+			AvailabilityZone: availabilityZone,
 		}
 
 		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
@@ -655,6 +657,7 @@ func init() {
 	clusterNodeGroupAddCmd.Flags().String("name", "", "Node group name (required)")
 	clusterNodeGroupAddCmd.Flags().String("instance-type", "", "Server type / flavor / plan for nodes (required)")
 	clusterNodeGroupAddCmd.Flags().Int("count", 1, "Number of nodes")
+	clusterNodeGroupAddCmd.Flags().String("availability-zone", "", "Pin every node of the group to one availability zone, on OVH 3-AZ regions (e.g. eu-west-par-b). See `ankra cluster ovh regions --with-zones`. Pin the group when it runs zonal storage: an OVH volume cannot attach from another zone")
 	_ = clusterNodeGroupAddCmd.MarkFlagRequired("name")
 	_ = clusterNodeGroupAddCmd.MarkFlagRequired("instance-type")
 

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -911,7 +911,7 @@ func (m baseMock) UpgradeOvhK8sVersion(clusterID, targetVersion string, force bo
 	return nil, errors.New("not implemented")
 }
 
-func (m baseMock) ListOvhRegions(credentialID string) (*client.OvhRegionListResult, error) {
+func (m baseMock) ListOvhRegions(credentialID string, withDetails bool) (*client.OvhRegionListResult, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/cmd/ovh_cluster.go
+++ b/cmd/ovh_cluster.go
@@ -26,6 +26,7 @@ var ovhCreateCmd = &cobra.Command{
 		credentialID, _ := cmd.Flags().GetString("credential-id")
 		sshKeyCredentialID, _ := cmd.Flags().GetString("ssh-key-credential-id")
 		region, _ := cmd.Flags().GetString("region")
+		availabilityZones, _ := cmd.Flags().GetStringSlice("availability-zones")
 		networkVlanID, _ := cmd.Flags().GetInt("network-vlan-id")
 		subnetCIDR, _ := cmd.Flags().GetString("subnet-cidr")
 		dhcpStart, _ := cmd.Flags().GetString("dhcp-start")
@@ -53,6 +54,7 @@ var ovhCreateCmd = &cobra.Command{
 			CredentialID:          credentialID,
 			SSHKeyCredentialID:    sshKeyCredentialID,
 			Region:                region,
+			AvailabilityZones:     availabilityZones,
 			NetworkVlanID:         networkVlanID,
 			SubnetCIDR:            subnetCIDR,
 			DHCPStart:             dhcpStart,
@@ -268,8 +270,9 @@ var ovhRegionsCmd = &cobra.Command{
 	Long:  "List the OVH Cloud regions the supplied credential's project can deploy in. Only these regions are valid for cluster creation.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		credentialID, _ := cmd.Flags().GetString("credential-id")
+		withZones, _ := cmd.Flags().GetBool("with-zones")
 
-		result, err := apiClient.ListOvhRegions(credentialID)
+		result, err := apiClient.ListOvhRegions(credentialID, withZones)
 		if err != nil {
 			return fmt.Errorf("listing regions: %w", err)
 		}
@@ -283,8 +286,19 @@ var ovhRegionsCmd = &cobra.Command{
 			return nil
 		}
 		fmt.Printf("Regions available to credential %s:\n", credentialID)
-		for _, region := range result.Regions {
-			fmt.Printf("  %s\n", region)
+		if !withZones {
+			for _, region := range result.Regions {
+				fmt.Printf("  %s\n", region)
+			}
+			return nil
+		}
+		for _, detail := range result.RegionDetails {
+			if len(detail.AvailabilityZones) == 0 {
+				fmt.Printf("  %-16s %s\n", detail.Name, detail.Type)
+				continue
+			}
+			fmt.Printf("  %-16s %-14s zones: %s\n",
+				detail.Name, detail.Type, strings.Join(detail.AvailabilityZones, ", "))
 		}
 		return nil
 	},
@@ -633,6 +647,7 @@ var ovhNodeGroupAddCmd = &cobra.Command{
 		count, _ := cmd.Flags().GetInt("count")
 		labelsFlag, _ := cmd.Flags().GetString("labels")
 		taintsFlag, _ := cmd.Flags().GetString("taints")
+		availabilityZone, _ := cmd.Flags().GetString("availability-zone")
 
 		labels, err := parseLabelsFlag(labelsFlag)
 		if err != nil {
@@ -644,11 +659,12 @@ var ovhNodeGroupAddCmd = &cobra.Command{
 		}
 
 		req := client.AddNodeGroupRequest{
-			Name:         name,
-			InstanceType: instanceType,
-			Count:        count,
-			Labels:       labels,
-			Taints:       taints,
+			Name:             name,
+			InstanceType:     instanceType,
+			Count:            count,
+			Labels:           labels,
+			Taints:           taints,
+			AvailabilityZone: availabilityZone,
 		}
 
 		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
@@ -858,6 +874,7 @@ func init() {
 	ovhCreateCmd.Flags().String("credential-id", "", "OVH API credential ID (required)")
 	ovhCreateCmd.Flags().String("ssh-key-credential-id", "", "SSH key credential ID (required)")
 	ovhCreateCmd.Flags().String("region", "", "OVH Cloud region (required)")
+	ovhCreateCmd.Flags().StringSlice("availability-zones", nil, "Availability zones to spread the cluster across, in a 3-AZ region (e.g. eu-west-par-a,eu-west-par-b,eu-west-par-c). See `ankra cluster ovh regions --with-zones`. Omitted leaves placement to OVH, which puts every node in one zone. More than one zone needs --control-plane-count=3 for etcd quorum")
 	ovhCreateCmd.Flags().Int("network-vlan-id", 0, "Network VLAN ID")
 	ovhCreateCmd.Flags().String("subnet-cidr", "10.0.1.0/24", "Subnet CIDR")
 	ovhCreateCmd.Flags().String("dhcp-start", "10.0.1.100", "DHCP range start")
@@ -895,6 +912,7 @@ func init() {
 	ovhNodeGroupAddCmd.Flags().Int("count", 1, "Number of nodes (0-100)")
 	ovhNodeGroupAddCmd.Flags().String("labels", "", "Comma-separated key=value labels to apply to the node group")
 	ovhNodeGroupAddCmd.Flags().String("taints", "", "Comma-separated key=value:Effect taints to apply to the node group")
+	ovhNodeGroupAddCmd.Flags().String("availability-zone", "", "Pin every node of the group to one availability zone, in a 3-AZ region (e.g. eu-west-par-b). See `ankra cluster ovh regions --with-zones`. Pin the group when it runs zonal storage: an OVH volume cannot attach from another zone")
 	_ = ovhNodeGroupAddCmd.MarkFlagRequired("name")
 	registerAsyncWriteFlags(ovhNodeGroupAddCmd)
 	registerAsyncWriteFlags(ovhNodeGroupScaleCmd)
@@ -912,6 +930,7 @@ func init() {
 	ovhNodeGroupDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
 	ovhRegionsCmd.Flags().String("credential-id", "", "OVH API credential ID (required)")
+	ovhRegionsCmd.Flags().Bool("with-zones", false, "Also show each region's type and availability zones. Only region-3-az regions can place instances by zone; the zone names listed here are what --availability-zones and --availability-zone accept")
 	_ = ovhRegionsCmd.MarkFlagRequired("credential-id")
 
 	registerStructuredOutputFlags(

--- a/cmd/ovh_cluster.go
+++ b/cmd/ovh_cluster.go
@@ -286,9 +286,15 @@ var ovhRegionsCmd = &cobra.Command{
 			return nil
 		}
 		fmt.Printf("Regions available to credential %s:\n", credentialID)
-		if !withZones {
+		// An API that predates region details answers the bare list and
+		// ignores the query parameter. Printing the plain names beats
+		// printing nothing at all under a header.
+		if !withZones || len(result.RegionDetails) == 0 {
 			for _, region := range result.Regions {
 				fmt.Printf("  %s\n", region)
+			}
+			if withZones {
+				fmt.Println("\nThis Ankra API does not report region details yet, so no zones are shown.")
 			}
 			return nil
 		}

--- a/cmd/ovh_cluster_test.go
+++ b/cmd/ovh_cluster_test.go
@@ -207,6 +207,22 @@ func setStdin(t *testing.T, input string) {
 // resetOvhNodeGroupFlags clears flag state (notably Changed) that cobra retains
 // between Execute calls on the same command instance, so each test observes a
 // fresh invocation.
+// resetOvhCommandFlags clears flag state that cobra keeps on the command
+// between invocations; without it a slice flag set by one test is still set
+// for the next one.
+func resetOvhCommandFlags(t *testing.T, commands ...*cobra.Command) {
+	t.Helper()
+	for _, command := range commands {
+		command.Flags().VisitAll(func(flag *pflag.Flag) {
+			_ = flag.Value.Set(flag.DefValue)
+			if sliceValue, isSlice := flag.Value.(pflag.SliceValue); isSlice {
+				_ = sliceValue.Replace(nil)
+			}
+			flag.Changed = false
+		})
+	}
+}
+
 func resetOvhNodeGroupFlags(t *testing.T) {
 	t.Helper()
 	for _, command := range []*cobra.Command{
@@ -448,5 +464,131 @@ func TestOvhNodeGroupDelete_YesSkipsPrompt(t *testing.T) {
 	}
 	if !mock.called {
 		t.Error("API must be called when --yes skips the prompt")
+	}
+}
+
+type ovhCreateZonesMock struct {
+	baseMock
+	gotRequest client.CreateOvhClusterRequest
+}
+
+func (m *ovhCreateZonesMock) CreateOvhCluster(req client.CreateOvhClusterRequest) (*client.CreateOvhClusterResponse, error) {
+	m.gotRequest = req
+	return &client.CreateOvhClusterResponse{ClusterID: "ovh-123", Name: req.Name}, nil
+}
+
+// Without the flag reaching the request the cluster is created single-zone and
+// nothing downstream can tell, which is the failure this whole lane exists to
+// prevent.
+func TestOvhCreateSendsTheRequestedAvailabilityZones(t *testing.T) {
+	resetOvhCommandFlags(t, ovhCreateCmd)
+	mock := &ovhCreateZonesMock{}
+	setMockClient(t, mock)
+
+	_, err := executeCommand("cluster", "ovh", "create",
+		"--name", "prod-multi-az",
+		"--credential-id", "credential-1",
+		"--ssh-key-credential-id", "ssh-1",
+		"--region", "EU-WEST-PAR",
+		"--control-plane-count", "3",
+		"--availability-zones", "eu-west-par-a,eu-west-par-b,eu-west-par-c")
+	if err != nil {
+		t.Fatalf("creating the cluster: %v", err)
+	}
+
+	want := []string{"eu-west-par-a", "eu-west-par-b", "eu-west-par-c"}
+	if len(mock.gotRequest.AvailabilityZones) != len(want) {
+		t.Fatalf("availability zones = %v, want %v", mock.gotRequest.AvailabilityZones, want)
+	}
+	for index, zone := range want {
+		if mock.gotRequest.AvailabilityZones[index] != zone {
+			t.Fatalf("availability zones = %v, want %v in order (order decides where the first control plane lands)",
+				mock.gotRequest.AvailabilityZones, want)
+		}
+	}
+}
+
+// An unzoned create must keep sending no zones at all: an empty list would
+// change the stored definition shape of every single-zone cluster.
+func TestOvhCreateOmitsAvailabilityZonesWhenNotAsked(t *testing.T) {
+	resetOvhCommandFlags(t, ovhCreateCmd)
+	mock := &ovhCreateZonesMock{}
+	setMockClient(t, mock)
+
+	_, err := executeCommand("cluster", "ovh", "create",
+		"--name", "single-zone",
+		"--credential-id", "credential-1",
+		"--ssh-key-credential-id", "ssh-1",
+		"--region", "GRA")
+	if err != nil {
+		t.Fatalf("creating the cluster: %v", err)
+	}
+	if len(mock.gotRequest.AvailabilityZones) != 0 {
+		t.Fatalf("availability zones = %v, want none", mock.gotRequest.AvailabilityZones)
+	}
+}
+
+type ovhNodeGroupZoneMock struct {
+	baseMock
+	gotRequest client.AddNodeGroupRequest
+}
+
+func (m *ovhNodeGroupZoneMock) AddOvhNodeGroup(_ context.Context, _ string, req client.AddNodeGroupRequest, _ bool) (*client.AddNodeGroupResult, bool, error) {
+	m.gotRequest = req
+	return &client.AddNodeGroupResult{GroupName: req.Name, Count: req.Count}, false, nil
+}
+
+// Pinning is what a zonal-storage workload needs: an OVH volume cannot attach
+// from another zone, so the group has to stay where its volumes are.
+func TestOvhNodeGroupAddSendsTheAvailabilityZone(t *testing.T) {
+	resetOvhNodeGroupFlags(t)
+	mock := &ovhNodeGroupZoneMock{}
+	setMockClient(t, mock)
+
+	_, err := executeCommand("cluster", "ovh", "node-group", "add", "ovh-123",
+		"--name", "database", "--instance-type", "r3-128", "--count", "1",
+		"--availability-zone", "eu-west-par-c")
+	if err != nil {
+		t.Fatalf("adding the node group: %v", err)
+	}
+	if mock.gotRequest.AvailabilityZone != "eu-west-par-c" {
+		t.Fatalf("availability zone = %q, want eu-west-par-c", mock.gotRequest.AvailabilityZone)
+	}
+}
+
+type ovhRegionsZonesMock struct {
+	baseMock
+	gotWithDetails bool
+}
+
+func (m *ovhRegionsZonesMock) ListOvhRegions(_ string, withDetails bool) (*client.OvhRegionListResult, error) {
+	m.gotWithDetails = withDetails
+	return &client.OvhRegionListResult{
+		Regions: []string{"EU-WEST-PAR", "GRA"},
+		RegionDetails: []client.OvhRegionDetail{
+			{Name: "EU-WEST-PAR", Type: "region-3-az", AvailabilityZones: []string{"eu-west-par-a", "eu-west-par-b", "eu-west-par-c"}},
+			{Name: "GRA", Type: "region"},
+		},
+	}, nil
+}
+
+// The zone names are region-scoped, so this listing is the only place a
+// caller can discover how to spell an --availability-zone.
+func TestOvhRegionsWithZonesListsTheZoneNames(t *testing.T) {
+	resetOvhCommandFlags(t, ovhRegionsCmd)
+	mock := &ovhRegionsZonesMock{}
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		_, _ = executeCommand("cluster", "ovh", "regions", "--credential-id", "credential-1", "--with-zones")
+	})
+
+	if !mock.gotWithDetails {
+		t.Error("--with-zones must ask the API for region details")
+	}
+	for _, wanted := range []string{"EU-WEST-PAR", "region-3-az", "eu-west-par-a", "eu-west-par-c", "GRA"} {
+		if !strings.Contains(output, wanted) {
+			t.Errorf("expected %q in the listing, got: %s", wanted, output)
+		}
 	}
 }

--- a/cmd/ovh_cluster_test.go
+++ b/cmd/ovh_cluster_test.go
@@ -592,3 +592,30 @@ func TestOvhRegionsWithZonesListsTheZoneNames(t *testing.T) {
 		}
 	}
 }
+
+type ovhRegionsNoDetailsMock struct {
+	baseMock
+}
+
+func (m *ovhRegionsNoDetailsMock) ListOvhRegions(_ string, _ bool) (*client.OvhRegionListResult, error) {
+	return &client.OvhRegionListResult{Regions: []string{"EU-WEST-PAR", "GRA"}}, nil
+}
+
+// A CLI newer than the Ankra API it is talking to asks for details and gets
+// the bare list back. Printing the regions without zones beats printing a
+// header with nothing under it.
+func TestOvhRegionsWithZonesFallsBackOnAnOlderAPI(t *testing.T) {
+	resetOvhCommandFlags(t, ovhRegionsCmd)
+	mock := &ovhRegionsNoDetailsMock{}
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		_, _ = executeCommand("cluster", "ovh", "regions", "--credential-id", "credential-1", "--with-zones")
+	})
+
+	for _, wanted := range []string{"EU-WEST-PAR", "GRA", "does not report region details"} {
+		if !strings.Contains(output, wanted) {
+			t.Errorf("expected %q in the listing, got: %s", wanted, output)
+		}
+	}
+}

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -253,7 +253,7 @@ type APIClient interface {
 	ScaleOvhWorkers(clusterID string, workerCount int) (*client.ScaleWorkersResult, error)
 	GetOvhK8sVersion(clusterID string) (*client.K8sVersionInfo, error)
 	UpgradeOvhK8sVersion(clusterID, targetVersion string, force bool) (*client.UpgradeK8sVersionResult, error)
-	ListOvhRegions(credentialID string) (*client.OvhRegionListResult, error)
+	ListOvhRegions(credentialID string, withDetails bool) (*client.OvhRegionListResult, error)
 	ListHetznerLocations(credentialID string) ([]client.HetznerLocation, error)
 	ListHetznerServerTypes(credentialID, location string) ([]client.HetznerServerType, error)
 	ListK3sVersions() (*client.ListVersionsResult, error)

--- a/internal/client/hetzner_clusters.go
+++ b/internal/client/hetzner_clusters.go
@@ -238,6 +238,10 @@ type AddNodeGroupRequest struct {
 	Count        int               `json:"count"`
 	Labels       map[string]string `json:"labels,omitempty"`
 	Taints       []NodeTaint       `json:"taints,omitempty"`
+	// AvailabilityZone pins every node of the group to one zone, on OVH 3-AZ
+	// regions. Omitted spreads the group across the cluster's zone pool when
+	// it has one, and leaves placement to the provider when it does not.
+	AvailabilityZone string `json:"availability_zone,omitempty"`
 }
 
 type AddNodeGroupResult struct {

--- a/internal/client/ovh_clusters.go
+++ b/internal/client/ovh_clusters.go
@@ -11,6 +11,17 @@ import (
 
 type OvhRegionListResult struct {
 	Regions []string `json:"regions"`
+	// RegionDetails is populated only when details were requested.
+	RegionDetails []OvhRegionDetail `json:"region_details,omitempty"`
+}
+
+// OvhRegionDetail carries a region's placement shape. Zone names are
+// region-scoped ("eu-west-par-a"), so listing them is what lets a caller
+// spell an --availability-zone correctly without reading OVH's API docs.
+type OvhRegionDetail struct {
+	Name              string   `json:"name"`
+	Type              string   `json:"type"`
+	AvailabilityZones []string `json:"availability_zones"`
 }
 
 type CreateOvhClusterRequest struct {
@@ -38,6 +49,11 @@ type CreateOvhClusterRequest struct {
 	GitopsCredentialName  *string `json:"gitops_credential_name,omitempty"`
 	GitopsRepository      *string `json:"gitops_repository,omitempty"`
 	GitopsBranch          *string `json:"gitops_branch,omitempty"`
+
+	// AvailabilityZones spreads the cluster across the zones of a 3-AZ
+	// region. Omitted leaves placement to OVH, which puts every instance of
+	// the cluster in one zone.
+	AvailabilityZones []string `json:"availability_zones,omitempty"`
 }
 
 type CreateOvhClusterResponse struct {
@@ -155,8 +171,15 @@ func (c *Client) DeprovisionOvhCluster(clusterID string) (*DeprovisionOvhCluster
 	return &result, nil
 }
 
-func (c *Client) ListOvhRegions(credentialID string) (*OvhRegionListResult, error) {
+// ListOvhRegions lists the regions a credential's project can deploy in.
+// withDetails additionally resolves each region's type and availability
+// zones, which costs one OVH call per region server-side and so stays
+// opt-in.
+func (c *Client) ListOvhRegions(credentialID string, withDetails bool) (*OvhRegionListResult, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/clusters/ovh/regions?credential_id=%s", c.BaseURL, url.QueryEscape(credentialID))
+	if withDetails {
+		endpoint += "&details=true"
+	}
 	var result OvhRegionListResult
 	if err := c.getJSON(endpoint, &result); err != nil {
 		return nil, err

--- a/internal/skills/embedded/skills/ankra-cloud-clusters/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-cloud-clusters/SKILL.md
@@ -39,6 +39,19 @@ ankra cluster ovh create \
 
 Hetzner/UpCloud/DigitalOcean `create` take equivalent flags (`--name`, `--credential-id`, location/region, control-plane and worker sizes/counts, `--ssh-key-credential-id[s]`, optional `--kubernetes-version`). Run `ankra cluster <provider> create --help` for the provider-specific server-type/location flags.
 
+OVH availability zones (3-AZ regions only, currently `EU-WEST-PAR`):
+
+```bash
+ankra cluster ovh regions --credential-id <id> --with-zones     # only region-3-az regions take zones
+ankra cluster ovh create --name prod --region EU-WEST-PAR \
+  --availability-zones eu-west-par-a,eu-west-par-b,eu-west-par-c \
+  --control-plane-count 3                                       # 3 CPs required to spread: etcd quorum
+ankra cluster ovh node-group add <cluster_id> --name db-par-a \
+  --availability-zone eu-west-par-a                              # pin a group to one zone
+```
+
+Zone names are region-scoped, so read them from `--with-zones` rather than guessing. An instance's zone is fixed at creation: workers can be re-placed by adding a pinned group and draining the old one, a control plane cannot. **Node spread alone is not zone fault tolerance** - OVH block storage is zonal and cannot attach across zones, so a stateful workload also needs one replica and one volume per zone.
+
 DigitalOcean discovery before create:
 
 ```bash


### PR DESCRIPTION
Part of ankra-0enj. Pairs with ankraio/cluster#1048 and ankraio/ankra-docs#123.

Availability-zone placement shipped in cluster#1046 on the **REST API only**. There was no CLI flag, so a CLI or Terraform shop could not use it at all - and because zone names are region-scoped (`eu-west-par-a`, not `a`), there was no way to discover how to spell one either.

```bash
ankra cluster ovh regions --credential-id <id> --with-zones
#   EU-WEST-PAR      region-3-az    zones: eu-west-par-a, eu-west-par-b, eu-west-par-c
#   GRA              region

ankra cluster ovh create --name prod --region EU-WEST-PAR \
  --availability-zones eu-west-par-a,eu-west-par-b,eu-west-par-c \
  --control-plane-count 3

ankra cluster ovh node-group add <cluster-id> --name database-par-a \
  --instance-type r3-128 --availability-zone eu-west-par-a
```

`--with-zones` asks the API for region details (`?details=true`, added in cluster#1048), which costs one OVH call per region server-side, so it stays opt-in and the default listing is unchanged.

`--availability-zone` is on both `cluster node-group add` and `cluster ovh node-group add`, since both build an `AddNodeGroupRequest`.

The embedded `ankra-cloud-clusters` skill gains the same three commands plus the two facts that decide whether the result is what the reader wanted: an instance's zone is fixed at creation so a control plane cannot be re-placed, and node spread alone is not zone fault tolerance while the volume is zonal.

## Testing

`go build`, `go vet`, `golangci-lint` and the full `go test ./...` pass. New tests cover the zones reaching the create request, an unzoned create still sending none (an empty list would change the stored definition shape of every single-zone cluster), the node-group pin, and the `--with-zones` listing. They needed a flag-reset helper: cobra keeps flag state on the command between invocations, so a slice flag set by one test was still set for the next.

Only files this PR touches were gofmt'd - a fair number of files on master are not gofmt-clean and reformatting them would bury the diff.

## Note

`ankra-skills/skills/ankra-cloud-clusters/SKILL.md` is a byte-identical copy of the embedded skill, but that checkout is not a git repository locally, so it is not updated here. Worth a follow-up sync if it is maintained upstream.