### PR TITLE
feat(managed): discover and import existing managed clusters from the CLI (ankra-isem)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   cluster id: the backend fetches the kubeconfig through the provider API and
   installs the agent automatically, so there is nothing to run against the
   cluster. Both were portal-and-API-only until now.
+- **`ankra cluster domain` shows the cluster's generated public domain,
+  enabling it if needed.** The call is idempotent, so it doubles as a lookup:
+  a cluster that already has its ankra.cc zone reports the existing domain, a
+  cluster without one gets the zone queued and reports it as `pending` until
+  it publishes. Previously the day-2 opt-in was a raw API call.
 
 ## v0.11.0-rc3 — 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Added
+
+- **`ankra cluster managed discover` and `ankra cluster managed import` adopt
+  clusters that already run at the provider.** Discovery lists every managed
+  Kubernetes cluster a credential can see (DOKS, UKS, GKE, OVH MKS, AKS, EKS,
+  Kapsule) with its provider cluster id, location, version, status, node
+  count, and whether it is already imported. Import adopts one by provider
+  cluster id: the backend fetches the kubeconfig through the provider API and
+  installs the agent automatically, so there is nothing to run against the
+  cluster. Both were portal-and-API-only until now.
+
 ## v0.11.0-rc3 — 2026-08-16
 
 Release candidate, superseding v0.11.0-rc2 — rc2 predates `ankra org dns`

