### PR TITLE
feat(alerts): destinations and routes command family (ankra-z8ql)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### Added
+
+- **`ankra alerts destinations` and `ankra alerts routes` bring alerting as
+  code to the terminal.** Where alerts go and which notifications reach them
+  was portal-only until now. `destinations list|get|create|update|delete`
+  manage the webhook and chat-channel receivers (Slack, Microsoft Teams,
+  Discord, PagerDuty, or any custom URL; channel-based Slack and Teams
+  destinations take `--channel-id`, and `destinations channels` lists the
+  channels the Ankra bot can post to), `destinations test` and `test-url`
+  fire a sample notification and exit non-zero when the receiver rejects it,
+  and `routes list|create|update|delete|test` decide which notifications
+  reach which destination by kind, severity, cluster, and source, in priority
+  order with include/exclude modes. Updates send only the flags you pass, so
+  the rest of a destination or route stays untouched. Everything uses the
+  same personal access token as the rest of the CLI and honours `-o json` and
+  `-o yaml`, so the whole alerting setup can be scripted, diffed, and applied
+  from CI alongside your clusters.
+
 ## v0.11.0-rc4 — 2026-08-17
 
 Release candidate, superseding v0.11.0-rc3. Install it with `ankra config

--- a/cmd/alerts.go
+++ b/cmd/alerts.go
@@ -1,0 +1,597 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+var alertsCmd = &cobra.Command{
+	Use:   "alerts",
+	Short: "Manage alert destinations and notification routes",
+	Long: `Manage where Ankra delivers alerts and platform notifications.
+
+Destinations are the endpoints notifications are sent to: a webhook URL
+(Slack, Microsoft Teams, Discord, PagerDuty, or any custom receiver) or a
+Slack/Teams channel the Ankra bot posts to directly. Routes decide which
+notifications reach which destination, filtered by kind, severity, cluster,
+and source, so the whole alerting setup can live in scripts and CI next to
+the rest of your platform configuration.
+
+  ankra alerts destinations list
+  ankra alerts destinations create --name ops-slack --url https://hooks.slack.com/services/...
+  ankra alerts destinations test <destination-id>
+  ankra alerts routes create --destination-id <destination-id> --severity critical
+  ankra alerts routes list -o json`,
+}
+
+var alertsDestinationsCmd = &cobra.Command{
+	Use:   "destinations",
+	Short: "Manage alert destinations (webhooks and chat channels)",
+	Long: `Manage the organisation's alert destinations.
+
+A destination is either a webhook URL or a channel-based Slack/Teams
+destination that carries a channel id instead of a URL (list the channels
+the Ankra bot can post to with 'ankra alerts destinations channels').
+Webhook URLs are shown masked on every read.`,
+}
+
+var alertsDestinationsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List alert destinations",
+	Long: `List the organisation's alert destinations, 20 per page.
+
+Filter by name with --search and by state with --enabled or --disabled. The
+ID column is what routes and the other destination commands take.
+
+  ankra alerts destinations list --search slack
+  ankra alerts destinations list --disabled -o json`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		page, _ := cmd.Flags().GetInt("page")
+		pageSize, _ := cmd.Flags().GetInt("page-size")
+		search, _ := cmd.Flags().GetString("search")
+
+		list, listError := apiClient.ListAlertDestinations(client.ListAlertDestinationsOptions{
+			Page:     page,
+			PageSize: pageSize,
+			Search:   search,
+			Enabled:  enabledFromFlags(cmd),
+		})
+		if listError != nil {
+			return fmt.Errorf("listing alert destinations: %w", listError)
+		}
+		if rendered, renderError := renderStructured(cmd, list); rendered || renderError != nil {
+			return renderError
+		}
+		out := cmd.OutOrStdout()
+		if len(list.Items) == 0 {
+			if search != "" {
+				_, _ = fmt.Fprintf(out, "No alert destinations found matching %q.\n", search)
+			} else {
+				_, _ = fmt.Fprintln(out, "No alert destinations found.")
+			}
+			return nil
+		}
+		writer := table.NewWriter()
+		writer.SetOutputMirror(out)
+		writer.SetStyle(table.StyleRounded)
+		writer.AppendHeader(table.Row{"Name", "ID", "Type", "Target", "Enabled"})
+		for _, destination := range list.Items {
+			writer.AppendRow(table.Row{
+				destination.Name,
+				destination.ID,
+				alertDestinationType(destination),
+				alertDestinationTarget(destination),
+				destination.Enabled,
+			})
+		}
+		writer.Render()
+		_, _ = fmt.Fprintf(out, "\nPage %d of %d (total %d)\n",
+			list.Pagination.Page, list.Pagination.TotalPages, list.Pagination.TotalCount)
+		return nil
+	},
+}
+
+var alertsDestinationsGetCmd = &cobra.Command{
+	Use:   "get <destination-id>",
+	Short: "Show one alert destination",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		destination, getError := apiClient.GetAlertDestination(args[0])
+		if getError != nil {
+			return fmt.Errorf("getting alert destination: %w", getError)
+		}
+		if rendered, renderError := renderStructured(cmd, destination); rendered || renderError != nil {
+			return renderError
+		}
+		printAlertDestination(cmd.OutOrStdout(), destination)
+		return nil
+	},
+}
+
+var alertsDestinationsCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create an alert destination",
+	Long: `Create an alert destination.
+
+Pass --url for a webhook destination, or --channel-id for a channel-based
+Slack or Teams destination (find ids with 'ankra alerts destinations
+channels'); a Teams channel also needs --teams-tenant-id. --type records
+which receiver the destination targets (slack, teams, discord, pagerduty,
+custom; default slack) and selects the default payload format;
+--template-file overrides the payload with your own template.
+
+  ankra alerts destinations create --name ops-slack --url https://hooks.slack.com/services/...
+  ankra alerts destinations create --name oncall --type pagerduty --url https://events.pagerduty.com/...
+  ankra alerts destinations create --name ops-teams --type teams --channel-id 19:abc@thread.tacv2 --teams-tenant-id <tenant>`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := mustFlagString(cmd, "name")
+		webhookURL := mustFlagString(cmd, "url")
+		channelID := mustFlagString(cmd, "channel-id")
+		if webhookURL == "" && channelID == "" {
+			return withExitCode(exitUsage, errors.New("either --url or --channel-id is required"))
+		}
+		template, templateError := templateFromFlags(cmd)
+		if templateError != nil {
+			return templateError
+		}
+		request := client.CreateAlertDestinationRequest{
+			Name:            name,
+			URL:             changedStringFlag(cmd, "url"),
+			ChannelID:       changedStringFlag(cmd, "channel-id"),
+			ChannelName:     changedStringFlag(cmd, "channel-name"),
+			TeamsTenantID:   changedStringFlag(cmd, "teams-tenant-id"),
+			IntegrationType: changedStringFlag(cmd, "type"),
+			Description:     changedStringFlag(cmd, "description"),
+			Template:        template,
+			Enabled:         enabledFromFlags(cmd),
+		}
+		destination, createError := apiClient.CreateAlertDestination(request)
+		if createError != nil {
+			return fmt.Errorf("creating alert destination: %w", createError)
+		}
+		if rendered, renderError := renderStructured(cmd, destination); rendered || renderError != nil {
+			return renderError
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Alert destination %q created (%s).\n", destination.Name, destination.ID)
+		return nil
+	},
+}
+
+var alertsDestinationsUpdateCmd = &cobra.Command{
+	Use:   "update <destination-id>",
+	Short: "Update an alert destination",
+	Long: `Update an alert destination. Only the flags you pass are changed; the
+rest keep their current values.
+
+  ankra alerts destinations update <destination-id> --url https://hooks.slack.com/services/new
+  ankra alerts destinations update <destination-id> --disabled`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		template, templateError := templateFromFlags(cmd)
+		if templateError != nil {
+			return templateError
+		}
+		request := client.UpdateAlertDestinationRequest{
+			Name:          changedStringFlag(cmd, "name"),
+			URL:           changedStringFlag(cmd, "url"),
+			ChannelID:     changedStringFlag(cmd, "channel-id"),
+			ChannelName:   changedStringFlag(cmd, "channel-name"),
+			TeamsTenantID: changedStringFlag(cmd, "teams-tenant-id"),
+			Description:   changedStringFlag(cmd, "description"),
+			Template:      template,
+			Enabled:       enabledFromFlags(cmd),
+		}
+		if request == (client.UpdateAlertDestinationRequest{}) {
+			return withExitCode(exitUsage, errors.New("nothing to update: pass at least one flag"))
+		}
+		destination, updateError := apiClient.UpdateAlertDestination(args[0], request)
+		if updateError != nil {
+			return fmt.Errorf("updating alert destination: %w", updateError)
+		}
+		if rendered, renderError := renderStructured(cmd, destination); rendered || renderError != nil {
+			return renderError
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Alert destination %q updated (%s).\n", destination.Name, destination.ID)
+		return nil
+	},
+}
+
+var alertsDestinationsDeleteCmd = &cobra.Command{
+	Use:   "delete <destination-id>",
+	Short: "Delete an alert destination",
+	Long: `Delete an alert destination. Routes that pointed at it stop delivering;
+remove or re-point them with 'ankra alerts routes'.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		destinationID := args[0]
+		yes, _ := cmd.Flags().GetBool("yes")
+		if confirmError := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Delete alert destination %q? [y/N]: ", destinationID), yes); confirmError != nil {
+			return confirmError
+		}
+		if _, deleteError := apiClient.DeleteAlertDestination(destinationID); deleteError != nil {
+			return fmt.Errorf("deleting alert destination: %w", deleteError)
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Alert destination %s deleted.\n", destinationID)
+		return nil
+	},
+}
+
+var alertsDestinationsTestCmd = &cobra.Command{
+	Use:   "test <destination-id>",
+	Short: "Send a test notification to a destination",
+	Long: `Send a sample notification to a stored destination and report whether
+the receiver accepted it. A failed delivery exits non-zero so CI can gate
+on it; the details are still printed (or emitted with -o json).`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		result, testError := apiClient.TestAlertDestination(args[0])
+		if testError != nil {
+			return fmt.Errorf("testing alert destination: %w", testError)
+		}
+		return reportAlertDestinationTest(cmd, result)
+	},
+}
+
+var alertsDestinationsTestURLCmd = &cobra.Command{
+	Use:   "test-url",
+	Short: "Send a test notification to a webhook URL before storing it",
+	Long: `Send a sample notification to an ad-hoc webhook URL, optionally with a
+custom payload template, without creating a destination. A failed delivery
+exits non-zero.
+
+  ankra alerts destinations test-url --url https://hooks.slack.com/services/...
+  ankra alerts destinations test-url --url https://example.com/hook --template-file payload.json`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		template, templateError := templateFromFlags(cmd)
+		if templateError != nil {
+			return templateError
+		}
+		result, testError := apiClient.TestAlertDestinationURL(client.TestAlertDestinationURLRequest{
+			URL:      mustFlagString(cmd, "url"),
+			Template: template,
+		})
+		if testError != nil {
+			return fmt.Errorf("testing webhook url: %w", testError)
+		}
+		return reportAlertDestinationTest(cmd, result)
+	},
+}
+
+var alertsDestinationsChannelsCmd = &cobra.Command{
+	Use:   "channels",
+	Short: "List the Slack and Teams channels available for channel-based destinations",
+	Long: `List the channels the Ankra bot can post to, for use with
+'ankra alerts destinations create --channel-id'. Both providers are shown
+unless --provider narrows it to one.
+
+A provider whose workspace or tenant is not connected to the organisation
+reads "not connected"; one whose bot service is not configured on this
+platform reads "not available". Neither is an error.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		provider, _ := cmd.Flags().GetString("provider")
+		switch provider {
+		case "", "slack", "teams":
+		default:
+			return withExitCode(exitUsage, fmt.Errorf("unsupported --provider %q (use slack or teams)", provider))
+		}
+
+		var result alertChannelsResult
+		notices := make([]string, 0, 2)
+		if provider != "teams" {
+			slack, slackError := apiClient.ListSlackChannels()
+			state, classifyError := channelPickerState(slackError)
+			if classifyError != nil {
+				return fmt.Errorf("listing Slack channels: %w", classifyError)
+			}
+			if state != "" {
+				notices = append(notices, "Slack: "+state)
+			}
+			result.Slack = slack
+		}
+		if provider != "slack" {
+			teams, teamsError := apiClient.ListTeamsChannels()
+			state, classifyError := channelPickerState(teamsError)
+			if classifyError != nil {
+				return fmt.Errorf("listing Teams channels: %w", classifyError)
+			}
+			if state != "" {
+				notices = append(notices, "Teams: "+state)
+			}
+			result.Teams = teams
+		}
+
+		rendered, renderError := renderStructured(cmd, result)
+		if renderError != nil {
+			return renderError
+		}
+		if rendered {
+			for _, notice := range notices {
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), notice)
+			}
+			return nil
+		}
+		out := cmd.OutOrStdout()
+		if result.Slack != nil {
+			printSlackChannels(out, result.Slack)
+		}
+		if result.Teams != nil {
+			printTeamsChannels(out, result.Teams)
+		}
+		for _, notice := range notices {
+			_, _ = fmt.Fprintln(out, notice)
+		}
+		return nil
+	},
+}
+
+// alertChannelsResult is the structured shape of `destinations channels`.
+// A provider that was not requested, is not connected, or is not available
+// answers null; the reason is written to stderr so stdout stays parseable.
+type alertChannelsResult struct {
+	Slack *client.SlackChannelList `json:"slack" yaml:"slack"`
+	Teams *client.TeamsChannelList `json:"teams" yaml:"teams"`
+}
+
+// channelPickerState turns the channel picker's two "no picker" answers
+// into a human state: 404 means no workspace or tenant is connected to the
+// organisation, 503 means the bot service is not configured on this
+// platform. Any other error is passed back for the caller to return.
+func channelPickerState(listError error) (string, error) {
+	if listError == nil {
+		return "", nil
+	}
+	var unexpected *client.UnexpectedResponseError
+	if errors.As(listError, &unexpected) {
+		switch unexpected.StatusCode {
+		case http.StatusNotFound:
+			return fmt.Sprintf("not connected (%s)", unexpected.Error()), nil
+		case http.StatusServiceUnavailable:
+			return fmt.Sprintf("not available (%s)", unexpected.Error()), nil
+		}
+	}
+	return "", listError
+}
+
+func printSlackChannels(out io.Writer, list *client.SlackChannelList) {
+	heading := "Slack"
+	if list.TeamName != nil && *list.TeamName != "" {
+		heading += " (workspace " + *list.TeamName + ")"
+	}
+	_, _ = fmt.Fprintf(out, "%s:\n", heading)
+	if len(list.Channels) == 0 {
+		_, _ = fmt.Fprintln(out, "  No channels the Ankra bot can post to.")
+		return
+	}
+	writer := table.NewWriter()
+	writer.SetOutputMirror(out)
+	writer.SetStyle(table.StyleRounded)
+	writer.AppendHeader(table.Row{"Name", "ID", "Private"})
+	for _, channel := range list.Channels {
+		writer.AppendRow(table.Row{channel.Name, channel.ID, channel.IsPrivate})
+	}
+	writer.Render()
+}
+
+func printTeamsChannels(out io.Writer, list *client.TeamsChannelList) {
+	_, _ = fmt.Fprintln(out, "Teams:")
+	if len(list.Channels) == 0 {
+		_, _ = fmt.Fprintln(out, "  No channels the Ankra bot is installed in.")
+		return
+	}
+	writer := table.NewWriter()
+	writer.SetOutputMirror(out)
+	writer.SetStyle(table.StyleRounded)
+	writer.AppendHeader(table.Row{"Name", "ID", "Team", "Tenant"})
+	for _, channel := range list.Channels {
+		writer.AppendRow(table.Row{channel.Name, channel.ID, channel.TeamName, channel.TenantID})
+	}
+	writer.Render()
+}
+
+// alertDestinationType names the delivery mechanism, since the read shape
+// carries no receiver type: a destination with a channel id posts through
+// the Ankra bot, everything else is a webhook.
+func alertDestinationType(destination client.AlertDestination) string {
+	if destination.ChannelID != nil && *destination.ChannelID != "" {
+		return "channel"
+	}
+	return "webhook"
+}
+
+// alertDestinationTarget is the human label of where a destination
+// delivers: the channel name (or id) for channel destinations, the masked
+// URL for webhooks.
+func alertDestinationTarget(destination client.AlertDestination) string {
+	if destination.ChannelName != nil && *destination.ChannelName != "" {
+		return *destination.ChannelName
+	}
+	if destination.ChannelID != nil && *destination.ChannelID != "" {
+		return *destination.ChannelID
+	}
+	if destination.URL != nil && *destination.URL != "" {
+		return *destination.URL
+	}
+	return "-"
+}
+
+func printAlertDestination(out io.Writer, destination *client.AlertDestination) {
+	_, _ = fmt.Fprintf(out, "Name:        %s\n", destination.Name)
+	_, _ = fmt.Fprintf(out, "ID:          %s\n", destination.ID)
+	_, _ = fmt.Fprintf(out, "Type:        %s\n", alertDestinationType(*destination))
+	_, _ = fmt.Fprintf(out, "Target:      %s\n", alertDestinationTarget(*destination))
+	if destination.Description != nil && *destination.Description != "" {
+		_, _ = fmt.Fprintf(out, "Description: %s\n", *destination.Description)
+	}
+	if destination.Template != nil && *destination.Template != "" {
+		_, _ = fmt.Fprintln(out, "Template:    custom (use -o json to view)")
+	}
+	_, _ = fmt.Fprintf(out, "Enabled:     %t\n", destination.Enabled)
+	_, _ = fmt.Fprintf(out, "Created:     %s (%s)\n", destination.CreatedAt, formatTimeAgo(destination.CreatedAt))
+	_, _ = fmt.Fprintf(out, "Updated:     %s (%s)\n", destination.UpdatedAt, formatTimeAgo(destination.UpdatedAt))
+}
+
+// reportAlertDestinationTest renders a test outcome and turns a failed
+// delivery into a non-zero exit, so a pipeline can gate on the receiver
+// being reachable. With -o the structured result is still written first.
+func reportAlertDestinationTest(cmd *cobra.Command, result *client.AlertDestinationTestResult) error {
+	rendered, renderError := renderStructured(cmd, result)
+	if renderError != nil {
+		return renderError
+	}
+	summary := alertDestinationTestSummary(result)
+	if !result.Success {
+		return fmt.Errorf("test delivery failed (%s)", summary)
+	}
+	if !rendered {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Test delivery succeeded (%s).\n", summary)
+	}
+	return nil
+}
+
+func alertDestinationTestSummary(result *client.AlertDestinationTestResult) string {
+	parts := make([]string, 0, 3)
+	if result.StatusCode != nil {
+		parts = append(parts, fmt.Sprintf("HTTP %d", *result.StatusCode))
+	}
+	if result.ResponseTimeMS != nil {
+		parts = append(parts, fmt.Sprintf("%.0f ms", *result.ResponseTimeMS))
+	}
+	if result.Error != nil && *result.Error != "" {
+		parts = append(parts, *result.Error)
+	}
+	if len(parts) == 0 {
+		return "no response"
+	}
+	return strings.Join(parts, ", ")
+}
+
+// templateFromFlags reads --template-file into the payload template member;
+// nil when the flag was not passed so the backend keeps its default.
+func templateFromFlags(cmd *cobra.Command) (*string, error) {
+	path := mustFlagString(cmd, "template-file")
+	if path == "" {
+		return nil, nil
+	}
+	content, readError := os.ReadFile(path)
+	if readError != nil {
+		return nil, fmt.Errorf("reading template file %q: %w", path, readError)
+	}
+	template := string(content)
+	return &template, nil
+}
+
+// enabledFromFlags resolves the --enabled/--disabled pair to a tri-state:
+// nil when neither was passed, so lists stay unfiltered and updates leave
+// the current state alone. Commands that expose only --disabled resolve the
+// same way.
+func enabledFromFlags(cmd *cobra.Command) *bool {
+	if cmd.Flags().Changed("enabled") {
+		enabled := mustFlagBool(cmd, "enabled")
+		return &enabled
+	}
+	if cmd.Flags().Changed("disabled") {
+		enabled := !mustFlagBool(cmd, "disabled")
+		return &enabled
+	}
+	return nil
+}
+
+// changedStringFlag returns the flag's value only when it was passed, so
+// request members the user did not mention are left off the wire.
+func changedStringFlag(cmd *cobra.Command, name string) *string {
+	if !cmd.Flags().Changed(name) {
+		return nil
+	}
+	value := mustFlagString(cmd, name)
+	return &value
+}
+
+func changedIntFlag(cmd *cobra.Command, name string) *int {
+	if !cmd.Flags().Changed(name) {
+		return nil
+	}
+	value := mustFlagInt(cmd, name)
+	return &value
+}
+
+func changedBoolFlag(cmd *cobra.Command, name string) *bool {
+	if !cmd.Flags().Changed(name) {
+		return nil
+	}
+	value := mustFlagBool(cmd, name)
+	return &value
+}
+
+func init() {
+	alertsDestinationsListCmd.Flags().String("search", "", "Filter destinations by name")
+	alertsDestinationsListCmd.Flags().Bool("enabled", false, "Only enabled destinations")
+	alertsDestinationsListCmd.Flags().Bool("disabled", false, "Only disabled destinations")
+	alertsDestinationsListCmd.Flags().Int("page", 1, "Page number")
+	alertsDestinationsListCmd.Flags().Int("page-size", 20, "Destinations per page (max 100)")
+	alertsDestinationsListCmd.MarkFlagsMutuallyExclusive("enabled", "disabled")
+
+	alertsDestinationsCreateCmd.Flags().String("name", "", "Destination name, unique within the organisation")
+	alertsDestinationsCreateCmd.Flags().String("url", "", "Webhook URL to deliver to")
+	alertsDestinationsCreateCmd.Flags().String("channel-id", "", "Slack or Teams channel id for a channel-based destination (instead of --url)")
+	alertsDestinationsCreateCmd.Flags().String("channel-name", "", "Display name of the channel behind --channel-id")
+	alertsDestinationsCreateCmd.Flags().String("teams-tenant-id", "", "Microsoft Teams tenant id (required with --channel-id for --type teams)")
+	alertsDestinationsCreateCmd.Flags().String("type", "", "Receiver type: slack, teams, discord, pagerduty, or custom (default slack)")
+	alertsDestinationsCreateCmd.Flags().String("description", "", "Free-text description")
+	alertsDestinationsCreateCmd.Flags().String("template-file", "", "File holding a custom payload template")
+	alertsDestinationsCreateCmd.Flags().Bool("disabled", false, "Create the destination disabled")
+	_ = alertsDestinationsCreateCmd.MarkFlagRequired("name")
+
+	alertsDestinationsUpdateCmd.Flags().String("name", "", "New destination name")
+	alertsDestinationsUpdateCmd.Flags().String("url", "", "New webhook URL")
+	alertsDestinationsUpdateCmd.Flags().String("channel-id", "", "New Slack or Teams channel id")
+	alertsDestinationsUpdateCmd.Flags().String("channel-name", "", "New display name of the channel")
+	alertsDestinationsUpdateCmd.Flags().String("teams-tenant-id", "", "New Microsoft Teams tenant id")
+	alertsDestinationsUpdateCmd.Flags().String("description", "", "New description")
+	alertsDestinationsUpdateCmd.Flags().String("template-file", "", "File holding the new payload template")
+	alertsDestinationsUpdateCmd.Flags().Bool("enabled", false, "Enable the destination")
+	alertsDestinationsUpdateCmd.Flags().Bool("disabled", false, "Disable the destination")
+	alertsDestinationsUpdateCmd.MarkFlagsMutuallyExclusive("enabled", "disabled")
+
+	alertsDestinationsDeleteCmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
+
+	alertsDestinationsTestURLCmd.Flags().String("url", "", "Webhook URL to send the test notification to")
+	alertsDestinationsTestURLCmd.Flags().String("template-file", "", "File holding a custom payload template")
+	_ = alertsDestinationsTestURLCmd.MarkFlagRequired("url")
+
+	alertsDestinationsChannelsCmd.Flags().String("provider", "", "Only one provider: slack or teams (default both)")
+
+	registerStructuredOutputFlags(
+		alertsDestinationsListCmd,
+		alertsDestinationsGetCmd,
+		alertsDestinationsCreateCmd,
+		alertsDestinationsUpdateCmd,
+		alertsDestinationsTestCmd,
+		alertsDestinationsTestURLCmd,
+		alertsDestinationsChannelsCmd,
+	)
+
+	alertsDestinationsCmd.AddCommand(alertsDestinationsListCmd)
+	alertsDestinationsCmd.AddCommand(alertsDestinationsGetCmd)
+	alertsDestinationsCmd.AddCommand(alertsDestinationsCreateCmd)
+	alertsDestinationsCmd.AddCommand(alertsDestinationsUpdateCmd)
+	alertsDestinationsCmd.AddCommand(alertsDestinationsDeleteCmd)
+	alertsDestinationsCmd.AddCommand(alertsDestinationsTestCmd)
+	alertsDestinationsCmd.AddCommand(alertsDestinationsTestURLCmd)
+	alertsDestinationsCmd.AddCommand(alertsDestinationsChannelsCmd)
+	alertsCmd.AddCommand(alertsDestinationsCmd)
+	rootCmd.AddCommand(alertsCmd)
+}

--- a/cmd/alerts.go
+++ b/cmd/alerts.go
@@ -402,10 +402,14 @@ func printTeamsChannels(out io.Writer, list *client.TeamsChannelList) {
 	writer.Render()
 }
 
-// alertDestinationType names the delivery mechanism, since the read shape
-// carries no receiver type: a destination with a channel id posts through
-// the Ankra bot, everything else is a webhook.
+// alertDestinationType names the receiver from the read shape's
+// integration_type; a backend that predates the field yields the delivery
+// mechanism instead (channel = posted by the Ankra bot, webhook = direct
+// POST) so the column never goes blank.
 func alertDestinationType(destination client.AlertDestination) string {
+	if destination.IntegrationType != "" {
+		return destination.IntegrationType
+	}
 	if destination.ChannelID != nil && *destination.ChannelID != "" {
 		return "channel"
 	}

--- a/cmd/alerts_routes.go
+++ b/cmd/alerts_routes.go
@@ -1,0 +1,268 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+var alertsRoutesCmd = &cobra.Command{
+	Use:   "routes",
+	Short: "Manage notification routes (which notifications reach which destination)",
+	Long: `Manage the organisation's notification routes.
+
+A route sends notifications matching every filter it sets (kind, severity,
+cluster, source) to one destination; a route with no filters matches
+everything. Routes are evaluated in ascending priority, mode "exclude"
+withholds matches instead of delivering them, and --stop-on-match ends the
+walk at that route so lower-priority routes never see the notification.
+
+  ankra alerts routes create --destination-id <destination-id> --severity critical
+  ankra alerts routes create --destination-id <destination-id> --kind execution_failed --cluster-id <cluster-id> --priority 10
+  ankra alerts routes update <route-id> --disabled
+  ankra alerts routes test <route-id>`,
+}
+
+var alertsRoutesListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List notification routes",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		list, listError := apiClient.ListNotificationRoutes()
+		if listError != nil {
+			return fmt.Errorf("listing notification routes: %w", listError)
+		}
+		if rendered, renderError := renderStructured(cmd, list); rendered || renderError != nil {
+			return renderError
+		}
+		out := cmd.OutOrStdout()
+		if len(list.Items) == 0 {
+			_, _ = fmt.Fprintln(out, "No notification routes found.")
+			return nil
+		}
+		writer := table.NewWriter()
+		writer.SetOutputMirror(out)
+		writer.SetStyle(table.StyleRounded)
+		writer.AppendHeader(table.Row{"ID", "Priority", "Kind", "Severity", "Cluster", "Destination", "Mode", "Enabled"})
+		for _, route := range list.Items {
+			writer.AppendRow(table.Row{
+				route.ID,
+				route.Priority,
+				valueOrAny(route.Kind),
+				valueOrAny(route.Severity),
+				valueOrAny(route.ClusterID),
+				route.DestinationID,
+				route.Mode,
+				route.Enabled,
+			})
+		}
+		writer.Render()
+		return nil
+	},
+}
+
+var alertsRoutesCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a notification route",
+	Long: `Create a notification route to a destination. Every filter is optional;
+a route with none matches every notification.
+
+Kinds include execution_failed, resource_deployment_failed,
+resource_health_degraded, alert_trigger_fired, gitops_sync_failed,
+agent_offline, security_new_severe_cves, and the other platform
+notification kinds; severities are critical, warning, and info.
+
+  ankra alerts routes create --destination-id <destination-id> --severity critical
+  ankra alerts routes create --destination-id <destination-id> --kind gitops_sync_failed --mode exclude --stop-on-match`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if validationError := validateRouteFilterFlags(cmd); validationError != nil {
+			return validationError
+		}
+		request := client.CreateNotificationRouteRequest{
+			DestinationID: mustFlagString(cmd, "destination-id"),
+			Kind:          changedStringFlag(cmd, "kind"),
+			Severity:      changedStringFlag(cmd, "severity"),
+			ClusterID:     changedStringFlag(cmd, "cluster-id"),
+			SourceID:      changedStringFlag(cmd, "source-id"),
+			Priority:      changedIntFlag(cmd, "priority"),
+			StopOnMatch:   changedBoolFlag(cmd, "stop-on-match"),
+			Mode:          changedStringFlag(cmd, "mode"),
+			Enabled:       enabledFromFlags(cmd),
+		}
+		route, createError := apiClient.CreateNotificationRoute(request)
+		if createError != nil {
+			return fmt.Errorf("creating notification route: %w", createError)
+		}
+		if rendered, renderError := renderStructured(cmd, route); rendered || renderError != nil {
+			return renderError
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Notification route %s created.\n", route.ID)
+		printNotificationRoute(cmd.OutOrStdout(), route)
+		return nil
+	},
+}
+
+var alertsRoutesUpdateCmd = &cobra.Command{
+	Use:   "update <route-id>",
+	Short: "Update a notification route",
+	Long: `Update a notification route. Only the flags you pass are changed; the
+rest keep their current values.
+
+  ankra alerts routes update <route-id> --priority 5 --stop-on-match
+  ankra alerts routes update <route-id> --destination-id <other-destination-id>
+  ankra alerts routes update <route-id> --disabled`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if validationError := validateRouteFilterFlags(cmd); validationError != nil {
+			return validationError
+		}
+		request := client.UpdateNotificationRouteRequest{
+			DestinationID: changedStringFlag(cmd, "destination-id"),
+			Kind:          changedStringFlag(cmd, "kind"),
+			Severity:      changedStringFlag(cmd, "severity"),
+			ClusterID:     changedStringFlag(cmd, "cluster-id"),
+			SourceID:      changedStringFlag(cmd, "source-id"),
+			Priority:      changedIntFlag(cmd, "priority"),
+			StopOnMatch:   changedBoolFlag(cmd, "stop-on-match"),
+			Mode:          changedStringFlag(cmd, "mode"),
+			Enabled:       enabledFromFlags(cmd),
+		}
+		if request == (client.UpdateNotificationRouteRequest{}) {
+			return withExitCode(exitUsage, errors.New("nothing to update: pass at least one flag"))
+		}
+		route, updateError := apiClient.UpdateNotificationRoute(args[0], request)
+		if updateError != nil {
+			return fmt.Errorf("updating notification route: %w", updateError)
+		}
+		if rendered, renderError := renderStructured(cmd, route); rendered || renderError != nil {
+			return renderError
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Notification route %s updated.\n", route.ID)
+		printNotificationRoute(cmd.OutOrStdout(), route)
+		return nil
+	},
+}
+
+var alertsRoutesDeleteCmd = &cobra.Command{
+	Use:   "delete <route-id>",
+	Short: "Delete a notification route",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		routeID := args[0]
+		yes, _ := cmd.Flags().GetBool("yes")
+		if confirmError := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Delete notification route %q? [y/N]: ", routeID), yes); confirmError != nil {
+			return confirmError
+		}
+		if deleteError := apiClient.DeleteNotificationRoute(routeID); deleteError != nil {
+			return fmt.Errorf("deleting notification route: %w", deleteError)
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Notification route %s deleted.\n", routeID)
+		return nil
+	},
+}
+
+var alertsRoutesTestCmd = &cobra.Command{
+	Use:   "test <route-id>",
+	Short: "Queue a sample notification through a route",
+	Long: `Queue a sample notification through a route's destination. Delivery is
+asynchronous: the command returns the delivery id once the sample is
+queued, not once the receiver has accepted it.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		result, testError := apiClient.TestNotificationRoute(args[0])
+		if testError != nil {
+			return fmt.Errorf("testing notification route: %w", testError)
+		}
+		if rendered, renderError := renderStructured(cmd, result); rendered || renderError != nil {
+			return renderError
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Test notification queued (delivery %s).\n", result.DeliveryID)
+		return nil
+	},
+}
+
+// validateRouteFilterFlags rejects enum values the backend would refuse
+// with a validation error, so a typo exits with the usage code and a plain
+// message instead of a 422 body.
+func validateRouteFilterFlags(cmd *cobra.Command) error {
+	if mode := mustFlagString(cmd, "mode"); cmd.Flags().Changed("mode") && mode != "include" && mode != "exclude" {
+		return withExitCode(exitUsage, fmt.Errorf("unsupported --mode %q (use include or exclude)", mode))
+	}
+	if severity := mustFlagString(cmd, "severity"); cmd.Flags().Changed("severity") &&
+		severity != "critical" && severity != "warning" && severity != "info" {
+		return withExitCode(exitUsage, fmt.Errorf("unsupported --severity %q (use critical, warning, or info)", severity))
+	}
+	return nil
+}
+
+// valueOrAny renders a nullable route filter: an unset filter matches any
+// value, which is what the table should say.
+func valueOrAny(value *string) string {
+	if value == nil || *value == "" {
+		return "any"
+	}
+	return *value
+}
+
+func printNotificationRoute(out io.Writer, route *client.NotificationRoute) {
+	_, _ = fmt.Fprintf(out, "ID:            %s\n", route.ID)
+	_, _ = fmt.Fprintf(out, "Destination:   %s\n", route.DestinationID)
+	_, _ = fmt.Fprintf(out, "Priority:      %d\n", route.Priority)
+	_, _ = fmt.Fprintf(out, "Kind:          %s\n", valueOrAny(route.Kind))
+	_, _ = fmt.Fprintf(out, "Severity:      %s\n", valueOrAny(route.Severity))
+	_, _ = fmt.Fprintf(out, "Cluster:       %s\n", valueOrAny(route.ClusterID))
+	_, _ = fmt.Fprintf(out, "Source:        %s\n", valueOrAny(route.SourceID))
+	_, _ = fmt.Fprintf(out, "Mode:          %s\n", route.Mode)
+	_, _ = fmt.Fprintf(out, "Stop on match: %t\n", route.StopOnMatch)
+	_, _ = fmt.Fprintf(out, "Enabled:       %t\n", route.Enabled)
+}
+
+// registerRouteFilterFlags adds the route shape flags shared by create and
+// update. Defaults are left zero on purpose: only flags the user passes are
+// sent, so create picks up the backend defaults (priority 100, mode include)
+// and update leaves unmentioned members alone.
+func registerRouteFilterFlags(cmd *cobra.Command) {
+	cmd.Flags().String("kind", "", "Only notifications of this kind (for example execution_failed)")
+	cmd.Flags().String("severity", "", "Only notifications of this severity: critical, warning, or info")
+	cmd.Flags().String("cluster-id", "", "Only notifications about this cluster (id)")
+	cmd.Flags().String("source-id", "", "Only notifications from this source id")
+	cmd.Flags().Int("priority", 0, "Evaluation order, lowest first (default 100)")
+	cmd.Flags().Bool("stop-on-match", false, "Stop evaluating lower-priority routes once this one matches")
+	cmd.Flags().String("mode", "", "include delivers matches, exclude withholds them (default include)")
+}
+
+func init() {
+	alertsRoutesCreateCmd.Flags().String("destination-id", "", "Destination to deliver to (see 'ankra alerts destinations list')")
+	registerRouteFilterFlags(alertsRoutesCreateCmd)
+	alertsRoutesCreateCmd.Flags().Bool("disabled", false, "Create the route disabled")
+	_ = alertsRoutesCreateCmd.MarkFlagRequired("destination-id")
+
+	alertsRoutesUpdateCmd.Flags().String("destination-id", "", "Re-point the route at another destination")
+	registerRouteFilterFlags(alertsRoutesUpdateCmd)
+	alertsRoutesUpdateCmd.Flags().Bool("enabled", false, "Enable the route")
+	alertsRoutesUpdateCmd.Flags().Bool("disabled", false, "Disable the route")
+	alertsRoutesUpdateCmd.MarkFlagsMutuallyExclusive("enabled", "disabled")
+
+	alertsRoutesDeleteCmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
+
+	registerStructuredOutputFlags(
+		alertsRoutesListCmd,
+		alertsRoutesCreateCmd,
+		alertsRoutesUpdateCmd,
+		alertsRoutesTestCmd,
+	)
+
+	alertsRoutesCmd.AddCommand(alertsRoutesListCmd)
+	alertsRoutesCmd.AddCommand(alertsRoutesCreateCmd)
+	alertsRoutesCmd.AddCommand(alertsRoutesUpdateCmd)
+	alertsRoutesCmd.AddCommand(alertsRoutesDeleteCmd)
+	alertsRoutesCmd.AddCommand(alertsRoutesTestCmd)
+	alertsCmd.AddCommand(alertsRoutesCmd)
+}

