### PR TITLE
fix(helm): surface registry sync errors and honour -o json on sync-jobs (ankra-sjf7)

### DIFF
--- a/cmd/helm.go
+++ b/cmd/helm.go
@@ -108,8 +108,33 @@ Examples:
 		t.Render()
 		fmt.Printf("\nPage %d of %d (total %d)\n",
 			response.Pagination.Page, response.Pagination.TotalPages, response.Pagination.TotalCount)
+		printRegistrySyncErrors(response.Result)
 		return nil
 	},
+}
+
+// printRegistrySyncErrors calls out registries whose last index sync failed.
+// A registry that cannot be indexed still reports a chart count and a recent
+// "Last Indexed", so without this the failure is invisible in the table.
+func printRegistrySyncErrors(registries []client.HelmRegistryListItem) {
+	var failing []client.HelmRegistryListItem
+	for _, registry := range registries {
+		if registry.LastSyncError != nil && *registry.LastSyncError != "" {
+			failing = append(failing, registry)
+		}
+	}
+	if len(failing) == 0 {
+		return
+	}
+	subject := "registries are"
+	if len(failing) == 1 {
+		subject = "registry is"
+	}
+	fmt.Printf("\n%d %s failing to sync:\n", len(failing), subject)
+	for _, registry := range failing {
+		fmt.Printf("  %s: %s\n", registry.Name, *registry.LastSyncError)
+	}
+	fmt.Println("\nInspect one with 'ankra helm registries get <name>'.")
 }
 
 // listAllHelmRegistries pages through the registry list until the backend
@@ -192,6 +217,11 @@ Examples:
 			response.Pagination.TotalCount, len(response.Charts))
 		if response.ResourceState != nil && *response.ResourceState != "" {
 			fmt.Printf("  State:         %s\n", *response.ResourceState)
+		}
+		// State stays "up" for a registry whose index cannot be fetched, so the
+		// sync error is the only signal that its chart list is stale.
+		if response.LastSyncError != nil && *response.LastSyncError != "" {
+			fmt.Printf("  Sync Error:    %s\n", *response.LastSyncError)
 		}
 		return nil
 	},
@@ -476,6 +506,10 @@ var helmRegistriesSyncJobsCmd = &cobra.Command{
 			return fmt.Errorf("listing sync jobs: %w", err)
 		}
 
