### PR TITLE
feat(stack-profiles): drafts family — annotate the guidance the launch form shows (ankra-s54g)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Added
+
+- **`ankra stack-profiles drafts` edits and publishes profile versions from
+  the terminal.** Open a draft on an existing profile (or seed one from a
+  deployed stack), see every parameter with `get`, and give each one the
+  guidance the launch form shows under its field with
+  `annotate --parameter <name> --description "..."` — this is how a profile
+  author instructs the person filling in variables and secrets. `publish`
+  cuts the version, `list` and `delete` manage open drafts. Drafts were
+  browser-and-MCP-only until now; the platform gained bearer-token twins for
+  the whole draft family in the same change.
+
 ## v0.11.0-rc4 — 2026-08-17
 
 Release candidate, superseding v0.11.0-rc3. Install it with `ankra config

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -107,6 +107,30 @@ func (m baseMock) InstantiateStackProfile(ctx context.Context, clusterID string,
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) CreateStackProfileDraft(request client.CreateStackProfileDraftRequest) (*client.StackProfileDraft, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ListStackProfileDrafts() ([]client.StackProfileDraftSummary, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetStackProfileDraft(draftID string) (*client.StackProfileDraft, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) UpdateStackProfileDraft(draftID string, request client.UpdateStackProfileDraftRequest) (*client.StackProfileDraft, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) DeleteStackProfileDraft(draftID string) (*client.DeleteStackProfileDraftResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) PublishStackProfileDraft(draftID string, request client.PublishStackProfileDraftRequest) (*client.PublishStackProfileDraftResult, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) CreateApplication(requestContext context.Context, applicationRequest client.CreateApplicationRequest) (*client.CreateApplicationResponse, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -98,6 +98,12 @@ type APIClient interface {
 	ImportStackProfile(importRequest client.ImportStackProfileRequest) (*client.CreateStackProfileResult, error)
 	GetStackProfile(profileID string) (*client.StackProfileDetail, error)
 	InstantiateStackProfile(ctx context.Context, clusterID string, instantiateRequest client.InstantiateStackProfileRequest) (*client.InstantiateStackProfileResult, error)
+	CreateStackProfileDraft(request client.CreateStackProfileDraftRequest) (*client.StackProfileDraft, error)
+	ListStackProfileDrafts() ([]client.StackProfileDraftSummary, error)
+	GetStackProfileDraft(draftID string) (*client.StackProfileDraft, error)
+	UpdateStackProfileDraft(draftID string, request client.UpdateStackProfileDraftRequest) (*client.StackProfileDraft, error)
+	DeleteStackProfileDraft(draftID string) (*client.DeleteStackProfileDraftResult, error)
+	PublishStackProfileDraft(draftID string, request client.PublishStackProfileDraftRequest) (*client.PublishStackProfileDraftResult, error)
 
 	CreateApplication(requestContext context.Context, applicationRequest client.CreateApplicationRequest) (*client.CreateApplicationResponse, error)
 	ListApplicationsRaw(requestContext context.Context, page int, pageSize int, search string) (json.RawMessage, error)

--- a/cmd/stack_profile_drafts.go
+++ b/cmd/stack_profile_drafts.go
@@ -1,0 +1,265 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+)
+
+var stackProfileDraftsCmd = &cobra.Command{
+	Use:   "drafts",
+	Short: "Open, edit, and publish stack profile builder drafts",
+	Long: `Work with stack profile builder drafts from the terminal.
+
+A draft is the editable working copy behind a profile version: open one from
+an existing profile (or from a deployed stack), annotate its parameters with
+the titles and descriptions the launch form shows as guidance, and publish it
+as the next version.`,
+}
+
+var stackProfileDraftsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List the organisation's open builder drafts",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		drafts, err := apiClient.ListStackProfileDrafts()
+		if err != nil {
+			return fmt.Errorf("listing stack profile drafts: %w", err)
+		}
+		if handled, err := renderStructured(cmd, drafts); err != nil {
+			return err
+		} else if handled {
+			return nil
+		}
+		if len(drafts) == 0 {
+			fmt.Println("No open stack profile drafts.")
+			return nil
+		}
+		for _, draft := range drafts {
+			target := "new profile"
+			if draft.ProfileID != nil {
+				target = "edits profile " + *draft.ProfileID
+			}
+			fmt.Printf("%s  %s\n", text.Bold.Sprint(draft.Name), draft.ID)
+			fmt.Printf("  %s   updated %s\n", target, draft.UpdatedAt)
+		}
+		return nil
+	},
+}
+
+var stackProfileDraftsCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Open a builder draft",
+	Long: `Open a builder draft: --profile edits an existing profile (publishing
+creates its next version), --name starts a brand-new profile, and
+--source-cluster with --source-stack seeds the draft from a deployed stack.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name, _ := cmd.Flags().GetString("name")
+		profileReference, _ := cmd.Flags().GetString("profile")
+		sourceCluster, _ := cmd.Flags().GetString("source-cluster")
+		sourceStack, _ := cmd.Flags().GetString("source-stack")
+		if name == "" && profileReference == "" && sourceCluster == "" {
+			return withExitCode(exitUsage, errors.New("one of --name, --profile or --source-cluster is required"))
+		}
+
+		request := client.CreateStackProfileDraftRequest{Name: name}
+		if profileReference != "" {
+			profileID, err := resolveStackProfileID(apiClient, profileReference)
+			if err != nil {
+				return err
+			}
+			request.ProfileID = profileID
+		}
+		if sourceCluster != "" {
+			if sourceStack == "" {
+				return withExitCode(exitUsage, errors.New("--source-stack is required with --source-cluster"))
+			}
+			clusterID, err := resolveClusterID(sourceCluster)
+			if err != nil {
+				return err
+			}
+			request.SourceClusterID = clusterID
+			request.SourceStackName = sourceStack
+		}
+
+		draft, err := apiClient.CreateStackProfileDraft(request)
+		if err != nil {
+			return fmt.Errorf("creating stack profile draft: %w", err)
+		}
+		if handled, err := renderStructured(cmd, draft); err != nil {
+			return err
+		} else if handled {
+			return nil
+		}
+		fmt.Printf("Draft '%s' opened.\n", draft.Name)
+		fmt.Printf("  Draft ID: %s\n", draft.ID)
+		fmt.Printf("  Parameters detected: %d\n", len(draft.Parameters))
+		fmt.Printf("\nAnnotate the launch form's guidance with:\n  ankra stack-profiles drafts annotate %s --parameter <name> --description \"...\"\n", draft.ID)
+		return nil
+	},
+}
+
+var stackProfileDraftsGetCmd = &cobra.Command{
+	Use:   "get <draft-id>",
+	Short: "Show a draft's parameters and their annotations",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		draft, err := apiClient.GetStackProfileDraft(args[0])
+		if err != nil {
+			return fmt.Errorf("reading stack profile draft: %w", err)
+		}
+		if handled, err := renderStructured(cmd, draft); err != nil {
+			return err
+		} else if handled {
+			return nil
+		}
+		fmt.Printf("%s  (version %d)\n", text.Bold.Sprint(draft.Name), draft.Version)
+		for _, parameter := range draft.Parameters {
+			name, _ := parameter["name"].(string)
+			parameterType, _ := parameter["type"].(string)
+			description, _ := parameter["description"].(string)
+			if description == "" {
+				description = text.Faint.Sprint("(no description yet)")
+			}
+			fmt.Printf("  %s  [%s]\n    %s\n", text.Bold.Sprint(name), parameterType, description)
+		}
+		return nil
+	},
+}
+
+var stackProfileDraftsAnnotateCmd = &cobra.Command{
+	Use:   "annotate <draft-id>",
+	Short: "Set the guidance a parameter shows in the launch form",
+	Long: `Set a parameter's title and description on a draft. The description is
+the guidance the launch form shows under the field, so this is how a profile
+author instructs the person filling it in. Publishing the draft makes the
+annotations live.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		parameterName, _ := cmd.Flags().GetString("parameter")
+		description, _ := cmd.Flags().GetString("description")
+		title, _ := cmd.Flags().GetString("title")
+		if description == "" && title == "" {
+			return withExitCode(exitUsage, errors.New("provide --description and/or --title"))
+		}
+
+		draft, err := apiClient.GetStackProfileDraft(args[0])
+		if err != nil {
+			return fmt.Errorf("reading stack profile draft: %w", err)
+		}
+		found := false
+		for _, parameter := range draft.Parameters {
+			if name, _ := parameter["name"].(string); name == parameterName {
+				if description != "" {
+					parameter["description"] = description
+				}
+				if title != "" {
+					parameter["title"] = title
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			names := make([]string, 0, len(draft.Parameters))
+			for _, parameter := range draft.Parameters {
+				if name, _ := parameter["name"].(string); name != "" {
+					names = append(names, name)
+				}
+			}
+			return fmt.Errorf("parameter %q not found on the draft; it has: %v", parameterName, names)
+		}
+
+		updated, err := apiClient.UpdateStackProfileDraft(draft.ID, client.UpdateStackProfileDraftRequest{
+			Spec:       draft.Spec,
+			Parameters: draft.Parameters,
+			Version:    draft.Version,
+		})
+		if err != nil {
+			return fmt.Errorf("annotating stack profile draft: %w", err)
+		}
+		if handled, err := renderStructured(cmd, updated); err != nil {
+			return err
+		} else if handled {
+			return nil
+		}
+		fmt.Printf("Annotated %s on draft '%s'.\n", parameterName, updated.Name)
+		fmt.Println("Publish to make it live:")
+		fmt.Printf("  ankra stack-profiles drafts publish %s --changelog \"...\"\n", updated.ID)
+		return nil
+	},
+}
+
+var stackProfileDraftsPublishCmd = &cobra.Command{
+	Use:   "publish <draft-id>",
+	Short: "Publish a draft as a profile version",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		channel, _ := cmd.Flags().GetString("channel")
+		changelog, _ := cmd.Flags().GetString("changelog")
+		visibility, _ := cmd.Flags().GetString("visibility")
+
+		result, err := apiClient.PublishStackProfileDraft(args[0], client.PublishStackProfileDraftRequest{
+			Channel: channel, Changelog: changelog, Visibility: visibility,
+		})
+		if err != nil {
+			return fmt.Errorf("publishing stack profile draft: %w", err)
+		}
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
+		}
+		profileName, _ := result.Profile["name"].(string)
+		versionNumber := result.Version["version"]
+		fmt.Printf("Published '%s' version %v.\n", profileName, versionNumber)
+		return nil
+	},
+}
+
+var stackProfileDraftsDeleteCmd = &cobra.Command{
+	Use:   "delete <draft-id>",
+	Short: "Discard a builder draft",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		result, err := apiClient.DeleteStackProfileDraft(args[0])
+		if err != nil {
+			return fmt.Errorf("deleting stack profile draft: %w", err)
+		}
+		if handled, err := renderStructured(cmd, result); err != nil {
+			return err
+		} else if handled {
+			return nil
+		}
+		fmt.Println("Draft deleted.")
+		return nil
+	},
+}
+
+func init() {
+	stackProfileDraftsCreateCmd.Flags().String("name", "", "Name for a brand-new profile draft")
+	stackProfileDraftsCreateCmd.Flags().String("profile", "", "Existing profile (name or ID) to open a draft on")
+	stackProfileDraftsCreateCmd.Flags().String("source-cluster", "", "Cluster (name or ID) to seed the draft from a deployed stack")
+	stackProfileDraftsCreateCmd.Flags().String("source-stack", "", "Deployed stack name to seed the draft from (with --source-cluster)")
+
+	stackProfileDraftsAnnotateCmd.Flags().String("parameter", "", "Parameter name to annotate")
+	stackProfileDraftsAnnotateCmd.Flags().String("description", "", "Guidance shown under the field in the launch form")
+	stackProfileDraftsAnnotateCmd.Flags().String("title", "", "Display title for the field (optional)")
+	_ = stackProfileDraftsAnnotateCmd.MarkFlagRequired("parameter")
+
+	stackProfileDraftsPublishCmd.Flags().String("channel", "stable", "Release channel for the version")
+	stackProfileDraftsPublishCmd.Flags().String("changelog", "", "Changelog entry for the version")
+	stackProfileDraftsPublishCmd.Flags().String("visibility", "", "Profile visibility applied at publish (organisation or public)")
+
+	stackProfileDraftsCmd.AddCommand(stackProfileDraftsListCmd, stackProfileDraftsCreateCmd,
+		stackProfileDraftsGetCmd, stackProfileDraftsAnnotateCmd,
+		stackProfileDraftsPublishCmd, stackProfileDraftsDeleteCmd)
+	stackProfilesCmd.AddCommand(stackProfileDraftsCmd)
+
+	registerStructuredOutputFlags(stackProfileDraftsListCmd, stackProfileDraftsCreateCmd,
+		stackProfileDraftsGetCmd, stackProfileDraftsAnnotateCmd,
+		stackProfileDraftsPublishCmd, stackProfileDraftsDeleteCmd)
+}

--- a/internal/client/stack_profile_drafts.go
+++ b/internal/client/stack_profile_drafts.go
@@ -1,0 +1,133 @@
+package client
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+// StackProfileDraftSummary is one open builder draft in the drafts list.
+type StackProfileDraftSummary struct {
+	ID          string  `json:"id"`
+	ProfileID   *string `json:"profile_id"`
+	Name        string  `json:"name"`
+	BaseVersion *int    `json:"base_version"`
+	Version     int     `json:"version"`
+	CreatedAt   string  `json:"created_at"`
+	UpdatedAt   string  `json:"updated_at"`
+}
+
+// StackProfileDraft is the full draft. The spec stays raw JSON so an edit
+// round-trips it unchanged, and parameters stay generic maps so an
+// annotation update never drops fields this client does not model.
+type StackProfileDraft struct {
+	ID          string           `json:"id"`
+	ProfileID   *string          `json:"profile_id"`
+	Name        string           `json:"name"`
+	Spec        json.RawMessage  `json:"spec"`
+	Parameters  []map[string]any `json:"parameters"`
+	BaseVersion *int             `json:"base_version"`
+	Version     int              `json:"version"`
+}
+
+// CreateStackProfileDraftRequest opens a draft: a blank named one, one
+// editing an existing profile, or one seeded from a deployed stack.
+type CreateStackProfileDraftRequest struct {
+	Name            string `json:"name,omitempty"`
+	ProfileID       string `json:"profile_id,omitempty"`
+	SourceClusterID string `json:"source_cluster_id,omitempty"`
+	SourceStackName string `json:"source_stack_name,omitempty"`
+}
+
+// UpdateStackProfileDraftRequest writes the draft back: the full spec, the
+// full parameter list (annotations included), and the version read from the
+// draft for optimistic concurrency.
+type UpdateStackProfileDraftRequest struct {
+	Spec       json.RawMessage  `json:"spec"`
+	Parameters []map[string]any `json:"parameters"`
+	Version    int              `json:"version"`
+}
+
+// PublishStackProfileDraftRequest publishes the draft as a profile version.
+type PublishStackProfileDraftRequest struct {
+	Channel    string `json:"channel,omitempty"`
+	Changelog  string `json:"changelog,omitempty"`
+	Visibility string `json:"visibility,omitempty"`
+}
+
+// PublishStackProfileDraftResult carries the published profile and version
+// as returned by the API; kept generic so new fields pass through -o json.
+type PublishStackProfileDraftResult struct {
+	Profile map[string]any `json:"profile"`
+	Version map[string]any `json:"version"`
+}
+
+// DeleteStackProfileDraftResult reports the deletion outcome.
+type DeleteStackProfileDraftResult struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}
+
+func (c *Client) stackProfileDraftsBasePath() string {
+	return c.BaseURL + "/api/v1/org/stack-profiles/drafts"
+}
+
+// CreateStackProfileDraft opens a builder draft.
+func (c *Client) CreateStackProfileDraft(request CreateStackProfileDraftRequest) (*StackProfileDraft, error) {
+	var draft StackProfileDraft
+	if err := c.postCSRFJSON(c.stackProfileDraftsBasePath(), request, &draft, "create stack profile draft"); err != nil {
+		return nil, err
+	}
+	return &draft, nil
+}
+
+// ListStackProfileDrafts lists the organisation's open builder drafts. The
+// API wraps the list in a result envelope.
+func (c *Client) ListStackProfileDrafts() ([]StackProfileDraftSummary, error) {
+	var envelope struct {
+		Result []StackProfileDraftSummary `json:"result"`
+	}
+	if err := c.getJSON(c.stackProfileDraftsBasePath(), &envelope); err != nil {
+		return nil, err
+	}
+	return envelope.Result, nil
+}
+
+// GetStackProfileDraft reads one draft in full.
+func (c *Client) GetStackProfileDraft(draftID string) (*StackProfileDraft, error) {
+	var draft StackProfileDraft
+	if err := c.getJSON(c.stackProfileDraftsBasePath()+"/"+url.PathEscape(draftID), &draft); err != nil {
+		return nil, err
+	}
+	return &draft, nil
+}
+
+// UpdateStackProfileDraft writes the draft's spec and parameters back.
+func (c *Client) UpdateStackProfileDraft(draftID string, request UpdateStackProfileDraftRequest) (*StackProfileDraft, error) {
+	var draft StackProfileDraft
+	if err := c.postCSRFJSON(c.stackProfileDraftsBasePath()+"/"+url.PathEscape(draftID),
+		request, &draft, "update stack profile draft"); err != nil {
+		return nil, err
+	}
+	return &draft, nil
+}
+
+// DeleteStackProfileDraft discards a draft.
+func (c *Client) DeleteStackProfileDraft(draftID string) (*DeleteStackProfileDraftResult, error) {
+	var result DeleteStackProfileDraftResult
+	if err := c.deleteCSRFJSON(c.stackProfileDraftsBasePath()+"/"+url.PathEscape(draftID),
+		&result, "delete stack profile draft"); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// PublishStackProfileDraft publishes the draft as a new profile version
+// (or a brand-new profile for a draft opened with a name).
+func (c *Client) PublishStackProfileDraft(draftID string, request PublishStackProfileDraftRequest) (*PublishStackProfileDraftResult, error) {
+	var result PublishStackProfileDraftResult
+	if err := c.postCSRFJSON(c.stackProfileDraftsBasePath()+"/"+url.PathEscape(draftID)+"/publish",
+		request, &result, "publish stack profile draft"); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/internal/client/stack_profile_drafts_test.go
+++ b/internal/client/stack_profile_drafts_test.go
@@ -65,8 +65,8 @@ func TestListStackProfileDrafts_UnwrapsResultEnvelope(t *testing.T) {
 func TestUpdateStackProfileDraft_RoundTripsUnknownParameterFields(t *testing.T) {
 	var receivedBody map[string]any
 	handler := func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet:
+		switch r.Method {
+		case http.MethodGet:
 			jsonResponse(t, w, http.StatusOK, map[string]any{
 				"id": "draft-1", "name": "hermes-agent", "version": 3,
 				"spec": map[string]any{"stacks": []any{}},
@@ -75,7 +75,7 @@ func TestUpdateStackProfileDraft_RoundTripsUnknownParameterFields(t *testing.T) 
 					"resource_kind": "manifest", "enum_values": []string{"a"},
 				}},
 			})
-		case r.Method == http.MethodPost:
+		case http.MethodPost:
 			if r.URL.Path != "/api/v1/org/stack-profiles/drafts/draft-1" {
 				t.Errorf("path = %s", r.URL.Path)
 			}

--- a/internal/client/stack_profile_drafts_test.go
+++ b/internal/client/stack_profile_drafts_test.go
@@ -1,0 +1,144 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestCreateStackProfileDraft_PostsAndDecodes(t *testing.T) {
+	var receivedBody map[string]any
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/org/stack-profiles/drafts" {
+			t.Errorf("path = %s, want /api/v1/org/stack-profiles/drafts", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&receivedBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		jsonResponse(t, w, http.StatusCreated, map[string]any{
+			"id": "draft-1", "name": "hermes-agent", "version": 1,
+			"profile_id": "profile-1",
+			"parameters": []map[string]any{{"name": "model_name", "type": "string"}},
+		})
+	}
+	testClient := newTestClient(t, handler)
+
+	draft, err := testClient.CreateStackProfileDraft(CreateStackProfileDraftRequest{ProfileID: "profile-1"})
+	if err != nil {
+		t.Fatalf("CreateStackProfileDraft: %v", err)
+	}
+	if draft.ID != "draft-1" || len(draft.Parameters) != 1 {
+		t.Errorf("draft = %+v", draft)
+	}
+	if receivedBody["profile_id"] != "profile-1" {
+		t.Errorf("body = %v, want profile_id profile-1", receivedBody)
+	}
+	if _, present := receivedBody["name"]; present {
+		t.Error("empty name must be omitted from the body")
+	}
+}
+
+func TestListStackProfileDrafts_UnwrapsResultEnvelope(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/org/stack-profiles/drafts" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		jsonResponse(t, w, http.StatusOK, map[string]any{"result": []map[string]any{
+			{"id": "draft-1", "name": "hermes-agent", "version": 2},
+			{"id": "draft-2", "name": "scout", "version": 1},
+		}})
+	}
+	testClient := newTestClient(t, handler)
+
+	drafts, err := testClient.ListStackProfileDrafts()
+	if err != nil {
+		t.Fatalf("ListStackProfileDrafts: %v", err)
+	}
+	if len(drafts) != 2 || drafts[1].Name != "scout" {
+		t.Errorf("drafts = %+v", drafts)
+	}
+}
+
+func TestUpdateStackProfileDraft_RoundTripsUnknownParameterFields(t *testing.T) {
+	var receivedBody map[string]any
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet:
+			jsonResponse(t, w, http.StatusOK, map[string]any{
+				"id": "draft-1", "name": "hermes-agent", "version": 3,
+				"spec": map[string]any{"stacks": []any{}},
+				"parameters": []map[string]any{{
+					"name": "model_name", "type": "string",
+					"resource_kind": "manifest", "enum_values": []string{"a"},
+				}},
+			})
+		case r.Method == http.MethodPost:
+			if r.URL.Path != "/api/v1/org/stack-profiles/drafts/draft-1" {
+				t.Errorf("path = %s", r.URL.Path)
+			}
+			if err := json.NewDecoder(r.Body).Decode(&receivedBody); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			jsonResponse(t, w, http.StatusOK, map[string]any{"id": "draft-1", "name": "hermes-agent", "version": 4})
+		}
+	}
+	testClient := newTestClient(t, handler)
+
+	draft, err := testClient.GetStackProfileDraft("draft-1")
+	if err != nil {
+		t.Fatalf("GetStackProfileDraft: %v", err)
+	}
+	draft.Parameters[0]["description"] = "Pick the model."
+	if _, err := testClient.UpdateStackProfileDraft("draft-1", UpdateStackProfileDraftRequest{
+		Spec: draft.Spec, Parameters: draft.Parameters, Version: draft.Version,
+	}); err != nil {
+		t.Fatalf("UpdateStackProfileDraft: %v", err)
+	}
+
+	parameters := receivedBody["parameters"].([]any)
+	parameter := parameters[0].(map[string]any)
+	if parameter["description"] != "Pick the model." {
+		t.Errorf("description not sent: %v", parameter)
+	}
+	if parameter["resource_kind"] != "manifest" {
+		t.Errorf("unknown fields must round-trip untouched, got %v", parameter)
+	}
+	if receivedBody["version"] != float64(3) {
+		t.Errorf("version = %v, want 3", receivedBody["version"])
+	}
+}
+
+func TestPublishStackProfileDraft_PostsChannelAndChangelog(t *testing.T) {
+	var receivedBody map[string]any
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/org/stack-profiles/drafts/draft-1/publish" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&receivedBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		jsonResponse(t, w, http.StatusCreated, map[string]any{
+			"profile": map[string]any{"name": "hermes-agent", "latest_version": 3},
+			"version": map[string]any{"version": 3},
+		})
+	}
+	testClient := newTestClient(t, handler)
+
+	result, err := testClient.PublishStackProfileDraft("draft-1", PublishStackProfileDraftRequest{
+		Channel: "stable", Changelog: "tooltips"})
+	if err != nil {
+		t.Fatalf("PublishStackProfileDraft: %v", err)
+	}
+	if result.Profile["name"] != "hermes-agent" {
+		t.Errorf("result = %+v", result)
+	}
+	if receivedBody["channel"] != "stable" || receivedBody["changelog"] != "tooltips" {
+		t.Errorf("body = %v", receivedBody)
+	}
+	if _, present := receivedBody["visibility"]; present {
+		t.Error("empty visibility must be omitted from the body")
+	}
+}


### PR DESCRIPTION
## Why

Stack profile parameters (variables and secrets) can carry a title and description that the launch form renders as guidance under each field — but authoring them was portal-builder-only. A profile author had no terminal or scriptable way to instruct the people filling in a profile. Trigger: the `hermes-agent` launch form showed its variables with no explanation.

## What

`ankra stack-profiles drafts`:

- `create --profile <name|id>` (or `--name` for a new profile, or `--source-cluster` + `--source-stack` to seed from a deployed stack) — opens a builder draft
- `get <draft-id>` — every parameter with its type and current description
- `annotate <draft-id> --parameter <name> --description "..." [--title ...]` — **the tooltip-authoring lane**: reads the draft, sets the annotation, writes it back with optimistic concurrency; unknown parameter fields round-trip untouched
- `publish <draft-id> [--changelog ...] [--channel ...] [--visibility ...]` — cuts the version
- `list`, `delete`

All support `-o json`. Backed by the bearer draft twins in **ankraio/cluster#1263** (`/api/v1/org/stack-profiles/drafts`).

## Tests

Client tests pin: create body shape and omitted empties, list envelope unwrapping (`{"result": [...]}` — caught by the parity run), annotate round-tripping unknown parameter fields and the concurrency version, publish body. Full `go build ./... && go vet ./... && go test ./...` green.

Bead: ankra-s54g