--- a/cmd/alerts_routes_test.go
+++ b/cmd/alerts_routes_test.go
@@ -1,0 +1,433 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type notificationRoutesMock struct {
+	baseMock
+	routes        []client.NotificationRoute
+	createRequest *client.CreateNotificationRouteRequest
+	updatedID     string
+	updateRequest *client.UpdateNotificationRouteRequest
+	deleteCalls   []string
+	testCalls     []string
+}
+
+func (m *notificationRoutesMock) ListNotificationRoutes() (*client.NotificationRouteList, error) {
+	return &client.NotificationRouteList{Items: m.routes}, nil
+}
+
+func (m *notificationRoutesMock) CreateNotificationRoute(request client.CreateNotificationRouteRequest) (*client.NotificationRoute, error) {
+	m.createRequest = &request
+	priority := 100
+	if request.Priority != nil {
+		priority = *request.Priority
+	}
+	mode := "include"
+	if request.Mode != nil {
+		mode = *request.Mode
+	}
+	return &client.NotificationRoute{
+		ID:             "7c1e0d5a-0000-4000-8000-000000000010",
+		OrganisationID: "0f0f0f0f-0000-4000-8000-000000000001",
+		Kind:           request.Kind,
+		Severity:       request.Severity,
+		ClusterID:      request.ClusterID,
+		SourceID:       request.SourceID,
+		DestinationID:  request.DestinationID,
+		Priority:       priority,
+		StopOnMatch:    request.StopOnMatch != nil && *request.StopOnMatch,
+		Mode:           mode,
+		Enabled:        request.Enabled == nil || *request.Enabled,
+		CreatedAt:      "2026-08-17T10:00:00Z",
+		UpdatedAt:      "2026-08-17T10:00:00Z",
+	}, nil
+}
+
+func (m *notificationRoutesMock) UpdateNotificationRoute(routeID string, request client.UpdateNotificationRouteRequest) (*client.NotificationRoute, error) {
+	m.updatedID = routeID
+	m.updateRequest = &request
+	for index := range m.routes {
+		if m.routes[index].ID == routeID {
+			updated := m.routes[index]
+			if request.Priority != nil {
+				updated.Priority = *request.Priority
+			}
+			if request.Enabled != nil {
+				updated.Enabled = *request.Enabled
+			}
+			return &updated, nil
+		}
+	}
+	return nil, client.NewUnexpectedResponseError(404, "Route not found")
+}
+
+func (m *notificationRoutesMock) DeleteNotificationRoute(routeID string) error {
+	m.deleteCalls = append(m.deleteCalls, routeID)
+	return nil
+}
+
+func (m *notificationRoutesMock) TestNotificationRoute(routeID string) (*client.NotificationRouteTestResult, error) {
+	m.testCalls = append(m.testCalls, routeID)
+	return &client.NotificationRouteTestResult{DeliveryID: "9e9e9e9e-0000-4000-8000-000000000042"}, nil
+}
+
+func sampleNotificationRoutes() []client.NotificationRoute {
+	return []client.NotificationRoute{
+		{
+			ID:             "7c1e0d5a-0000-4000-8000-000000000001",
+			OrganisationID: "0f0f0f0f-0000-4000-8000-000000000001",
+			Severity:       strPtrCmd("critical"),
+			DestinationID:  "3d0f6a2e-0000-4000-8000-000000000001",
+			Priority:       10,
+			StopOnMatch:    true,
+			Mode:           "include",
+			Enabled:        true,
+			CreatedAt:      "2026-08-01T10:00:00Z",
+			UpdatedAt:      "2026-08-02T10:00:00Z",
+		},
+		{
+			ID:             "7c1e0d5a-0000-4000-8000-000000000002",
+			OrganisationID: "0f0f0f0f-0000-4000-8000-000000000001",
+			Kind:           strPtrCmd("gitops_sync_failed"),
+			ClusterID:      strPtrCmd("c1c1c1c1-0000-4000-8000-000000000001"),
+			DestinationID:  "3d0f6a2e-0000-4000-8000-000000000002",
+			Priority:       100,
+			Mode:           "exclude",
+			Enabled:        false,
+			CreatedAt:      "2026-08-01T10:00:00Z",
+			UpdatedAt:      "2026-08-02T10:00:00Z",
+		},
+	}
+}
+
+func TestAlertsRoutesListRendersTable(t *testing.T) {
+	mock := &notificationRoutesMock{routes: sampleNotificationRoutes()}
+	stdout, _, runError := runAlertsCommand(t, mock, "", "alerts", "routes", "list")
+	if runError != nil {
+		t.Fatalf("alerts routes list failed: %v", runError)
+	}
+	for _, fragment := range []string{
+		"7c1e0d5a-0000-4000-8000-000000000001", "critical", "include",
+		"7c1e0d5a-0000-4000-8000-000000000002", "gitops_sync_failed", "c1c1c1c1-0000-4000-8000-000000000001", "exclude",
+		"3d0f6a2e-0000-4000-8000-000000000002",
+	} {
+		if !strings.Contains(stdout, fragment) {
+			t.Errorf("expected table to contain %q, got:\n%s", fragment, stdout)
+		}
+	}
+	if !strings.Contains(stdout, "any") {
+		t.Errorf("expected unset filters to read 'any', got:\n%s", stdout)
+	}
+}
+
+func TestAlertsRoutesListEmptyAndJSON(t *testing.T) {
+	mock := &notificationRoutesMock{}
+	stdout, _, runError := runAlertsCommand(t, mock, "", "alerts", "routes", "list")
+	if runError != nil {
+		t.Fatalf("alerts routes list failed: %v", runError)
+	}
+	if !strings.Contains(stdout, "No notification routes found.") {
+		t.Errorf("expected the empty message, got: %s", stdout)
+	}
+
+	mock.routes = sampleNotificationRoutes()
+	stdout, _, runError = runAlertsCommand(t, mock, "", "alerts", "routes", "list", "-o", "json")
+	if runError != nil {
+		t.Fatalf("alerts routes list -o json failed: %v", runError)
+	}
+	var decoded struct {
+		Items []map[string]interface{} `json:"items"`
+	}
+	if unmarshalError := json.Unmarshal([]byte(stdout), &decoded); unmarshalError != nil {
+		t.Fatalf("expected parseable JSON on stdout, got %v: %s", unmarshalError, stdout)
+	}
+	if len(decoded.Items) != 2 || decoded.Items[0]["severity"] != "critical" || decoded.Items[0]["kind"] != nil {
+		t.Errorf("unexpected items in JSON output: %s", stdout)
+	}
+}
+
+func TestAlertsRoutesCreateSendsOnlyPassedFlags(t *testing.T) {
+	mock := &notificationRoutesMock{}
+	stdout, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "routes", "create",
+		"--destination-id", "3d0f6a2e-0000-4000-8000-000000000001",
+		"--severity", "critical", "--priority", "10", "--stop-on-match", "--disabled")
+	if runError != nil {
+		t.Fatalf("alerts routes create failed: %v", runError)
+	}
+	request := mock.createRequest
+	if request == nil {
+		t.Fatal("expected the create call to reach the client")
+	}
+	if request.DestinationID != "3d0f6a2e-0000-4000-8000-000000000001" {
+		t.Errorf("destination_id = %q", request.DestinationID)
+	}
+	if request.Severity == nil || *request.Severity != "critical" {
+		t.Errorf("severity = %v, want critical", request.Severity)
+	}
+	if request.Priority == nil || *request.Priority != 10 {
+		t.Errorf("priority = %v, want 10", request.Priority)
+	}
+	if request.StopOnMatch == nil || !*request.StopOnMatch {
+		t.Errorf("stop_on_match = %v, want true", request.StopOnMatch)
+	}
+	if request.Enabled == nil || *request.Enabled {
+		t.Errorf("enabled = %v, want false from --disabled", request.Enabled)
+	}
+	if request.Kind != nil || request.ClusterID != nil || request.SourceID != nil || request.Mode != nil {
+		t.Errorf("unset filters must stay nil so the backend defaults apply, got %+v", request)
+	}
+	for _, fragment := range []string{
+		"Notification route 7c1e0d5a-0000-4000-8000-000000000010 created.",
+		"Priority:      10",
+		"Severity:      critical",
+		"Kind:          any",
+		"Stop on match: true",
+		"Enabled:       false",
+	} {
+		if !strings.Contains(stdout, fragment) {
+			t.Errorf("expected output to contain %q, got:\n%s", fragment, stdout)
+		}
+	}
+}
+
+func TestAlertsRoutesCreateSendsAllFilters(t *testing.T) {
+	mock := &notificationRoutesMock{}
+	_, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "routes", "create",
+		"--destination-id", "3d0f6a2e-0000-4000-8000-000000000001",
+		"--kind", "execution_failed", "--cluster-id", "c1c1c1c1-0000-4000-8000-000000000001",
+		"--source-id", "stack:platform", "--mode", "exclude")
+	if runError != nil {
+		t.Fatalf("alerts routes create failed: %v", runError)
+	}
+	request := mock.createRequest
+	if request.Kind == nil || *request.Kind != "execution_failed" {
+		t.Errorf("kind = %v, want execution_failed", request.Kind)
+	}
+	if request.ClusterID == nil || *request.ClusterID != "c1c1c1c1-0000-4000-8000-000000000001" {
+		t.Errorf("cluster_id = %v", request.ClusterID)
+	}
+	if request.SourceID == nil || *request.SourceID != "stack:platform" {
+		t.Errorf("source_id = %v, want stack:platform", request.SourceID)
+	}
+	if request.Mode == nil || *request.Mode != "exclude" {
+		t.Errorf("mode = %v, want exclude", request.Mode)
+	}
+	if request.Priority != nil || request.StopOnMatch != nil || request.Enabled != nil {
+		t.Errorf("untouched members must stay nil, got %+v", request)
+	}
+}
+
+func TestAlertsRoutesCreateValidatesEnums(t *testing.T) {
+	mock := &notificationRoutesMock{}
+	_, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "routes", "create", "--destination-id", "3d0f6a2e-0000-4000-8000-000000000001", "--mode", "drop")
+	if runError == nil || exitCodeFor(runError) != exitUsage {
+		t.Errorf("expected an unsupported mode to be a usage error, got %v", runError)
+	}
+	_, _, runError = runAlertsCommand(t, mock, "",
+		"alerts", "routes", "create", "--destination-id", "3d0f6a2e-0000-4000-8000-000000000001", "--severity", "fatal")
+	if runError == nil || exitCodeFor(runError) != exitUsage {
+		t.Errorf("expected an unsupported severity to be a usage error, got %v", runError)
+	}
+	if mock.createRequest != nil {
+		t.Error("usage errors must not reach the client")
+	}
+}
+
+func TestAlertsRoutesCreateRequiresDestination(t *testing.T) {
+	mock := &notificationRoutesMock{}
+	_, _, runError := runAlertsCommand(t, mock, "", "alerts", "routes", "create", "--severity", "critical")
+	if runError == nil {
+		t.Fatal("expected create without --destination-id to fail")
+	}
+	if got := exitCodeFor(runError); got != exitUsage {
+		t.Errorf("expected exit code %d, got %d (%v)", exitUsage, got, runError)
+	}
+}
+
+func TestAlertsRoutesCreateNotFoundDestinationUsesExitNotFound(t *testing.T) {
+	mock := &notFoundDestinationRoutesMock{}
+	_, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "routes", "create", "--destination-id", "3d0f6a2e-0000-4000-8000-00000000dead")
+	if runError == nil {
+		t.Fatal("expected an error for an unknown destination")
+	}
+	if got := exitCodeFor(runError); got != exitNotFound {
+		t.Errorf("expected exit code %d, got %d (%v)", exitNotFound, got, runError)
+	}
+	if !strings.Contains(runError.Error(), "not found in this organisation") {
+		t.Errorf("expected the backend detail to surface, got: %v", runError)
+	}
+}
+
+type notFoundDestinationRoutesMock struct{ baseMock }
+
+func (m *notFoundDestinationRoutesMock) CreateNotificationRoute(request client.CreateNotificationRouteRequest) (*client.NotificationRoute, error) {
+	return nil, client.NewUnexpectedResponseError(404,
+		"Destination "+request.DestinationID+" not found in this organisation.")
+}
+
+func TestAlertsRoutesCreateJSONOutputIsPure(t *testing.T) {
+	mock := &notificationRoutesMock{}
+	stdout, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "routes", "create", "--destination-id", "3d0f6a2e-0000-4000-8000-000000000001", "-o", "json")
+	if runError != nil {
+		t.Fatalf("alerts routes create -o json failed: %v", runError)
+	}
+	var decoded map[string]interface{}
+	if unmarshalError := json.Unmarshal([]byte(stdout), &decoded); unmarshalError != nil {
+		t.Fatalf("expected parseable JSON on stdout, got %v: %s", unmarshalError, stdout)
+	}
+	if decoded["id"] != "7c1e0d5a-0000-4000-8000-000000000010" || decoded["mode"] != "include" {
+		t.Errorf("unexpected JSON document: %s", stdout)
+	}
+	if decoded["priority"] != float64(100) {
+		t.Errorf("priority = %v, want the backend default 100", decoded["priority"])
+	}
+}
+
+func TestAlertsRoutesUpdateSendsOnlyChangedFields(t *testing.T) {
+	mock := &notificationRoutesMock{routes: sampleNotificationRoutes()}
+	stdout, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "routes", "update", "7c1e0d5a-0000-4000-8000-000000000001", "--priority", "5")
+	if runError != nil {
+		t.Fatalf("alerts routes update failed: %v", runError)
+	}
+	if mock.updatedID != "7c1e0d5a-0000-4000-8000-000000000001" {
+		t.Errorf("updated id = %q", mock.updatedID)
+	}
+	request := mock.updateRequest
+	if request == nil {
+		t.Fatal("expected the update call to reach the client")
+	}
+	if request.Priority == nil || *request.Priority != 5 {
+		t.Errorf("priority = %v, want 5", request.Priority)
+	}
+	if request.DestinationID != nil || request.Kind != nil || request.Severity != nil || request.ClusterID != nil ||
+		request.SourceID != nil || request.StopOnMatch != nil || request.Mode != nil || request.Enabled != nil {
+		t.Errorf("unchanged members must stay nil for the PATCH, got %+v", request)
+	}
+	if !strings.Contains(stdout, "Notification route 7c1e0d5a-0000-4000-8000-000000000001 updated.") ||
+		!strings.Contains(stdout, "Priority:      5") {
+		t.Errorf("expected the updated line and new priority, got: %s", stdout)
+	}
+}
+
+func TestAlertsRoutesUpdateEnabledAndDestination(t *testing.T) {
+	mock := &notificationRoutesMock{routes: sampleNotificationRoutes()}
+	_, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "routes", "update", "7c1e0d5a-0000-4000-8000-000000000002",
+		"--enabled", "--destination-id", "3d0f6a2e-0000-4000-8000-000000000001", "--stop-on-match=false")
+	if runError != nil {
+		t.Fatalf("alerts routes update failed: %v", runError)
+	}
+	request := mock.updateRequest
+	if request.Enabled == nil || !*request.Enabled {
+		t.Errorf("enabled = %v, want true from --enabled", request.Enabled)
+	}
+	if request.DestinationID == nil || *request.DestinationID != "3d0f6a2e-0000-4000-8000-000000000001" {
+		t.Errorf("destination_id = %v", request.DestinationID)
+	}
+	if request.StopOnMatch == nil || *request.StopOnMatch {
+		t.Errorf("stop_on_match = %v, want an explicit false", request.StopOnMatch)
+	}
+	if request.Priority != nil {
+		t.Errorf("priority must stay nil when not passed, got %d", *request.Priority)
+	}
+}
+
+func TestAlertsRoutesUpdateWithoutFlagsIsUsageError(t *testing.T) {
+	mock := &notificationRoutesMock{routes: sampleNotificationRoutes()}
+	_, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "routes", "update", "7c1e0d5a-0000-4000-8000-000000000001")
+	if runError == nil || exitCodeFor(runError) != exitUsage {
+		t.Errorf("expected update without flags to be a usage error, got %v", runError)
+	}
+	if mock.updateRequest != nil {
+		t.Error("an empty update must not reach the client")
+	}
+}
+
+func TestAlertsRoutesUpdateNotFoundUsesExitNotFound(t *testing.T) {
+	mock := &notificationRoutesMock{}
+	_, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "routes", "update", "7c1e0d5a-0000-4000-8000-00000000dead", "--priority", "1")
+	if runError == nil {
+		t.Fatal("expected an error for a missing route")
+	}
+	if got := exitCodeFor(runError); got != exitNotFound {
+		t.Errorf("expected exit code %d, got %d (%v)", exitNotFound, got, runError)
+	}
+}
+
+func TestAlertsRoutesDeleteDeclinedUsesExitCancelled(t *testing.T) {
+	mock := &notificationRoutesMock{}
+	_, _, runError := runAlertsCommand(t, mock, "n\n",
+		"alerts", "routes", "delete", "7c1e0d5a-0000-4000-8000-000000000001")
+	if !errors.Is(runError, errCancelled) {
+		t.Fatalf("expected errCancelled on decline, got %v", runError)
+	}
+	if got := exitCodeFor(runError); got != exitCancelled {
+		t.Errorf("expected exit code %d, got %d", exitCancelled, got)
+	}
+	if len(mock.deleteCalls) != 0 {
+		t.Errorf("declined confirmation must not delete, got %v", mock.deleteCalls)
+	}
+}
+
+func TestAlertsRoutesDeleteConfirmedAndYes(t *testing.T) {
+	mock := &notificationRoutesMock{}
+	stdout, _, runError := runAlertsCommand(t, mock, "yes\n",
+		"alerts", "routes", "delete", "7c1e0d5a-0000-4000-8000-000000000001")
+	if runError != nil {
+		t.Fatalf("alerts routes delete failed: %v", runError)
+	}
+	if !strings.Contains(stdout, "Notification route 7c1e0d5a-0000-4000-8000-000000000001 deleted.") {
+		t.Errorf("expected the deleted line, got: %s", stdout)
+	}
+	_, _, runError = runAlertsCommand(t, mock, "",
+		"alerts", "routes", "delete", "7c1e0d5a-0000-4000-8000-000000000002", "-y")
+	if runError != nil {
+		t.Fatalf("alerts routes delete -y failed: %v", runError)
+	}
+	if len(mock.deleteCalls) != 2 {
+		t.Fatalf("expected two delete calls, got %v", mock.deleteCalls)
+	}
+}
+
+func TestAlertsRoutesTestPrintsDeliveryID(t *testing.T) {
+	mock := &notificationRoutesMock{}
+	stdout, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "routes", "test", "7c1e0d5a-0000-4000-8000-000000000001")
+	if runError != nil {
+		t.Fatalf("alerts routes test failed: %v", runError)
+	}
+	if len(mock.testCalls) != 1 || mock.testCalls[0] != "7c1e0d5a-0000-4000-8000-000000000001" {
+		t.Errorf("test calls = %v", mock.testCalls)
+	}
+	if !strings.Contains(stdout, "Test notification queued (delivery 9e9e9e9e-0000-4000-8000-000000000042).") {
+		t.Errorf("expected the delivery id line, got: %s", stdout)
+	}
+
+	stdout, _, runError = runAlertsCommand(t, mock, "",
+		"alerts", "routes", "test", "7c1e0d5a-0000-4000-8000-000000000001", "-o", "json")
+	if runError != nil {
+		t.Fatalf("alerts routes test -o json failed: %v", runError)
+	}
+	var decoded map[string]interface{}
+	if unmarshalError := json.Unmarshal([]byte(stdout), &decoded); unmarshalError != nil {
+		t.Fatalf("expected parseable JSON on stdout, got %v: %s", unmarshalError, stdout)
+	}
+	if decoded["delivery_id"] != "9e9e9e9e-0000-4000-8000-000000000042" {
+		t.Errorf("unexpected JSON document: %s", stdout)
+	}
+}