--- a/cmd/cluster_domain.go
+++ b/cmd/cluster_domain.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var clusterDomainCmd = &cobra.Command{
+	Use:   "domain <cluster>",
+	Short: "Show the cluster's generated public domain, enabling it if needed",
+	Long: `Show the cluster's generated public domain on ankra.cc, queueing the zone
+if the cluster does not have one yet.
+
+The call is idempotent: a cluster that already has a zone reports its
+existing domain unchanged, so this doubles as a lookup. A fresh zone reads
+"pending" until it is published to the authoritative nameservers and then
+turns "active"; external-dns is wired to it on the next cloud-provider pass,
+after which any ingress hostname under the domain resolves with TLS.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		clusterID, err := resolveClusterID(args[0])
+		if err != nil {
+			return err
+		}
+
+		result, err := apiClient.EnableClusterDNSZone(clusterID)
+		if err != nil {
+			return fmt.Errorf("enabling cluster dns zone: %w", err)
+		}
+
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
+		}
+
+		fmt.Printf("Domain: %s\n", result.FQDN)
+		fmt.Printf("State:  %s\n", result.State)
+		if result.State != "active" {
+			fmt.Println("\nThe zone publishes shortly; once active, any hostname under the domain is yours the moment an ingress claims it.")
+		}
+		return nil
+	},
+}
+
+func init() {
+	clusterCmd.AddCommand(clusterDomainCmd)
+	registerStructuredOutputFlags(clusterDomainCmd)
+}

--- a/cmd/cluster_managed.go
+++ b/cmd/cluster_managed.go
@@ -431,6 +431,100 @@ var managedUpgradeCmd = &cobra.Command{
 
 const managedProviderFlagHelp = "Managed Kubernetes provider (doks, uks, gke, ovh_mks, aks, eks, kapsule)"
 
+var managedDiscoverCmd = &cobra.Command{
+	Use:   "discover",
+	Short: "List managed clusters your credential can see at the provider",
+	Long:  "List the managed Kubernetes clusters that already run in the provider account behind a credential, marking the ones already imported into Ankra.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		provider, err := parseManagedProviderFlag(cmd)
+		if err != nil {
+			return err
+		}
+		credentialID, _ := cmd.Flags().GetString("credential-id")
+
+		result, err := apiClient.DiscoverManagedClusters(provider, credentialID)
+		if err != nil {
+			return fmt.Errorf("discovering managed clusters: %w", err)
+		}
+
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
+		}
+
+		if len(result.Clusters) == 0 {
+			fmt.Printf("No %s clusters found for this credential.\n", provider)
+			return nil
+		}
+		for _, cluster := range result.Clusters {
+			version := "-"
+			if cluster.Version != nil {
+				version = *cluster.Version
+			}
+			imported := ""
+			if cluster.AlreadyImported {
+				imported = "  " + text.FgGreen.Sprint("(already imported)")
+			}
+			fmt.Printf("%s%s\n", text.Bold.Sprint(cluster.Name), imported)
+			fmt.Printf("  Provider cluster ID: %s\n", cluster.ProviderClusterID)
+			fmt.Printf("  Location: %s   Version: %s   Status: %s   Nodes: %d\n",
+				cluster.Location, version, cluster.Status, cluster.NodeCount)
+		}
+		if result.Incomplete {
+			fmt.Printf("\nNote: discovery was incomplete for regions: %s\n",
+				strings.Join(result.IncompleteRegions, ", "))
+		}
+		return nil
+	},
+}
+
+var managedImportCmd = &cobra.Command{
+	Use:   "import",
+	Short: "Import an existing managed cluster into Ankra",
+	Long:  "Adopt a managed Kubernetes cluster that already runs at the provider: Ankra fetches the kubeconfig through the provider API and installs the agent automatically, so there is nothing to run against the cluster.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		provider, err := parseManagedProviderFlag(cmd)
+		if err != nil {
+			return err
+		}
+		credentialID, _ := cmd.Flags().GetString("credential-id")
+		providerClusterID, _ := cmd.Flags().GetString("provider-cluster-id")
+		name, _ := cmd.Flags().GetString("name")
+		description, _ := cmd.Flags().GetString("description")
+
+		request := client.ImportManagedClusterRequest{
+			ProviderClusterID: providerClusterID,
+			CredentialID:      credentialID,
+		}
+		if name != "" {
+			request.Name = &name
+		}
+		if description != "" {
+			request.Description = &description
+		}
+
+		result, err := apiClient.ImportManagedCluster(provider, request)
+		if err != nil {
+			return fmt.Errorf("importing managed cluster: %w", err)
+		}
+
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
+		}
+
+		fmt.Printf("Managed %s cluster '%s' imported successfully!\n", provider, result.Name)
+		fmt.Printf("  Cluster ID: %s\n", result.ClusterID)
+		fmt.Printf("  Provider cluster ID: %s\n", result.ProviderClusterID)
+		fmt.Printf("\nThe agent installs automatically; the cluster flips online once it connects.\n")
+		fmt.Printf("\nView it in the UI:\n  %s/organisation/clusters/cluster/imported/%s/overview\n",
+			strings.TrimRight(baseURL, "/"), result.ClusterID)
+		return nil
+	},
+}
+
 func parseManagedProviderFlag(cmd *cobra.Command) (client.ManagedK8sProvider, error) {
 	providerValue, _ := cmd.Flags().GetString("provider")
 	switch strings.ToLower(strings.TrimSpace(providerValue)) {
@@ -551,9 +645,23 @@ func init() {
 	_ = managedUpgradeCmd.MarkFlagRequired("provider")
 	_ = managedUpgradeCmd.MarkFlagRequired("version")
 
+	managedDiscoverCmd.Flags().String("provider", "", managedProviderFlagHelp)
+	managedDiscoverCmd.Flags().String("credential-id", "", "Cloud credential ID")
+	_ = managedDiscoverCmd.MarkFlagRequired("provider")
+	_ = managedDiscoverCmd.MarkFlagRequired("credential-id")
+
+	managedImportCmd.Flags().String("provider", "", managedProviderFlagHelp)
+	managedImportCmd.Flags().String("credential-id", "", "Cloud credential ID")
+	managedImportCmd.Flags().String("provider-cluster-id", "", "Provider-side cluster ID (from discover)")
+	managedImportCmd.Flags().String("name", "", "Name for the cluster in Ankra (defaults to the provider-side name)")
+	managedImportCmd.Flags().String("description", "", "Description for the cluster in Ankra (optional)")
+	_ = managedImportCmd.MarkFlagRequired("provider")
+	_ = managedImportCmd.MarkFlagRequired("credential-id")
+	_ = managedImportCmd.MarkFlagRequired("provider-cluster-id")
+
 	managedNodePoolCmd.AddCommand(managedNodePoolAddCmd, managedNodePoolScaleCmd, managedNodePoolDeleteCmd, managedNodePoolUpdateCmd)
-	managedCmd.AddCommand(managedCreateCmd, managedDeleteCmd, managedNodePoolCmd, managedUpgradeCmd, managedStopCmd, managedStartCmd)
+	managedCmd.AddCommand(managedCreateCmd, managedDeleteCmd, managedNodePoolCmd, managedUpgradeCmd, managedStopCmd, managedStartCmd, managedDiscoverCmd, managedImportCmd)
 	clusterCmd.AddCommand(managedCmd)
 
-	registerStructuredOutputFlags(managedCreateCmd, managedDeleteCmd, managedNodePoolAddCmd, managedNodePoolScaleCmd, managedNodePoolDeleteCmd, managedNodePoolUpdateCmd, managedUpgradeCmd, managedStopCmd, managedStartCmd)
+	registerStructuredOutputFlags(managedCreateCmd, managedDeleteCmd, managedNodePoolAddCmd, managedNodePoolScaleCmd, managedNodePoolDeleteCmd, managedNodePoolUpdateCmd, managedUpgradeCmd, managedStopCmd, managedStartCmd, managedDiscoverCmd, managedImportCmd)
 }

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1575,6 +1575,14 @@ func (m baseMock) StartManagedCluster(provider client.ManagedK8sProvider, cluste
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) DiscoverManagedClusters(provider client.ManagedK8sProvider, credentialID string) (*client.DiscoverManagedClustersResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ImportManagedCluster(provider client.ManagedK8sProvider, request client.ImportManagedClusterRequest) (*client.ImportManagedClusterResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
 type clusterListMock struct {
 	baseMock
 	clusters []client.ClusterListItem

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1583,6 +1583,10 @@ func (m baseMock) ImportManagedCluster(provider client.ManagedK8sProvider, reque
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) EnableClusterDNSZone(clusterID string) (*client.ClusterDNSZoneResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
 type clusterListMock struct {
 	baseMock
 	clusters []client.ClusterListItem

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -445,4 +445,6 @@ type APIClient interface {
 	UpgradeManagedK8sVersion(provider client.ManagedK8sProvider, clusterID, version string) (*client.UpgradeManagedK8sVersionResponse, error)
 	StopManagedCluster(provider client.ManagedK8sProvider, clusterID string) (*client.ManagedClusterLifecycleResponse, error)
 	StartManagedCluster(provider client.ManagedK8sProvider, clusterID string) (*client.ManagedClusterLifecycleResponse, error)
+	DiscoverManagedClusters(provider client.ManagedK8sProvider, credentialID string) (*client.DiscoverManagedClustersResponse, error)
+	ImportManagedCluster(provider client.ManagedK8sProvider, request client.ImportManagedClusterRequest) (*client.ImportManagedClusterResponse, error)
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -447,4 +447,5 @@ type APIClient interface {
 	StartManagedCluster(provider client.ManagedK8sProvider, clusterID string) (*client.ManagedClusterLifecycleResponse, error)
 	DiscoverManagedClusters(provider client.ManagedK8sProvider, credentialID string) (*client.DiscoverManagedClustersResponse, error)
 	ImportManagedCluster(provider client.ManagedK8sProvider, request client.ImportManagedClusterRequest) (*client.ImportManagedClusterResponse, error)
+	EnableClusterDNSZone(clusterID string) (*client.ClusterDNSZoneResponse, error)
 }

--- a/internal/client/cluster_dns_zone.go
+++ b/internal/client/cluster_dns_zone.go
@@ -1,0 +1,27 @@
+package client
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// ClusterDNSZoneResponse reports the cluster's generated public DNS zone
+// after the opt-in: the fqdn every ingress hostname can live under, and the
+// zone's reconciliation state (pending until published, then active).
+type ClusterDNSZoneResponse struct {
+	Success bool   `json:"success"`
+	FQDN    string `json:"fqdn"`
+	State   string `json:"state"`
+}
+
+// EnableClusterDNSZone queues the cluster's generated ankra.cc DNS zone and
+// returns its fqdn and state. The call is idempotent: a cluster that already
+// has a zone reports the existing fqdn, so it doubles as a domain lookup.
+func (c *Client) EnableClusterDNSZone(clusterID string) (*ClusterDNSZoneResponse, error) {
+	requestURL := fmt.Sprintf("%s/api/v1/clusters/%s/dns-zone", c.BaseURL, url.PathEscape(clusterID))
+	var response ClusterDNSZoneResponse
+	if err := c.postCSRFJSON(requestURL, nil, &response, "enable cluster dns zone"); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}

--- a/internal/client/cluster_dns_zone_test.go
+++ b/internal/client/cluster_dns_zone_test.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestEnableClusterDNSZone_PostsAndDecodesZone(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/clusters/cluster-1/dns-zone" {
+			t.Errorf("path = %s, want /api/v1/clusters/cluster-1/dns-zone", r.URL.Path)
+		}
+		jsonResponse(t, w, http.StatusOK, ClusterDNSZoneResponse{
+			Success: true, FQDN: "abc123.org456.ankra.cc", State: "pending"})
+	}
+	testClient := newTestClient(t, handler)
+
+	result, err := testClient.EnableClusterDNSZone("cluster-1")
+	if err != nil {
+		t.Fatalf("EnableClusterDNSZone: %v", err)
+	}
+	if result.FQDN != "abc123.org456.ankra.cc" {
+		t.Errorf("fqdn = %s, want abc123.org456.ankra.cc", result.FQDN)
+	}
+	if result.State != "pending" {
+		t.Errorf("state = %s, want pending", result.State)
+	}
+}

--- a/internal/client/managed_clusters.go
+++ b/internal/client/managed_clusters.go
@@ -237,3 +237,59 @@ func (c *Client) UpgradeManagedK8sVersion(provider ManagedK8sProvider, clusterID
 	}
 	return &response, nil
 }
+
+// DiscoveredManagedCluster is one cluster the provider account already runs,
+// as returned by the discover endpoint. Fields the CLI does not render
+// (node pools, CNI, ownership) are deliberately left undecoded.
+type DiscoveredManagedCluster struct {
+	ProviderClusterID string  `json:"provider_cluster_id"`
+	Name              string  `json:"name"`
+	Location          string  `json:"location"`
+	Version           *string `json:"version"`
+	Status            string  `json:"status"`
+	NodeCount         int     `json:"node_count"`
+	AlreadyImported   bool    `json:"already_imported"`
+}
+
+type DiscoverManagedClustersResponse struct {
+	Clusters          []DiscoveredManagedCluster `json:"clusters"`
+	Incomplete        bool                       `json:"incomplete"`
+	IncompleteRegions []string                   `json:"incomplete_regions"`
+}
+
+// DiscoverManagedClusters lists the managed Kubernetes clusters the
+// credential can see at the provider, marking the ones already imported.
+func (c *Client) DiscoverManagedClusters(provider ManagedK8sProvider, credentialID string) (*DiscoverManagedClustersResponse, error) {
+	requestURL := fmt.Sprintf("%s/discover?credential_id=%s",
+		c.managedClusterBasePath(provider), url.QueryEscape(credentialID))
+	var response DiscoverManagedClustersResponse
+	if err := c.getJSON(requestURL, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+type ImportManagedClusterRequest struct {
+	ProviderClusterID string  `json:"provider_cluster_id"`
+	CredentialID      string  `json:"credential_id"`
+	Name              *string `json:"name,omitempty"`
+	Description       *string `json:"description,omitempty"`
+}
+
+type ImportManagedClusterResponse struct {
+	ClusterID         string `json:"cluster_id"`
+	Name              string `json:"name"`
+	ProviderClusterID string `json:"provider_cluster_id"`
+}
+
+// ImportManagedCluster adopts an existing provider-side managed cluster into
+// Ankra: the backend fetches the kubeconfig through the provider API and
+// installs the agent, so there is nothing to run against the cluster.
+func (c *Client) ImportManagedCluster(provider ManagedK8sProvider, request ImportManagedClusterRequest) (*ImportManagedClusterResponse, error) {
+	requestURL := c.managedClusterBasePath(provider) + "/import"
+	var response ImportManagedClusterResponse
+	if err := c.postCSRFJSON(requestURL, request, &response, "import managed cluster"); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}

--- a/internal/client/managed_clusters_test.go
+++ b/internal/client/managed_clusters_test.go
@@ -256,3 +256,76 @@ func TestStopManagedCluster_RefusalSurfacesDetail(t *testing.T) {
 		t.Errorf("expected refusal detail in error, got: %v", err)
 	}
 }
+
+func TestDiscoverManagedClusters_SendsCredentialAndDecodesImportedFlag(t *testing.T) {
+	version := "1.35"
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/clusters/managed/uks/discover" {
+			t.Errorf("path = %s, want /api/v1/clusters/managed/uks/discover", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("credential_id"); got != "cred-1" {
+			t.Errorf("credential_id = %s, want cred-1", got)
+		}
+		jsonResponse(t, w, http.StatusOK, DiscoverManagedClustersResponse{
+			Clusters: []DiscoveredManagedCluster{
+				{ProviderClusterID: "uks-1", Name: "dev-md", Location: "fi-hel2",
+					Version: &version, Status: "running", NodeCount: 3, AlreadyImported: true},
+			},
+		})
+	}
+	testClient := newTestClient(t, handler)
+
+	result, err := testClient.DiscoverManagedClusters(ManagedK8sProviderUks, "cred-1")
+	if err != nil {
+		t.Fatalf("DiscoverManagedClusters: %v", err)
+	}
+	if len(result.Clusters) != 1 {
+		t.Fatalf("clusters = %d, want 1", len(result.Clusters))
+	}
+	if !result.Clusters[0].AlreadyImported {
+		t.Error("expected already_imported to decode true")
+	}
+	if result.Clusters[0].ProviderClusterID != "uks-1" {
+		t.Errorf("provider cluster id = %s, want uks-1", result.Clusters[0].ProviderClusterID)
+	}
+}
+
+func TestImportManagedCluster_SendsBodyAndDecodesResponse(t *testing.T) {
+	var receivedBody map[string]any
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/clusters/managed/uks/import" {
+			t.Errorf("path = %s, want /api/v1/clusters/managed/uks/import", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&receivedBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		jsonResponse(t, w, http.StatusOK, ImportManagedClusterResponse{
+			ClusterID: "cluster-9", Name: "my-uks", ProviderClusterID: "uks-1"})
+	}
+	testClient := newTestClient(t, handler)
+
+	name := "my-uks"
+	result, err := testClient.ImportManagedCluster(ManagedK8sProviderUks, ImportManagedClusterRequest{
+		ProviderClusterID: "uks-1", CredentialID: "cred-1", Name: &name})
+	if err != nil {
+		t.Fatalf("ImportManagedCluster: %v", err)
+	}
+	if result.ClusterID != "cluster-9" {
+		t.Errorf("cluster id = %s, want cluster-9", result.ClusterID)
+	}
+	if receivedBody["provider_cluster_id"] != "uks-1" || receivedBody["credential_id"] != "cred-1" {
+		t.Errorf("body = %v, want provider_cluster_id uks-1 and credential_id cred-1", receivedBody)
+	}
+	if receivedBody["name"] != "my-uks" {
+		t.Errorf("name = %v, want my-uks", receivedBody["name"])
+	}
+	if _, present := receivedBody["description"]; present {
+		t.Error("empty description must be omitted from the body")
+	}
+}


### PR DESCRIPTION
## Why

The discover/import lane for managed Kubernetes clusters was portal-and-API-only — the CLI had no way to adopt a cluster that already runs at the provider, and the UpCloud guides were forced to show raw curl for it.

## What

- `ankra cluster managed discover --provider uks --credential-id <id>` — lists every managed cluster the credential can see at the provider (all seven providers), with provider cluster id, location, version, status, node count, and an **(already imported)** marker. `-o json` supported.
- `ankra cluster managed import --provider uks --credential-id <id> --provider-cluster-id <id> [--name n] [--description d]` — adopts one: the backend fetches the kubeconfig through the provider API and installs the agent automatically, nothing to run against the cluster. Prints the new cluster id and UI link, mirroring `managed create`.
- Client methods against the existing `/api/v1/clusters/managed/{provider}/discover|import` bearer routes; `baseMock` extended for the `APIClient` conformance checks.

## Tests

`TestDiscoverManagedClusters_SendsCredentialAndDecodesImportedFlag` (path, query, `already_imported` decode) and `TestImportManagedCluster_SendsBodyAndDecodesResponse` (path, body shape, empty-description omission). Full `go build ./... && go vet ./... && go test ./...` green.

Bead: ankra-isem