### PR TITLE
release: cut v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Ankra CLI Changelog
 
+## v0.10.1 — 2026-08-13
+
+### Fixed
+
+- **The OVH availability-zone flags render their type in `--help` again.**
+  Cobra takes the first backquoted text in a flag's usage string as the
+  value placeholder, so the pointer to the discovery command turned into the
+  placeholder itself and `--availability-zones` displayed as
+  `--availability-zones ankra cluster ovh regions --with-zones` instead of
+  `--availability-zones strings`. The flags themselves were never affected.
+
 ## v0.10.0 — 2026-08-13
 
 Promotes v0.10.0-rc1 and rc2, and adds everything since: OVH availability


### PR DESCRIPTION
Patch on v0.10.0 for the flag-help fix in #77.

CHANGELOG only. Verified the release workflow's awk extraction picks up the v0.10.1 section and stops at the v0.10.0 heading. No hyphen in the tag, so it publishes as a full release.