--- a/cmd/alerts_test.go
+++ b/cmd/alerts_test.go
@@ -158,14 +158,16 @@ func sampleAlertDestinations() []client.AlertDestination {
 			UpdatedAt: "2026-08-02T10:00:00Z",
 		},
 		{
-			ID:          "3d0f6a2e-0000-4000-8000-000000000002",
-			Name:        "ops-teams",
-			ChannelID:   strPtrCmd("19:abc@thread.tacv2"),
-			ChannelName: strPtrCmd("Platform Alerts"),
-			Description: strPtrCmd("Teams channel for the platform team"),
-			Enabled:     false,
-			CreatedAt:   "2026-08-01T10:00:00Z",
-			UpdatedAt:   "2026-08-02T10:00:00Z",
+			ID:              "3d0f6a2e-0000-4000-8000-000000000002",
+			Name:            "ops-teams",
+			ChannelID:       strPtrCmd("19:abc@thread.tacv2"),
+			ChannelName:     strPtrCmd("Platform Alerts"),
+			IntegrationType: "teams",
+			TeamsTenantID:   strPtrCmd("tenant-1"),
+			Description:     strPtrCmd("Teams channel for the platform team"),
+			Enabled:         false,
+			CreatedAt:       "2026-08-01T10:00:00Z",
+			UpdatedAt:       "2026-08-02T10:00:00Z",
 		},
 	}
 }
