### PR TITLE
feat(cluster): --force on UpCloud stop/deprovision reclaims CSI volumes and load balancers (ankra-c4di)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@
   cuts the version, `list` and `delete` manage open drafts. Drafts were
   browser-and-MCP-only until now; the platform gained bearer-token twins for
   the whole draft family in the same change.
+- **`--force` on UpCloud deprovision and stop now reclaims leaked cloud
+  resources.** `ankra cluster deprovision --force` and
+  `ankra cluster upcloud stop|deprovision --force` also delete the cluster's
+  CSI-provisioned storage volumes and load balancers, which UpCloud never
+  reclaims on its own and which keep billing after a plain stop or terminate.
+  The backend deletes exactly the volumes recorded for the cluster - never
+  another cluster's disks. Without `--force`, behaviour is unchanged.
 
 ## v0.11.0-rc4 — 2026-08-17
 

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1067,11 +1067,11 @@ func (m baseMock) CreateUpcloudCluster(req client.CreateUpcloudClusterRequest) (
 	return nil, errors.New("not implemented")
 }
 
-func (m baseMock) DeprovisionUpcloudCluster(clusterID string) (*client.DeprovisionUpcloudClusterResponse, error) {
+func (m baseMock) DeprovisionUpcloudCluster(clusterID string, force bool) (*client.DeprovisionUpcloudClusterResponse, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (m baseMock) StopUpcloudCluster(clusterID string) (*client.StopUpcloudClusterResponse, error) {
+func (m baseMock) StopUpcloudCluster(clusterID string, force bool) (*client.StopUpcloudClusterResponse, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -305,12 +305,13 @@ to the provider-specific deprovision endpoint so cloud resources are released.`,
 			return err
 		}
 
-		// Only the Hetzner deprovision endpoint honors force; every other
-		// lane would silently drop it, so say so instead of implying a
-		// forced teardown that never happens.
-		if force && cloudClusterKind(clusterKind) != cloudClusterKindHetzner {
+		// Only the Hetzner and UpCloud deprovision endpoints honor force;
+		// every other lane would silently drop it, so say so instead of
+		// implying a forced teardown that never happens.
+		if force && cloudClusterKind(clusterKind) != cloudClusterKindHetzner &&
+			cloudClusterKind(clusterKind) != cloudClusterKindUpcloud {
 			_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
-				"warning: --force has no effect for this cluster type (only Hetzner deprovision supports it)")
+				"warning: --force has no effect for this cluster type (only Hetzner and UpCloud deprovision support it)")
 		}
 
 		if err := confirmPrompt(
@@ -352,7 +353,7 @@ to the provider-specific deprovision endpoint so cloud resources are released.`,
 			fmt.Printf("  Cluster ID: %s\n", result.ClusterID)
 			return nil
 		case cloudClusterKindUpcloud:
-			result, err := apiClient.DeprovisionUpcloudCluster(clusterID)
+			result, err := apiClient.DeprovisionUpcloudCluster(clusterID, force)
 			if err != nil {
 				return fmt.Errorf("deprovisioning UpCloud cluster: %w", err)
 			}
@@ -499,7 +500,7 @@ func init() {
 	// so existing scripts don't break on an unknown flag; see DEPRECATIONS.md.
 	_ = clusterDeprovisionCmd.Flags().MarkDeprecated("auto-delete",
 		"the backend does not support it; deprovision never deletes the cluster record (use 'ankra delete cluster' afterwards)")
-	clusterDeprovisionCmd.Flags().Bool("force", false, "Force deprovision even if cluster is in an unexpected state (only honored for Hetzner clusters)")
+	clusterDeprovisionCmd.Flags().Bool("force", false, "Force deprovision even if cluster is in an unexpected state (Hetzner and UpCloud; on UpCloud also deletes leftover CSI storage volumes and load balancers)")
 	clusterDeprovisionCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
 	clusterRollToCmd.Flags().String("version", "", "Resource version ID to roll to (required)")

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -297,8 +297,8 @@ type APIClient interface {
 	CreateOvhSSHKeyCredential(req client.CreateSSHKeyCredentialRequest) (*client.CreateSSHKeyCredentialResponse, error)
 
 	CreateUpcloudCluster(req client.CreateUpcloudClusterRequest) (*client.CreateUpcloudClusterResponse, error)
-	DeprovisionUpcloudCluster(clusterID string) (*client.DeprovisionUpcloudClusterResponse, error)
-	StopUpcloudCluster(clusterID string) (*client.StopUpcloudClusterResponse, error)
+	DeprovisionUpcloudCluster(clusterID string, force bool) (*client.DeprovisionUpcloudClusterResponse, error)
+	StopUpcloudCluster(clusterID string, force bool) (*client.StopUpcloudClusterResponse, error)
 	StartUpcloudCluster(clusterID, scope string) (*client.StartUpcloudClusterResult, error)
 	GetUpcloudWorkerCount(clusterID string) (*client.WorkerCountResult, error)
 	ScaleUpcloudWorkers(clusterID string, workerCount int) (*client.ScaleWorkersResult, error)

--- a/cmd/upcloud_cluster.go
+++ b/cmd/upcloud_cluster.go
@@ -101,14 +101,19 @@ var upcloudDeprovisionCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		yes, _ := cmd.Flags().GetBool("yes")
+		force, _ := cmd.Flags().GetBool("force")
 
+		warning := "This deletes all its servers, networks and SSH keys!"
+		if force {
+			warning = "This deletes all its servers, networks, SSH keys, CSI storage volumes and load balancers!"
+		}
 		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
-			fmt.Sprintf("Deprovision UpCloud cluster %q? This deletes all its servers, networks and SSH keys! [y/N]: ", clusterID),
+			fmt.Sprintf("Deprovision UpCloud cluster %q? %s [y/N]: ", clusterID, warning),
 			yes); err != nil {
 			return err
 		}
 
-		result, err := apiClient.DeprovisionUpcloudCluster(clusterID)
+		result, err := apiClient.DeprovisionUpcloudCluster(clusterID, force)
 		if err != nil {
 			return fmt.Errorf("deprovisioning cluster: %w", err)
 		}
@@ -136,12 +141,15 @@ var upcloudDeprovisionCmd = &cobra.Command{
 var upcloudStopCmd = &cobra.Command{
 	Use:   "stop <cluster_id>",
 	Short: "Stop an UpCloud cluster",
-	Long:  "Stop an UpCloud cluster's compute while keeping its configuration so it can be started again later.",
-	Args:  cobra.ExactArgs(1),
+	Long: "Stop an UpCloud cluster's compute while keeping its configuration so it can be started again later.\n\n" +
+		"--force also deletes the cluster's CSI storage volumes and load balancers, which otherwise keep billing " +
+		"while the cluster is stopped - the persisted data is lost.",
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
+		force, _ := cmd.Flags().GetBool("force")
 
-		result, err := apiClient.StopUpcloudCluster(clusterID)
+		result, err := apiClient.StopUpcloudCluster(clusterID, force)
 		if err != nil {
 			return fmt.Errorf("stopping cluster: %w", err)
 		}
@@ -539,6 +547,8 @@ func init() {
 	upcloudStartCmd.Flags().String("scope", "all", "Provisioning scope: 'all' or 'control_plane'")
 
 	upcloudDeprovisionCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
+	upcloudDeprovisionCmd.Flags().Bool("force", false, "Force teardown: also delete the cluster's CSI storage volumes and load balancers, and tolerate unreachable infrastructure")
+	upcloudStopCmd.Flags().Bool("force", false, "Also delete the cluster's CSI storage volumes and load balancers (destroys persisted data; they otherwise keep billing while stopped)")
 	upcloudNodeGroupDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
 	upcloudNodeGroupAddCmd.Flags().String("name", "", "Node group name (required)")

--- a/cmd/upcloud_cluster_test.go
+++ b/cmd/upcloud_cluster_test.go
@@ -14,7 +14,7 @@ type upcloudDeprovisionMock struct {
 	gotClusterID string
 }
 
-func (m *upcloudDeprovisionMock) DeprovisionUpcloudCluster(clusterID string) (*client.DeprovisionUpcloudClusterResponse, error) {
+func (m *upcloudDeprovisionMock) DeprovisionUpcloudCluster(clusterID string, force bool) (*client.DeprovisionUpcloudClusterResponse, error) {
 	m.called = true
 	m.gotClusterID = clusterID
 	return &client.DeprovisionUpcloudClusterResponse{Success: true, ClusterID: clusterID}, nil

--- a/internal/client/upcloud_clusters.go
+++ b/internal/client/upcloud_clusters.go
@@ -93,8 +93,11 @@ func (c *Client) CreateUpcloudCluster(req CreateUpcloudClusterRequest) (*CreateU
 	return &result, nil
 }
 
-func (c *Client) DeprovisionUpcloudCluster(clusterID string) (*DeprovisionUpcloudClusterResponse, error) {
+func (c *Client) DeprovisionUpcloudCluster(clusterID string, force bool) (*DeprovisionUpcloudClusterResponse, error) {
 	url := fmt.Sprintf("%s/api/v1/clusters/upcloud/%s", c.BaseURL, clusterID)
+	if force {
+		url = url + "?force=true"
+	}
 	req, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
@@ -223,8 +226,11 @@ func (c *Client) ScaleUpcloudWorkers(clusterID string, workerCount int) (*ScaleW
 	return c.doScaleWorkers(scaleURL, workerCount)
 }
 
-func (c *Client) StopUpcloudCluster(clusterID string) (*StopUpcloudClusterResponse, error) {
+func (c *Client) StopUpcloudCluster(clusterID string, force bool) (*StopUpcloudClusterResponse, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/clusters/upcloud/%s/stop", c.BaseURL, url.PathEscape(clusterID))
+	if force {
+		endpoint = endpoint + "?force=true"
+	}
 	req, err := http.NewRequest(http.MethodPost, endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)

--- a/internal/client/upcloud_clusters_test.go
+++ b/internal/client/upcloud_clusters_test.go
@@ -130,12 +130,29 @@ func TestDeprovisionUpcloudCluster_Success(t *testing.T) {
 		}
 		jsonResponse(t, w, http.StatusOK, expectedResponse)
 	})
-	result, err := testClient.DeprovisionUpcloudCluster("upcloud-cluster-123")
+	result, err := testClient.DeprovisionUpcloudCluster("upcloud-cluster-123", false)
 	if err != nil {
 		t.Fatalf("DeprovisionUpcloudCluster: %v", err)
 	}
 	if !result.Success {
 		t.Error("Success = false, want true")
+	}
+}
+
+func TestDeprovisionUpcloudCluster_ForceAppendsQuery(t *testing.T) {
+	expectedResponse := DeprovisionUpcloudClusterResponse{Success: true, ClusterID: "upcloud-cluster-123"}
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/api/v1/clusters/upcloud/upcloud-cluster-123" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if r.URL.Query().Get("force") != "true" {
+			t.Errorf("force query = %q, want true", r.URL.Query().Get("force"))
+		}
+		jsonResponse(t, w, http.StatusOK, expectedResponse)
+	})
+	if _, err := testClient.DeprovisionUpcloudCluster("upcloud-cluster-123", true); err != nil {
+		t.Fatalf("DeprovisionUpcloudCluster: %v", err)
 	}
 }
 


### PR DESCRIPTION
Bead: ankra-c4di. CLI half of ankraio/cluster#1246.

UpCloud teardown leaks CSI-provisioned storage volumes (they keep billing after stop/terminate) and can leave load balancers behind. The backend now sweeps both when `force=true` is passed; this PR forwards it from the CLI:

- `DeprovisionUpcloudCluster` / `StopUpcloudCluster` take a `force` flag appending `?force=true`, same shape as `DeprovisionHetznerCluster`.
- `ankra cluster deprovision --force` now reaches UpCloud instead of warning that only Hetzner supports it.
- `ankra cluster upcloud stop --force` and `ankra cluster upcloud deprovision --force` added; the deprovision confirmation prompt names the volumes and load balancers when forcing, and the stop help says plainly that persisted data is lost.

Without `--force` nothing changes. Full `go test ./...` green; client test asserts the query string; CHANGELOG Unreleased entry included.