### PR TITLE
release: cut v0.11.0-rc4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v0.11.0-rc4 — 2026-08-17
+
+Release candidate, superseding v0.11.0-rc3. Install it with `ankra config
+beta enable && ankra upgrade`, or download a binary from the release page;
+`ankra config beta disable` returns you to the stable channel.
+
 ### Added
 
 - **`ankra cluster managed discover` and `ankra cluster managed import` adopt


### PR DESCRIPTION
Moves the Unreleased section under a v0.11.0-rc4 heading: `ankra cluster managed discover` / `import` (#90) and `ankra cluster domain` (#90). Notes extractor dry-run verified against the new heading.

Bead: ankra-isem