@@ -188,7 +190,7 @@ func TestAlertsDestinationsListRendersTableAndFilters(t *testing.T) {
 	}
 	for _, fragment := range []string{
 		"ops-slack", "webhook", "https://***",
-		"ops-teams", "channel", "Platform Alerts",
+		"ops-teams", "teams", "Platform Alerts",
 		"Page 1 of 1 (total 2)",
 	} {
 		if !strings.Contains(stdout, fragment) {
@@ -252,7 +254,7 @@ func TestAlertsDestinationsGetRendersDetails(t *testing.T) {
 	}
 	for _, fragment := range []string{
 		"Name:        ops-teams",
-		"Type:        channel",
+		"Type:        teams",
 		"Target:      Platform Alerts",
 		"Description: Teams channel for the platform team",
 		"Enabled:     false",

--- a/cmd/alerts_test.go
+++ b/cmd/alerts_test.go
@@ -1,0 +1,680 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// alertsCommandTree lists every alerts command whose flags carry state
+// between Execute calls, for resetTreeFlags.
+func alertsCommandTree() []*cobra.Command {
+	return []*cobra.Command{
+		alertsDestinationsListCmd,
+		alertsDestinationsGetCmd,
+		alertsDestinationsCreateCmd,
+		alertsDestinationsUpdateCmd,
+		alertsDestinationsDeleteCmd,
+		alertsDestinationsTestCmd,
+		alertsDestinationsTestURLCmd,
+		alertsDestinationsChannelsCmd,
+		alertsRoutesListCmd,
+		alertsRoutesCreateCmd,
+		alertsRoutesUpdateCmd,
+		alertsRoutesDeleteCmd,
+		alertsRoutesTestCmd,
+	}
+}
+
+// runAlertsCommand executes rootCmd with the given stdin and separate
+// stdout/stderr captures, so structured-output tests can prove stdout stays
+// parseable. The alerts flag tree is reset afterwards so Changed markers do
+// not leak between cases.
+func runAlertsCommand(t *testing.T, mock APIClient, input string, args ...string) (string, string, error) {
+	t.Helper()
+	withTempHome(t)
+	setMockClient(t, mock)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(stderr)
+	rootCmd.SetIn(strings.NewReader(input))
+	rootCmd.SetArgs(args)
+	t.Cleanup(func() { resetTreeFlags(t, alertsCommandTree()...) })
+	executeError := rootCmd.Execute()
+	return stdout.String(), stderr.String(), executeError
+}
+
+type alertDestinationsMock struct {
+	baseMock
+	destinations   []client.AlertDestination
+	listOptions    *client.ListAlertDestinationsOptions
+	createRequest  *client.CreateAlertDestinationRequest
+	updatedID      string
+	updateRequest  *client.UpdateAlertDestinationRequest
+	deleteCalls    []string
+	testCalls      []string
+	testURLRequest *client.TestAlertDestinationURLRequest
+	testResult     *client.AlertDestinationTestResult
+	slackChannels  *client.SlackChannelList
+	slackError     error
+	teamsChannels  *client.TeamsChannelList
+	teamsError     error
+}
+
+func (m *alertDestinationsMock) ListAlertDestinations(options client.ListAlertDestinationsOptions) (*client.AlertDestinationList, error) {
+	m.listOptions = &options
+	return &client.AlertDestinationList{
+		Items: m.destinations,
+		Pagination: client.AlertDestinationPagination{
+			Page: 1, PageSize: 20, TotalCount: len(m.destinations), TotalPages: 1,
+		},
+	}, nil
+}
+
+func (m *alertDestinationsMock) GetAlertDestination(destinationID string) (*client.AlertDestination, error) {
+	for index := range m.destinations {
+		if m.destinations[index].ID == destinationID {
+			return &m.destinations[index], nil
+		}
+	}
+	return nil, client.NewUnexpectedResponseError(404, "Integration not found")
+}
+
+func (m *alertDestinationsMock) CreateAlertDestination(request client.CreateAlertDestinationRequest) (*client.AlertDestination, error) {
+	m.createRequest = &request
+	created := client.AlertDestination{
+		ID:        "3d0f6a2e-0000-4000-8000-000000000010",
+		Name:      request.Name,
+		URL:       request.URL,
+		ChannelID: request.ChannelID,
+		Enabled:   request.Enabled == nil || *request.Enabled,
+		CreatedAt: "2026-08-17T10:00:00Z",
+		UpdatedAt: "2026-08-17T10:00:00Z",
+	}
+	return &created, nil
+}
+
+func (m *alertDestinationsMock) UpdateAlertDestination(destinationID string, request client.UpdateAlertDestinationRequest) (*client.AlertDestination, error) {
+	m.updatedID = destinationID
+	m.updateRequest = &request
+	for index := range m.destinations {
+		if m.destinations[index].ID == destinationID {
+			updated := m.destinations[index]
+			if request.Name != nil {
+				updated.Name = *request.Name
+			}
+			return &updated, nil
+		}
+	}
+	return nil, client.NewUnexpectedResponseError(404, "Integration not found")
+}
+
+func (m *alertDestinationsMock) DeleteAlertDestination(destinationID string) (*client.DeleteAlertDestinationResult, error) {
+	m.deleteCalls = append(m.deleteCalls, destinationID)
+	return &client.DeleteAlertDestinationResult{Success: true, Message: "Integration deleted successfully"}, nil
+}
+
+func (m *alertDestinationsMock) TestAlertDestination(destinationID string) (*client.AlertDestinationTestResult, error) {
+	m.testCalls = append(m.testCalls, destinationID)
+	return m.testResult, nil
+}
+
+func (m *alertDestinationsMock) TestAlertDestinationURL(request client.TestAlertDestinationURLRequest) (*client.AlertDestinationTestResult, error) {
+	m.testURLRequest = &request
+	return m.testResult, nil
+}
+
+func (m *alertDestinationsMock) ListSlackChannels() (*client.SlackChannelList, error) {
+	if m.slackError != nil {
+		return nil, m.slackError
+	}
+	return m.slackChannels, nil
+}
+
+func (m *alertDestinationsMock) ListTeamsChannels() (*client.TeamsChannelList, error) {
+	if m.teamsError != nil {
+		return nil, m.teamsError
+	}
+	return m.teamsChannels, nil
+}
+
+func sampleAlertDestinations() []client.AlertDestination {
+	return []client.AlertDestination{
+		{
+			ID:        "3d0f6a2e-0000-4000-8000-000000000001",
+			Name:      "ops-slack",
+			URL:       strPtrCmd("https://***"),
+			Enabled:   true,
+			CreatedAt: "2026-08-01T10:00:00Z",
+			UpdatedAt: "2026-08-02T10:00:00Z",
+		},
+		{
+			ID:          "3d0f6a2e-0000-4000-8000-000000000002",
+			Name:        "ops-teams",
+			ChannelID:   strPtrCmd("19:abc@thread.tacv2"),
+			ChannelName: strPtrCmd("Platform Alerts"),
+			Description: strPtrCmd("Teams channel for the platform team"),
+			Enabled:     false,
+			CreatedAt:   "2026-08-01T10:00:00Z",
+			UpdatedAt:   "2026-08-02T10:00:00Z",
+		},
+	}
+}
+
+func TestAlertsDestinationsListRendersTableAndFilters(t *testing.T) {
+	mock := &alertDestinationsMock{destinations: sampleAlertDestinations()}
+	stdout, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "destinations", "list", "--search", "ops", "--enabled", "--page", "2", "--page-size", "50")
+	if runError != nil {
+		t.Fatalf("alerts destinations list failed: %v", runError)
+	}
+	if mock.listOptions == nil {
+		t.Fatal("expected the list call to reach the client")
+	}
+	if mock.listOptions.Search != "ops" || mock.listOptions.Page != 2 || mock.listOptions.PageSize != 50 {
+		t.Errorf("list options = %+v, want search ops page 2 size 50", mock.listOptions)
+	}
+	if mock.listOptions.Enabled == nil || !*mock.listOptions.Enabled {
+		t.Errorf("expected --enabled to filter enabled=true, got %v", mock.listOptions.Enabled)
+	}
+	for _, fragment := range []string{
+		"ops-slack", "webhook", "https://***",
+		"ops-teams", "channel", "Platform Alerts",
+		"Page 1 of 1 (total 2)",
+	} {
+		if !strings.Contains(stdout, fragment) {
+			t.Errorf("expected table to contain %q, got:\n%s", fragment, stdout)
+		}
+	}
+}
+
+func TestAlertsDestinationsListDisabledFilterAndEmpty(t *testing.T) {
+	mock := &alertDestinationsMock{}
+	stdout, _, runError := runAlertsCommand(t, mock, "", "alerts", "destinations", "list", "--disabled")
+	if runError != nil {
+		t.Fatalf("alerts destinations list failed: %v", runError)
+	}
+	if mock.listOptions.Enabled == nil || *mock.listOptions.Enabled {
+		t.Errorf("expected --disabled to filter enabled=false, got %v", mock.listOptions.Enabled)
+	}
+	if !strings.Contains(stdout, "No alert destinations found.") {
+		t.Errorf("expected the empty message, got: %s", stdout)
+	}
+}
+
+func TestAlertsDestinationsListEnabledAndDisabledAreExclusive(t *testing.T) {
+	mock := &alertDestinationsMock{}
+	_, _, runError := runAlertsCommand(t, mock, "", "alerts", "destinations", "list", "--enabled", "--disabled")
+	if runError == nil {
+		t.Fatal("expected --enabled with --disabled to be rejected")
+	}
+	if got := exitCodeFor(runError); got != exitUsage {
+		t.Errorf("expected exit code %d, got %d (%v)", exitUsage, got, runError)
+	}
+}
+
+func TestAlertsDestinationsListJSONOutputIsPure(t *testing.T) {
+	mock := &alertDestinationsMock{destinations: sampleAlertDestinations()}
+	stdout, _, runError := runAlertsCommand(t, mock, "", "alerts", "destinations", "list", "-o", "json")
+	if runError != nil {
+		t.Fatalf("alerts destinations list -o json failed: %v", runError)
+	}
+	var decoded struct {
+		Items      []map[string]interface{} `json:"items"`
+		Pagination map[string]interface{}   `json:"pagination"`
+	}
+	if unmarshalError := json.Unmarshal([]byte(stdout), &decoded); unmarshalError != nil {
+		t.Fatalf("expected parseable JSON on stdout, got %v: %s", unmarshalError, stdout)
+	}
+	if len(decoded.Items) != 2 || decoded.Items[0]["name"] != "ops-slack" {
+		t.Errorf("unexpected items in JSON output: %s", stdout)
+	}
+	if decoded.Pagination["total_count"] != float64(2) {
+		t.Errorf("pagination.total_count = %v, want 2", decoded.Pagination["total_count"])
+	}
+}
+
+func TestAlertsDestinationsGetRendersDetails(t *testing.T) {
+	mock := &alertDestinationsMock{destinations: sampleAlertDestinations()}
+	stdout, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "destinations", "get", "3d0f6a2e-0000-4000-8000-000000000002")
+	if runError != nil {
+		t.Fatalf("alerts destinations get failed: %v", runError)
+	}
+	for _, fragment := range []string{
+		"Name:        ops-teams",
+		"Type:        channel",
+		"Target:      Platform Alerts",
+		"Description: Teams channel for the platform team",
+		"Enabled:     false",
+	} {
+		if !strings.Contains(stdout, fragment) {
+			t.Errorf("expected output to contain %q, got:\n%s", fragment, stdout)
+		}
+	}
+}
+
+func TestAlertsDestinationsGetNotFoundUsesExitNotFound(t *testing.T) {
+	mock := &alertDestinationsMock{}
+	_, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "destinations", "get", "3d0f6a2e-0000-4000-8000-00000000dead")
+	if runError == nil {
+		t.Fatal("expected an error for a missing destination")
+	}
+	if got := exitCodeFor(runError); got != exitNotFound {
+		t.Errorf("expected exit code %d, got %d (%v)", exitNotFound, got, runError)
+	}
+}
+
+func TestAlertsDestinationsGetJSONOutputIsPure(t *testing.T) {
+	mock := &alertDestinationsMock{destinations: sampleAlertDestinations()}
+	stdout, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "destinations", "get", "3d0f6a2e-0000-4000-8000-000000000001", "-o", "json")
+	if runError != nil {
+		t.Fatalf("alerts destinations get -o json failed: %v", runError)
+	}
+	var decoded map[string]interface{}
+	if unmarshalError := json.Unmarshal([]byte(stdout), &decoded); unmarshalError != nil {
+		t.Fatalf("expected parseable JSON on stdout, got %v: %s", unmarshalError, stdout)
+	}
+	if decoded["name"] != "ops-slack" || decoded["url"] != "https://***" {
+		t.Errorf("unexpected JSON document: %s", stdout)
+	}
+	if _, present := decoded["channel_id"]; !present {
+		t.Errorf("expected nullable channel_id to be present as null: %s", stdout)
+	}
+}
+
+func TestAlertsDestinationsCreateSendsOnlyPassedFlags(t *testing.T) {
+	mock := &alertDestinationsMock{}
+	stdout, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "destinations", "create",
+		"--name", "oncall", "--url", "https://events.pagerduty.com/v2/enqueue",
+		"--type", "pagerduty", "--disabled")
+	if runError != nil {
+		t.Fatalf("alerts destinations create failed: %v", runError)
+	}
+	request := mock.createRequest
+	if request == nil {
+		t.Fatal("expected the create call to reach the client")
+	}
+	if request.Name != "oncall" {
+		t.Errorf("name = %q, want oncall", request.Name)
+	}
+	if request.URL == nil || *request.URL != "https://events.pagerduty.com/v2/enqueue" {
+		t.Errorf("url = %v, want the pagerduty url", request.URL)
+	}
+	if request.IntegrationType == nil || *request.IntegrationType != "pagerduty" {
+		t.Errorf("integration_type = %v, want pagerduty", request.IntegrationType)
+	}
+	if request.Enabled == nil || *request.Enabled {
+		t.Errorf("enabled = %v, want false from --disabled", request.Enabled)
+	}
+	if request.ChannelID != nil || request.ChannelName != nil || request.TeamsTenantID != nil ||
+		request.Description != nil || request.Template != nil {
+		t.Errorf("unset flags must stay nil, got %+v", request)
+	}
+	if !strings.Contains(stdout, `Alert destination "oncall" created (3d0f6a2e-0000-4000-8000-000000000010).`) {
+		t.Errorf("expected the created line, got: %s", stdout)
+	}
+}
+
+func TestAlertsDestinationsCreateChannelWithTemplateFile(t *testing.T) {
+	templatePath := filepath.Join(t.TempDir(), "payload.json")
+	if writeError := os.WriteFile(templatePath, []byte(`{"text": "{{title}}"}`), 0o600); writeError != nil {
+		t.Fatalf("write template: %v", writeError)
+	}
+	mock := &alertDestinationsMock{}
+	_, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "destinations", "create",
+		"--name", "ops-teams", "--type", "teams",
+		"--channel-id", "19:abc@thread.tacv2", "--channel-name", "Platform Alerts",
+		"--teams-tenant-id", "tenant-1", "--description", "Teams channel",
+		"--template-file", templatePath)
+	if runError != nil {
+		t.Fatalf("alerts destinations create failed: %v", runError)
+	}
+	request := mock.createRequest
+	if request.URL != nil {
+		t.Errorf("url must be nil for a channel destination, got %q", *request.URL)
+	}
+	if request.ChannelID == nil || *request.ChannelID != "19:abc@thread.tacv2" {
+		t.Errorf("channel_id = %v, want 19:abc@thread.tacv2", request.ChannelID)
+	}
+	if request.ChannelName == nil || *request.ChannelName != "Platform Alerts" {
+		t.Errorf("channel_name = %v, want Platform Alerts", request.ChannelName)
+	}
+	if request.TeamsTenantID == nil || *request.TeamsTenantID != "tenant-1" {
+		t.Errorf("teams_tenant_id = %v, want tenant-1", request.TeamsTenantID)
+	}
+	if request.Description == nil || *request.Description != "Teams channel" {
+		t.Errorf("description = %v, want Teams channel", request.Description)
+	}
+	if request.Template == nil || *request.Template != `{"text": "{{title}}"}` {
+		t.Errorf("template = %v, want the file contents", request.Template)
+	}
+	if request.Enabled != nil {
+		t.Errorf("enabled must be nil when --disabled is not passed, got %v", *request.Enabled)
+	}
+}
+
+func TestAlertsDestinationsCreateRequiresURLOrChannel(t *testing.T) {
+	mock := &alertDestinationsMock{}
+	_, _, runError := runAlertsCommand(t, mock, "", "alerts", "destinations", "create", "--name", "lonely")
+	if runError == nil {
+		t.Fatal("expected create without --url or --channel-id to fail")
+	}
+	if got := exitCodeFor(runError); got != exitUsage {
+		t.Errorf("expected exit code %d, got %d (%v)", exitUsage, got, runError)
+	}
+	if mock.createRequest != nil {
+		t.Error("usage errors must not reach the client")
+	}
+}
+
+func TestAlertsDestinationsCreateJSONOutputIsPure(t *testing.T) {
+	mock := &alertDestinationsMock{}
+	stdout, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "destinations", "create", "--name", "ops", "--url", "https://hooks.example/1", "-o", "json")
+	if runError != nil {
+		t.Fatalf("alerts destinations create -o json failed: %v", runError)
+	}
+	var decoded map[string]interface{}
+	if unmarshalError := json.Unmarshal([]byte(stdout), &decoded); unmarshalError != nil {
+		t.Fatalf("expected parseable JSON on stdout, got %v: %s", unmarshalError, stdout)
+	}
+	if decoded["id"] != "3d0f6a2e-0000-4000-8000-000000000010" || decoded["name"] != "ops" {
+		t.Errorf("unexpected JSON document: %s", stdout)
+	}
+}
+
+func TestAlertsDestinationsUpdateSendsOnlyChangedFields(t *testing.T) {
+	mock := &alertDestinationsMock{destinations: sampleAlertDestinations()}
+	stdout, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "destinations", "update", "3d0f6a2e-0000-4000-8000-000000000001",
+		"--description", "primary on-call channel", "--enabled")
+	if runError != nil {
+		t.Fatalf("alerts destinations update failed: %v", runError)
+	}
+	if mock.updatedID != "3d0f6a2e-0000-4000-8000-000000000001" {
+		t.Errorf("updated id = %q", mock.updatedID)
+	}
+	request := mock.updateRequest
+	if request == nil {
+		t.Fatal("expected the update call to reach the client")
+	}
+	if request.Description == nil || *request.Description != "primary on-call channel" {
+		t.Errorf("description = %v, want the new description", request.Description)
+	}
+	if request.Enabled == nil || !*request.Enabled {
+		t.Errorf("enabled = %v, want true from --enabled", request.Enabled)
+	}
+	if request.Name != nil || request.URL != nil || request.ChannelID != nil ||
+		request.ChannelName != nil || request.TeamsTenantID != nil || request.Template != nil {
+		t.Errorf("unchanged flags must stay nil, got %+v", request)
+	}
+	if !strings.Contains(stdout, `Alert destination "ops-slack" updated`) {
+		t.Errorf("expected the updated line, got: %s", stdout)
+	}
+}
+
+func TestAlertsDestinationsUpdateDisabledOnly(t *testing.T) {
+	mock := &alertDestinationsMock{destinations: sampleAlertDestinations()}
+	_, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "destinations", "update", "3d0f6a2e-0000-4000-8000-000000000001", "--disabled")
+	if runError != nil {
+		t.Fatalf("alerts destinations update failed: %v", runError)
+	}
+	request := mock.updateRequest
+	if request.Enabled == nil || *request.Enabled {
+		t.Errorf("enabled = %v, want false from --disabled", request.Enabled)
+	}
+	if request.Description != nil {
+		t.Errorf("description must stay nil, got %q", *request.Description)
+	}
+}
+
+func TestAlertsDestinationsUpdateWithoutFlagsIsUsageError(t *testing.T) {
+	mock := &alertDestinationsMock{destinations: sampleAlertDestinations()}
+	_, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "destinations", "update", "3d0f6a2e-0000-4000-8000-000000000001")
+	if runError == nil {
+		t.Fatal("expected update without flags to fail")
+	}
+	if got := exitCodeFor(runError); got != exitUsage {
+		t.Errorf("expected exit code %d, got %d (%v)", exitUsage, got, runError)
+	}
+	if mock.updateRequest != nil {
+		t.Error("an empty update must not reach the client")
+	}
+}
+
+func TestAlertsDestinationsDeleteDeclinedUsesExitCancelled(t *testing.T) {
+	mock := &alertDestinationsMock{}
+	_, _, runError := runAlertsCommand(t, mock, "n\n",
+		"alerts", "destinations", "delete", "3d0f6a2e-0000-4000-8000-000000000001")
+	if !errors.Is(runError, errCancelled) {
+		t.Fatalf("expected errCancelled on decline, got %v", runError)
+	}
+	if got := exitCodeFor(runError); got != exitCancelled {
+		t.Errorf("expected exit code %d, got %d", exitCancelled, got)
+	}
+	if len(mock.deleteCalls) != 0 {
+		t.Errorf("declined confirmation must not delete, got %v", mock.deleteCalls)
+	}
+}
+
+func TestAlertsDestinationsDeleteConfirmedAndYes(t *testing.T) {
+	mock := &alertDestinationsMock{}
+	stdout, _, runError := runAlertsCommand(t, mock, "y\n",
+		"alerts", "destinations", "delete", "3d0f6a2e-0000-4000-8000-000000000001")
+	if runError != nil {
+		t.Fatalf("alerts destinations delete failed: %v", runError)
+	}
+	if !strings.Contains(stdout, "Alert destination 3d0f6a2e-0000-4000-8000-000000000001 deleted.") {
+		t.Errorf("expected the deleted line, got: %s", stdout)
+	}
+	_, _, runError = runAlertsCommand(t, mock, "",
+		"alerts", "destinations", "delete", "3d0f6a2e-0000-4000-8000-000000000002", "--yes")
+	if runError != nil {
+		t.Fatalf("alerts destinations delete --yes failed: %v", runError)
+	}
+	if len(mock.deleteCalls) != 2 {
+		t.Fatalf("expected two delete calls, got %v", mock.deleteCalls)
+	}
+}
+
+func TestAlertsDestinationsTestReportsSuccess(t *testing.T) {
+	statusCode := 200
+	responseTime := 123.4
+	mock := &alertDestinationsMock{testResult: &client.AlertDestinationTestResult{
+		Success: true, StatusCode: &statusCode, ResponseTimeMS: &responseTime,
+	}}
+	stdout, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "destinations", "test", "3d0f6a2e-0000-4000-8000-000000000001")
+	if runError != nil {
+		t.Fatalf("alerts destinations test failed: %v", runError)
+	}
+	if len(mock.testCalls) != 1 || mock.testCalls[0] != "3d0f6a2e-0000-4000-8000-000000000001" {
+		t.Errorf("test calls = %v", mock.testCalls)
+	}
+	if !strings.Contains(stdout, "Test delivery succeeded (HTTP 200, 123 ms).") {
+		t.Errorf("expected the success line, got: %s", stdout)
+	}
+}
+
+func TestAlertsDestinationsTestFailureExitsNonZero(t *testing.T) {
+	statusCode := 500
+	failure := "receiver returned 500"
+	mock := &alertDestinationsMock{testResult: &client.AlertDestinationTestResult{
+		Success: false, StatusCode: &statusCode, Error: &failure,
+	}}
+	stdout, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "destinations", "test", "3d0f6a2e-0000-4000-8000-000000000001")
+	if runError == nil {
+		t.Fatal("expected a failed delivery to return an error")
+	}
+	if got := exitCodeFor(runError); got != exitError {
+		t.Errorf("expected exit code %d, got %d", exitError, got)
+	}
+	if !strings.Contains(runError.Error(), "HTTP 500") || !strings.Contains(runError.Error(), "receiver returned 500") {
+		t.Errorf("expected the failure details in the error, got: %v", runError)
+	}
+	if strings.Contains(stdout, "succeeded") {
+		t.Errorf("stdout must not claim success: %s", stdout)
+	}
+}
+
+func TestAlertsDestinationsTestJSONOutputIsPureEvenOnFailure(t *testing.T) {
+	failure := "connection refused"
+	mock := &alertDestinationsMock{testResult: &client.AlertDestinationTestResult{Success: false, Error: &failure}}
+	stdout, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "destinations", "test", "3d0f6a2e-0000-4000-8000-000000000001", "-o", "json")
+	if runError == nil {
+		t.Fatal("expected a failed delivery to return an error")
+	}
+	var decoded map[string]interface{}
+	if unmarshalError := json.Unmarshal([]byte(stdout), &decoded); unmarshalError != nil {
+		t.Fatalf("expected parseable JSON on stdout, got %v: %s", unmarshalError, stdout)
+	}
+	if decoded["success"] != false || decoded["error"] != "connection refused" {
+		t.Errorf("unexpected JSON document: %s", stdout)
+	}
+	if decoded["status_code"] != nil {
+		t.Errorf("status_code should be null when the request never completed: %s", stdout)
+	}
+}
+
+func TestAlertsDestinationsTestURLSendsURLAndTemplate(t *testing.T) {
+	templatePath := filepath.Join(t.TempDir(), "payload.json")
+	if writeError := os.WriteFile(templatePath, []byte(`{"text":"hi"}`), 0o600); writeError != nil {
+		t.Fatalf("write template: %v", writeError)
+	}
+	statusCode := 204
+	mock := &alertDestinationsMock{testResult: &client.AlertDestinationTestResult{Success: true, StatusCode: &statusCode}}
+	stdout, _, runError := runAlertsCommand(t, mock, "",
+		"alerts", "destinations", "test-url", "--url", "https://hooks.example/1", "--template-file", templatePath)
+	if runError != nil {
+		t.Fatalf("alerts destinations test-url failed: %v", runError)
+	}
+	if mock.testURLRequest == nil || mock.testURLRequest.URL != "https://hooks.example/1" {
+		t.Fatalf("test-url request = %+v", mock.testURLRequest)
+	}
+	if mock.testURLRequest.Template == nil || *mock.testURLRequest.Template != `{"text":"hi"}` {
+		t.Errorf("template = %v, want the file contents", mock.testURLRequest.Template)
+	}
+	if !strings.Contains(stdout, "Test delivery succeeded (HTTP 204).") {
+		t.Errorf("expected the success line, got: %s", stdout)
+	}
+}
+
+func TestAlertsDestinationsTestURLRequiresURL(t *testing.T) {
+	mock := &alertDestinationsMock{}
+	_, _, runError := runAlertsCommand(t, mock, "", "alerts", "destinations", "test-url")
+	if runError == nil {
+		t.Fatal("expected test-url without --url to fail")
+	}
+	if got := exitCodeFor(runError); got != exitUsage {
+		t.Errorf("expected exit code %d, got %d (%v)", exitUsage, got, runError)
+	}
+}
+
+func TestAlertsDestinationsChannelsShowsBothProviders(t *testing.T) {
+	mock := &alertDestinationsMock{
+		slackChannels: &client.SlackChannelList{
+			TeamID:   "T123",
+			TeamName: strPtrCmd("Acme"),
+			Channels: []client.SlackChannel{{ID: "C1", Name: "alerts", IsPrivate: false}},
+		},
+		teamsChannels: &client.TeamsChannelList{
+			Channels: []client.TeamsChannel{{ID: "19:abc@thread.tacv2", Name: "Platform Alerts", TeamID: "team-1", TeamName: "Platform", TenantID: "tenant-1"}},
+		},
+	}
+	stdout, _, runError := runAlertsCommand(t, mock, "", "alerts", "destinations", "channels")
+	if runError != nil {
+		t.Fatalf("alerts destinations channels failed: %v", runError)
+	}
+	for _, fragment := range []string{
+		"Slack (workspace Acme):", "alerts", "C1",
+		"Teams:", "Platform Alerts", "19:abc@thread.tacv2", "tenant-1",
+	} {
+		if !strings.Contains(stdout, fragment) {
+			t.Errorf("expected output to contain %q, got:\n%s", fragment, stdout)
+		}
+	}
+}
+
+func TestAlertsDestinationsChannelsReportsNotConnectedAndNotAvailable(t *testing.T) {
+	mock := &alertDestinationsMock{
+		slackError: client.NewUnexpectedResponseError(404, "No Slack workspace is connected to this organisation"),
+		teamsError: client.NewUnexpectedResponseError(503, "Teams bot service is not configured"),
+	}
+	stdout, _, runError := runAlertsCommand(t, mock, "", "alerts", "destinations", "channels")
+	if runError != nil {
+		t.Fatalf("not-connected providers must not fail the command: %v", runError)
+	}
+	if !strings.Contains(stdout, "Slack: not connected") {
+		t.Errorf("expected the Slack not-connected line, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "Teams: not available") {
+		t.Errorf("expected the Teams not-available line, got: %s", stdout)
+	}
+}
+
+func TestAlertsDestinationsChannelsProviderFilterAndOtherErrors(t *testing.T) {
+	mock := &alertDestinationsMock{
+		slackChannels: &client.SlackChannelList{TeamID: "T123", Channels: []client.SlackChannel{{ID: "C1", Name: "alerts"}}},
+		teamsError:    errors.New("boom"),
+	}
+	stdout, _, runError := runAlertsCommand(t, mock, "", "alerts", "destinations", "channels", "--provider", "slack")
+	if runError != nil {
+		t.Fatalf("--provider slack must not touch Teams: %v", runError)
+	}
+	if strings.Contains(stdout, "Teams") {
+		t.Errorf("Teams must not be listed with --provider slack, got: %s", stdout)
+	}
+
+	_, _, runError = runAlertsCommand(t, mock, "", "alerts", "destinations", "channels", "--provider", "teams")
+	if runError == nil || !strings.Contains(runError.Error(), "boom") {
+		t.Errorf("expected a non-picker Teams error to surface, got %v", runError)
+	}
+
+	_, _, runError = runAlertsCommand(t, mock, "", "alerts", "destinations", "channels", "--provider", "discord")
+	if runError == nil || exitCodeFor(runError) != exitUsage {
+		t.Errorf("expected an unsupported provider to be a usage error, got %v", runError)
+	}
+}
+
+func TestAlertsDestinationsChannelsJSONKeepsStdoutPure(t *testing.T) {
+	mock := &alertDestinationsMock{
+		slackError:    client.NewUnexpectedResponseError(404, "No Slack workspace is connected to this organisation"),
+		teamsChannels: &client.TeamsChannelList{Channels: []client.TeamsChannel{{ID: "19:abc@thread.tacv2", Name: "Platform Alerts"}}},
+	}
+	stdout, stderr, runError := runAlertsCommand(t, mock, "", "alerts", "destinations", "channels", "-o", "json")
+	if runError != nil {
+		t.Fatalf("alerts destinations channels -o json failed: %v", runError)
+	}
+	var decoded map[string]interface{}
+	if unmarshalError := json.Unmarshal([]byte(stdout), &decoded); unmarshalError != nil {
+		t.Fatalf("expected parseable JSON on stdout, got %v: %s", unmarshalError, stdout)
+	}
+	if decoded["slack"] != nil {
+		t.Errorf("slack should be null when not connected: %s", stdout)
+	}
+	teams, ok := decoded["teams"].(map[string]interface{})
+	if !ok || len(teams["channels"].([]interface{})) != 1 {
+		t.Errorf("unexpected teams document: %s", stdout)
+	}
+	if !strings.Contains(stderr, "Slack: not connected") {
+		t.Errorf("expected the not-connected notice on stderr, got: %q", stderr)
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1587,6 +1587,62 @@ func (m baseMock) EnableClusterDNSZone(clusterID string) (*client.ClusterDNSZone
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) ListAlertDestinations(options client.ListAlertDestinationsOptions) (*client.AlertDestinationList, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetAlertDestination(destinationID string) (*client.AlertDestination, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) CreateAlertDestination(request client.CreateAlertDestinationRequest) (*client.AlertDestination, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) UpdateAlertDestination(destinationID string, request client.UpdateAlertDestinationRequest) (*client.AlertDestination, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) DeleteAlertDestination(destinationID string) (*client.DeleteAlertDestinationResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) TestAlertDestination(destinationID string) (*client.AlertDestinationTestResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) TestAlertDestinationURL(request client.TestAlertDestinationURLRequest) (*client.AlertDestinationTestResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ListSlackChannels() (*client.SlackChannelList, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ListTeamsChannels() (*client.TeamsChannelList, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ListNotificationRoutes() (*client.NotificationRouteList, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) CreateNotificationRoute(request client.CreateNotificationRouteRequest) (*client.NotificationRoute, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) UpdateNotificationRoute(routeID string, request client.UpdateNotificationRouteRequest) (*client.NotificationRoute, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) DeleteNotificationRoute(routeID string) error {
+	return errors.New("not implemented")
+}
+
+func (m baseMock) TestNotificationRoute(routeID string) (*client.NotificationRouteTestResult, error) {
+	return nil, errors.New("not implemented")
+}
+
 type clusterListMock struct {
 	baseMock
 	clusters []client.ClusterListItem

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -448,4 +448,19 @@ type APIClient interface {
 	DiscoverManagedClusters(provider client.ManagedK8sProvider, credentialID string) (*client.DiscoverManagedClustersResponse, error)
 	ImportManagedCluster(provider client.ManagedK8sProvider, request client.ImportManagedClusterRequest) (*client.ImportManagedClusterResponse, error)
 	EnableClusterDNSZone(clusterID string) (*client.ClusterDNSZoneResponse, error)
+
+	ListAlertDestinations(options client.ListAlertDestinationsOptions) (*client.AlertDestinationList, error)
+	GetAlertDestination(destinationID string) (*client.AlertDestination, error)
+	CreateAlertDestination(request client.CreateAlertDestinationRequest) (*client.AlertDestination, error)
+	UpdateAlertDestination(destinationID string, request client.UpdateAlertDestinationRequest) (*client.AlertDestination, error)
+	DeleteAlertDestination(destinationID string) (*client.DeleteAlertDestinationResult, error)
+	TestAlertDestination(destinationID string) (*client.AlertDestinationTestResult, error)
+	TestAlertDestinationURL(request client.TestAlertDestinationURLRequest) (*client.AlertDestinationTestResult, error)
+	ListSlackChannels() (*client.SlackChannelList, error)
+	ListTeamsChannels() (*client.TeamsChannelList, error)
+	ListNotificationRoutes() (*client.NotificationRouteList, error)
+	CreateNotificationRoute(request client.CreateNotificationRouteRequest) (*client.NotificationRoute, error)
+	UpdateNotificationRoute(routeID string, request client.UpdateNotificationRouteRequest) (*client.NotificationRoute, error)
+	DeleteNotificationRoute(routeID string) error
+	TestNotificationRoute(routeID string) (*client.NotificationRouteTestResult, error)
 }

--- a/internal/client/alerts.go
+++ b/internal/client/alerts.go
@@ -1,0 +1,359 @@
+package client
+
+import (
+	"net/http"
+	neturl "net/url"
+	"strconv"
+)
+
+const (
+	alertDestinationsBasePath  = "/api/v1/org/alerts/integrations"
+	notificationRoutesBasePath = "/api/v1/org/notifications/routes"
+)
+
+// AlertDestination mirrors the backend's IntegrationItem for the alert
+// webhook integrations under /api/v1/org/alerts/integrations. The URL is
+// masked ("https://***") on every read so a webhook secret never round-trips
+// through the CLI; a channel-based Slack or Teams destination carries a
+// channel_id instead and answers a null URL.
+type AlertDestination struct {
+	ID             string  `json:"id" yaml:"id"`
+	Name           string  `json:"name" yaml:"name"`
+	URL            *string `json:"url" yaml:"url"`
+	ChannelID      *string `json:"channel_id" yaml:"channel_id"`
+	ChannelName    *string `json:"channel_name" yaml:"channel_name"`
+	Description    *string `json:"description" yaml:"description"`
+	Template       *string `json:"template" yaml:"template"`
+	Enabled        bool    `json:"enabled" yaml:"enabled"`
+	OrganisationID *string `json:"organisation_id" yaml:"organisation_id"`
+	CreatedAt      string  `json:"created_at" yaml:"created_at"`
+	UpdatedAt      string  `json:"updated_at" yaml:"updated_at"`
+}
+
+// AlertDestinationPagination is the page envelope of the destinations list.
+type AlertDestinationPagination struct {
+	Page       int `json:"page" yaml:"page"`
+	PageSize   int `json:"page_size" yaml:"page_size"`
+	TotalCount int `json:"total_count" yaml:"total_count"`
+	TotalPages int `json:"total_pages" yaml:"total_pages"`
+}
+
+// AlertDestinationList is the GET /api/v1/org/alerts/integrations body.
+type AlertDestinationList struct {
+	Items      []AlertDestination         `json:"items" yaml:"items"`
+	Pagination AlertDestinationPagination `json:"pagination" yaml:"pagination"`
+}
+
+// ListAlertDestinationsOptions narrows the destinations list. Enabled nil
+// lists both enabled and disabled destinations.
+type ListAlertDestinationsOptions struct {
+	Page     int
+	PageSize int
+	Search   string
+	Enabled  *bool
+}
+
+// CreateAlertDestinationRequest is the POST body. URL is required unless
+// ChannelID is set (a channel-based Slack or Teams destination); a Teams
+// channel additionally needs TeamsTenantID. IntegrationType defaults to
+// "slack" and Enabled to true when omitted.
+type CreateAlertDestinationRequest struct {
+	Name            string  `json:"name"`
+	URL             *string `json:"url,omitempty"`
+	ChannelID       *string `json:"channel_id,omitempty"`
+	ChannelName     *string `json:"channel_name,omitempty"`
+	TeamsTenantID   *string `json:"teams_tenant_id,omitempty"`
+	IntegrationType *string `json:"integration_type,omitempty"`
+	Description     *string `json:"description,omitempty"`
+	Template        *string `json:"template,omitempty"`
+	Enabled         *bool   `json:"enabled,omitempty"`
+}
+
+// UpdateAlertDestinationRequest is the PUT body; every member is optional
+// and an omitted member keeps its current value.
+type UpdateAlertDestinationRequest struct {
+	Name          *string `json:"name,omitempty"`
+	URL           *string `json:"url,omitempty"`
+	ChannelID     *string `json:"channel_id,omitempty"`
+	ChannelName   *string `json:"channel_name,omitempty"`
+	TeamsTenantID *string `json:"teams_tenant_id,omitempty"`
+	Description   *string `json:"description,omitempty"`
+	Template      *string `json:"template,omitempty"`
+	Enabled       *bool   `json:"enabled,omitempty"`
+}
+
+// DeleteAlertDestinationResult is the DELETE body.
+type DeleteAlertDestinationResult struct {
+	Success bool   `json:"success" yaml:"success"`
+	Message string `json:"message" yaml:"message"`
+}
+
+// AlertDestinationTestResult is the outcome of firing a sample payload at a
+// destination (POST .../{id}/test) or at an ad-hoc URL (POST .../test-url).
+// StatusCode and ResponseTimeMS are null when the request never completed.
+type AlertDestinationTestResult struct {
+	Success        bool     `json:"success" yaml:"success"`
+	StatusCode     *int     `json:"status_code" yaml:"status_code"`
+	ResponseTimeMS *float64 `json:"response_time_ms" yaml:"response_time_ms"`
+	Error          *string  `json:"error" yaml:"error"`
+}
+
+// TestAlertDestinationURLRequest is the POST .../test-url body.
+type TestAlertDestinationURLRequest struct {
+	URL      string  `json:"url"`
+	Template *string `json:"template,omitempty"`
+}
+
+// SlackChannel is one conversation the Ankra Slack bot can post to.
+type SlackChannel struct {
+	ID        string `json:"id" yaml:"id"`
+	Name      string `json:"name" yaml:"name"`
+	IsPrivate bool   `json:"is_private" yaml:"is_private"`
+}
+
+// SlackChannelList is the GET .../integrations/slack/channels body. The
+// endpoint answers 404 when no Slack workspace is connected to the
+// organisation and 503 when the Slack bot service is not configured.
+type SlackChannelList struct {
+	TeamID   string         `json:"team_id" yaml:"team_id"`
+	TeamName *string        `json:"team_name" yaml:"team_name"`
+	Channels []SlackChannel `json:"channels" yaml:"channels"`
+}
+
+// TeamsChannel is one channel of a team the Ankra Teams bot is installed in.
+type TeamsChannel struct {
+	ID       string `json:"id" yaml:"id"`
+	Name     string `json:"name" yaml:"name"`
+	TeamID   string `json:"team_id" yaml:"team_id"`
+	TeamName string `json:"team_name" yaml:"team_name"`
+	TenantID string `json:"tenant_id" yaml:"tenant_id"`
+}
+
+// TeamsChannelList is the GET .../integrations/teams/channels body. The
+// endpoint answers 404 when no Teams tenant is connected and 503 when the
+// Teams bot service is not configured.
+type TeamsChannelList struct {
+	Channels []TeamsChannel `json:"channels" yaml:"channels"`
+}
+
+// NotificationRoute mirrors one routing rule under
+// /api/v1/org/notifications/routes: a notification matching every non-null
+// filter (kind, severity, cluster_id, source_id) is delivered to (mode
+// "include") or withheld from (mode "exclude") the destination. Routes are
+// evaluated in ascending priority; StopOnMatch ends the walk at this rule.
+type NotificationRoute struct {
+	ID             string  `json:"id" yaml:"id"`
+	OrganisationID string  `json:"organisation_id" yaml:"organisation_id"`
+	Kind           *string `json:"kind" yaml:"kind"`
+	Severity       *string `json:"severity" yaml:"severity"`
+	ClusterID      *string `json:"cluster_id" yaml:"cluster_id"`
+	SourceID       *string `json:"source_id" yaml:"source_id"`
+	DestinationID  string  `json:"destination_id" yaml:"destination_id"`
+	Priority       int     `json:"priority" yaml:"priority"`
+	StopOnMatch    bool    `json:"stop_on_match" yaml:"stop_on_match"`
+	Mode           string  `json:"mode" yaml:"mode"`
+	Enabled        bool    `json:"enabled" yaml:"enabled"`
+	CreatedAt      string  `json:"created_at" yaml:"created_at"`
+	UpdatedAt      string  `json:"updated_at" yaml:"updated_at"`
+}
+
+// NotificationRouteList is the GET /api/v1/org/notifications/routes body.
+type NotificationRouteList struct {
+	Items []NotificationRoute `json:"items" yaml:"items"`
+}
+
+// CreateNotificationRouteRequest is the POST body. Only DestinationID is
+// required; the backend defaults priority to 100, stop_on_match to false,
+// mode to "include", and enabled to true for omitted members.
+type CreateNotificationRouteRequest struct {
+	DestinationID string  `json:"destination_id"`
+	Kind          *string `json:"kind,omitempty"`
+	Severity      *string `json:"severity,omitempty"`
+	ClusterID     *string `json:"cluster_id,omitempty"`
+	SourceID      *string `json:"source_id,omitempty"`
+	Priority      *int    `json:"priority,omitempty"`
+	StopOnMatch   *bool   `json:"stop_on_match,omitempty"`
+	Mode          *string `json:"mode,omitempty"`
+	Enabled       *bool   `json:"enabled,omitempty"`
+}
+
+// UpdateNotificationRouteRequest is the PATCH body. The backend applies
+// only the members present in the JSON document, so a nil member is left
+// out of the wire body entirely rather than sent as null.
+type UpdateNotificationRouteRequest struct {
+	DestinationID *string `json:"destination_id,omitempty"`
+	Kind          *string `json:"kind,omitempty"`
+	Severity      *string `json:"severity,omitempty"`
+	ClusterID     *string `json:"cluster_id,omitempty"`
+	SourceID      *string `json:"source_id,omitempty"`
+	Priority      *int    `json:"priority,omitempty"`
+	StopOnMatch   *bool   `json:"stop_on_match,omitempty"`
+	Mode          *string `json:"mode,omitempty"`
+	Enabled       *bool   `json:"enabled,omitempty"`
+}
+
+// NotificationRouteTestResult is the 202 body of POST .../routes/{id}/test:
+// the id of the sample delivery queued through the notification outbox.
+type NotificationRouteTestResult struct {
+	DeliveryID string `json:"delivery_id" yaml:"delivery_id"`
+}
+
+type alertDestinationEnvelope struct {
+	Item AlertDestination `json:"item"`
+}
+
+func (c *Client) alertDestinationURL(destinationID string) string {
+	return c.BaseURL + alertDestinationsBasePath + "/" + neturl.PathEscape(destinationID)
+}
+
+func (c *Client) notificationRouteURL(routeID string) string {
+	return c.BaseURL + notificationRoutesBasePath + "/" + neturl.PathEscape(routeID)
+}
+
+// ListAlertDestinations pages through the organisation's alert destinations.
+func (c *Client) ListAlertDestinations(options ListAlertDestinationsOptions) (*AlertDestinationList, error) {
+	query := neturl.Values{}
+	if options.Page > 0 {
+		query.Set("page", strconv.Itoa(options.Page))
+	}
+	if options.PageSize > 0 {
+		query.Set("page_size", strconv.Itoa(options.PageSize))
+	}
+	if options.Search != "" {
+		query.Set("search", options.Search)
+	}
+	if options.Enabled != nil {
+		query.Set("enabled", strconv.FormatBool(*options.Enabled))
+	}
+	requestURL := c.BaseURL + alertDestinationsBasePath
+	if encoded := query.Encode(); encoded != "" {
+		requestURL += "?" + encoded
+	}
+	var list AlertDestinationList
+	if listError := c.sendJSON(http.MethodGet, requestURL, nil, &list); listError != nil {
+		return nil, listError
+	}
+	return &list, nil
+}
+
+// GetAlertDestination fetches one destination by id.
+func (c *Client) GetAlertDestination(destinationID string) (*AlertDestination, error) {
+	var envelope alertDestinationEnvelope
+	if getError := c.sendJSON(http.MethodGet, c.alertDestinationURL(destinationID), nil, &envelope); getError != nil {
+		return nil, getError
+	}
+	return &envelope.Item, nil
+}
+
+// CreateAlertDestination registers a new destination. A duplicate name
+// answers 400 with the backend's detail.
+func (c *Client) CreateAlertDestination(request CreateAlertDestinationRequest) (*AlertDestination, error) {
+	var envelope alertDestinationEnvelope
+	if createError := c.sendJSON(http.MethodPost, c.BaseURL+alertDestinationsBasePath, request, &envelope); createError != nil {
+		return nil, createError
+	}
+	return &envelope.Item, nil
+}
+
+// UpdateAlertDestination changes the members set on request and leaves the
+// rest untouched.
+func (c *Client) UpdateAlertDestination(destinationID string, request UpdateAlertDestinationRequest) (*AlertDestination, error) {
+	var envelope alertDestinationEnvelope
+	if updateError := c.sendJSON(http.MethodPut, c.alertDestinationURL(destinationID), request, &envelope); updateError != nil {
+		return nil, updateError
+	}
+	return &envelope.Item, nil
+}
+
+// DeleteAlertDestination removes a destination.
+func (c *Client) DeleteAlertDestination(destinationID string) (*DeleteAlertDestinationResult, error) {
+	var result DeleteAlertDestinationResult
+	if deleteError := c.sendJSON(http.MethodDelete, c.alertDestinationURL(destinationID), nil, &result); deleteError != nil {
+		return nil, deleteError
+	}
+	return &result, nil
+}
+
+// TestAlertDestination fires a sample payload at a stored destination. A
+// delivery failure is reported inside the result, not as an error.
+func (c *Client) TestAlertDestination(destinationID string) (*AlertDestinationTestResult, error) {
+	var result AlertDestinationTestResult
+	if testError := c.sendJSON(http.MethodPost, c.alertDestinationURL(destinationID)+"/test", nil, &result); testError != nil {
+		return nil, testError
+	}
+	return &result, nil
+}
+
+// TestAlertDestinationURL fires a sample payload at an ad-hoc webhook URL
+// before it is stored as a destination.
+func (c *Client) TestAlertDestinationURL(request TestAlertDestinationURLRequest) (*AlertDestinationTestResult, error) {
+	var result AlertDestinationTestResult
+	if testError := c.sendJSON(http.MethodPost, c.BaseURL+alertDestinationsBasePath+"/test-url", request, &result); testError != nil {
+		return nil, testError
+	}
+	return &result, nil
+}
+
+// ListSlackChannels lists the conversations the Ankra Slack bot can post to
+// in the organisation's connected workspace.
+func (c *Client) ListSlackChannels() (*SlackChannelList, error) {
+	var list SlackChannelList
+	if listError := c.sendJSON(http.MethodGet, c.BaseURL+alertDestinationsBasePath+"/slack/channels", nil, &list); listError != nil {
+		return nil, listError
+	}
+	return &list, nil
+}
+
+// ListTeamsChannels lists the channels of every team the Ankra Teams bot is
+// installed in across the organisation's bound tenants.
+func (c *Client) ListTeamsChannels() (*TeamsChannelList, error) {
+	var list TeamsChannelList
+	if listError := c.sendJSON(http.MethodGet, c.BaseURL+alertDestinationsBasePath+"/teams/channels", nil, &list); listError != nil {
+		return nil, listError
+	}
+	return &list, nil
+}
+
+// ListNotificationRoutes lists the organisation's routing rules.
+func (c *Client) ListNotificationRoutes() (*NotificationRouteList, error) {
+	var list NotificationRouteList
+	if listError := c.sendJSON(http.MethodGet, c.BaseURL+notificationRoutesBasePath, nil, &list); listError != nil {
+		return nil, listError
+	}
+	return &list, nil
+}
+
+// CreateNotificationRoute adds a routing rule. An unknown destination
+// answers 404 with the backend's detail.
+func (c *Client) CreateNotificationRoute(request CreateNotificationRouteRequest) (*NotificationRoute, error) {
+	var route NotificationRoute
+	if createError := c.sendJSON(http.MethodPost, c.BaseURL+notificationRoutesBasePath, request, &route); createError != nil {
+		return nil, createError
+	}
+	return &route, nil
+}
+
+// UpdateNotificationRoute patches only the members set on request.
+func (c *Client) UpdateNotificationRoute(routeID string, request UpdateNotificationRouteRequest) (*NotificationRoute, error) {
+	var route NotificationRoute
+	if updateError := c.sendJSON(http.MethodPatch, c.notificationRouteURL(routeID), request, &route); updateError != nil {
+		return nil, updateError
+	}
+	return &route, nil
+}
+
+// DeleteNotificationRoute removes a routing rule; the backend answers 204
+// with no body.
+func (c *Client) DeleteNotificationRoute(routeID string) error {
+	return c.sendJSON(http.MethodDelete, c.notificationRouteURL(routeID), nil, nil)
+}
+
+// TestNotificationRoute queues a sample delivery through the route's
+// destination and returns the delivery id (202).
+func (c *Client) TestNotificationRoute(routeID string) (*NotificationRouteTestResult, error) {
+	var result NotificationRouteTestResult
+	if testError := c.sendJSON(http.MethodPost, c.notificationRouteURL(routeID)+"/test", nil, &result); testError != nil {
+		return nil, testError
+	}
+	return &result, nil
+}

--- a/internal/client/alerts.go
+++ b/internal/client/alerts.go
@@ -17,17 +17,22 @@ const (
 // through the CLI; a channel-based Slack or Teams destination carries a
 // channel_id instead and answers a null URL.
 type AlertDestination struct {
-	ID             string  `json:"id" yaml:"id"`
-	Name           string  `json:"name" yaml:"name"`
-	URL            *string `json:"url" yaml:"url"`
-	ChannelID      *string `json:"channel_id" yaml:"channel_id"`
-	ChannelName    *string `json:"channel_name" yaml:"channel_name"`
-	Description    *string `json:"description" yaml:"description"`
-	Template       *string `json:"template" yaml:"template"`
-	Enabled        bool    `json:"enabled" yaml:"enabled"`
-	OrganisationID *string `json:"organisation_id" yaml:"organisation_id"`
-	CreatedAt      string  `json:"created_at" yaml:"created_at"`
-	UpdatedAt      string  `json:"updated_at" yaml:"updated_at"`
+	ID          string  `json:"id" yaml:"id"`
+	Name        string  `json:"name" yaml:"name"`
+	URL         *string `json:"url" yaml:"url"`
+	ChannelID   *string `json:"channel_id" yaml:"channel_id"`
+	ChannelName *string `json:"channel_name" yaml:"channel_name"`
+	// IntegrationType is the receiver (slack, teams, discord, pagerduty,
+	// custom); empty from a backend that predates the field. TeamsTenantID
+	// travels with Teams channel destinations.
+	IntegrationType string  `json:"integration_type,omitempty" yaml:"integration_type,omitempty"`
+	TeamsTenantID   *string `json:"teams_tenant_id" yaml:"teams_tenant_id"`
+	Description     *string `json:"description" yaml:"description"`
+	Template        *string `json:"template" yaml:"template"`
+	Enabled         bool    `json:"enabled" yaml:"enabled"`
+	OrganisationID  *string `json:"organisation_id" yaml:"organisation_id"`
+	CreatedAt       string  `json:"created_at" yaml:"created_at"`
+	UpdatedAt       string  `json:"updated_at" yaml:"updated_at"`
 }
 
 // AlertDestinationPagination is the page envelope of the destinations list.

--- a/internal/client/alerts_test.go
+++ b/internal/client/alerts_test.go
@@ -1,0 +1,489 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// alertsRequestRecorder captures the one request a handler receives so
+// tests can pin the method, path, query, bearer header, and body.
+type alertsRequestRecorder struct {
+	method string
+	path   string
+	query  string
+	bearer string
+	body   []byte
+}
+
+func recordAlertsRequest(t *testing.T, statusCode int, responseBody interface{}) (*alertsRequestRecorder, http.HandlerFunc) {
+	t.Helper()
+	recorder := &alertsRequestRecorder{}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		recorder.method = r.Method
+		recorder.path = r.URL.Path
+		recorder.query = r.URL.RawQuery
+		recorder.bearer = r.Header.Get("Authorization")
+		body, readError := io.ReadAll(r.Body)
+		if readError != nil {
+			t.Fatalf("read request body: %v", readError)
+		}
+		recorder.body = body
+		if responseBody == nil {
+			w.WriteHeader(statusCode)
+			return
+		}
+		jsonResponse(t, w, statusCode, responseBody)
+	}
+	return recorder, handler
+}
+
+func (recorder *alertsRequestRecorder) assert(t *testing.T, method, path string) {
+	t.Helper()
+	if recorder.method != method {
+		t.Errorf("method = %s, want %s", recorder.method, method)
+	}
+	if recorder.path != path {
+		t.Errorf("path = %s, want %s", recorder.path, path)
+	}
+	if recorder.bearer != "Bearer "+testToken {
+		t.Errorf("Authorization = %q, want the bearer PAT", recorder.bearer)
+	}
+}
+
+func (recorder *alertsRequestRecorder) decodedBody(t *testing.T) map[string]interface{} {
+	t.Helper()
+	var decoded map[string]interface{}
+	if unmarshalError := json.Unmarshal(recorder.body, &decoded); unmarshalError != nil {
+		t.Fatalf("decode request body %q: %v", recorder.body, unmarshalError)
+	}
+	return decoded
+}
+
+func TestListAlertDestinations_SendsFiltersAndDecodesPage(t *testing.T) {
+	recorder, handler := recordAlertsRequest(t, http.StatusOK, map[string]interface{}{
+		"items": []map[string]interface{}{{
+			"id": "dest-1", "name": "ops-slack", "url": "https://***", "channel_id": nil,
+			"enabled": true, "created_at": "2026-08-01T10:00:00Z", "updated_at": "2026-08-01T10:00:00Z",
+		}},
+		"pagination": map[string]int{"page": 2, "page_size": 50, "total_count": 51, "total_pages": 2},
+	})
+	testClient := newTestClient(t, handler)
+
+	enabled := true
+	list, listError := testClient.ListAlertDestinations(ListAlertDestinationsOptions{
+		Page: 2, PageSize: 50, Search: "ops", Enabled: &enabled,
+	})
+	if listError != nil {
+		t.Fatalf("ListAlertDestinations: %v", listError)
+	}
+	recorder.assert(t, http.MethodGet, "/api/v1/org/alerts/integrations")
+	if recorder.query != "enabled=true&page=2&page_size=50&search=ops" {
+		t.Errorf("query = %q", recorder.query)
+	}
+	if len(list.Items) != 1 || list.Items[0].Name != "ops-slack" || list.Items[0].URL == nil || *list.Items[0].URL != "https://***" {
+		t.Errorf("items = %+v", list.Items)
+	}
+	if list.Items[0].ChannelID != nil {
+		t.Errorf("null channel_id must decode to nil, got %q", *list.Items[0].ChannelID)
+	}
+	if list.Pagination.TotalCount != 51 || list.Pagination.TotalPages != 2 {
+		t.Errorf("pagination = %+v", list.Pagination)
+	}
+}
+
+func TestListAlertDestinations_NoOptionsSendsNoQuery(t *testing.T) {
+	recorder, handler := recordAlertsRequest(t, http.StatusOK, map[string]interface{}{
+		"items": []interface{}{}, "pagination": map[string]int{"page": 1, "page_size": 20, "total_count": 0, "total_pages": 0},
+	})
+	testClient := newTestClient(t, handler)
+	if _, listError := testClient.ListAlertDestinations(ListAlertDestinationsOptions{}); listError != nil {
+		t.Fatalf("ListAlertDestinations: %v", listError)
+	}
+	if recorder.query != "" {
+		t.Errorf("query = %q, want none", recorder.query)
+	}
+}
+
+func TestGetAlertDestination_UnwrapsItemEnvelope(t *testing.T) {
+	recorder, handler := recordAlertsRequest(t, http.StatusOK, map[string]interface{}{
+		"item": map[string]interface{}{
+			"id": "dest-1", "name": "ops-teams", "url": nil, "channel_id": "19:abc@thread.tacv2",
+			"channel_name": "Platform Alerts", "enabled": true,
+			"created_at": "2026-08-01T10:00:00Z", "updated_at": "2026-08-01T10:00:00Z",
+		},
+	})
+	testClient := newTestClient(t, handler)
+
+	destination, getError := testClient.GetAlertDestination("dest-1")
+	if getError != nil {
+		t.Fatalf("GetAlertDestination: %v", getError)
+	}
+	recorder.assert(t, http.MethodGet, "/api/v1/org/alerts/integrations/dest-1")
+	if destination.Name != "ops-teams" || destination.ChannelName == nil || *destination.ChannelName != "Platform Alerts" {
+		t.Errorf("destination = %+v", destination)
+	}
+	if destination.URL != nil {
+		t.Errorf("null url must decode to nil, got %q", *destination.URL)
+	}
+}
+
+func TestGetAlertDestination_NotFoundSurfacesDetailAndStatus(t *testing.T) {
+	_, handler := recordAlertsRequest(t, http.StatusNotFound, map[string]string{"detail": "Integration not found"})
+	testClient := newTestClient(t, handler)
+
+	_, getError := testClient.GetAlertDestination("missing")
+	if getError == nil {
+		t.Fatal("expected an error for 404")
+	}
+	var unexpected *UnexpectedResponseError
+	if !errors.As(getError, &unexpected) || unexpected.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected an UnexpectedResponseError with status 404, got %v", getError)
+	}
+	if !strings.Contains(getError.Error(), "Integration not found") {
+		t.Errorf("expected the backend detail, got: %v", getError)
+	}
+}
+
+func TestCreateAlertDestination_SendsBodyAndOmitsUnset(t *testing.T) {
+	recorder, handler := recordAlertsRequest(t, http.StatusOK, map[string]interface{}{
+		"item": map[string]interface{}{
+			"id": "dest-9", "name": "oncall", "url": "https://events.pagerduty.com/v2/enqueue", "enabled": false,
+			"organisation_id": "org-1", "created_at": "2026-08-01T10:00:00Z", "updated_at": "2026-08-01T10:00:00Z",
+		},
+	})
+	testClient := newTestClient(t, handler)
+
+	enabled := false
+	destination, createError := testClient.CreateAlertDestination(CreateAlertDestinationRequest{
+		Name:            "oncall",
+		URL:             strPtr("https://events.pagerduty.com/v2/enqueue"),
+		IntegrationType: strPtr("pagerduty"),
+		Enabled:         &enabled,
+	})
+	if createError != nil {
+		t.Fatalf("CreateAlertDestination: %v", createError)
+	}
+	recorder.assert(t, http.MethodPost, "/api/v1/org/alerts/integrations")
+	body := recorder.decodedBody(t)
+	if body["name"] != "oncall" || body["url"] != "https://events.pagerduty.com/v2/enqueue" || body["integration_type"] != "pagerduty" {
+		t.Errorf("body = %v", body)
+	}
+	if body["enabled"] != false {
+		t.Errorf("enabled = %v, want an explicit false", body["enabled"])
+	}
+	for _, absent := range []string{"channel_id", "channel_name", "teams_tenant_id", "description", "template"} {
+		if _, present := body[absent]; present {
+			t.Errorf("%s must be omitted when unset, body = %v", absent, body)
+		}
+	}
+	if destination.ID != "dest-9" || destination.OrganisationID == nil || *destination.OrganisationID != "org-1" {
+		t.Errorf("destination = %+v", destination)
+	}
+}
+
+func TestCreateAlertDestination_DuplicateNameSurfacesDetail(t *testing.T) {
+	_, handler := recordAlertsRequest(t, http.StatusBadRequest,
+		map[string]string{"detail": "A webhook with the name 'oncall' already exists"})
+	testClient := newTestClient(t, handler)
+
+	_, createError := testClient.CreateAlertDestination(CreateAlertDestinationRequest{Name: "oncall", URL: strPtr("https://x")})
+	if createError == nil || !strings.Contains(createError.Error(), "already exists") {
+		t.Errorf("expected the duplicate-name detail, got %v", createError)
+	}
+}
+
+func TestUpdateAlertDestination_PutsOnlySetMembers(t *testing.T) {
+	recorder, handler := recordAlertsRequest(t, http.StatusOK, map[string]interface{}{
+		"item": map[string]interface{}{
+			"id": "dest-1", "name": "ops-slack", "url": "https://***", "enabled": true,
+			"created_at": "2026-08-01T10:00:00Z", "updated_at": "2026-08-02T10:00:00Z",
+		},
+	})
+	testClient := newTestClient(t, handler)
+
+	enabled := true
+	if _, updateError := testClient.UpdateAlertDestination("dest-1", UpdateAlertDestinationRequest{
+		Description: strPtr("primary"), Enabled: &enabled,
+	}); updateError != nil {
+		t.Fatalf("UpdateAlertDestination: %v", updateError)
+	}
+	recorder.assert(t, http.MethodPut, "/api/v1/org/alerts/integrations/dest-1")
+	body := recorder.decodedBody(t)
+	if body["description"] != "primary" || body["enabled"] != true {
+		t.Errorf("body = %v", body)
+	}
+	if len(body) != 2 {
+		t.Errorf("only the set members may be sent, body = %v", body)
+	}
+}
+
+func TestDeleteAlertDestination_DecodesSuccessBody(t *testing.T) {
+	recorder, handler := recordAlertsRequest(t, http.StatusOK,
+		map[string]interface{}{"success": true, "message": "Integration deleted successfully"})
+	testClient := newTestClient(t, handler)
+
+	result, deleteError := testClient.DeleteAlertDestination("dest-1")
+	if deleteError != nil {
+		t.Fatalf("DeleteAlertDestination: %v", deleteError)
+	}
+	recorder.assert(t, http.MethodDelete, "/api/v1/org/alerts/integrations/dest-1")
+	if !result.Success || result.Message != "Integration deleted successfully" {
+		t.Errorf("result = %+v", result)
+	}
+}
+
+func TestTestAlertDestination_DecodesNullableOutcome(t *testing.T) {
+	recorder, handler := recordAlertsRequest(t, http.StatusOK, map[string]interface{}{
+		"success": false, "status_code": nil, "response_time_ms": nil, "error": "connection refused",
+	})
+	testClient := newTestClient(t, handler)
+
+	result, testError := testClient.TestAlertDestination("dest-1")
+	if testError != nil {
+		t.Fatalf("TestAlertDestination: %v", testError)
+	}
+	recorder.assert(t, http.MethodPost, "/api/v1/org/alerts/integrations/dest-1/test")
+	if result.Success || result.StatusCode != nil || result.ResponseTimeMS != nil {
+		t.Errorf("result = %+v, want a failed outcome with null status and timing", result)
+	}
+	if result.Error == nil || *result.Error != "connection refused" {
+		t.Errorf("error = %v, want connection refused", result.Error)
+	}
+}
+
+func TestTestAlertDestinationURL_SendsURLAndTemplate(t *testing.T) {
+	recorder, handler := recordAlertsRequest(t, http.StatusOK, map[string]interface{}{
+		"success": true, "status_code": 200, "response_time_ms": 88.5, "error": nil,
+	})
+	testClient := newTestClient(t, handler)
+
+	result, testError := testClient.TestAlertDestinationURL(TestAlertDestinationURLRequest{
+		URL: "https://hooks.example/1", Template: strPtr(`{"text":"hi"}`),
+	})
+	if testError != nil {
+		t.Fatalf("TestAlertDestinationURL: %v", testError)
+	}
+	recorder.assert(t, http.MethodPost, "/api/v1/org/alerts/integrations/test-url")
+	body := recorder.decodedBody(t)
+	if body["url"] != "https://hooks.example/1" || body["template"] != `{"text":"hi"}` {
+		t.Errorf("body = %v", body)
+	}
+	if !result.Success || result.StatusCode == nil || *result.StatusCode != 200 ||
+		result.ResponseTimeMS == nil || *result.ResponseTimeMS != 88.5 {
+		t.Errorf("result = %+v", result)
+	}
+}
+
+func TestListSlackChannels_DecodesWorkspaceAndChannels(t *testing.T) {
+	recorder, handler := recordAlertsRequest(t, http.StatusOK, map[string]interface{}{
+		"team_id": "T123", "team_name": nil,
+		"channels": []map[string]interface{}{{"id": "C1", "name": "alerts", "is_private": true}},
+	})
+	testClient := newTestClient(t, handler)
+
+	list, listError := testClient.ListSlackChannels()
+	if listError != nil {
+		t.Fatalf("ListSlackChannels: %v", listError)
+	}
+	recorder.assert(t, http.MethodGet, "/api/v1/org/alerts/integrations/slack/channels")
+	if list.TeamID != "T123" || list.TeamName != nil || len(list.Channels) != 1 || !list.Channels[0].IsPrivate {
+		t.Errorf("list = %+v", list)
+	}
+}
+
+func TestListSlackChannels_NotConnectedKeepsStatus(t *testing.T) {
+	_, handler := recordAlertsRequest(t, http.StatusNotFound,
+		map[string]string{"detail": "No Slack workspace is connected to this organisation"})
+	testClient := newTestClient(t, handler)
+
+	_, listError := testClient.ListSlackChannels()
+	var unexpected *UnexpectedResponseError
+	if !errors.As(listError, &unexpected) || unexpected.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected a 404 UnexpectedResponseError, got %v", listError)
+	}
+}
+
+func TestListTeamsChannels_DecodesChannelsAndNotConfigured(t *testing.T) {
+	recorder, handler := recordAlertsRequest(t, http.StatusOK, map[string]interface{}{
+		"channels": []map[string]interface{}{{
+			"id": "19:abc@thread.tacv2", "name": "Platform Alerts", "team_id": "team-1", "team_name": "Platform", "tenant_id": "tenant-1",
+		}},
+	})
+	testClient := newTestClient(t, handler)
+
+	list, listError := testClient.ListTeamsChannels()
+	if listError != nil {
+		t.Fatalf("ListTeamsChannels: %v", listError)
+	}
+	recorder.assert(t, http.MethodGet, "/api/v1/org/alerts/integrations/teams/channels")
+	if len(list.Channels) != 1 || list.Channels[0].TenantID != "tenant-1" || list.Channels[0].TeamName != "Platform" {
+		t.Errorf("list = %+v", list)
+	}
+
+	_, unavailableHandler := recordAlertsRequest(t, http.StatusServiceUnavailable,
+		map[string]string{"detail": "Teams bot service is not configured"})
+	unavailableClient := newTestClient(t, unavailableHandler)
+	_, unavailableError := unavailableClient.ListTeamsChannels()
+	var unexpected *UnexpectedResponseError
+	if !errors.As(unavailableError, &unexpected) || unexpected.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected a 503 UnexpectedResponseError, got %v", unavailableError)
+	}
+}
+
+func TestListNotificationRoutes_DecodesItems(t *testing.T) {
+	recorder, handler := recordAlertsRequest(t, http.StatusOK, map[string]interface{}{
+		"items": []map[string]interface{}{{
+			"id": "route-1", "organisation_id": "org-1", "kind": nil, "severity": "critical",
+			"cluster_id": nil, "source_id": nil, "destination_id": "dest-1", "priority": 10,
+			"stop_on_match": true, "mode": "include", "enabled": true,
+			"created_at": "2026-08-01T10:00:00Z", "updated_at": "2026-08-01T10:00:00Z",
+		}},
+	})
+	testClient := newTestClient(t, handler)
+
+	list, listError := testClient.ListNotificationRoutes()
+	if listError != nil {
+		t.Fatalf("ListNotificationRoutes: %v", listError)
+	}
+	recorder.assert(t, http.MethodGet, "/api/v1/org/notifications/routes")
+	if len(list.Items) != 1 {
+		t.Fatalf("items = %+v", list.Items)
+	}
+	route := list.Items[0]
+	if route.Kind != nil || route.Severity == nil || *route.Severity != "critical" || route.Priority != 10 || !route.StopOnMatch {
+		t.Errorf("route = %+v", route)
+	}
+}
+
+func TestCreateNotificationRoute_SendsOnlySetMembers(t *testing.T) {
+	recorder, handler := recordAlertsRequest(t, http.StatusOK, map[string]interface{}{
+		"id": "route-9", "organisation_id": "org-1", "destination_id": "dest-1", "priority": 100,
+		"stop_on_match": false, "mode": "include", "enabled": true, "severity": "critical",
+		"created_at": "2026-08-01T10:00:00Z", "updated_at": "2026-08-01T10:00:00Z",
+	})
+	testClient := newTestClient(t, handler)
+
+	route, createError := testClient.CreateNotificationRoute(CreateNotificationRouteRequest{
+		DestinationID: "dest-1", Severity: strPtr("critical"),
+	})
+	if createError != nil {
+		t.Fatalf("CreateNotificationRoute: %v", createError)
+	}
+	recorder.assert(t, http.MethodPost, "/api/v1/org/notifications/routes")
+	body := recorder.decodedBody(t)
+	if body["destination_id"] != "dest-1" || body["severity"] != "critical" {
+		t.Errorf("body = %v", body)
+	}
+	for _, absent := range []string{"kind", "cluster_id", "source_id", "priority", "stop_on_match", "mode", "enabled"} {
+		if _, present := body[absent]; present {
+			t.Errorf("%s must be omitted so the backend default applies, body = %v", absent, body)
+		}
+	}
+	if route.ID != "route-9" || route.Priority != 100 {
+		t.Errorf("route = %+v", route)
+	}
+}
+
+func TestCreateNotificationRoute_UnknownDestinationIs404WithDetail(t *testing.T) {
+	_, handler := recordAlertsRequest(t, http.StatusNotFound,
+		map[string]string{"detail": "Destination dest-x not found in this organisation."})
+	testClient := newTestClient(t, handler)
+
+	_, createError := testClient.CreateNotificationRoute(CreateNotificationRouteRequest{DestinationID: "dest-x"})
+	var unexpected *UnexpectedResponseError
+	if !errors.As(createError, &unexpected) || unexpected.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected a 404 UnexpectedResponseError, got %v", createError)
+	}
+	if !strings.Contains(createError.Error(), "not found in this organisation") {
+		t.Errorf("expected the backend detail, got %v", createError)
+	}
+}
+
+func TestUpdateNotificationRoute_PatchesOnlySetMembers(t *testing.T) {
+	recorder, handler := recordAlertsRequest(t, http.StatusOK, map[string]interface{}{
+		"id": "route-1", "organisation_id": "org-1", "destination_id": "dest-1", "priority": 5,
+		"stop_on_match": false, "mode": "include", "enabled": false,
+		"created_at": "2026-08-01T10:00:00Z", "updated_at": "2026-08-02T10:00:00Z",
+	})
+	testClient := newTestClient(t, handler)
+
+	priority := 5
+	enabled := false
+	route, updateError := testClient.UpdateNotificationRoute("route-1", UpdateNotificationRouteRequest{
+		Priority: &priority, Enabled: &enabled,
+	})
+	if updateError != nil {
+		t.Fatalf("UpdateNotificationRoute: %v", updateError)
+	}
+	recorder.assert(t, http.MethodPatch, "/api/v1/org/notifications/routes/route-1")
+	body := recorder.decodedBody(t)
+	if body["priority"] != float64(5) || body["enabled"] != false {
+		t.Errorf("body = %v", body)
+	}
+	if len(body) != 2 {
+		t.Errorf("PATCH must carry only the set members, body = %v", body)
+	}
+	if route.Priority != 5 || route.Enabled {
+		t.Errorf("route = %+v", route)
+	}
+}
+
+func TestUpdateNotificationRoute_NotFound(t *testing.T) {
+	_, handler := recordAlertsRequest(t, http.StatusNotFound, map[string]string{"detail": "Route not found"})
+	testClient := newTestClient(t, handler)
+
+	priority := 1
+	_, updateError := testClient.UpdateNotificationRoute("route-x", UpdateNotificationRouteRequest{Priority: &priority})
+	var unexpected *UnexpectedResponseError
+	if !errors.As(updateError, &unexpected) || unexpected.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected a 404 UnexpectedResponseError, got %v", updateError)
+	}
+}
+
+func TestDeleteNotificationRoute_Accepts204WithoutBody(t *testing.T) {
+	recorder, handler := recordAlertsRequest(t, http.StatusNoContent, nil)
+	testClient := newTestClient(t, handler)
+
+	if deleteError := testClient.DeleteNotificationRoute("route-1"); deleteError != nil {
+		t.Fatalf("DeleteNotificationRoute: %v", deleteError)
+	}
+	recorder.assert(t, http.MethodDelete, "/api/v1/org/notifications/routes/route-1")
+}
+
+func TestDeleteNotificationRoute_NotFound(t *testing.T) {
+	_, handler := recordAlertsRequest(t, http.StatusNotFound, map[string]string{"detail": "Route not found"})
+	testClient := newTestClient(t, handler)
+
+	deleteError := testClient.DeleteNotificationRoute("route-x")
+	var unexpected *UnexpectedResponseError
+	if !errors.As(deleteError, &unexpected) || unexpected.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected a 404 UnexpectedResponseError, got %v", deleteError)
+	}
+}
+
+func TestTestNotificationRoute_Accepts202WithDeliveryID(t *testing.T) {
+	recorder, handler := recordAlertsRequest(t, http.StatusAccepted, map[string]string{"delivery_id": "delivery-42"})
+	testClient := newTestClient(t, handler)
+
+	result, testError := testClient.TestNotificationRoute("route-1")
+	if testError != nil {
+		t.Fatalf("TestNotificationRoute: %v", testError)
+	}
+	recorder.assert(t, http.MethodPost, "/api/v1/org/notifications/routes/route-1/test")
+	if result.DeliveryID != "delivery-42" {
+		t.Errorf("delivery id = %q, want delivery-42", result.DeliveryID)
+	}
+}
+
+func TestAlertsClient_UnauthorizedMapsToErrUnauthorized(t *testing.T) {
+	_, handler := recordAlertsRequest(t, http.StatusUnauthorized, map[string]string{"detail": "Not authenticated"})
+	testClient := newTestClient(t, handler)
+
+	if _, listError := testClient.ListNotificationRoutes(); !errors.Is(listError, ErrUnauthorized) {
+		t.Errorf("expected ErrUnauthorized, got %v", listError)
+	}
+}


### PR DESCRIPTION
## What & why

Alerting as code from the terminal (ankra-z8ql). Until now, where alerts go and which notifications reach which receiver could only be configured in the portal. This adds the `ankra alerts` command family, using the same personal access token as the rest of the CLI:

**`ankra alerts destinations`** (webhook and chat-channel receivers)
- `list [--search] [--enabled|--disabled] [--page] [--page-size]` — table of Name/ID/Type/Target/Enabled (Type is derived: `channel` when the destination carries a channel id, `webhook` otherwise; Target is the channel name or the masked URL)
- `get <id>` — label/value view
- `create --name X [--url U | --channel-id C [--channel-name N] [--teams-tenant-id T]] [--type slack|teams|discord|pagerduty|custom] [--description D] [--template-file F] [--disabled]` — `--url` or `--channel-id` is required (usage error otherwise)
- `update <id> [same flags] [--enabled|--disabled]` — sends only the flags whose `Changed()` is true; no flags is a usage error
- `delete <id> [--yes]` — confirms first; declining exits 4
- `test <id>` and `test-url --url U [--template-file F]` — fire a sample notification; a failed delivery exits non-zero (with `-o json` the result is still emitted first) so CI can gate on receiver reachability
- `channels [--provider slack|teams]` — the channel picker for channel-based destinations; a 404 renders as `not connected` and a 503 as `not available` (plain lines, not errors; on stderr with `-o`)

**`ankra alerts routes`** (which notifications reach which destination)
- `list` — table of ID/Priority/Kind/Severity/Cluster/Destination/Mode/Enabled (unset filters read `any`)
- `create --destination-id D [--kind] [--severity] [--cluster-id] [--source-id] [--priority] [--stop-on-match] [--mode include|exclude] [--disabled]` — only passed flags are sent, so backend defaults (priority 100, mode include, enabled) apply; `--mode` and `--severity` are validated client-side as usage errors
- `update <id> [same flags, plus --destination-id and --enabled|--disabled]` — PATCH carries only the members passed (pydantic `model_fields_set` semantics)
- `delete <id> [--yes]` — confirms first; expects the 204
- `test <id>` — prints the queued delivery id from the 202

All list/get/create/update/test commands take `-o json|yaml` via `registerStructuredOutputFlags` with a clean stdout. 404s map to exit code 3 through the existing `UnexpectedResponseError` classification, and the backend `detail` string surfaces in errors.

Wire contract: the bearer-PAT `/api/v1` twins shipped in ankraio/cluster on the `feat/ankra-n5d6-teams-channel-destinations` branch — `/api/v1/org/alerts/integrations` (list/get/create/update/delete, `/{id}/test`, `/test-url`, `/slack/channels`, `/teams/channels`) and `/api/v1/org/notifications/routes` (list/create, `PATCH /{id}`, `DELETE /{id}` → 204, `POST /{id}/test` → 202).

New `internal/client/alerts.go` methods are added to the `APIClient` interface (`cmd/services.go`) and stubbed on `baseMock` (`cmd/e2e_test.go`). CHANGELOG has an entry under Unreleased; no version bump.

## Test plan

- `make build test lint` green locally (golangci-lint v2, 0 issues); pre-commit hook ran tests + lint on commit.
- `cmd/alerts_test.go` (25 cases) and `cmd/alerts_routes_test.go` (17 cases): per-command mocks embedding `baseMock`; assert request payloads (create sends only passed flags, update/PATCH omit unset members), human table/detail substrings, confirmation decline → exit 4 and no API call, `--yes`, usage errors → exit 2, not-found → exit 3, failed test delivery → non-zero, `-o json` purity (`json.Unmarshal` on stdout, notices on stderr).
- `internal/client/alerts_test.go` (22 cases): httptest via `newTestClient` pinning method, path, query, and the `Authorization: Bearer` header for every method; the 204 delete and 202 test shapes; nullable decoding; backend `detail` surfacing on 400/404; 401 → `ErrUnauthorized`.

## Docs checklist

- [ ] No user-facing command/flag changes — no docs needed
- [x] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); `Short`/`Long` on every new command are written for docs readers
- [ ] Broader behaviour changes — docs updated in [ankra-docs](https://github.com/ankraio/ankra-docs) (link the PR): <!-- PR link -->
