### PR TITLE
feat(application): set an existing application's image registry (ankra-tpwy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Ankra CLI Changelog
 
+## Unreleased
+
+### Added
+
+- **`ankra application registry` points an existing application at a container
+  registry you operate.** An application publishes into the organisation's own
+  Ankra registry project unless it declares otherwise, and that declaration
+  could previously only be made when the application was created — so an
+  organisation whose builds push to their own Harbor had no way to correct an
+  already-onboarded application, and Ankra kept reporting its images as never
+  published. `registry get` shows the effective registry, the host and project
+  it resolves to, and the image repository each component is expected to
+  publish to, so you can compare them against where your builds actually push.
+  `registry set --url oci://<host>/<project> --credential <name>` declares one;
+  `registry clear` returns the application to the organisation's own registry.
+  Setting a registry without `--credential` is allowed but warns, because
+  without a credential Ankra can describe where the images live and neither
+  read nor pull them.
+
 ## v0.10.1 — 2026-08-13
 
 ### Fixed

--- a/cmd/application_registry.go
+++ b/cmd/application_registry.go
@@ -1,0 +1,173 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"ankra/internal/client"
+)
+
+// The application image-registry commands. An application publishes into the
+// organisation's own Ankra registry project by default; one that declares a
+// registry it already operates publishes there instead, and Ankra reads its
+// image tags back with the organisation registry credential the declaration
+// names. Until these commands existed the declaration could only be made at
+// create time, so an already-onboarded application could not be pointed at a
+// customer-operated Harbor at all.
+
+func newApplicationRegistryCommand() *cobra.Command {
+	registryCommand := &cobra.Command{
+		Use:     "registry",
+		Aliases: []string{"image-registry"},
+		Short:   "Inspect and set the container image registry an application publishes to",
+		Long: `Inspect and set the container image registry an application publishes to.
+
+An application with no declaration publishes into the organisation's own Ankra
+registry project. Declare a registry you already operate to have Ankra read
+image tags, verify builds, and pull demo images from there instead.`,
+	}
+	registryCommand.AddCommand(newApplicationRegistryGetCommand())
+	registryCommand.AddCommand(newApplicationRegistrySetCommand())
+	registryCommand.AddCommand(newApplicationRegistryClearCommand())
+	return registryCommand
+}
+
+func newApplicationRegistryGetCommand() *cobra.Command {
+	getCommand := &cobra.Command{
+		Use:   "get <application-id>",
+		Short: "Show the image registry an application publishes to",
+		Long: `Show the image registry an application publishes to.
+
+Reports the stored declaration, whether it is one at all, the host and project
+it resolves to, and the image repository each component is expected to publish
+to - so you can compare them against where your builds actually push.`,
+		Example: "  ankra application registry get 23298741-6a5a-401a-a681-66f31fbdebe1",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+				return formatError
+			}
+			payload, getError := apiClient.GetApplicationImageRegistry(command.Context(),
+				strings.TrimSpace(arguments[0]))
+			if getError != nil {
+				return getError
+			}
+			return renderApplicationPayload(command, payload)
+		},
+	}
+	registerStructuredOutputFlags(getCommand)
+	return getCommand
+}
+
+func newApplicationRegistrySetCommand() *cobra.Command {
+	setCommand := &cobra.Command{
+		Use:   "set <application-id>",
+		Short: "Point an application at a container image registry you operate",
+		Long: `Point an application at a container image registry you operate.
+
+--url is the registry project, as oci://<host>/<project> (the scheme is
+optional). --credential names an existing registry credential of this
+organisation; without one Ankra can describe where the images live but cannot
+read or pull them, so builds keep reporting as never published.
+
+Ankra never mints robots for a registry it does not administer, so it will not
+write your repository's Actions secrets unless you ask it to with
+--manage-actions-secrets.`,
+		Example: `  ankra application registry set 23298741-6a5a-401a-a681-66f31fbdebe1 \
+    --url oci://artifact.example.com/commerce --credential example-harbor
+
+  ankra application registry set <application-id> \
+    --url artifact.example.com/commerce --credential example-harbor \
+    --username-secret HARBOR_USERNAME --password-secret HARBOR_PASSWORD`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+				return formatError
+			}
+			registryURL, _ := command.Flags().GetString("url")
+			registryURL = strings.TrimSpace(registryURL)
+			if registryURL == "" {
+				return withExitCode(exitUsage,
+					errors.New("--url is required: the registry project, as oci://<host>/<project>"))
+			}
+			credentialName, _ := command.Flags().GetString("credential")
+			apiURL, _ := command.Flags().GetString("api-url")
+			pullSecretName, _ := command.Flags().GetString("pull-secret")
+			usernameSecretName, _ := command.Flags().GetString("username-secret")
+			passwordSecretName, _ := command.Flags().GetString("password-secret")
+			manageActionsSecrets, _ := command.Flags().GetBool("manage-actions-secrets")
+
+			declaration := &client.ApplicationImageRegistry{
+				URL:                  registryURL,
+				CredentialName:       strings.TrimSpace(credentialName),
+				APIURL:               strings.TrimSpace(apiURL),
+				PullSecretName:       strings.TrimSpace(pullSecretName),
+				UsernameSecretName:   strings.TrimSpace(usernameSecretName),
+				PasswordSecretName:   strings.TrimSpace(passwordSecretName),
+				ManageActionsSecrets: manageActionsSecrets,
+			}
+			payload, updateError := apiClient.UpdateApplicationImageRegistry(command.Context(),
+				strings.TrimSpace(arguments[0]),
+				client.UpdateApplicationImageRegistryRequest{ImageRegistry: declaration})
+			if updateError != nil {
+				return updateError
+			}
+			if declaration.CredentialName == "" {
+				_, _ = fmt.Fprintln(command.ErrOrStderr(),
+					"Warning: no --credential was named, so Ankra cannot read image tags from this registry. "+
+						"Builds will keep reporting as never published.")
+			}
+			return renderApplicationPayload(command, payload)
+		},
+	}
+	setCommand.Flags().String("url", "", "Registry project as oci://<host>/<project> (required)")
+	setCommand.Flags().String("credential", "", "Registry credential of this organisation that authenticates to it")
+	setCommand.Flags().String("api-url", "", "Registry management API base (defaults to https://<host>)")
+	setCommand.Flags().String("pull-secret", "", "Name of the dockerconfigjson Secret generated manifests reference")
+	setCommand.Flags().String("username-secret", "", "Repository Actions secret the build workflow logs in with")
+	setCommand.Flags().String("password-secret", "", "Repository Actions secret holding the registry password")
+	setCommand.Flags().Bool("manage-actions-secrets", false,
+		"Let Ankra write the named credential into the repository's Actions secrets")
+	registerStructuredOutputFlags(setCommand)
+	return setCommand
+}
+
+func newApplicationRegistryClearCommand() *cobra.Command {
+	clearCommand := &cobra.Command{
+		Use:   "clear <application-id>",
+		Short: "Return an application to the organisation's own Ankra registry",
+		Long: `Return an application to the organisation's own Ankra registry.
+
+Clears the declaration, so the application publishes into - and is read back
+from - the organisation's provisioned registry project again.`,
+		Example: "  ankra application registry clear 23298741-6a5a-401a-a681-66f31fbdebe1",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+				return formatError
+			}
+			applicationID := strings.TrimSpace(arguments[0])
+			yes, _ := command.Flags().GetBool("yes")
+			if confirmError := confirmPrompt(
+				command.InOrStdin(), command.OutOrStdout(),
+				fmt.Sprintf("Clear the declared image registry of application %q? "+
+					"It will publish to the organisation's own registry again. [y/N]: ", applicationID),
+				yes,
+			); confirmError != nil {
+				return confirmError
+			}
+			payload, updateError := apiClient.UpdateApplicationImageRegistry(command.Context(), applicationID,
+				client.UpdateApplicationImageRegistryRequest{ImageRegistry: nil})
+			if updateError != nil {
+				return updateError
+			}
+			return renderApplicationPayload(command, payload)
+		},
+	}
+	clearCommand.Flags().Bool("yes", false, "Skip the confirmation prompt")
+	registerStructuredOutputFlags(clearCommand)
+	return clearCommand
+}

