### PR TITLE
fix(upcloud): stop sending a colliding default network range; add --cni and --include-dns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+### Fixed
+
+- **`ankra cluster upcloud create` no longer collides with existing networks.**
+  The command shipped `--network-ip-range` with a literal `10.0.0.0/16` default
+  and always sent it, so on any account that already had a `10.0.x` private
+  network the create wedged at the network step with `UpCloud API 409: Network
+  address 10.0.0.0/16 overlaps with an existing private network`. The flag now
+  defaults to empty and an unset range is omitted from the request, letting the
+  platform pick a range that is free in your account — the same behaviour the
+  portal's API and AI lanes always had. Pass `--network-ip-range` only to pin
+  a specific range.
+
+### Added
+
+- **`ankra cluster upcloud create --cni`** selects the container network
+  interface for k3s clusters (`flannel`, `calico`, or `cilium`; kubeadm
+  clusters always use cilium), closing a gap where the CNI was only choosable
+  from the portal wizard.
+- **`ankra cluster upcloud create --include-dns`** surfaces the delegated
+  ankra.cc subdomain opt-out (default on), completing the
+  `--external-cloud-provider` / `--include-networking` / `--include-dns` trio
+  the API and portal already expose.
+
 ## v0.11.0-rc3 — 2026-08-16
 
 Release candidate, superseding v0.11.0-rc2 — rc2 predates `ankra org dns`

