### PR TITLE
fix(org dns): correct the --ttl range in help to 30..86400 (ankra-k7w5)

### DIFF
--- a/cmd/org_dns.go
+++ b/cmd/org_dns.go
@@ -277,8 +277,8 @@ func renderDnsRecords(out io.Writer, records []client.DnsRecord, format outputFo
 
 func init() {
 	registerStructuredOutputFlags(orgDnsZoneCmd, orgDnsListCmd)
-	orgDnsAddCmd.Flags().Int("ttl", 0, "TTL in seconds (30..604800); omitted means Auto")
-	orgDnsUpdateCmd.Flags().Int("ttl", 0, "TTL in seconds (30..604800); omitted keeps the record's current ttl")
+	orgDnsAddCmd.Flags().Int("ttl", 0, "TTL in seconds (30..86400); omitted means Auto")
+	orgDnsUpdateCmd.Flags().Int("ttl", 0, "TTL in seconds (30..86400); omitted keeps the record's current ttl")
 	orgDnsUpdateCmd.Flags().String("type", "", "Record type (CNAME, A, TXT) to disambiguate a name reference")
 	orgDnsDeleteCmd.Flags().String("type", "", "Record type (CNAME, A, TXT) to disambiguate a name reference")
 	orgDnsDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")


### PR DESCRIPTION
Help-text follow-up to cluster#1209.

**bead:** ankra-k7w5

`ankra org dns add|update --ttl` advertised `(30..604800)`. Records land in Avura, whose `validateRecord` **clamps** ttl into `[TTL_MIN, TTL_MAX] = [30, 86400]` rather than rejecting — on both the create and the edit path. So a week was never actually served; the caller just got told it was. cluster#1209 lowers the backend bound to match, and this brings the help in line.

The CLI passes `--ttl` straight through with no client-side validation, so this is help text only: before cluster#1209 a larger value was silently clamped by Avura, after it the backend answers 400.

The generated CLI reference under `ankra-docs/reference/cli` picks this up on the next STABLE tag.

## Verification

- `make build test` — exit 0 (`ankra/cmd`, `internal/client`, `internal/kubeconfig`, `internal/skills` all ok, `-race`)
- `make lint` — 0 issues