--- a/cmd/application_registry_test.go
+++ b/cmd/application_registry_test.go
@@ -1,0 +1,183 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"ankra/internal/client"
+)
+
+type applicationRegistryMock struct {
+	baseMock
+	payload json.RawMessage
+	fail    error
+
+	getApplicationID    string
+	getCalls            int
+	updateApplicationID string
+	updateRequest       client.UpdateApplicationImageRegistryRequest
+	updateCalls         int
+}
+
+func (mock *applicationRegistryMock) GetApplicationImageRegistry(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	mock.getCalls++
+	mock.getApplicationID = applicationID
+	if mock.fail != nil {
+		return nil, mock.fail
+	}
+	return mock.payload, nil
+}
+
+func (mock *applicationRegistryMock) UpdateApplicationImageRegistry(requestContext context.Context, applicationID string, registryRequest client.UpdateApplicationImageRegistryRequest) (json.RawMessage, error) {
+	mock.updateCalls++
+	mock.updateApplicationID = applicationID
+	mock.updateRequest = registryRequest
+	if mock.fail != nil {
+		return nil, mock.fail
+	}
+	return mock.payload, nil
+}
+
+func TestApplicationRegistryCommandsRegistered(t *testing.T) {
+	applicationCommand := newApplicationCommand()
+	var registryCommand *cobra.Command
+	for _, subcommand := range applicationCommand.Commands() {
+		if subcommand.Name() == "registry" {
+			registryCommand = subcommand
+		}
+	}
+	if registryCommand == nil {
+		t.Fatal("the registry subcommand is not registered")
+	}
+	registered := map[string]bool{}
+	for _, subcommand := range registryCommand.Commands() {
+		registered[subcommand.Name()] = true
+	}
+	for _, expected := range []string{"get", "set", "clear"} {
+		if !registered[expected] {
+			t.Errorf("registry subcommand %q is not registered", expected)
+		}
+	}
+}
+
+func TestApplicationRegistryGetRendersThePayload(t *testing.T) {
+	mockClient := &applicationRegistryMock{
+		payload: json.RawMessage(`{"declared":true,"host":"artifact.example.com","project":"commerce"}`),
+	}
+	output, executeError := runApplicationCommand(t, mockClient, "registry", "get", "app-1")
+	if executeError != nil {
+		t.Fatalf("registry get error = %v", executeError)
+	}
+	if mockClient.getApplicationID != "app-1" {
+		t.Errorf("application id = %q, want app-1", mockClient.getApplicationID)
+	}
+	if !strings.Contains(output, "\"host\": \"artifact.example.com\"") {
+		t.Errorf("output is not indented JSON: %q", output)
+	}
+}
+
+func TestApplicationRegistrySetMapsEveryFlag(t *testing.T) {
+	mockClient := &applicationRegistryMock{payload: json.RawMessage(`{"declared":true}`)}
+	_, executeError := runApplicationCommand(t, mockClient,
+		"registry", "set", "app-1",
+		"--url", " oci://artifact.example.com/commerce ",
+		"--credential", "example-harbor",
+		"--api-url", "https://artifact.example.com",
+		"--pull-secret", "harbor-pull",
+		"--username-secret", "HARBOR_USERNAME",
+		"--password-secret", "HARBOR_PASSWORD",
+		"--manage-actions-secrets",
+	)
+	if executeError != nil {
+		t.Fatalf("registry set error = %v", executeError)
+	}
+	if mockClient.updateCalls != 1 {
+		t.Fatalf("UpdateApplicationImageRegistry calls = %d, want 1", mockClient.updateCalls)
+	}
+	declaration := mockClient.updateRequest.ImageRegistry
+	if declaration == nil {
+		t.Fatal("the declaration must be sent")
+	}
+	if declaration.URL != "oci://artifact.example.com/commerce" {
+		t.Errorf("url = %q, want it trimmed", declaration.URL)
+	}
+	if declaration.CredentialName != "example-harbor" || declaration.APIURL != "https://artifact.example.com" ||
+		declaration.PullSecretName != "harbor-pull" || declaration.UsernameSecretName != "HARBOR_USERNAME" ||
+		declaration.PasswordSecretName != "HARBOR_PASSWORD" || !declaration.ManageActionsSecrets {
+		t.Errorf("declaration = %+v", declaration)
+	}
+}
+
+func TestApplicationRegistrySetRequiresURL(t *testing.T) {
+	mockClient := &applicationRegistryMock{}
+	_, executeError := runApplicationCommand(t, mockClient, "registry", "set", "app-1", "--credential", "harbor")
+	if executeError == nil {
+		t.Fatal("expected a missing --url to fail")
+	}
+	if exitCodeFor(executeError) != exitUsage {
+		t.Errorf("exit code = %d, want %d", exitCodeFor(executeError), exitUsage)
+	}
+	if mockClient.updateCalls != 0 {
+		t.Errorf("UpdateApplicationImageRegistry calls = %d, want 0", mockClient.updateCalls)
+	}
+}
+
+// Without a credential Ankra can describe where the images live but cannot
+// read or pull them, so builds keep reporting as never published - the
+// declaration is accepted, but the user is told on stderr so structured
+// output stays parseable.
+func TestApplicationRegistrySetWarnsWithoutACredential(t *testing.T) {
+	mockClient := &applicationRegistryMock{payload: json.RawMessage(`{"declared":true}`)}
+	output, executeError := runApplicationCommand(t, mockClient,
+		"registry", "set", "app-1", "--url", "oci://artifact.example.com/commerce")
+	if executeError != nil {
+		t.Fatalf("registry set error = %v", executeError)
+	}
+	if mockClient.updateCalls != 1 {
+		t.Fatalf("UpdateApplicationImageRegistry calls = %d, want 1", mockClient.updateCalls)
+	}
+	if !strings.Contains(output, "no --credential was named") {
+		t.Errorf("expected the missing-credential warning, got %q", output)
+	}
+}
+
+// Clearing sends an explicit null rather than omitting the key: an absent
+// key would leave the declaration in place.
+func TestApplicationRegistryClearSendsAnExplicitNull(t *testing.T) {
+	mockClient := &applicationRegistryMock{payload: json.RawMessage(`{"declared":false}`)}
+	_, executeError := runApplicationCommand(t, mockClient, "registry", "clear", "app-1", "--yes")
+	if executeError != nil {
+		t.Fatalf("registry clear error = %v", executeError)
+	}
+	if mockClient.updateCalls != 1 {
+		t.Fatalf("UpdateApplicationImageRegistry calls = %d, want 1", mockClient.updateCalls)
+	}
+	if mockClient.updateRequest.ImageRegistry != nil {
+		t.Errorf("clear must send a nil declaration, got %+v", mockClient.updateRequest.ImageRegistry)
+	}
+	encoded, marshalError := json.Marshal(mockClient.updateRequest)
+	if marshalError != nil {
+		t.Fatalf("marshalling the request: %v", marshalError)
+	}
+	if !strings.Contains(string(encoded), `"image_registry":null`) {
+		t.Errorf("the cleared key must ride as an explicit null, got %s", encoded)
+	}
+}
+
+func TestApplicationRegistryClearRefusesWhenDeclined(t *testing.T) {
+	mockClient := &applicationRegistryMock{}
+	_, executeError := runApplicationCommandWithInput(t, mockClient, "n\n", "registry", "clear", "app-1")
+	if executeError == nil {
+		t.Fatal("a declined confirmation must fail")
+	}
+	if exitCodeFor(executeError) != exitCancelled {
+		t.Errorf("exit code = %d, want %d", exitCodeFor(executeError), exitCancelled)
+	}
+	if mockClient.updateCalls != 0 {
+		t.Errorf("UpdateApplicationImageRegistry calls = %d, want 0", mockClient.updateCalls)
+	}
+}

