### PR TITLE
fix(stack-profiles): accept a profile name and the v-prefixed version form (ankra-ql3t)

### DIFF
--- a/cmd/stack_profiles.go
+++ b/cmd/stack_profiles.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,6 +20,73 @@ var stackProfilesCmd = &cobra.Command{
 	Use:   "stack-profiles",
 	Short: "Manage reusable stack profiles",
 	Long:  "List, export, and import organisation-level stack profiles.",
+}
+
+// stackProfileIDPattern matches the canonical UUID form the API expects for a
+// profile id. Anything else is treated as a profile name to resolve.
+var stackProfileIDPattern = regexp.MustCompile(
+	`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// resolveStackProfileID accepts either a profile id or a profile name.
+//
+// `stack-profiles list` prints a NAME column, so a name is the obvious thing
+// to pass to the next command; before this the API answered with a raw
+// pydantic uuid_parsing dump, which tells the user nothing about what to do
+// instead (ankra-ql3t).
+func resolveStackProfileID(profiles APIClient, reference string) (string, error) {
+	if stackProfileIDPattern.MatchString(reference) {
+		return reference, nil
+	}
+	listing, listError := profiles.ListStackProfiles(1, 200, reference, "")
+	if listError != nil {
+		// The lookup is a convenience, not the operation. If listing is
+		// unavailable, hand the reference to the API unchanged and let the
+		// real call decide - failing here would turn a working id into an
+		// error just because the search endpoint was unhappy.
+		return reference, nil
+	}
+	matched := []client.StackProfileSummary{}
+	for _, profile := range listing.Result {
+		if profile.Name == reference {
+			matched = append(matched, profile)
+		}
+	}
+	switch len(matched) {
+	case 1:
+		return matched[0].ID, nil
+	case 0:
+		return "", fmt.Errorf(
+			"no stack profile named %q - run 'ankra stack-profiles list' to see the available profiles", reference)
+	default:
+		identifiers := make([]string, 0, len(matched))
+		for _, profile := range matched {
+			identifiers = append(identifiers, profile.ID)
+		}
+		return "", fmt.Errorf("%d stack profiles are named %q - pass the id instead (%s)",
+			len(matched), reference, strings.Join(identifiers, ", "))
+	}
+}
+
+// parseProfileVersionFlag accepts both the bare integer and the v-prefixed
+// form every Ankra surface prints ("Latest version: v1", and a LATEST column
+// reading v1), so a version copied straight out of `list` or `get` works.
+// An empty value means "use the profile's current version".
+func parseProfileVersionFlag(raw string) (int, error) {
+	trimmed := strings.TrimSpace(raw)
+	// "0" kept its old meaning from when this was an int flag: unset, i.e.
+	// fall back to the profile's current version.
+	if trimmed == "" || trimmed == "0" {
+		return 0, nil
+	}
+	trimmed = strings.TrimPrefix(strings.TrimPrefix(trimmed, "v"), "V")
+	version, parseError := strconv.Atoi(trimmed)
+	if parseError != nil {
+		return 0, fmt.Errorf("invalid --version %q: use a version number such as 1 or v1", raw)
+	}
+	if version <= 0 {
+		return 0, fmt.Errorf("invalid --version %q: profile versions start at 1", raw)
+	}
+	return version, nil
 }
 
 var stackProfilesListCmd = &cobra.Command{
@@ -59,12 +128,19 @@ var stackProfilesListCmd = &cobra.Command{
 }
 
 var stackProfilesExportIacCmd = &cobra.Command{
-	Use:   "export-iac [profile-id]",
+	Use:   "export-iac [profile-id|profile-name]",
 	Short: "Export a profile version as ClusterInfrastructureAsCode YAML",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		profileID := args[0]
-		version, _ := cmd.Flags().GetInt("version")
+		profileID, resolveError := resolveStackProfileID(apiClient, args[0])
+		if resolveError != nil {
+			return resolveError
+		}
+		versionRaw, _ := cmd.Flags().GetString("version")
+		version, versionError := parseProfileVersionFlag(versionRaw)
+		if versionError != nil {
+			return versionError
+		}
 		outputPath, _ := cmd.Flags().GetString("output")
 
 		if version <= 0 {
@@ -139,13 +215,20 @@ var stackProfilesImportCmd = &cobra.Command{
 }
 
 var stackProfilesGetCmd = &cobra.Command{
-	Use:   "get [profile-id]",
+	Use:   "get [profile-id|profile-name]",
 	Short: "Show a stack profile's versions and parameters",
 	Long:  "Describe a stack profile: its metadata, published versions, and the parameters you can bind when applying it.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		profileID := args[0]
-		versionFlag, _ := cmd.Flags().GetInt("version")
+		profileID, resolveError := resolveStackProfileID(apiClient, args[0])
+		if resolveError != nil {
+			return resolveError
+		}
+		versionRaw, _ := cmd.Flags().GetString("version")
+		versionFlag, versionError := parseProfileVersionFlag(versionRaw)
+		if versionError != nil {
+			return versionError
+		}
 
 		detail, err := apiClient.GetStackProfile(profileID)
 		if err != nil {
@@ -223,7 +306,7 @@ var stackProfilesGetCmd = &cobra.Command{
 }
 
 var stackProfilesApplyCmd = &cobra.Command{
-	Use:   "apply [profile-id]",
+	Use:   "apply [profile-id|profile-name]",
 	Short: "Apply a stack profile to a cluster as a draft (optionally deploy)",
 	Long: `Apply (instantiate) a stack profile onto a cluster.
 
@@ -236,10 +319,17 @@ shell history or process list. Use 'ankra stack-profiles get <profile-id>' to se
 which parameters a profile expects.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		profileID := args[0]
+		profileID, resolveError := resolveStackProfileID(apiClient, args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		clusterFlag, _ := cmd.Flags().GetString("cluster")
 		stackName, _ := cmd.Flags().GetString("stack-name")
-		versionFlag, _ := cmd.Flags().GetInt("version")
+		versionRaw, _ := cmd.Flags().GetString("version")
+		versionFlag, versionError := parseProfileVersionFlag(versionRaw)
+		if versionError != nil {
+			return versionError
+		}
 		deploy, _ := cmd.Flags().GetBool("deploy")
 		setValues, _ := cmd.Flags().GetStringArray("set")
 		setFiles, _ := cmd.Flags().GetStringArray("set-file")
@@ -410,17 +500,17 @@ func init() {
 	stackProfilesListCmd.Flags().String("category", "", "Filter profiles by category (e.g. 'monitoring')")
 	registerStructuredOutputFlags(stackProfilesListCmd)
 
-	stackProfilesExportIacCmd.Flags().Int("version", 0, "Profile version to export (defaults to the profile's current version)")
+	stackProfilesExportIacCmd.Flags().String("version", "", "Profile version to export, as 1 or v1 (defaults to the profile's current version)")
 	stackProfilesExportIacCmd.Flags().StringP("output", "o", "", "Write YAML to this file instead of stdout")
 
 	stackProfilesImportCmd.Flags().String("name", "", "Profile name (defaults to metadata.name in the file)")
 	stackProfilesImportCmd.Flags().String("category", "general", "Profile category")
 
-	stackProfilesGetCmd.Flags().Int("version", 0, "Profile version to describe (defaults to the current version)")
+	stackProfilesGetCmd.Flags().String("version", "", "Profile version to describe, as 1 or v1 (defaults to the current version)")
 	registerStructuredOutputFlags(stackProfilesGetCmd)
 
 	stackProfilesApplyCmd.Flags().String("cluster", "", "Target cluster name or ID (defaults to the selected cluster)")
-	stackProfilesApplyCmd.Flags().Int("version", 0, "Profile version to apply (defaults to the profile's current version)")
+	stackProfilesApplyCmd.Flags().String("version", "", "Profile version to apply, as 1 or v1 (defaults to the profile's current version)")
 	stackProfilesApplyCmd.Flags().String("stack-name", "", "Name for the new stack (defaults to the profile's stack name)")
 	stackProfilesApplyCmd.Flags().StringArray("set", nil, "Bind a parameter: name=value (repeatable; not for secrets)")
 	stackProfilesApplyCmd.Flags().StringArray("set-file", nil, "Bind a parameter from a file: name=path (repeatable; secret-safe)")

--- a/cmd/stack_profiles_reference_test.go
+++ b/cmd/stack_profiles_reference_test.go
@@ -1,0 +1,123 @@
+package cmd
+
+// Regression cover for ankra-ql3t: `stack-profiles list` prints NAME and
+// LATEST columns, so those are the values a user reaches for next. Before
+// this, a name produced a raw pydantic uuid_parsing dump from the API and
+// `--version v1` was rejected by strconv even though every Ankra surface
+// prints versions as v1.
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+// profileLookupMock answers the profile listing used to resolve a name.
+type profileLookupMock struct {
+	baseMock
+	profiles  []client.StackProfileSummary
+	listError error
+	searched  string
+}
+
+func (mock *profileLookupMock) ListStackProfiles(_, _ int, search string, _ string) (*client.StackProfileListResponse, error) {
+	mock.searched = search
+	if mock.listError != nil {
+		return nil, mock.listError
+	}
+	return &client.StackProfileListResponse{Result: mock.profiles}, nil
+}
+
+func TestResolveStackProfileIDPassesAUUIDStraightThrough(t *testing.T) {
+	mock := &profileLookupMock{listError: errors.New("listing must not be called for a uuid")}
+	const profileID = "3435f700-7f47-475c-9f69-864dcba502bc"
+
+	resolved, resolveError := resolveStackProfileID(mock, profileID)
+
+	if resolveError != nil {
+		t.Fatalf("a uuid must resolve to itself: %v", resolveError)
+	}
+	if resolved != profileID {
+		t.Fatalf("expected %q, got %q", profileID, resolved)
+	}
+	if mock.searched != "" {
+		t.Fatal("resolving a uuid must not cost a listing round-trip")
+	}
+}
+
+func TestResolveStackProfileIDResolvesAName(t *testing.T) {
+	mock := &profileLookupMock{profiles: []client.StackProfileSummary{
+		{ID: "3cd57498-062c-4dd8-878a-cd0372e5fcf6", Name: "llm-d"},
+		{ID: "3435f700-7f47-475c-9f69-864dcba502bc", Name: "gpu-inference"},
+	}}
+
+	resolved, resolveError := resolveStackProfileID(mock, "gpu-inference")
+
+	if resolveError != nil {
+		t.Fatalf("resolving a name printed by `list`: %v", resolveError)
+	}
+	if resolved != "3435f700-7f47-475c-9f69-864dcba502bc" {
+		t.Fatalf("resolved to the wrong profile: %q", resolved)
+	}
+}
+
+func TestResolveStackProfileIDExplainsAnUnknownName(t *testing.T) {
+	mock := &profileLookupMock{profiles: []client.StackProfileSummary{{ID: "id-1", Name: "gpu-inference"}}}
+
+	_, resolveError := resolveStackProfileID(mock, "gpu-inferenc")
+
+	if resolveError == nil {
+		t.Fatal("an unknown name must be reported, not passed to the API as a bogus uuid")
+	}
+	if !strings.Contains(resolveError.Error(), "stack-profiles list") {
+		t.Fatalf("the error must point at how to find the right name, got: %v", resolveError)
+	}
+}
+
+func TestResolveStackProfileIDFallsBackWhenLookupIsUnavailable(t *testing.T) {
+	// The listing is a convenience. If it fails, the reference still has to
+	// reach the API - failing here would break a working id because an
+	// unrelated endpoint was down.
+	mock := &profileLookupMock{listError: errors.New("listing unavailable")}
+
+	resolved, resolveError := resolveStackProfileID(mock, "profile-1")
+
+	if resolveError != nil {
+		t.Fatalf("a failed lookup must not fail the command: %v", resolveError)
+	}
+	if resolved != "profile-1" {
+		t.Fatalf("the reference must pass through unchanged, got %q", resolved)
+	}
+}
+
+func TestParseProfileVersionFlagAcceptsBothForms(t *testing.T) {
+	for _, accepted := range []struct {
+		raw    string
+		expect int
+	}{
+		{"1", 1},
+		{"v1", 1},
+		{"V2", 2},
+		{" v3 ", 3},
+		{"", 0},  // unset - use the profile's current version
+		{"0", 0}, // the old int flag's "unset" value
+	} {
+		version, parseError := parseProfileVersionFlag(accepted.raw)
+		if parseError != nil {
+			t.Fatalf("--version %q must be accepted: %v", accepted.raw, parseError)
+		}
+		if version != accepted.expect {
+			t.Fatalf("--version %q gave %d, want %d", accepted.raw, version, accepted.expect)
+		}
+	}
+}
+
+func TestParseProfileVersionFlagRejectsNonsense(t *testing.T) {
+	for _, rejected := range []string{"latest", "v", "-1", "1.2"} {
+		if _, parseError := parseProfileVersionFlag(rejected); parseError == nil {
+			t.Fatalf("--version %q must be rejected with an explanation", rejected)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module ankra
 
 go 1.25.0
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e


### PR DESCRIPTION
Fixes **ankra-ql3t**.

`ankra stack-profiles list` prints a **NAME** column and a **LATEST** column reading `v1`. Those are the two values a user naturally reaches for next — and both were rejected.

## 1. A profile name leaked the API's validation dump

```
$ ankra stack-profiles get llm-d
Error: getting stack profile: get stack profile failed (422):
{"detail":[{"ctx":{"error":"invalid character: expected an optional prefix of
`urn:uuid:` followed by [0-9a-fA-F-], found `l` at 1"},"input":"llm-d",
"loc":["path","profile_id"],...,"type":"uuid_parsing"}]}
```

`get`, `export-iac` and `apply` now resolve a non-uuid reference through the profile listing the CLI already has:

- a uuid is used directly, with **no extra round-trip**
- a name resolves to its id
- an unknown name is reported as such and points at `stack-profiles list`
- an ambiguous name lists the matching ids

If the listing itself is unavailable the reference is **passed through unchanged**. The lookup is a convenience; it must not turn a working id into an error because an unrelated endpoint was down. (This also keeps the existing test fixtures, which use ids like `profile-1`, working.)

## 2. `--version` rejected the form the CLI itself prints

```
$ ankra stack-profiles export-iac <uuid> --version v1
Error: invalid argument "v1" for "--version" flag:
strconv.ParseInt: parsing "v1": invalid syntax
```

It was an int flag. It is now a string accepting both `1` and `v1`.

**Backwards compatible:** empty *and* `"0"` keep the int flag's meaning of "use the profile's current version", so existing scripts and the existing test helpers are unaffected. Anything else fails with a message naming the accepted forms rather than a strconv dump.

## Tests

uuid pass-through (asserting no listing call is made), name resolution, unknown-name guidance, listing-unavailable fallback, and both the accepted (`1`, `v1`, `V2`, ` v3 `, ``, `0`) and rejected (`latest`, `v`, `-1`, `1.2`) version forms.

`make test` and `make lint` (golangci-lint, 0 issues) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVNqBDf1pxciy8Dhe8YMXY
