### PR TITLE
release: cut v0.11.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Ankra CLI Changelog
 
+## v0.11.0-rc2 — 2026-08-16
+
+Release candidate, superseding v0.11.0-rc1 — **do not use rc1**, the headline
+change in it did not work.
+
+### Fixed
+
+- **Profile-name resolution actually resolves now.** The lookup asked the
+  profiles endpoint for a page of 200, but it caps `page_size` at 100 and
+  rejects anything larger. Because the lookup falls back to the reference you
+  typed whenever listing fails — so that a working profile id never breaks on
+  account of an unrelated endpoint — every name silently fell through to the
+  API and produced exactly the `uuid_parsing` error the feature exists to
+  remove. `ankra stack-profiles get llm-d` works in rc2; in rc1 it still
+  failed.
+
 ## v0.11.0-rc1 — 2026-08-16
 
 Release candidate. Install it with `ankra config beta enable && ankra upgrade`,


### PR DESCRIPTION
Cuts **v0.11.0-rc2**, superseding v0.11.0-rc1.

**rc1 should not be promoted.** Its headline change — `stack-profiles` accepting a profile name — was inert in the shipped binary. The lookup asked the profiles endpoint for a page of 200, which it rejects (`page_size` caps at 100), and the lookup's deliberate fallback to the raw reference turned that into exactly the `uuid_parsing` error the feature exists to remove. Fixed in #82, which also makes the test fake refuse any page size above the cap so the paging contract is asserted rather than assumed.

Caught by downloading and running the published rc1 binary — which is what an RC is for.

## Contents relative to v0.10.1

- `stack-profiles get` / `export-iac` / `apply` accept a **profile name** (#80, fixed in #82)
- `--version` accepts the **`v1` form the CLI prints** (#80)
- **Go 1.26.6 toolchain**, clearing four reachable stdlib vulnerabilities (#80)

## Verified against the live API

```
$ ankra stack-profiles get llm-d
Stack Profile:
  Name:            llm-d
  ID:              3cd57498-062c-4dd8-878a-cd0372e5fcf6
$ ankra stack-profiles export-iac gpu-inference --version v1 -o /dev/null
Exported profile v1 to /dev/null
$ ankra stack-profiles get llm-dd
Error: no stack profile named "llm-dd" - run 'ankra stack-profiles list' to see the available profiles
```

Tag `v0.11.0-rc2` after merging; the `-rc2` suffix keeps it a prerelease on the beta channel. I verified the workflow's `awk` extractor matches the new heading, so the notes come from CHANGELOG.md.

CHANGELOG-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVNqBDf1pxciy8Dhe8YMXY