--- a/cmd/application_resources.go
+++ b/cmd/application_resources.go
@@ -124,6 +124,7 @@ func registerApplicationResourceCommands(applicationCommand *cobra.Command) {
 		}),
 	)
 	applicationCommand.AddCommand(newApplicationDemoCommand())
+	applicationCommand.AddCommand(newApplicationRegistryCommand())
 }
 
 func newApplicationDeleteCommand() *cobra.Command {

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -235,6 +235,14 @@ func (m baseMock) FixApplicationDemo(requestContext context.Context, application
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) GetApplicationImageRegistry(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) UpdateApplicationImageRegistry(requestContext context.Context, applicationID string, registryRequest client.UpdateApplicationImageRegistryRequest) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) ListClusterAddons(clusterID string) ([]client.ClusterAddonListItem, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -125,6 +125,8 @@ type APIClient interface {
 	GetApplicationDemoConfig(requestContext context.Context, applicationID string) (json.RawMessage, error)
 	UpdateApplicationDemoConfig(requestContext context.Context, applicationID string, configuration json.RawMessage) (json.RawMessage, error)
 	FixApplicationDemo(requestContext context.Context, applicationID string, workspaceID string) (json.RawMessage, error)
+	GetApplicationImageRegistry(requestContext context.Context, applicationID string) (json.RawMessage, error)
+	UpdateApplicationImageRegistry(requestContext context.Context, applicationID string, registryRequest client.UpdateApplicationImageRegistryRequest) (json.RawMessage, error)
 
 	ListOrganisations() ([]client.OrganisationSummary, error)
 	SwitchOrganisation(orgID string) (*client.SwitchOrganisationResponse, error)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module ankra
 
 go 1.25.0
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e

--- a/internal/client/application_resources.go
+++ b/internal/client/application_resources.go
@@ -44,6 +44,26 @@ type DeployApplicationDemoRequest struct {
 	ContainerPort *int    `json:"container_port,omitempty"`
 }
 
+// UpdateApplicationImageRegistryRequest mirrors the image-registry body. The
+// key is always sent: an explicit null is how the declaration is cleared and
+// the application handed back to the organisation's own registry project, so
+// the pointer must survive marshalling rather than being omitted.
+type UpdateApplicationImageRegistryRequest struct {
+	ImageRegistry *ApplicationImageRegistry `json:"image_registry"`
+}
+
+// ApplicationImageRegistry is the declared registry an application publishes
+// to and Ankra reads its images back from.
+type ApplicationImageRegistry struct {
+	URL                  string `json:"url"`
+	CredentialName       string `json:"credential_name,omitempty"`
+	APIURL               string `json:"api_url,omitempty"`
+	PullSecretName       string `json:"pull_secret_name,omitempty"`
+	UsernameSecretName   string `json:"username_secret_name,omitempty"`
+	PasswordSecretName   string `json:"password_secret_name,omitempty"`
+	ManageActionsSecrets bool   `json:"manage_actions_secrets,omitempty"`
+}
+
 // applicationResourceRequest performs a bearer-authenticated request against
 // an application subresource and returns the raw JSON body on success. The
 // FastAPI `detail` string is surfaced as the error message on non-200 so the
@@ -285,4 +305,14 @@ func (client *Client) UpdateApplicationDemoConfig(requestContext context.Context
 
 func (client *Client) FixApplicationDemo(requestContext context.Context, applicationID string, workspaceID string) (json.RawMessage, error) {
 	return client.applicationResourceRequest(requestContext, http.MethodPost, applicationPath(applicationID, "/demos/"+workspaceID+"/fix"), nil, nil)
+}
+
+// --- image registry ---
+
+func (client *Client) GetApplicationImageRegistry(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodGet, applicationPath(applicationID, "/image-registry"), nil, nil)
+}
+
+func (client *Client) UpdateApplicationImageRegistry(requestContext context.Context, applicationID string, registryRequest UpdateApplicationImageRegistryRequest) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodPut, applicationPath(applicationID, "/image-registry"), nil, registryRequest)
 }