+		if rendered, err := renderStructured(cmd, response); rendered || err != nil {
+			return err
+		}
+
 		if len(response.Jobs) == 0 {
 			fmt.Println("No sync jobs found.")
 			return nil
@@ -724,7 +758,7 @@ func init() {
 	_ = helmCredentialsUpdateCmd.MarkFlagRequired("username")
 	helmCredentialsDeleteCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
 
-	registerStructuredOutputFlags(helmRegistriesListCmd, helmRegistriesGetCmd, helmCredentialsListCmd)
+	registerStructuredOutputFlags(helmRegistriesListCmd, helmRegistriesGetCmd, helmRegistriesSyncJobsCmd, helmCredentialsListCmd)
 
 	helmRegistriesCmd.AddCommand(helmRegistriesListCmd)
 	helmRegistriesCmd.AddCommand(helmRegistriesGetCmd)

--- a/cmd/helm_registry_sync_error_test.go
+++ b/cmd/helm_registry_sync_error_test.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+// The API has always returned last_sync_error on both the list and the detail
+// route. It was not modelled, so a registry whose index cannot be fetched
+// decoded as healthy: chart_count populated, resource_state "up", no hint that
+// its chart list was stale.
+func TestHelmRegistryListItemDecodesLastSyncError(t *testing.T) {
+	body := `{"name":"acme","kind":"http","url":"https://charts.example.com",` +
+		`"indexing":false,"chart_count":6,"is_global":true,` +
+		`"last_sync_error":"Failed to fetch index.yaml from https://charts.example.com: HTTP 404"}`
+
+	var item client.HelmRegistryListItem
+	if err := json.Unmarshal([]byte(body), &item); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if item.LastSyncError == nil {
+		t.Fatal("LastSyncError was dropped; a failing registry still looks healthy")
+	}
+	if !strings.Contains(*item.LastSyncError, "HTTP 404") {
+		t.Errorf("LastSyncError = %q, want the fetch failure", *item.LastSyncError)
+	}
+}
+
+func TestHelmRegistryListItemLeavesLastSyncErrorNilWhenHealthy(t *testing.T) {
+	var item client.HelmRegistryListItem
+	if err := json.Unmarshal([]byte(`{"name":"acme","chart_count":6,"last_sync_error":null}`), &item); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if item.LastSyncError != nil {
+		t.Errorf("LastSyncError = %q, want nil for a healthy registry", *item.LastSyncError)
+	}
+}
+
+func TestGetHelmRegistryResponseDecodesLastSyncError(t *testing.T) {
+	body := `{"registry":{"name":"acme","url":"https://charts.example.com"},"charts":[],` +
+		`"indexing":false,"resource_state":"up",` +
+		`"last_sync_error":"Failed to fetch index.yaml from https://charts.example.com: HTTP 500",` +
+		`"pagination":{"page":1,"total_pages":1,"total_count":0}}`
+
+	var response client.GetHelmRegistryResponse
+	if err := json.Unmarshal([]byte(body), &response); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if response.LastSyncError == nil {
+		t.Fatal("LastSyncError was dropped from the detail response")
+	}
+	// resource_state stays "up" for a registry that cannot be indexed, which is
+	// exactly why the error has to be surfaced separately.
+	if response.ResourceState == nil || *response.ResourceState != "up" {
+		t.Errorf("ResourceState = %v, want \"up\" alongside the sync error", response.ResourceState)
+	}
+}
+
+func TestPrintRegistrySyncErrors(t *testing.T) {
+	failing := "Failed to fetch index.yaml from https://charts.example.com: HTTP 404"
+	empty := ""
+
+	cases := []struct {
+		name        string
+		registries  []client.HelmRegistryListItem
+		wantOutput  []string
+		wantSilence bool
+	}{
+		{
+			name:        "no registries",
+			registries:  nil,
+			wantSilence: true,
+		},
+		{
+			name: "all healthy",
+			registries: []client.HelmRegistryListItem{
+				{Name: "acme"},
+				{Name: "globex", LastSyncError: &empty},
+			},
+			wantSilence: true,
+		},
+		{
+			name: "one failing is singular",
+			registries: []client.HelmRegistryListItem{
+				{Name: "acme", LastSyncError: &failing},
+				{Name: "globex"},
+			},
+			wantOutput: []string{"1 registry is failing to sync", "acme: ", "HTTP 404"},
+		},
+		{
+			name: "several failing are plural",
+			registries: []client.HelmRegistryListItem{
+				{Name: "acme", LastSyncError: &failing},
+				{Name: "globex", LastSyncError: &failing},
+			},
+			wantOutput: []string{"2 registries are failing to sync", "acme", "globex"},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			output := captureStdout(t, func() {
+				printRegistrySyncErrors(testCase.registries)
+			})
+			if testCase.wantSilence {
+				if strings.TrimSpace(output) != "" {
+					t.Errorf("expected no output, got %q", output)
+				}
+				return
+			}
+			for _, want := range testCase.wantOutput {
+				if !strings.Contains(output, want) {
+					t.Errorf("output %q does not contain %q", output, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/client/helm.go
+++ b/internal/client/helm.go
@@ -29,6 +29,10 @@ type HelmRegistryListItem struct {
 	NextSyncAt     *string  `json:"next_sync_at,omitempty"`
 	ChartCount     int      `json:"chart_count"`
 	IsGlobal       bool     `json:"is_global"`
+	// LastSyncError carries the reason the most recent index sync failed. The
+	// API has always returned it; leaving it unmodelled made a broken registry
+	// indistinguishable from a healthy one.
+	LastSyncError *string `json:"last_sync_error,omitempty"`
 }
 
 // helmRegistryKindFromURL returns "oci" for an oci:// URL and "http"
@@ -55,6 +59,7 @@ type GetHelmRegistryResponse struct {
 	ReadJobInterval *int                      `json:"read_job_interval,omitempty"`
 	OrganisationID  *string                   `json:"organisation_id,omitempty"`
 	ResourceState   *string                   `json:"resource_state,omitempty"`
+	LastSyncError   *string                   `json:"last_sync_error,omitempty"`
 	Pagination      Pagination                `json:"pagination"`
 }
 


### PR DESCRIPTION
Two CLI papercuts that cost real debugging time today while tracking down why a chart published to a connected registry was not appearing in the catalog.

Bead: `ankra-sjf7`

## A failing registry looks healthy

`last_sync_error` has been on both the list and detail responses all along (the `helmapi` parity tests assert it), but neither CLI struct modelled it, so it was dropped at decode time.

That matters because a registry whose `index.yaml` cannot be fetched keeps `resource_state: up`, keeps its previous `chart_count`, and keeps a fresh `last_indexed_at` — the read lane records the failure and moves on. So `registries get` printed a clean, healthy record for a registry that had not successfully indexed in days:

```
Registry: acme
  Last Indexed:  57 seconds ago
  Charts:        6 (showing 6 on this page)
  State:         up            # ← and nothing about the 404 behind it
```

Now:

```
  State:         up
  Sync Error:    Failed to fetch index.yaml from https://charts.example.com: HTTP 404
```

`registries list` names the failing registries under the table — a column would make the table unreadable, and staying silent is what caused the confusion:

```
2 registries are failing to sync:
  acme: Failed to fetch index.yaml from https://charts.example.com: HTTP 404
  globex: Failed to fetch index.yaml from https://charts.globex.test: HTTP 500

Inspect one with 'ankra helm registries get <name>'.
```

## `sync-jobs -o json` silently produced nothing

`registries sync-jobs` never called `renderStructured` and was not passed to `registerStructuredOutputFlags`, so `-o json` was an unknown shorthand: exit non-zero, error on stderr, nothing on stdout. Redirect stdout to a file and you get an empty file, which reads as "no sync jobs" rather than "that flag does not exist". Every sibling command (`registries list`, `registries get`, `credentials list`) supports it, so this was just an omission.

Verified against production after rebuilding:

```console
$ ankra helm registries sync-jobs ankra-charts -o json
{
  "jobs": [
    { "id": "d0d381b9-...", "name": "read_chart_resource", "status": "success", ... }
```

## Tests

Four new tests in `cmd/helm_registry_sync_error_test.go`: both response shapes decode `last_sync_error` (and leave it nil when healthy), the detail case asserts the error survives *alongside* `resource_state: "up"` because that combination is the whole point, and `printRegistrySyncErrors` is covered for none/all-healthy/one (singular)/several (plural).

`make test` (with `-race`) and `make lint` are both clean; the rebuilt binary was smoke-tested against production for both behaviours.

## Not in scope

The thing I was originally chasing is server-side and still open: a chart published to the already-connected global `ankra-charts` registry does not get created. `chart_count` stays at 6 while the published `index.yaml` has had 7 entries for hours, the only jobs visible to the org are `read_http_registry` (which refreshes existing charts rather than creating new ones), and for a **global** registry an org cannot see the sync job or usefully force one — `registries sync` is rate-limited to once per 10 minutes with a message that does not say when you may retry. Worth a separate look at `scheduler/go/internal/handlers/helm_{read,sync}_http_registry.go`.
