### PR TITLE
feat(cluster): --force reclaims volumes and load balancers on every cloud provider (ankra-phep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,18 @@
   cuts the version, `list` and `delete` manage open drafts. Drafts were
   browser-and-MCP-only until now; the platform gained bearer-token twins for
   the whole draft family in the same change.
-- **`--force` on UpCloud deprovision and stop now reclaims leaked cloud
-  resources.** `ankra cluster deprovision --force` and
-  `ankra cluster upcloud stop|deprovision --force` also delete the cluster's
-  CSI-provisioned storage volumes and load balancers, which UpCloud never
-  reclaims on its own and which keep billing after a plain stop or terminate.
-  The backend deletes exactly the volumes recorded for the cluster - never
-  another cluster's disks. Without `--force`, behaviour is unchanged.
+- **`--force` on cloud cluster deprovision and stop now reclaims leaked cloud
+  resources, on every provider that leaks them.** `ankra cluster deprovision
+  --force` and the provider `stop|deprovision --force` commands (UpCloud,
+  Hetzner, OVH, DigitalOcean, plus Scaleway stop) also delete the cluster's
+  CSI-provisioned storage volumes and load balancers, which these providers
+  never reclaim on their own and which keep billing after a plain stop or
+  terminate. The backend deletes exactly the volumes recorded for the
+  cluster - never another cluster's disks. Without `--force`, behaviour is
+  unchanged, with one exception: a plain Hetzner stop or deprovision now
+  keeps the cluster's volumes (previously it always deleted them, so a
+  stopped Hetzner cluster restarted with empty storage); pass `--force` to
+  get the old reclaim-everything behaviour.
 
 ## v0.11.0-rc4 — 2026-08-17
 

--- a/cmd/digitalocean_cluster.go
+++ b/cmd/digitalocean_cluster.go
@@ -103,13 +103,18 @@ var digitaloceanDeprovisionCmd = &cobra.Command{
 		clusterID := args[0]
 		yes, _ := cmd.Flags().GetBool("yes")
 
+		force, _ := cmd.Flags().GetBool("force")
+		warning := "This deletes all its servers, networks and SSH keys!"
+		if force {
+			warning = "This deletes all its servers, networks, SSH keys, block storage volumes and load balancers!"
+		}
 		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
-			fmt.Sprintf("Deprovision DigitalOcean cluster %q? This deletes all its servers, networks and SSH keys! [y/N]: ", clusterID),
+			fmt.Sprintf("Deprovision DigitalOcean cluster %q? %s [y/N]: ", clusterID, warning),
 			yes); err != nil {
 			return err
 		}
 
-		result, err := apiClient.DeprovisionDigitaloceanCluster(clusterID)
+		result, err := apiClient.DeprovisionDigitaloceanCluster(clusterID, force)
 		if err != nil {
 			return fmt.Errorf("deprovisioning cluster: %w", err)
 		}
@@ -141,8 +146,9 @@ var digitaloceanStopCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
+		force, _ := cmd.Flags().GetBool("force")
 
-		result, err := apiClient.StopDigitaloceanCluster(clusterID)
+		result, err := apiClient.StopDigitaloceanCluster(clusterID, force)
 		if err != nil {
 			return fmt.Errorf("stopping cluster: %w", err)
 		}