### PR DESCRIPTION
Bead: `ankra-tpwy` · Linear: PLA-756 · Ankra ticket #1067 (Smartoptics) · Backend: ankraio/cluster#1197

## Why

An application publishes into the organisation's own Ankra registry project unless it declares otherwise. That declaration could only be made **at create time** — there was no update endpoint, no portal field, and no CLI flag. An organisation whose builds push to their own Harbor therefore had no way to correct an already-onboarded application: the readiness lane kept reporting its images as never published while the application ran healthily, and demo mode (which pulls from the resolved registry) stayed closed to them entirely.

## What

Three subcommands over the new `GET`/`PUT /api/v1/org/applications/{id}/image-registry` endpoints landing in ankraio/cluster#1197.

```
ankra application registry get <application-id>
ankra application registry set <application-id> --url oci://<host>/<project> --credential <name>
ankra application registry clear <application-id>
```

**`get`** reports the effective registry: the stored declaration, whether it is one at all, the host and project it resolves to, the primary component's expected image repository, and each component's own — so the coordinates can be compared against where the builds actually push.

**`set`** declares a registry. `--url` is required (scheme optional; `artifact.example.com/commerce` works). `--credential` names the organisation registry credential that authenticates to it — the same credential resource the Helm OCI chart registries already use. Optional `--api-url`, `--pull-secret`, `--username-secret`, `--password-secret`, and `--manage-actions-secrets`.