--- a/cmd/upcloud_cluster.go
+++ b/cmd/upcloud_cluster.go
@@ -32,6 +32,7 @@ var upcloudCreateCmd = &cobra.Command{
 		workerCount, _ := cmd.Flags().GetInt("worker-count")
 		workerPlan, _ := cmd.Flags().GetString("worker-plan")
 		distribution, _ := cmd.Flags().GetString("distribution")
+		cni, _ := cmd.Flags().GetString("cni")
 		kubeVersion, _ := cmd.Flags().GetString("kubernetes-version")
 		etcdTopology, _ := cmd.Flags().GetString("etcd-topology")
 		etcdNodeCount, _ := cmd.Flags().GetInt("etcd-node-count")
@@ -40,6 +41,7 @@ var upcloudCreateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		includeDNS, _ := cmd.Flags().GetBool("include-dns")
 		gitopsCredentialName, _ := cmd.Flags().GetString("gitops-credential-name")
 		gitopsRepository, _ := cmd.Flags().GetString("gitops-repository")
 		gitopsBranch, _ := cmd.Flags().GetString("gitops-branch")
@@ -56,11 +58,13 @@ var upcloudCreateCmd = &cobra.Command{
 			WorkerCount:           workerCount,
 			WorkerPlan:            workerPlan,
 			Distribution:          distribution,
+			CNI:                   cni,
 			EtcdTopology:          etcdTopology,
 			EtcdNodeCount:         etcdNodeCount,
 			EtcdPlan:              etcdPlan,
 			ExternalCloudProvider: externalCloudProvider,
 			IncludeNetworking:     includeNetworking,
+			IncludeDNS:            includeDNS,
 		}
 		if kubeVersion != "" {
 			req.KubernetesVersion = &kubeVersion
@@ -514,7 +518,7 @@ func init() {
 	upcloudCreateCmd.Flags().String("credential-id", "", "UpCloud API credential ID (required)")
 	upcloudCreateCmd.Flags().String("ssh-key-credential-id", "", "SSH key credential ID (required)")
 	upcloudCreateCmd.Flags().String("zone", "", "UpCloud zone (required)")
-	upcloudCreateCmd.Flags().String("network-ip-range", "10.0.0.0/16", "Network IP range")
+	upcloudCreateCmd.Flags().String("network-ip-range", "", "Private network IP range. Omitted lets Ankra pick a range that is free in your UpCloud account; pass one only to pin it (a range that overlaps an existing network is rejected by UpCloud)")
 	upcloudCreateCmd.Flags().String("bastion-plan", "1xCPU-2GB", "Bastion plan")
 	upcloudCreateCmd.Flags().Int("control-plane-count", 1, "Number of control plane nodes")
 	upcloudCreateCmd.Flags().String("control-plane-plan", "2xCPU-4GB", "Control plane plan")
@@ -526,6 +530,8 @@ func init() {
 	upcloudCreateCmd.Flags().Int("etcd-node-count", 3, "Number of dedicated etcd nodes when --etcd-topology=external (3 or 5)")
 	upcloudCreateCmd.Flags().String("etcd-plan", "2xCPU-4GB", "Plan for dedicated etcd nodes when --etcd-topology=external")
 	upcloudCreateCmd.Flags().Bool("external-cloud-provider", true, "Install the UpCloud CCM and CSI (cloud-provider=external) for LoadBalancers and persistent volumes (default on; pass --external-cloud-provider=false to skip, which also disables --include-networking)")
+	upcloudCreateCmd.Flags().String("cni", "", "Container network interface for k3s clusters: flannel (default), calico, or cilium. kubeadm clusters always use cilium")
+	upcloudCreateCmd.Flags().Bool("include-dns", true, "Give the cluster its own delegated ankra.cc subdomain with external-dns wired to it (default on; pass --include-dns=false to skip)")
 	upcloudCreateCmd.Flags().Bool("include-networking", true, "Install Traefik + cert-manager for ingress (default on; pass --include-networking=false to skip). Requires --external-cloud-provider (the ingress LoadBalancer is provisioned by the cloud controller manager)")
 	upcloudCreateCmd.Flags().String("gitops-credential-name", "", "GitOps GitHub credential name; when set with --gitops-repository, the generated upcloud-cloud-provider stack is committed to Git (optional)")
 	upcloudCreateCmd.Flags().String("gitops-repository", "", "GitOps repository (e.g. org/repo) to commit the generated stack to (optional)")

--- a/internal/client/upcloud_clusters.go
+++ b/internal/client/upcloud_clusters.go
@@ -15,19 +15,21 @@ type CreateUpcloudClusterRequest struct {
 	CredentialID          string  `json:"credential_id"`
 	SSHKeyCredentialID    string  `json:"ssh_key_credential_id"`
 	Zone                  string  `json:"zone"`
-	NetworkIPRange        string  `json:"network_ip_range"`
+	NetworkIPRange        string  `json:"network_ip_range,omitempty"`
 	BastionPlan           string  `json:"bastion_plan"`
 	ControlPlaneCount     int     `json:"control_plane_count"`
 	ControlPlanePlan      string  `json:"control_plane_plan"`
 	WorkerCount           int     `json:"worker_count"`
 	WorkerPlan            string  `json:"worker_plan"`
 	Distribution          string  `json:"distribution"`
+	CNI                   string  `json:"cni,omitempty"`
 	KubernetesVersion     *string `json:"kubernetes_version,omitempty"`
 	EtcdTopology          string  `json:"etcd_topology,omitempty"`
 	EtcdNodeCount         int     `json:"etcd_node_count,omitempty"`
 	EtcdPlan              string  `json:"etcd_plan,omitempty"`
 	ExternalCloudProvider bool    `json:"external_cloud_provider"`
 	IncludeNetworking     bool    `json:"include_networking"`
+	IncludeDNS            bool    `json:"include_dns"`
 	GitopsCredentialName  *string `json:"gitops_credential_name,omitempty"`
 	GitopsRepository      *string `json:"gitops_repository,omitempty"`
 	GitopsBranch          *string `json:"gitops_branch,omitempty"`

--- a/internal/client/upcloud_clusters_test.go
+++ b/internal/client/upcloud_clusters_test.go
@@ -452,3 +452,39 @@ func TestDeleteUpcloudNodeGroup_Error(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 }
+
+func TestCreateUpcloudCluster_OmitsUnsetNetworkRangeAndSendsParityFields(t *testing.T) {
+	expectedResponse := CreateUpcloudClusterResponse{ClusterID: "upcloud-cluster-456", Name: "gpu-chat"}
+	var receivedBody map[string]any
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&receivedBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		jsonResponse(t, w, http.StatusCreated, expectedResponse)
+	})
+	req := CreateUpcloudClusterRequest{
+		Name: "gpu-chat", CredentialID: "cred-1", SSHKeyCredentialID: "ssh-1",
+		Zone: "fi-hel2", BastionPlan: "1xCPU-2GB",
+		ControlPlaneCount: 1, ControlPlanePlan: "2xCPU-4GB",
+		WorkerCount: 1, WorkerPlan: "GPU-8xCPU-64GB-1xL4", Distribution: "k3s",
+		CNI:                   "cilium",
+		ExternalCloudProvider: true,
+		IncludeNetworking:     true,
+		IncludeDNS:            true,
+	}
+	if _, err := testClient.CreateUpcloudCluster(req); err != nil {
+		t.Fatalf("CreateUpcloudCluster: %v", err)
+	}
+	// An unset range must be omitted entirely: sending a literal default made
+	// every create collide with any existing 10.0.x network in the account
+	// (UpCloud 409), while omission lets the platform pick a free range.
+	if _, present := receivedBody["network_ip_range"]; present {
+		t.Errorf("network_ip_range must be omitted when unset, got %v", receivedBody["network_ip_range"])
+	}
+	if got, ok := receivedBody["cni"].(string); !ok || got != "cilium" {
+		t.Errorf("cni = %v, want cilium", receivedBody["cni"])
+	}
+	if got, ok := receivedBody["include_dns"].(bool); !ok || !got {
+		t.Errorf("include_dns = %v, want true", receivedBody["include_dns"])
+	}
+}


### PR DESCRIPTION
## The bug

`ankra cluster upcloud create` hardcoded `--network-ip-range 10.0.0.0/16` and always sent it. UpCloud rejects overlapping networks, so on any account that already holds a `10.0.x` private network the create is **accepted**, then wedges at the network step with the reconcile loop failing forever:

```
UpCloud API 409: Network address 10.0.0.0/16 overlaps with an existing private network 10.0.0.0/24.
```

Reproduced live today (cluster `379f68e0`, nine resources failing) while the identical create through the API lane — which omits the field — auto-picked a free range and provisioned first try. The CLI was the only surface pinning a literal default.

## The fix

- `--network-ip-range` defaults to empty; an unset range is **omitted** from the request (`omitempty`), so the platform picks a range that is free in the account. Passing a range still pins it, and the help text now says exactly that.
- Parity gaps closed while in the file: `--cni` (k3s: flannel/calico/cilium; kubeadm always cilium) and `--include-dns` (delegated ankra.cc subdomain opt-out, default on) — completing the `external-cloud-provider` / `include-networking` / `include-dns` trio the API and wizard already expose.

## Test

New client test pins the wire semantics: unset range absent from the body, `cni` and `include_dns` present. `go test ./cmd/... ./internal/client/...` green, gofmt clean on touched files, and the fixed binary verified live: the exact previously-failing command re-run with a locally built binary provisioned a cluster successfully (see follow-up comment with the run).

## Related

The portal wizard prefills the same `10.0.0.0/16` literal and would hit the same 409 — filed separately. A server-side create preflight that rejects an overlapping range at request time (instead of accepting and failing in reconcile) is also filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVjTVS6VVy8azWdVayMMsT