### PR TITLE
release: cut v0.11.0-rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,26 @@
 
 ## Unreleased
 
+## v0.11.0-rc3 — 2026-08-16
+
+Release candidate, superseding v0.11.0-rc2 — rc2 predates `ankra org dns`
+entirely. Install it with `ankra config beta enable && ankra upgrade`, or
+download a binary from the release page; `ankra config beta disable` returns
+you to the stable channel.
+
 ### Added
+
+- **`ankra org dns` manages records in the organisation's own delegated
+  zone.** Every organisation gets a zone of its own (`ankra org dns zone`), and
+  until now the only way to point a memorable name at an add-on's generated
+  hostname was the API. `list` shows every record with its reconciliation
+  state, `add <name> <type> <content>` creates a CNAME, A, or TXT record under
+  the zone — the zone fqdn is appended for you — `update` re-points one at a
+  new target, and `delete` removes it. Records reconcile asynchronously, so a
+  new or edited record reads `pending` until it is published to the
+  authoritative nameservers and then turns `active`; a record that could not
+  be published reports why in the `ERROR` column rather than sitting silently
+  wrong.
 
 - **`ankra application registry` points an existing application at a container
   registry you operate.** An application publishes into the organisation's own
@@ -18,6 +37,16 @@
   Setting a registry without `--credential` is allowed but warns, because
   without a credential Ankra can describe where the images live and neither
   read nor pull them.
+
+### Fixed
+
+- **`ankra org dns --ttl` no longer offers a range the nameservers will not
+  serve.** The help advertised `30..604800`, but a record's ttl is capped at
+  one day upstream, and anything longer used to be quietly reduced to that —
+  so a record you set to a week reported a week back to you while resolvers
+  were told one day. The accepted range is now `30..86400` in both the help
+  and the platform, and a longer value is refused outright instead of being
+  silently rewritten.
 
 ## v0.11.0-rc2 — 2026-08-16
 


### PR DESCRIPTION
## Summary

Cuts **v0.11.0-rc3**. CHANGELOG.md only — there is no version constant in the source.

**rc2 was tagged before `ankra org dns` landed.** Three commits sit above it on master:

```
v0.11.0-rc2  (tagged 17:58)
  ├─ c78f3cc  feat(org): add 'ankra org dns' record management commands (#84)
  ├─ a032c2a  feat(application): set an existing application's image registry (#79)
  └─ c87eac4  fix(org dns): correct the --ttl range in help to 30..86400 (#85)
```

Promoting rc2 to v0.11.0 would ship the minor without the org DNS surface at all. rc3 carries all three, and adds the changelog entry #84 landed without.

## Test plan

The rc1 lesson was that green gates prove nothing about the shipped artifact, so `ankra org dns` was exercised against **production** with a binary built from `c87eac4`, full lifecycle on a throwaway label:

| Step | Result |
|---|---|
| `org dns zone` | `2hqbgfae9a.ankra.cc`, active |
| `org dns add clitest-tmp A 203.0.113.10 --ttl 300` | created, `pending` |
| `org dns update clitest-tmp 203.0.113.20` | re-pointed |
| reconcile | `pending` → **`active`** within ~90s |
| `dig clitest-tmp.2hqbgfae9a.ankra.cc` | **`203.0.113.20`** — resolves publicly |
| `org dns list -o json` | well-formed |
| `org dns delete clitest-tmp --yes` | `deleting` → row reaped |
| ttl `86400` | accepted (new ceiling) |
| ttl `86401` / `29` / `604800` | refused with the 30..86400 message |

Test record fully removed; the zone is back to its two real records. `make build test` (`-race`) and `make lint` both clean, and `go.mod` is already on `toolchain go1.26.6`, so govulncheck is not red.

Release-notes extractor dry-run matches the heading (45 lines extracted, no silent `--generate-notes` fallback):

```
awk -v version="0.11.0-rc3" '$0 ~ "^## v?"version"([[:space:]]|$)" {found=1; next} found && /^## / {exit} found {print}' CHANGELOG.md
```

## Docs

`ankra-docs/reference/cli` regenerates on stable tags only, so no docs PR is due for an `-rcN`.
