### PR TITLE
feat(org): add 'ankra org dns' record management commands

### DIFF
--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -343,6 +343,26 @@ func (m baseMock) DeleteClusterVariable(ctx context.Context, clusterID, name str
 	return errors.New("not implemented")
 }
 
+func (m baseMock) GetOrganisationDnsZone(ctx context.Context) (*client.DnsZone, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ListOrganisationDnsRecords(ctx context.Context) (*client.DnsRecordsListResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) CreateOrganisationDnsRecord(ctx context.Context, name, recordType, content string, ttl *int) (*client.DnsRecord, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) UpdateOrganisationDnsRecord(ctx context.Context, recordID, content string, ttl *int) (*client.DnsRecord, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) DeleteOrganisationDnsRecord(ctx context.Context, recordID string) error {
+	return errors.New("not implemented")
+}
+
 func (m baseMock) CreateSupportTicket(ctx context.Context, req client.CreateSupportTicketRequest) (*client.SupportTicket, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/org_dns.go
+++ b/cmd/org_dns.go
@@ -1,0 +1,292 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+var orgDnsCmd = &cobra.Command{
+	Use:   "dns",
+	Short: "Manage DNS records in the organisation's delegated zone",
+	Long: `Manage CNAME/A/TXT records under the organisation's own delegated DNS
+zone (shown by 'ankra org dns zone'). Records are reconciled asynchronously:
+a new or edited record starts in state pending and turns active once it is
+published to the authoritative nameservers.
+
+  ankra org dns zone
+  ankra org dns list
+  ankra org dns add chat CNAME lb-1234.example-lb.com --ttl 300
+  ankra org dns update chat target.example.com
+  ankra org dns delete chat
+
+Creating, editing, and deleting records requires organisation admin.`,
+}
+
+var orgDnsZoneCmd = &cobra.Command{
+	Use:   "zone",
+	Short: "Show the organisation's delegated DNS zone",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out, err := structuredFormatFromFlags(cmd)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+		defer cancel()
+
+		zone, err := apiClient.GetOrganisationDnsZone(ctx)
+		if err != nil {
+			return fmt.Errorf("get organisation DNS zone: %w", err)
+		}
+		switch out {
+		case outputJSON:
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(zone)
+		case outputYAML:
+			enc := yaml.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent(2)
+			defer func() { _ = enc.Close() }()
+			return enc.Encode(zone)
+		}
+		if zone.State == "none" {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No DNS zone is provisioned for this organisation yet.")
+			return nil
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Zone:  %s\nState: %s\n", zone.FQDN, zone.State)
+		return nil
+	},
+}
+
+var orgDnsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List the organisation's DNS records",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out, err := structuredFormatFromFlags(cmd)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+		defer cancel()
+
+		list, err := apiClient.ListOrganisationDnsRecords(ctx)
+		if err != nil {
+			return fmt.Errorf("list DNS records: %w", err)
+		}
+		return renderDnsRecords(cmd.OutOrStdout(), list.Items, out)
+	},
+}
+
+var orgDnsAddCmd = &cobra.Command{
+	Use:   "add <name> <type> <content>",
+	Short: "Add a DNS record to the organisation's zone",
+	Long: `Add a record to the organisation's delegated zone. The name is the label
+inside the zone (the zone fqdn is appended server-side), the type is one of
+CNAME, A, or TXT, and the content is the record target.
+
+  ankra org dns add chat CNAME lb-1234.example-lb.com --ttl 300
+  ankra org dns add app A 203.0.113.10
+  ankra org dns add eu TXT "v=spf1 ~all"`,
+	Args: cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name, recordType, content := args[0], strings.ToUpper(args[1]), args[2]
+		ttl := ttlFromFlags(cmd)
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+		defer cancel()
+
+		record, err := apiClient.CreateOrganisationDnsRecord(ctx, name, recordType, content, ttl)
+		if err != nil {
+			return fmt.Errorf("add DNS record: %w", err)
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "DNS record %s %s -> %s created (state: %s).\n",
+			record.RecordType, record.Name, record.Content, record.State)
+		return nil
+	},
+}
+
+var orgDnsUpdateCmd = &cobra.Command{
+	Use:   "update <record> <content>",
+	Short: "Re-point an existing DNS record at new content",
+	Long: `Re-point a record at new content. The record is referenced by its id or
+by its name (the label or the full fqdn); the name and type of a record
+never change - delete and re-add to rename. Pass --ttl to change the ttl at
+the same time.`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		reference, content := args[0], args[1]
+		recordType, _ := cmd.Flags().GetString("type")
+		ttl := ttlFromFlags(cmd)
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+		defer cancel()
+
+		recordID, err := resolveDnsRecordID(ctx, reference, recordType)
+		if err != nil {
+			return err
+		}
+		record, err := apiClient.UpdateOrganisationDnsRecord(ctx, recordID, content, ttl)
+		if err != nil {
+			return fmt.Errorf("update DNS record: %w", err)
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "DNS record %s %s -> %s updated (state: %s).\n",
+			record.RecordType, record.Name, record.Content, record.State)
+		return nil
+	},
+}
+
+var orgDnsDeleteCmd = &cobra.Command{
+	Use:   "delete <record>",
+	Short: "Delete a DNS record from the organisation's zone",
+	Long: `Delete a record, referenced by its id or by its name (the label or the
+full fqdn). When several records share a name, disambiguate with --type.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		reference := args[0]
+		recordType, _ := cmd.Flags().GetString("type")
+		yes, _ := cmd.Flags().GetBool("yes")
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+		defer cancel()
+
+		recordID, err := resolveDnsRecordID(ctx, reference, recordType)
+		if err != nil {
+			return err
+		}
+
+		if err := confirmPrompt(
+			cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Delete DNS record %q? [y/N]: ", reference),
+			yes,
+		); err != nil {
+			return err
+		}
+
+		if err := apiClient.DeleteOrganisationDnsRecord(ctx, recordID); err != nil {
+			if errors.Is(err, client.ErrDnsRecordNotFound) {
+				return fmt.Errorf("DNS record %q not found", reference)
+			}
+			return fmt.Errorf("delete DNS record: %w", err)
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "DNS record %q deleted.\n", reference)
+		return nil
+	},
+}
+
+// ttlFromFlags returns the --ttl value, nil when the flag was not passed so
+// the backend keeps its Auto default (or an edited record's existing ttl).
+func ttlFromFlags(cmd *cobra.Command) *int {
+	flag := cmd.Flags().Lookup("ttl")
+	if flag == nil || !flag.Changed {
+		return nil
+	}
+	value, err := cmd.Flags().GetInt("ttl")
+	if err != nil {
+		return nil
+	}
+	return &value
+}
+
+// resolveDnsRecordID resolves a record reference - an id, the record's full
+// fqdn, or its label inside the zone - to the record id, listing candidates
+// when the reference is ambiguous.
+func resolveDnsRecordID(ctx context.Context, reference string, recordType string) (string, error) {
+	if looksLikeUUID(reference) {
+		return reference, nil
+	}
+
+	list, err := apiClient.ListOrganisationDnsRecords(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list DNS records: %w", err)
+	}
+	normalisedReference := strings.ToLower(strings.TrimSuffix(reference, "."))
+	wantedType := strings.ToUpper(recordType)
+	var matches []client.DnsRecord
+	for _, record := range list.Items {
+		if record.Name != normalisedReference && !strings.HasPrefix(record.Name, normalisedReference+".") {
+			continue
+		}
+		if wantedType != "" && record.RecordType != wantedType {
+			continue
+		}
+		matches = append(matches, record)
+	}
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("no DNS record matches %q; run 'ankra org dns list'", reference)
+	case 1:
+		return matches[0].ID, nil
+	default:
+		candidates := make([]string, 0, len(matches))
+		for _, record := range matches {
+			candidates = append(candidates, fmt.Sprintf("%s %s (%s)", record.RecordType, record.Name, record.ID))
+		}
+		return "", fmt.Errorf("%q is ambiguous, disambiguate with --type or use an id:\n  %s",
+			reference, strings.Join(candidates, "\n  "))
+	}
+}
+
+func renderDnsRecords(out io.Writer, records []client.DnsRecord, format outputFormat) error {
+	switch format {
+	case outputJSON:
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(client.DnsRecordsListResult{Items: records})
+	case outputYAML:
+		enc := yaml.NewEncoder(out)
+		enc.SetIndent(2)
+		defer func() { _ = enc.Close() }()
+		return enc.Encode(client.DnsRecordsListResult{Items: records})
+	}
+	if len(records) == 0 {
+		_, _ = fmt.Fprintln(out, "No DNS records.")
+		return nil
+	}
+	t := table.NewWriter()
+	t.SetOutputMirror(out)
+	t.SetStyle(table.StyleRounded)
+	t.AppendHeader(table.Row{"NAME", "TYPE", "CONTENT", "TTL", "STATE", "ERROR"})
+	for _, record := range records {
+		ttl := "Auto"
+		if record.TTL != nil {
+			ttl = fmt.Sprintf("%d", *record.TTL)
+		}
+		lastError := ""
+		if record.LastError != nil {
+			lastError = truncateForDisplay(*record.LastError, 40)
+		}
+		t.AppendRow(table.Row{record.Name, record.RecordType, truncateForDisplay(record.Content, 50), ttl, record.State, lastError})
+	}
+	t.Render()
+	return nil
+}
+
+func init() {
+	registerStructuredOutputFlags(orgDnsZoneCmd, orgDnsListCmd)
+	orgDnsAddCmd.Flags().Int("ttl", 0, "TTL in seconds (30..604800); omitted means Auto")
+	orgDnsUpdateCmd.Flags().Int("ttl", 0, "TTL in seconds (30..604800); omitted keeps the record's current ttl")
+	orgDnsUpdateCmd.Flags().String("type", "", "Record type (CNAME, A, TXT) to disambiguate a name reference")
+	orgDnsDeleteCmd.Flags().String("type", "", "Record type (CNAME, A, TXT) to disambiguate a name reference")
+	orgDnsDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
+
+	orgDnsCmd.AddCommand(orgDnsZoneCmd)
+	orgDnsCmd.AddCommand(orgDnsListCmd)
+	orgDnsCmd.AddCommand(orgDnsAddCmd)
+	orgDnsCmd.AddCommand(orgDnsUpdateCmd)
+	orgDnsCmd.AddCommand(orgDnsDeleteCmd)
+	orgCmd.AddCommand(orgDnsCmd)
+}

--- a/cmd/org_dns_test.go
+++ b/cmd/org_dns_test.go
@@ -1,0 +1,212 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/pflag"
+)
+
+// resetOrgDnsFlags clears flag state the previous Execute left behind - flag
+// values and their Changed markers persist on the shared command objects
+// across tests in this package.
+func resetOrgDnsFlags(t *testing.T) {
+	t.Helper()
+	for _, flagged := range []interface{ Flags() *pflag.FlagSet }{
+		orgDnsAddCmd, orgDnsUpdateCmd, orgDnsDeleteCmd,
+	} {
+		flagged.Flags().VisitAll(func(f *pflag.Flag) {
+			_ = f.Value.Set(f.DefValue)
+			f.Changed = false
+		})
+	}
+}
+
+// dnsMock captures DNS record calls so the command tests can assert the wire
+// shapes and the id/name resolution. It embeds baseMock for the rest of the
+// APIClient surface.
+type dnsMock struct {
+	baseMock
+
+	zone        client.DnsZone
+	records     []client.DnsRecord
+	createCalls []createDnsCall
+	updateCalls []updateDnsCall
+	deleteCalls []string
+	createErr   error
+}
+
+type createDnsCall struct {
+	Name, RecordType, Content string
+	TTL                       *int
+}
+
+type updateDnsCall struct {
+	RecordID, Content string
+	TTL               *int
+}
+
+func (m *dnsMock) GetOrganisationDnsZone(ctx context.Context) (*client.DnsZone, error) {
+	return &m.zone, nil
+}
+
+func (m *dnsMock) ListOrganisationDnsRecords(ctx context.Context) (*client.DnsRecordsListResult, error) {
+	return &client.DnsRecordsListResult{Items: m.records}, nil
+}
+
+func (m *dnsMock) CreateOrganisationDnsRecord(ctx context.Context, name, recordType, content string, ttl *int) (*client.DnsRecord, error) {
+	m.createCalls = append(m.createCalls, createDnsCall{Name: name, RecordType: recordType, Content: content, TTL: ttl})
+	if m.createErr != nil {
+		return nil, m.createErr
+	}
+	return &client.DnsRecord{ID: "3f0a2f7e-0000-4000-8000-000000000001",
+		Name: name + ".org1234.ankra.cc", RecordType: recordType, Content: content, TTL: ttl, State: "pending"}, nil
+}
+
+func (m *dnsMock) UpdateOrganisationDnsRecord(ctx context.Context, recordID, content string, ttl *int) (*client.DnsRecord, error) {
+	m.updateCalls = append(m.updateCalls, updateDnsCall{RecordID: recordID, Content: content, TTL: ttl})
+	return &client.DnsRecord{ID: recordID, Name: "chat.org1234.ankra.cc", RecordType: "CNAME",
+		Content: content, TTL: ttl, State: "pending"}, nil
+}
+
+func (m *dnsMock) DeleteOrganisationDnsRecord(ctx context.Context, recordID string) error {
+	m.deleteCalls = append(m.deleteCalls, recordID)
+	return nil
+}
+
+func TestRunOrgDnsZone(t *testing.T) {
+	mock := &dnsMock{zone: client.DnsZone{FQDN: "org1234.ankra.cc", State: "active"}}
+	setMockClient(t, mock)
+	resetOrgDnsFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"org", "dns", "zone"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "org1234.ankra.cc") || !strings.Contains(out.String(), "active") {
+		t.Errorf("expected zone fqdn and state, got: %s", out.String())
+	}
+}
+
+func TestRunOrgDnsAdd_SendsLabelTypeContentAndTTL(t *testing.T) {
+	mock := &dnsMock{}
+	setMockClient(t, mock)
+	resetOrgDnsFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"org", "dns", "add", "chat", "cname", "lb-1.upcloudlb.com", "--ttl", "300"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+	if len(mock.createCalls) != 1 {
+		t.Fatalf("expected one create call, got %d", len(mock.createCalls))
+	}
+	got := mock.createCalls[0]
+	if got.Name != "chat" || got.RecordType != "CNAME" || got.Content != "lb-1.upcloudlb.com" {
+		t.Errorf("create call = %+v", got)
+	}
+	if got.TTL == nil || *got.TTL != 300 {
+		t.Errorf("ttl = %v, want 300", got.TTL)
+	}
+	if !strings.Contains(out.String(), "chat.org1234.ankra.cc") || !strings.Contains(out.String(), "pending") {
+		t.Errorf("expected created fqdn and state, got: %s", out.String())
+	}
+}
+
+func TestRunOrgDnsAdd_OmittedTTLStaysAuto(t *testing.T) {
+	mock := &dnsMock{}
+	setMockClient(t, mock)
+	resetOrgDnsFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"org", "dns", "add", "app", "A", "203.0.113.10"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+	if len(mock.createCalls) != 1 || mock.createCalls[0].TTL != nil {
+		t.Fatalf("expected one create call with nil ttl, got %+v", mock.createCalls)
+	}
+}
+
+func TestRunOrgDnsUpdate_ResolvesNameToID(t *testing.T) {
+	mock := &dnsMock{records: []client.DnsRecord{
+		{ID: "3f0a2f7e-0000-4000-8000-0000000000aa", Name: "chat.org1234.ankra.cc", RecordType: "CNAME", Content: "old.example.com", State: "active"},
+		{ID: "3f0a2f7e-0000-4000-8000-0000000000bb", Name: "app.org1234.ankra.cc", RecordType: "A", Content: "203.0.113.10", State: "active"},
+	}}
+	setMockClient(t, mock)
+	resetOrgDnsFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"org", "dns", "update", "chat", "new.example.com"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+	if len(mock.updateCalls) != 1 {
+		t.Fatalf("expected one update call, got %d", len(mock.updateCalls))
+	}
+	got := mock.updateCalls[0]
+	if got.RecordID != "3f0a2f7e-0000-4000-8000-0000000000aa" || got.Content != "new.example.com" || got.TTL != nil {
+		t.Errorf("update call = %+v", got)
+	}
+}
+
+func TestRunOrgDnsDelete_AmbiguousNameNeedsType(t *testing.T) {
+	mock := &dnsMock{records: []client.DnsRecord{
+		{ID: "3f0a2f7e-0000-4000-8000-0000000000aa", Name: "eu.org1234.ankra.cc", RecordType: "A", Content: "203.0.113.10", State: "active"},
+		{ID: "3f0a2f7e-0000-4000-8000-0000000000bb", Name: "eu.org1234.ankra.cc", RecordType: "TXT", Content: "v=spf1 ~all", State: "active"},
+	}}
+	setMockClient(t, mock)
+	resetOrgDnsFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"org", "dns", "delete", "eu", "--yes"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("expected an ambiguity error, got err=%v output=%s", err, out.String())
+	}
+	if len(mock.deleteCalls) != 0 {
+		t.Fatalf("no delete must be issued on ambiguity, got %v", mock.deleteCalls)
+	}
+
+	cmd.SetArgs([]string{"org", "dns", "delete", "eu", "--type", "TXT", "--yes"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+	if len(mock.deleteCalls) != 1 || mock.deleteCalls[0] != "3f0a2f7e-0000-4000-8000-0000000000bb" {
+		t.Fatalf("delete calls = %v", mock.deleteCalls)
+	}
+}
+
+func TestRunOrgDnsDelete_UnknownNameFails(t *testing.T) {
+	mock := &dnsMock{}
+	setMockClient(t, mock)
+	resetOrgDnsFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"org", "dns", "delete", "missing", "--yes"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "no DNS record matches") {
+		t.Fatalf("expected a not-found resolution error, got %v", err)
+	}
+}

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -72,6 +72,12 @@ type APIClient interface {
 	UpdateClusterVariable(ctx context.Context, clusterID, name, value, description string) (*client.ClusterVariableResult, error)
 	DeleteClusterVariable(ctx context.Context, clusterID, name string) error
 
+	GetOrganisationDnsZone(ctx context.Context) (*client.DnsZone, error)
+	ListOrganisationDnsRecords(ctx context.Context) (*client.DnsRecordsListResult, error)
+	CreateOrganisationDnsRecord(ctx context.Context, name, recordType, content string, ttl *int) (*client.DnsRecord, error)
+	UpdateOrganisationDnsRecord(ctx context.Context, recordID, content string, ttl *int) (*client.DnsRecord, error)
+	DeleteOrganisationDnsRecord(ctx context.Context, recordID string) error
+
 	CreateSupportTicket(ctx context.Context, req client.CreateSupportTicketRequest) (*client.SupportTicket, error)
 	ReviewSupportTicket(ctx context.Context, req client.ReviewSupportTicketRequest) (*client.SupportTicketReview, error)
 	ListSupportTickets(ctx context.Context, opts client.ListSupportTicketsOptions) (*client.SupportTicketListResponse, error)

--- a/internal/client/dnsrecords.go
+++ b/internal/client/dnsrecords.go
@@ -1,0 +1,182 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	neturl "net/url"
+)
+
+// DnsZone mirrors the backend response for the organisation's own delegated
+// DNS zone: the fqdn new record names hang off and its provisioning state
+// ("active", "pending", or "none" when no zone exists yet).
+type DnsZone struct {
+	FQDN  string `json:"fqdn"`
+	State string `json:"state"`
+}
+
+// DnsRecord mirrors the backend response shape for one org-managed DNS
+// record. Name is the full FQDN (label + org zone); State follows the
+// pending/active/deleting/failed reconciler lifecycle.
+type DnsRecord struct {
+	ID         string  `json:"id"`
+	Name       string  `json:"name"`
+	RecordType string  `json:"record_type"`
+	Content    string  `json:"content"`
+	TTL        *int    `json:"ttl,omitempty"`
+	State      string  `json:"state"`
+	LastError  *string `json:"last_error,omitempty"`
+	CreatedBy  string  `json:"created_by"`
+	CreatedAt  string  `json:"created_at"`
+	UpdatedAt  string  `json:"updated_at"`
+}
+
+type DnsRecordsListResult struct {
+	Items []DnsRecord `json:"items"`
+}
+
+type createDnsRecordRequest struct {
+	Name       string `json:"name"`
+	RecordType string `json:"record_type"`
+	Content    string `json:"content"`
+	TTL        *int   `json:"ttl,omitempty"`
+}
+
+type updateDnsRecordRequest struct {
+	Content string `json:"content"`
+	TTL     *int   `json:"ttl,omitempty"`
+}
+
+// ErrDnsRecordNotFound is returned when the backend reports 404 for a record
+// id. Callers use errors.Is to distinguish it from network/auth errors.
+var ErrDnsRecordNotFound = errors.New("DNS record not found")
+
+func (c *Client) GetOrganisationDnsZone(ctx context.Context) (*DnsZone, error) {
+	body, err := c.doDnsRequest(ctx, http.MethodGet, c.BaseURL+"/api/v1/org/dns/zone", nil)
+	if err != nil {
+		return nil, err
+	}
+	var out DnsZone
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &out, nil
+}
+
+func (c *Client) ListOrganisationDnsRecords(ctx context.Context) (*DnsRecordsListResult, error) {
+	body, err := c.doDnsRequest(ctx, http.MethodGet, c.BaseURL+"/api/v1/org/dns/records", nil)
+	if err != nil {
+		return nil, err
+	}
+	var out DnsRecordsListResult
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &out, nil
+}
+
+func (c *Client) CreateOrganisationDnsRecord(ctx context.Context, name, recordType, content string, ttl *int) (*DnsRecord, error) {
+	payload, err := json.Marshal(createDnsRecordRequest{Name: name, RecordType: recordType, Content: content, TTL: ttl})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	body, err := c.doDnsRequest(ctx, http.MethodPost, c.BaseURL+"/api/v1/org/dns/records", payload)
+	if err != nil {
+		return nil, err
+	}
+	var out DnsRecord
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &out, nil
+}
+
+func (c *Client) UpdateOrganisationDnsRecord(ctx context.Context, recordID, content string, ttl *int) (*DnsRecord, error) {
+	payload, err := json.Marshal(updateDnsRecordRequest{Content: content, TTL: ttl})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	url := fmt.Sprintf("%s/api/v1/org/dns/records/%s", c.BaseURL, neturl.PathEscape(recordID))
+	body, err := c.doDnsRequest(ctx, http.MethodPatch, url, payload)
+	if err != nil {
+		return nil, err
+	}
+	var out DnsRecord
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &out, nil
+}
+
+func (c *Client) DeleteOrganisationDnsRecord(ctx context.Context, recordID string) error {
+	url := fmt.Sprintf("%s/api/v1/org/dns/records/%s", c.BaseURL, neturl.PathEscape(recordID))
+	_, err := c.doDnsRequest(ctx, http.MethodDelete, url, nil)
+	return err
+}
+
+// doDnsRequest sends an authenticated JSON request to the DNS record routes.
+// 400/403 responses surface the backend's detail message verbatim - those
+// texts are user-actionable validation and admin-gate explanations.
+func (c *Client) doDnsRequest(ctx context.Context, method, url string, body []byte) ([]byte, error) {
+	var bodyReader *bytes.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	var req *http.Request
+	var err error
+	if bodyReader != nil {
+		req, err = http.NewRequestWithContext(ctx, method, url, bodyReader)
+	} else {
+		req, err = http.NewRequestWithContext(ctx, method, url, nil)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer closeBody(resp)
+
+	respBody, err := readResponseBody(resp)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
+		return respBody, nil
+	case http.StatusUnauthorized:
+		return nil, ErrUnauthorized
+	case http.StatusNotFound:
+		return nil, ErrDnsRecordNotFound
+	case http.StatusBadRequest, http.StatusForbidden:
+		if detail := dnsDetailFromBody(respBody); detail != "" {
+			return nil, errors.New(detail)
+		}
+		return nil, newUnexpectedResponseError("DNS record request failed", resp.StatusCode, truncateForError(respBody, 500))
+	default:
+		return nil, newUnexpectedResponseError("DNS record request failed", resp.StatusCode, truncateForError(respBody, 500))
+	}
+}
+
+// dnsDetailFromBody extracts the {"detail": "..."} member the backend uses
+// for validation and permission errors; empty when the body has another
+// shape.
+func dnsDetailFromBody(body []byte) string {
+	var envelope struct {
+		Detail string `json:"detail"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return ""
+	}
+	return envelope.Detail
+}