@@ -604,6 +610,8 @@ func init() {
 	digitaloceanStartCmd.Flags().String("scope", "all", "Provisioning scope: 'all' or 'control_plane'")
 
 	digitaloceanDeprovisionCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
+	digitaloceanDeprovisionCmd.Flags().Bool("force", false, "Force teardown: also delete the cluster's block storage volumes and load balancers, and tolerate unreachable infrastructure")
+	digitaloceanStopCmd.Flags().Bool("force", false, "Also delete the cluster's block storage volumes and load balancers (destroys persisted data; they otherwise keep billing while stopped)")
 	digitaloceanNodeGroupDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
 	digitaloceanNodeGroupAddCmd.Flags().String("name", "", "Node group name (required)")

--- a/cmd/digitalocean_cluster_test.go
+++ b/cmd/digitalocean_cluster_test.go
@@ -14,7 +14,7 @@ type digitaloceanDeprovisionMock struct {
 	gotClusterID string
 }
 
-func (m *digitaloceanDeprovisionMock) DeprovisionDigitaloceanCluster(clusterID string) (*client.DeprovisionDigitaloceanClusterResponse, error) {
+func (m *digitaloceanDeprovisionMock) DeprovisionDigitaloceanCluster(clusterID string, force bool) (*client.DeprovisionDigitaloceanClusterResponse, error) {
 	m.called = true
 	m.gotClusterID = clusterID
 	return &client.DeprovisionDigitaloceanClusterResponse{Success: true, ClusterID: clusterID}, nil

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -779,7 +779,7 @@ func (m baseMock) DeprovisionHetznerCluster(clusterID string, force bool) (*clie
 	return nil, errors.New("not implemented")
 }
 
-func (m baseMock) StopHetznerCluster(clusterID string) (*client.ProviderStopClusterResponse, error) {
+func (m baseMock) StopHetznerCluster(clusterID string, force bool) (*client.ProviderStopClusterResponse, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -895,11 +895,11 @@ func (m baseMock) CreateOvhCluster(req client.CreateOvhClusterRequest) (*client.
 	return nil, errors.New("not implemented")
 }
 
-func (m baseMock) DeprovisionOvhCluster(clusterID string) (*client.DeprovisionOvhClusterResponse, error) {
+func (m baseMock) DeprovisionOvhCluster(clusterID string, force bool) (*client.DeprovisionOvhClusterResponse, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (m baseMock) StopOvhCluster(clusterID string) (*client.StopOvhClusterResponse, error) {
+func (m baseMock) StopOvhCluster(clusterID string, force bool) (*client.StopOvhClusterResponse, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -1163,11 +1163,11 @@ func (m baseMock) CreateDigitaloceanCluster(req client.CreateDigitaloceanCluster
 	return nil, errors.New("not implemented")
 }
 
-func (m baseMock) DeprovisionDigitaloceanCluster(clusterID string) (*client.DeprovisionDigitaloceanClusterResponse, error) {
+func (m baseMock) DeprovisionDigitaloceanCluster(clusterID string, force bool) (*client.DeprovisionDigitaloceanClusterResponse, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (m baseMock) StopDigitaloceanCluster(clusterID string) (*client.StopDigitaloceanClusterResponse, error) {
+func (m baseMock) StopDigitaloceanCluster(clusterID string, force bool) (*client.StopDigitaloceanClusterResponse, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -1283,7 +1283,7 @@ func (m baseMock) CreateDigitaloceanSSHKeyCredential(req client.CreateSSHKeyCred
 	return nil, errors.New("not implemented")
 }
 
-func (m baseMock) StopScalewayCluster(clusterID string) (*client.ProviderStopClusterResponse, error) {
+func (m baseMock) StopScalewayCluster(clusterID string, force bool) (*client.ProviderStopClusterResponse, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/cmd/hetzner_cluster.go
+++ b/cmd/hetzner_cluster.go
@@ -241,8 +241,9 @@ var hetznerStopCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
+		force, _ := cmd.Flags().GetBool("force")
 
-		result, stopError := apiClient.StopHetznerCluster(clusterID)
+		result, stopError := apiClient.StopHetznerCluster(clusterID, force)
 		if stopError != nil {
 			return fmt.Errorf("stopping cluster: %w", stopError)
 		}
@@ -643,6 +644,7 @@ func init() {
 	registerAsyncWriteFlags(nodeGroupDeleteCmd)
 
 	hetznerStartCmd.Flags().String("scope", "all", "Provisioning scope: 'all' or 'control_plane'")
+	hetznerStopCmd.Flags().Bool("force", false, "Also delete the cluster's CSI volumes and load balancers (destroys persisted data; they otherwise keep billing while stopped)")
 
 	registerStructuredOutputFlags(
 		hetznerCreateCmd,

--- a/cmd/ovh_cluster.go
+++ b/cmd/ovh_cluster.go
@@ -110,14 +110,19 @@ var ovhDeprovisionCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
 		yes, _ := cmd.Flags().GetBool("yes")
+		force, _ := cmd.Flags().GetBool("force")
 
+		warning := "This deletes all its servers, networks and SSH keys!"
+		if force {
+			warning = "This deletes all its servers, networks, SSH keys, Cinder volumes and load balancers!"
+		}
 		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
-			fmt.Sprintf("Deprovision OVH cluster %q? This deletes all its servers, networks and SSH keys! [y/N]: ", clusterID),
+			fmt.Sprintf("Deprovision OVH cluster %q? %s [y/N]: ", clusterID, warning),
 			yes); err != nil {
 			return err
 		}
 
-		result, err := apiClient.DeprovisionOvhCluster(clusterID)
+		result, err := apiClient.DeprovisionOvhCluster(clusterID, force)
 		if err != nil {
 			return fmt.Errorf("deprovisioning cluster: %w", err)
 		}
@@ -317,8 +322,9 @@ var ovhStopCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterID := args[0]
+		force, _ := cmd.Flags().GetBool("force")
 
-		result, err := apiClient.StopOvhCluster(clusterID)
+		result, err := apiClient.StopOvhCluster(clusterID, force)
 		if err != nil {
 			return fmt.Errorf("stopping cluster: %w", err)
 		}
@@ -933,6 +939,8 @@ func init() {
 	ovhNodeGroupTaintsCmd.Flags().Bool("clear", false, "Remove all taints from the node group")
 
 	ovhDeprovisionCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
+	ovhDeprovisionCmd.Flags().Bool("force", false, "Force teardown: also delete the cluster's Cinder volumes and load balancers, and tolerate unreachable infrastructure")
+	ovhStopCmd.Flags().Bool("force", false, "Also delete the cluster's Cinder volumes and load balancers (destroys persisted data; they otherwise keep billing while stopped)")
 	ovhNodeGroupDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
 	ovhRegionsCmd.Flags().String("credential-id", "", "OVH API credential ID (required)")

--- a/cmd/ovh_cluster_test.go
+++ b/cmd/ovh_cluster_test.go
@@ -17,7 +17,7 @@ type ovhStopMock struct {
 	gotClusterID string
 }
 
-func (m *ovhStopMock) StopOvhCluster(clusterID string) (*client.StopOvhClusterResponse, error) {
+func (m *ovhStopMock) StopOvhCluster(clusterID string, force bool) (*client.StopOvhClusterResponse, error) {
 	m.gotClusterID = clusterID
 	return &client.StopOvhClusterResponse{Success: true, ClusterID: clusterID}, nil
 }
@@ -392,7 +392,7 @@ type ovhDeprovisionMock struct {
 	called bool
 }
 
-func (m *ovhDeprovisionMock) DeprovisionOvhCluster(clusterID string) (*client.DeprovisionOvhClusterResponse, error) {
+func (m *ovhDeprovisionMock) DeprovisionOvhCluster(clusterID string, force bool) (*client.DeprovisionOvhClusterResponse, error) {
 	m.called = true
 	return &client.DeprovisionOvhClusterResponse{Success: true, ClusterID: clusterID}, nil
 }

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -305,13 +305,18 @@ to the provider-specific deprovision endpoint so cloud resources are released.`,
 			return err
 		}
 
-		// Only the Hetzner and UpCloud deprovision endpoints honor force;
-		// every other lane would silently drop it, so say so instead of
-		// implying a forced teardown that never happens.
-		if force && cloudClusterKind(clusterKind) != cloudClusterKindHetzner &&
-			cloudClusterKind(clusterKind) != cloudClusterKindUpcloud {
-			_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
-				"warning: --force has no effect for this cluster type (only Hetzner and UpCloud deprovision support it)")
+		// The Hetzner, UpCloud, OVH and DigitalOcean deprovision endpoints
+		// honor force; the Proxmox/Morpheus lanes and the generic imported
+		// deprovision drop it, so say so instead of implying a forced
+		// teardown that never happens.
+		if force {
+			switch cloudClusterKind(clusterKind) {
+			case cloudClusterKindHetzner, cloudClusterKindUpcloud,
+				cloudClusterKindOvh, cloudClusterKindDigitalocean:
+			default:
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
+					"warning: --force has no effect for this cluster type")
+			}
 		}
 
 		if err := confirmPrompt(
@@ -342,7 +347,7 @@ to the provider-specific deprovision endpoint so cloud resources are released.`,
 			}
 			return nil
 		case cloudClusterKindOvh:
-			result, err := apiClient.DeprovisionOvhCluster(clusterID)
+			result, err := apiClient.DeprovisionOvhCluster(clusterID, force)
 			if err != nil {
 				return fmt.Errorf("deprovisioning OVH cluster: %w", err)
 			}
@@ -367,7 +372,7 @@ to the provider-specific deprovision endpoint so cloud resources are released.`,
 			}
 			return nil
 		case cloudClusterKindDigitalocean:
-			result, err := apiClient.DeprovisionDigitaloceanCluster(clusterID)
+			result, err := apiClient.DeprovisionDigitaloceanCluster(clusterID, force)
 			if err != nil {
 				return fmt.Errorf("deprovisioning DigitalOcean cluster: %w", err)
 			}
@@ -500,7 +505,7 @@ func init() {
 	// so existing scripts don't break on an unknown flag; see DEPRECATIONS.md.
 	_ = clusterDeprovisionCmd.Flags().MarkDeprecated("auto-delete",
 		"the backend does not support it; deprovision never deletes the cluster record (use 'ankra delete cluster' afterwards)")
-	clusterDeprovisionCmd.Flags().Bool("force", false, "Force deprovision even if cluster is in an unexpected state (Hetzner and UpCloud; on UpCloud also deletes leftover CSI storage volumes and load balancers)")
+	clusterDeprovisionCmd.Flags().Bool("force", false, "Force deprovision even if cluster is in an unexpected state; on UpCloud, Hetzner, OVH and DigitalOcean also deletes leftover CSI storage volumes and load balancers")
 	clusterDeprovisionCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
 	clusterRollToCmd.Flags().String("version", "", "Resource version ID to roll to (required)")

--- a/cmd/scaleway_cluster.go
+++ b/cmd/scaleway_cluster.go
@@ -18,9 +18,10 @@ var scalewayStopCmd = &cobra.Command{
 	Short: "Stop a Scaleway cluster",
 	Long:  "Stop a Scaleway cluster by terminating its compute while preserving its configuration so it can be re-provisioned later.",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(_ *cobra.Command, arguments []string) error {
+	RunE: func(cmd *cobra.Command, arguments []string) error {
 		clusterID := arguments[0]
-		result, stopError := apiClient.StopScalewayCluster(clusterID)
+		force, _ := cmd.Flags().GetBool("force")
+		result, stopError := apiClient.StopScalewayCluster(clusterID, force)
 		if stopError != nil {
 			return fmt.Errorf("stopping Scaleway cluster: %w", stopError)
 		}
@@ -70,6 +71,7 @@ var scalewayStartCmd = &cobra.Command{
 
 func init() {
 	scalewayStartCmd.Flags().String("scope", "all", "Provisioning scope: 'all' or 'control_plane'")
+	scalewayStopCmd.Flags().Bool("force", false, "Also delete the cluster's tagged volumes and load balancers even when retention_policy is retain (destroys persisted data)")
 	scalewayCmd.AddCommand(scalewayStopCmd)
 	scalewayCmd.AddCommand(scalewayStartCmd)
 	clusterCmd.AddCommand(scalewayCmd)

--- a/cmd/scaleway_cluster_test.go
+++ b/cmd/scaleway_cluster_test.go
@@ -14,7 +14,7 @@ type scalewayLifecycleMock struct {
 	stopClusterID  string
 }
 
-func (mock *scalewayLifecycleMock) StopScalewayCluster(clusterID string) (*client.ProviderStopClusterResponse, error) {
+func (mock *scalewayLifecycleMock) StopScalewayCluster(clusterID string, force bool) (*client.ProviderStopClusterResponse, error) {
 	mock.stopClusterID = clusterID
 	return &client.ProviderStopClusterResponse{Success: true, ClusterID: clusterID}, nil
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -224,7 +224,7 @@ type APIClient interface {
 
 	CreateHetznerCluster(req client.CreateHetznerClusterRequest) (*client.CreateHetznerClusterResponse, error)
 	DeprovisionHetznerCluster(clusterID string, force bool) (*client.DeprovisionHetznerClusterResponse, error)
-	StopHetznerCluster(clusterID string) (*client.ProviderStopClusterResponse, error)
+	StopHetznerCluster(clusterID string, force bool) (*client.ProviderStopClusterResponse, error)
 	StartHetznerCluster(clusterID, scope string) (*client.ProviderStartClusterResult, error)
 	GetHetznerWorkerCount(clusterID string) (*client.WorkerCountResult, error)
 	ScaleHetznerWorkers(clusterID string, workerCount int) (*client.ScaleWorkersResult, error)
@@ -256,8 +256,8 @@ type APIClient interface {
 	CreateSSHKeyCredential(req client.CreateSSHKeyCredentialRequest) (*client.CreateSSHKeyCredentialResponse, error)
 
 	CreateOvhCluster(req client.CreateOvhClusterRequest) (*client.CreateOvhClusterResponse, error)
-	DeprovisionOvhCluster(clusterID string) (*client.DeprovisionOvhClusterResponse, error)
-	StopOvhCluster(clusterID string) (*client.StopOvhClusterResponse, error)
+	DeprovisionOvhCluster(clusterID string, force bool) (*client.DeprovisionOvhClusterResponse, error)
+	StopOvhCluster(clusterID string, force bool) (*client.StopOvhClusterResponse, error)
 	StartOvhCluster(clusterID, scope string) (*client.StartOvhClusterResult, error)
 	GetOvhClusterSSHKeys(clusterID string) (*client.ClusterSSHKeysResult, error)
 	UpdateOvhClusterSSHKeys(clusterID string, sshKeyCredentialIDs []string) (*client.UpdateClusterSSHKeysResult, error)
@@ -330,8 +330,8 @@ type APIClient interface {
 	CreateUpcloudSSHKeyCredential(req client.CreateSSHKeyCredentialRequest) (*client.CreateSSHKeyCredentialResponse, error)
 
 	CreateDigitaloceanCluster(req client.CreateDigitaloceanClusterRequest) (*client.CreateDigitaloceanClusterResponse, error)
-	DeprovisionDigitaloceanCluster(clusterID string) (*client.DeprovisionDigitaloceanClusterResponse, error)
-	StopDigitaloceanCluster(clusterID string) (*client.StopDigitaloceanClusterResponse, error)
+	DeprovisionDigitaloceanCluster(clusterID string, force bool) (*client.DeprovisionDigitaloceanClusterResponse, error)
+	StopDigitaloceanCluster(clusterID string, force bool) (*client.StopDigitaloceanClusterResponse, error)
 	StartDigitaloceanCluster(clusterID, scope string) (*client.StartDigitaloceanClusterResult, error)
 	GetDigitaloceanWorkerCount(clusterID string) (*client.WorkerCountResult, error)
 	ScaleDigitaloceanWorkers(clusterID string, workerCount int) (*client.ScaleWorkersResult, error)
@@ -364,7 +364,7 @@ type APIClient interface {
 	ListDigitaloceanSSHKeyCredentials() ([]client.DigitaloceanCredentialListItem, error)
 	CreateDigitaloceanSSHKeyCredential(req client.CreateSSHKeyCredentialRequest) (*client.CreateSSHKeyCredentialResponse, error)
 
-	StopScalewayCluster(clusterID string) (*client.ProviderStopClusterResponse, error)
+	StopScalewayCluster(clusterID string, force bool) (*client.ProviderStopClusterResponse, error)
 	StartScalewayCluster(clusterID, scope string) (*client.ProviderStartClusterResult, error)
 	ListScalewayClusterNodes(clusterID string) (*client.NodeListResult, error)
 	GetScalewayClusterNode(clusterID, nodeID string) (*client.NodeDetail, error)

--- a/internal/client/digitalocean_clusters.go
+++ b/internal/client/digitalocean_clusters.go
@@ -93,8 +93,11 @@ func (c *Client) CreateDigitaloceanCluster(req CreateDigitaloceanClusterRequest)
 	return &result, nil
 }
 
-func (c *Client) DeprovisionDigitaloceanCluster(clusterID string) (*DeprovisionDigitaloceanClusterResponse, error) {
+func (c *Client) DeprovisionDigitaloceanCluster(clusterID string, force bool) (*DeprovisionDigitaloceanClusterResponse, error) {
 	url := fmt.Sprintf("%s/api/v1/clusters/digitalocean/%s", c.BaseURL, clusterID)
+	if force {
+		url = url + "?force=true"
+	}
 	req, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
@@ -223,8 +226,11 @@ func (c *Client) ScaleDigitaloceanWorkers(clusterID string, workerCount int) (*S
 	return c.doScaleWorkers(scaleURL, workerCount)
 }
 
-func (c *Client) StopDigitaloceanCluster(clusterID string) (*StopDigitaloceanClusterResponse, error) {
+func (c *Client) StopDigitaloceanCluster(clusterID string, force bool) (*StopDigitaloceanClusterResponse, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/clusters/digitalocean/%s/stop", c.BaseURL, url.PathEscape(clusterID))
+	if force {
+		endpoint = endpoint + "?force=true"
+	}
 	req, err := http.NewRequest(http.MethodPost, endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)

--- a/internal/client/digitalocean_clusters_test.go
+++ b/internal/client/digitalocean_clusters_test.go
@@ -130,7 +130,7 @@ func TestDeprovisionDigitaloceanCluster_Success(t *testing.T) {
 		}
 		jsonResponse(t, w, http.StatusOK, expectedResponse)
 	})
-	result, err := testClient.DeprovisionDigitaloceanCluster("digitalocean-cluster-123")
+	result, err := testClient.DeprovisionDigitaloceanCluster("digitalocean-cluster-123", false)
 	if err != nil {
 		t.Fatalf("DeprovisionDigitaloceanCluster: %v", err)
 	}

--- a/internal/client/hetzner_clusters.go
+++ b/internal/client/hetzner_clusters.go
@@ -181,8 +181,8 @@ func (c *Client) DeprovisionHetznerCluster(clusterID string, force bool) (*Depro
 	return &result, nil
 }
 
-func (c *Client) StopHetznerCluster(clusterID string) (*ProviderStopClusterResponse, error) {
-	return c.stopProviderCluster("hetzner", clusterID)
+func (c *Client) StopHetznerCluster(clusterID string, force bool) (*ProviderStopClusterResponse, error) {
+	return c.stopProviderCluster("hetzner", clusterID, force)
 }
 
 func (c *Client) StartHetznerCluster(clusterID, scope string) (*ProviderStartClusterResult, error) {

--- a/internal/client/morpheus_clusters.go
+++ b/internal/client/morpheus_clusters.go
@@ -82,11 +82,11 @@ func (c *Client) CreateMorpheusCluster(request CreateMorpheusClusterRequest) (*C
 }
 
 func (c *Client) DeprovisionMorpheusCluster(clusterID string) (*ProviderDeprovisionClusterResponse, error) {
-	return c.deprovisionProviderCluster(morpheusKind, clusterID)
+	return c.deprovisionProviderCluster(morpheusKind, clusterID, false)
 }
 
 func (c *Client) StopMorpheusCluster(clusterID string) (*ProviderStopClusterResponse, error) {
-	return c.stopProviderCluster(morpheusKind, clusterID)
+	return c.stopProviderCluster(morpheusKind, clusterID, false)
 }
 
 func (c *Client) StartMorpheusCluster(clusterID, scope string) (*ProviderStartClusterResult, error) {

--- a/internal/client/ovh_clusters.go
+++ b/internal/client/ovh_clusters.go
@@ -142,8 +142,11 @@ func (c *Client) CreateOvhCluster(req CreateOvhClusterRequest) (*CreateOvhCluste
 	return &result, nil
 }
 
-func (c *Client) DeprovisionOvhCluster(clusterID string) (*DeprovisionOvhClusterResponse, error) {
+func (c *Client) DeprovisionOvhCluster(clusterID string, force bool) (*DeprovisionOvhClusterResponse, error) {
 	url := fmt.Sprintf("%s/api/v1/clusters/ovh/%s", c.BaseURL, clusterID)
+	if force {
+		url = url + "?force=true"
+	}
 	req, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
@@ -288,8 +291,11 @@ func (c *Client) ScaleOvhWorkers(clusterID string, workerCount int) (*ScaleWorke
 	return c.doScaleWorkers(url, workerCount)
 }
 
-func (c *Client) StopOvhCluster(clusterID string) (*StopOvhClusterResponse, error) {
+func (c *Client) StopOvhCluster(clusterID string, force bool) (*StopOvhClusterResponse, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/clusters/ovh/%s/stop", c.BaseURL, url.PathEscape(clusterID))
+	if force {
+		endpoint = endpoint + "?force=true"
+	}
 	req, err := http.NewRequest(http.MethodPost, endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)

--- a/internal/client/ovh_clusters_test.go
+++ b/internal/client/ovh_clusters_test.go
@@ -140,7 +140,7 @@ func TestDeprovisionOvhCluster_Success(t *testing.T) {
 		jsonResponse(t, w, http.StatusOK, expectedResponse)
 	}
 	testClient := newTestClient(t, handler)
-	result, err := testClient.DeprovisionOvhCluster("ovh-cluster-123")
+	result, err := testClient.DeprovisionOvhCluster("ovh-cluster-123", false)
 	if err != nil {
 		t.Fatalf("DeprovisionOvhCluster: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestStopOvhCluster_Success(t *testing.T) {
 		jsonResponse(t, w, http.StatusOK, expectedResponse)
 	}
 	testClient := newTestClient(t, handler)
-	result, err := testClient.StopOvhCluster("ovh-cluster-123")
+	result, err := testClient.StopOvhCluster("ovh-cluster-123", false)
 	if err != nil {
 		t.Fatalf("StopOvhCluster: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestStopOvhCluster_Error(t *testing.T) {
 		jsonResponse(t, w, http.StatusNotFound, map[string]string{"error": "not found"})
 	}
 	testClient := newTestClient(t, handler)
-	_, err := testClient.StopOvhCluster("ovh-cluster-123")
+	_, err := testClient.StopOvhCluster("ovh-cluster-123", false)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/internal/client/provider_lifecycle.go
+++ b/internal/client/provider_lifecycle.go
@@ -80,8 +80,12 @@ func (c *Client) createProviderCluster(kind string, request interface{}, result 
 	return nil
 }
 
-func (c *Client) deprovisionProviderCluster(kind, clusterID string) (*ProviderDeprovisionClusterResponse, error) {
-	httpRequest, requestError := http.NewRequest(http.MethodDelete, c.providerClusterURL(kind, clusterID, ""), nil)
+func (c *Client) deprovisionProviderCluster(kind, clusterID string, force bool) (*ProviderDeprovisionClusterResponse, error) {
+	endpoint := c.providerClusterURL(kind, clusterID, "")
+	if force {
+		endpoint += "?force=true"
+	}
+	httpRequest, requestError := http.NewRequest(http.MethodDelete, endpoint, nil)
 	if requestError != nil {
 		return nil, fmt.Errorf("create request: %w", requestError)
 	}
@@ -108,8 +112,12 @@ func (c *Client) deprovisionProviderCluster(kind, clusterID string) (*ProviderDe
 	return &result, nil
 }
 
-func (c *Client) stopProviderCluster(kind, clusterID string) (*ProviderStopClusterResponse, error) {
-	httpRequest, requestError := http.NewRequest(http.MethodPost, c.providerClusterURL(kind, clusterID, "stop"), nil)
+func (c *Client) stopProviderCluster(kind, clusterID string, force bool) (*ProviderStopClusterResponse, error) {
+	endpoint := c.providerClusterURL(kind, clusterID, "stop")
+	if force {
+		endpoint += "?force=true"
+	}
+	httpRequest, requestError := http.NewRequest(http.MethodPost, endpoint, nil)
 	if requestError != nil {
 		return nil, fmt.Errorf("create request: %w", requestError)
 	}

--- a/internal/client/proxmox_clusters.go
+++ b/internal/client/proxmox_clusters.go
@@ -86,11 +86,11 @@ func (c *Client) CreateProxmoxCluster(request CreateProxmoxClusterRequest) (*Cre
 }
 
 func (c *Client) DeprovisionProxmoxCluster(clusterID string) (*ProviderDeprovisionClusterResponse, error) {
-	return c.deprovisionProviderCluster(proxmoxKind, clusterID)
+	return c.deprovisionProviderCluster(proxmoxKind, clusterID, false)
 }
 
 func (c *Client) StopProxmoxCluster(clusterID string) (*ProviderStopClusterResponse, error) {
-	return c.stopProviderCluster(proxmoxKind, clusterID)
+	return c.stopProviderCluster(proxmoxKind, clusterID, false)
 }
 
 func (c *Client) StartProxmoxCluster(clusterID, scope string) (*ProviderStartClusterResult, error) {

--- a/internal/client/scaleway_clusters.go
+++ b/internal/client/scaleway_clusters.go
@@ -2,8 +2,8 @@ package client
 
 const scalewayKind = "scaleway"
 
-func (c *Client) StopScalewayCluster(clusterID string) (*ProviderStopClusterResponse, error) {
-	return c.stopProviderCluster(scalewayKind, clusterID)
+func (c *Client) StopScalewayCluster(clusterID string, force bool) (*ProviderStopClusterResponse, error) {
+	return c.stopProviderCluster(scalewayKind, clusterID, force)
 }
 
 func (c *Client) StartScalewayCluster(clusterID, scope string) (*ProviderStartClusterResult, error) {

--- a/internal/client/scaleway_clusters_test.go
+++ b/internal/client/scaleway_clusters_test.go
@@ -19,7 +19,7 @@ func TestStopScalewayCluster(t *testing.T) {
 		})
 	})
 
-	result, stopError := testClient.StopScalewayCluster("cluster-123")
+	result, stopError := testClient.StopScalewayCluster("cluster-123", false)
 	if stopError != nil {
 		t.Fatalf("StopScalewayCluster: %v", stopError)
 	}


### PR DESCRIPTION
Bead: ankra-phep. Stacked on #87 (base moves to master when #87 merges). CLI half of ankraio/cluster#1260.

- Shared `stopProviderCluster`/`deprovisionProviderCluster` client helpers take `force` and append `?force=true`; the OVH and DigitalOcean bespoke functions match. Proxmox/Morpheus wrappers pass false (their lanes drop it).
- `ankra cluster deprovision --force` now reaches OVH and DigitalOcean; the no-effect warning survives only for the lanes that genuinely drop force (generic imported, Proxmox, Morpheus).
- `ankra cluster hetzner|ovh|digitalocean|scaleway stop --force` added, each naming what gets destroyed; OVH and DigitalOcean deprovision confirmations name the volumes and load balancers when forcing.
- CHANGELOG documents the Hetzner default flip (plain stop now keeps volume data; `--force` restores the old reclaim-everything behaviour).

Full `go test ./...` green.