### PR TITLE
fix(stack-profiles): ask for a page size the profiles endpoint accepts (ankra-ql3t)

### DIFF
--- a/cmd/stack_profiles.go
+++ b/cmd/stack_profiles.go
@@ -22,6 +22,15 @@ var stackProfilesCmd = &cobra.Command{
 	Long:  "List, export, and import organisation-level stack profiles.",
 }
 
+// maxProfileLookupPageSize is the largest page_size the profiles endpoint
+// accepts. Asking for more is rejected outright ("Input should be less than
+// or equal to 100"), which - because the lookup falls back to the raw
+// reference when listing fails - turned every name resolution back into the
+// uuid_parsing error it exists to prevent. The `search` filter runs
+// server-side on the name, so one page is more than enough to find an exact
+// match.
+const maxProfileLookupPageSize = 100
+
 // stackProfileIDPattern matches the canonical UUID form the API expects for a
 // profile id. Anything else is treated as a profile name to resolve.
 var stackProfileIDPattern = regexp.MustCompile(
@@ -37,7 +46,7 @@ func resolveStackProfileID(profiles APIClient, reference string) (string, error)
 	if stackProfileIDPattern.MatchString(reference) {
 		return reference, nil
 	}
-	listing, listError := profiles.ListStackProfiles(1, 200, reference, "")
+	listing, listError := profiles.ListStackProfiles(1, maxProfileLookupPageSize, reference, "")
 	if listError != nil {
 		// The lookup is a convenience, not the operation. If listing is
 		// unavailable, hand the reference to the API unchanged and let the

--- a/cmd/stack_profiles_reference_test.go
+++ b/cmd/stack_profiles_reference_test.go
@@ -8,6 +8,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -17,13 +18,24 @@ import (
 // profileLookupMock answers the profile listing used to resolve a name.
 type profileLookupMock struct {
 	baseMock
-	profiles  []client.StackProfileSummary
-	listError error
-	searched  string
+	profiles     []client.StackProfileSummary
+	listError    error
+	searched     string
+	pageSize     int
+	requestedAny bool
 }
 
-func (mock *profileLookupMock) ListStackProfiles(_, _ int, search string, _ string) (*client.StackProfileListResponse, error) {
+// ListStackProfiles records the paging the caller asked for and refuses
+// anything the real endpoint would reject, so a page size the API caps out is
+// a test failure here rather than a silent fallback in production.
+func (mock *profileLookupMock) ListStackProfiles(_, pageSize int, search string, _ string) (*client.StackProfileListResponse, error) {
 	mock.searched = search
+	mock.pageSize = pageSize
+	mock.requestedAny = true
+	if pageSize > maxProfileLookupPageSize {
+		return nil, fmt.Errorf("list stack profiles failed (422): page_size %d exceeds the API maximum of %d",
+			pageSize, maxProfileLookupPageSize)
+	}
 	if mock.listError != nil {
 		return nil, mock.listError
 	}
@@ -60,6 +72,36 @@ func TestResolveStackProfileIDResolvesAName(t *testing.T) {
 	}
 	if resolved != "3435f700-7f47-475c-9f69-864dcba502bc" {
 		t.Fatalf("resolved to the wrong profile: %q", resolved)
+	}
+}
+
+func TestResolveStackProfileIDAsksForAPageSizeTheAPIAccepts(t *testing.T) {
+	// Regression: the lookup asked for 200, the endpoint caps page_size at
+	// 100, so every resolution 422'd and fell back to the raw reference -
+	// which put the uuid_parsing error this whole path exists to remove
+	// straight back in front of the user. The shipped v0.11.0-rc1 binary had
+	// this bug; the unit tests missed it because the fake ignored paging.
+	mock := &profileLookupMock{profiles: []client.StackProfileSummary{
+		{ID: "3cd57498-062c-4dd8-878a-cd0372e5fcf6", Name: "llm-d"},
+	}}
+
+	resolved, resolveError := resolveStackProfileID(mock, "llm-d")
+
+	if resolveError != nil {
+		t.Fatalf("resolving a known name must not error: %v", resolveError)
+	}
+	if resolved != "3cd57498-062c-4dd8-878a-cd0372e5fcf6" {
+		t.Fatalf("the name did not resolve; got %q", resolved)
+	}
+	if !mock.requestedAny {
+		t.Fatal("a non-uuid reference must consult the listing")
+	}
+	if mock.pageSize > maxProfileLookupPageSize {
+		t.Fatalf("requested page_size %d exceeds the API maximum of %d",
+			mock.pageSize, maxProfileLookupPageSize)
+	}
+	if mock.searched != "llm-d" {
+		t.Fatalf("the name must be pushed down as the server-side search filter, got %q", mock.searched)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #80, reopening **ankra-ql3t**. Caught by testing the shipped `v0.11.0-rc1` binary — which is exactly what the RC was for.

## The bug

Profile-name resolution asked the listing for **200** profiles. The endpoint caps `page_size` at **100** and rejects anything larger:

```
list stack profiles failed (422): {"detail":[{"ctx":{"le":100},"input":"200",
"loc":["query","page_size"],"msg":"Input should be less than or equal to 100"}]}
```

The lookup deliberately falls back to the raw reference when listing fails — so that a working id never breaks because an unrelated endpoint is unhappy. That fallback swallowed this, so **every** name resolution fell through and produced exactly the `uuid_parsing` dump the feature exists to remove.

Reproduced against the published rc1 binary (checksum-verified download):

```
$ ./ankra-cli-darwin-arm64 --version
ankra version v0.11.0-rc1
$ ./ankra-cli-darwin-arm64 stack-profiles get llm-d
Error: getting stack profile: get stack profile failed (422): ... "type":"uuid_parsing" ...
```

## Why the tests missed it

The fake `ListStackProfiles` ignored its `pageSize` argument, so a page size the real API rejects was invisible. The fake now **refuses anything above the cap**, and a new test asserts the requested page size, that the name actually resolves, and that the name is pushed down as the server-side `search` filter. Reverting the constant to 200 fails that test with "the name did not resolve".

## Verified against the live API

```
$ ankra stack-profiles get llm-d
Stack Profile:
  Name:            llm-d
  ID:              3cd57498-062c-4dd8-878a-cd0372e5fcf6
...
$ ankra stack-profiles export-iac gpu-inference --version v1 -o /dev/null
Exported profile v1 to /dev/null

$ ankra stack-profiles get llm-dd
Error: no stack profile named "llm-dd" - run 'ankra stack-profiles list' to see the available profiles
```

Name resolution, the `v1` version form, and the unknown-name guidance all work. `make test` and `make lint` (0 issues) green.

Once this lands I'll cut **v0.11.0-rc2**; rc1 should not be promoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVNqBDf1pxciy8Dhe8YMXY