### PR DESCRIPTION
## What & why

Managing records in the organisation's delegated DNS zone was portal-only — the platform had no token surface and the CLI no commands, so pointing a hostname at a load balancer meant clicking through Organisation → Settings → DNS. This adds the `ankra org dns` group over the new bearer-PAT surface (ankraio/cluster#1201):

    ankra org dns zone                                     # delegated zone + state
    ankra org dns list
    ankra org dns add chat CNAME lb-1.example-lb.com --ttl 300
    ankra org dns update chat target.example.com
    ankra org dns delete chat

Records are referenced by id, full fqdn, or the label inside the zone; an ambiguous name lists its candidates and `--type` disambiguates. Backend validation and admin-gate messages surface verbatim (they are user-actionable), deletes confirm first (`--yes` skips), and `zone`/`list` support `-o json|yaml`.

Depends on ankraio/cluster#1201 deploying — until then the commands answer 404 from the API.

## Test plan

- `go build ./...`, `go vet ./...`, `golangci-lint run` — clean; full `go test -race -count=1 ./...` green (pre-commit hook also ran it).
- New `cmd/org_dns_test.go`: zone rendering, add wire shape incl. `--ttl` (and nil TTL when omitted), name→id resolution on update, ambiguity refusal + `--type` disambiguation on delete, unknown-name failure.
- `APIClient` interface, `baseMock`, and `internal/client` extended together per the triple-agreement invariant.

## Docs checklist

- [x] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); ensure `Short`/`Long`/`Example` on new commands are written for docs readers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwTGxDWHtE4Rdutspcybm1