Setting a registry **without** `--credential` is allowed but warns on stderr: without one Ankra can describe where the images live and neither read nor pull them, so builds keep reporting as never published. The warning goes to stderr so `-o json|yaml` stdout stays parseable.

`--manage-actions-secrets` is off by default and the backend refuses it without a credential name — Ankra never mints robots for a registry it does not administer, and overwriting a customer's push robot would break their build.

**`clear`** returns the application to the organisation's own registry project. It confirms first (declining exits 4), and sends `"image_registry": null` as an **explicit null** — omitting the key would leave the declaration in place.

## Notes

- `internal/client` gains `GetApplicationImageRegistry` / `UpdateApplicationImageRegistry`, mirrored into the `APIClient` interface in `cmd/services.go` and the `baseMock` stub set in `cmd/e2e_test.go`, per the repo invariant.
- `UpdateApplicationImageRegistryRequest.ImageRegistry` deliberately carries **no** `omitempty`: the null is load-bearing.
- Requires the backend endpoints; without them `set`/`clear` surface the platform's 404 with exit code 3.

## Testing

`cmd/application_registry_test.go` covers subcommand registration, JSON rendering, full flag mapping (including URL trimming), the missing-`--url` usage error (exit 2), the missing-credential warning, the explicit-null clear (asserted on the marshalled request), and a declined confirmation (exit 4).

`make test` (`-race`), `make lint` (0 issues), and `make build` all pass. Changelog entry added under `## Unreleased`.

## Follow-up (not in this PR)

Portal still has no field for this — tracked alongside the backend PR.
