### PR TITLE
release: cut v0.11.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Ankra CLI Changelog
 
+## v0.11.0-rc1 — 2026-08-16
+
+Release candidate. Install it with `ankra config beta enable && ankra upgrade`,
+or download a binary from the release page; `ankra config beta disable` returns
+you to the stable channel.
+
+### Fixed
+
+- **`ankra stack-profiles get`, `export-iac` and `apply` accept a profile
+  name.** `stack-profiles list` prints a NAME column, so a name is the obvious
+  thing to pass to the next command — but doing so leaked the API's raw
+  validation dump (`uuid_parsing`, `expected an optional prefix of urn:uuid:`),
+  which says nothing about what to do instead. The commands now resolve a name
+  to its id, report an unknown name by pointing at `stack-profiles list`, and
+  list the candidates when a name is ambiguous. A profile id is still used
+  directly and costs no extra lookup, and if the profile listing is
+  unavailable the reference is passed through unchanged so a working id never
+  fails on account of it.
+
+- **`--version` accepts the `v1` form the CLI itself prints.** Every Ankra
+  surface labels profile versions `v1` — the LATEST column in
+  `stack-profiles list`, and "Latest version: v1" in `stack-profiles get` —
+  but the flag was an integer, so copying that value back gave
+  `strconv.ParseInt: parsing "v1": invalid syntax`. Both `1` and `v1` now
+  work, and anything unparseable fails with a message naming the accepted
+  forms. Omitting the flag still means "the profile's current version".
+
+### Security
+
+- **The binaries are built with Go 1.26.6.** The toolchain was pinned to Go
+  1.26.5, against which `govulncheck` reports four reachable standard-library
+  vulnerabilities — including `encoding/asn1` recursion depth (GO-2026-5972)
+  and Punycode label handling in `net/http` (GO-2026-5026) — all of them
+  reachable from the CLI's own HTTP client and login paths, and all fixed in
+  Go 1.26.6.
+
 ## v0.10.1 — 2026-08-13
 
 ### Fixed


### PR DESCRIPTION
Cuts **v0.11.0-rc1**, a release candidate on top of v0.10.1.

## What's in it

Everything merged since v0.10.1 — which is exactly one PR, #80:

- `stack-profiles get` / `export-iac` / `apply` accept a **profile name**, not just an id. Passing a name previously leaked the API's raw `uuid_parsing` validation dump.
- `--version` accepts the **`v1` form the CLI itself prints**, alongside the bare integer.
- **Go 1.26.6 toolchain**, clearing four reachable standard-library vulnerabilities `govulncheck` reports against the previous 1.26.5 pin.

## Notes on the version choice

`v0.11.0-rc1`, not `v0.10.2-rc1`: this repo has only ever cut RCs ahead of **minor** releases (`v0.6.0-rc0`, `v0.7.0-rc3`, `v0.9.0-rc*`, `v0.10.0-rc*`) — patches like v0.9.1 and v0.10.1 shipped straight to stable without one. The content is additive (new accepted inputs for two flags/arguments) rather than purely corrective, so a minor line fits. Say the word if you'd rather this be `v0.10.2-rc1` and I'll retag.

**#79 is not included** — it is still open. If it should ship in this RC, merge it first and I'll re-cut.

## Mechanics

- The release workflow fires on the `v*` tag, not on this merge. Tag `v0.11.0-rc1` after merging.
- The tag's `-rc1` suffix makes the workflow publish with `--prerelease`, so it reaches only users on the beta channel (`ankra config beta enable`).
- I verified the workflow's `awk` extractor actually matches the new `## v0.11.0-rc1` heading, so the release notes come from CHANGELOG.md rather than silently falling back to `--generate-notes`.

CHANGELOG-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVNqBDf1pxciy8Dhe8YMXY
