### PR TITLE
feat(operations,logs): steps --results and logs --follow=false, the two gaps from a live teardown incident (ankra-tycp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **`ankra cluster logs --follow=false` prints the backlog and exits.** The
+  logs command always followed, so piping it into `grep` or a script hung
+  until you killed it. `--follow` (`-f`) now defaults to true, keeping the
+  familiar `kubectl logs -f` behaviour, and `--follow=false` returns as soon
+  as the current backlog has drained.
 - **`ankra cluster operations steps --results` shows what each step actually
   did.** The steps table only ever carried a status and an error excerpt; the
   scheduler's per-step result payload - the resources a teardown deleted,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Added
 
+- **`ankra cluster operations steps --results` shows what each step actually
+  did.** The steps table only ever carried a status and an error excerpt; the
+  scheduler's per-step result payload - the resources a teardown deleted,
+  skipped, or failed to reclaim, or the full error body behind a truncated
+  excerpt - was recorded by the platform but reachable only through the API.
+  `--results` fetches it and prints each step's result under the table, and
+  `-o json|yaml` gains a `step_results` list in step order so scripts can join
+  it without a second call. Steps that never finished are listed as having no
+  result rather than silently omitted.
 - **`ankra alerts destinations` and `ankra alerts routes` bring alerting as
   code to the terminal.** Where alerts go and which notifications reach them
   was portal-only until now. `destinations list|get|create|update|delete`

--- a/cmd/cluster_k8s.go
+++ b/cmd/cluster_k8s.go
@@ -712,8 +712,13 @@ var clusterLogsCmd = &cobra.Command{
 	Short: "Stream logs from a pod",
 	Long: `Stream log output from a pod in the active cluster.
 
+By default the stream stays open and prints new lines as they arrive, like
+kubectl logs -f. Pass --follow=false to print the current backlog and exit,
+which is what a pipeline into grep or a script wants.
+
 Example:
-  ankra cluster logs my-pod -n default -c my-container --tail 100`,
+  ankra cluster logs my-pod -n default -c my-container --tail 100
+  ankra cluster logs my-pod -n default --since 600 --follow=false | grep ERROR`,
 	Args:        cobra.ExactArgs(1),
 	Annotations: map[string]string{"group": "kubernetes"},
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -722,6 +727,7 @@ Example:
 		container, _ := cmd.Flags().GetString("container")
 		tailLines, _ := cmd.Flags().GetInt("tail")
 		sinceSeconds, _ := cmd.Flags().GetInt("since")
+		follow, _ := cmd.Flags().GetBool("follow")
 
 		if namespace == "" {
 			return withExitCode(exitUsage, errors.New("--namespace (-n) is required for logs"))
@@ -737,6 +743,7 @@ Example:
 			ContainerName: container,
 			TailLines:     tailLines,
 			SinceSeconds:  sinceSeconds,
+			Follow:        follow,
 		}
 
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -871,6 +878,7 @@ func init() {
 	clusterLogsCmd.Flags().StringP("container", "c", "", "Container name (defaults to pod name)")
 	clusterLogsCmd.Flags().Int("tail", 0, "Number of lines from the end of the logs")
 	clusterLogsCmd.Flags().Int("since", 0, "Seconds of logs to retrieve")
+	clusterLogsCmd.Flags().BoolP("follow", "f", true, "Keep the stream open for new lines; --follow=false prints the current backlog and exits")
 
 	clusterGenericResourcesCmd.Flags().StringP("namespace", "n", "", "Kubernetes namespace")
 	clusterGenericResourcesCmd.Flags().BoolP("all-namespaces", "A", false, "List across all namespaces")

--- a/cmd/cluster_operation.go
+++ b/cmd/cluster_operation.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -292,9 +293,16 @@ var clusterOperationsStepsCmd = &cobra.Command{
 	Use:     "steps <execution_id>",
 	Aliases: []string{"jobs"},
 	Short:   "List steps for a specific execution",
-	Args:    cobra.ExactArgs(1),
+	Long: `List the steps of an execution with their status and error excerpt.
+
+--results additionally fetches each step's job result - the structured
+payload the scheduler recorded when the step finished (for example the
+resources a teardown deleted, skipped, or failed to reclaim). Results are
+printed under each step, and merged into the steps in -o json|yaml output.`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		executionID := args[0]
+		includeResults, _ := cmd.Flags().GetBool("results")
 
 		format, err := structuredFormatFromFlags(cmd)
 		if err != nil {
@@ -306,7 +314,21 @@ var clusterOperationsStepsCmd = &cobra.Command{
 			return fmt.Errorf("fetching execution: %w", err)
 		}
 
+		var resultsByStep map[string]client.StepResult
+		if includeResults {
+			resultsByStep, err = loadExecutionStepResults(executionID)
+			if err != nil {
+				return err
+			}
+		}
+
 		if format != outputDefault {
+			if includeResults {
+				return encodeStructured(os.Stdout, format, executionDetailWithResults{
+					ExecutionDetail: detail,
+					StepResults:     orderedStepResults(detail, resultsByStep),
+				})
+			}
 			return encodeStructured(os.Stdout, format, detail)
 		}
 
@@ -353,8 +375,66 @@ var clusterOperationsStepsCmd = &cobra.Command{
 		}
 		t.Render()
 		printExecutionStepDrift(detail)
+		if includeResults {
+			printExecutionStepResults(detail, resultsByStep)
+		}
 		return nil
 	},
+}
+
+// executionDetailWithResults is the -o json|yaml shape of `steps --results`:
+// the execution detail plus each step's recorded result, keyed by step id
+// in step order, so scripts can join them without a second call.
+type executionDetailWithResults struct {
+	client.ExecutionDetail
+	StepResults []client.StepResult `json:"step_results" yaml:"step_results"`
+}
+
+// loadExecutionStepResults fetches the execution's step results and indexes
+// them by step id. A step that has not finished has no result row.
+func loadExecutionStepResults(executionID string) (map[string]client.StepResult, error) {
+	response, resultError := apiClient.GetExecutionResult(executionID)
+	if resultError != nil {
+		return nil, fmt.Errorf("fetching execution results %s: %w", executionID, resultError)
+	}
+	resultsByStep := make(map[string]client.StepResult, len(response.Results))
+	for _, stepResult := range response.Results {
+		resultsByStep[stepResult.StepID] = stepResult
+	}
+	return resultsByStep, nil
+}
+
+// orderedStepResults returns the results in the execution's step order,
+// dropping steps without one.
+func orderedStepResults(detail client.ExecutionDetail, resultsByStep map[string]client.StepResult) []client.StepResult {
+	ordered := make([]client.StepResult, 0, len(resultsByStep))
+	for _, step := range detail.Steps {
+		if stepResult, found := resultsByStep[step.ID]; found {
+			ordered = append(ordered, stepResult)
+		}
+	}
+	return ordered
+}
+
+// printExecutionStepResults renders each step's result payload as indented
+// JSON under a per-step heading; steps without a result are listed as such
+// so a missing sweep is visible rather than silently absent.
+func printExecutionStepResults(detail client.ExecutionDetail, resultsByStep map[string]client.StepResult) {
+	fmt.Println()
+	fmt.Println("Step results:")
+	for _, step := range detail.Steps {
+		stepResult, found := resultsByStep[step.ID]
+		if !found || len(stepResult.Result) == 0 {
+			fmt.Printf("  %s (%s): no result recorded\n", step.Name, step.ID)
+			continue
+		}
+		encoded, marshalError := json.MarshalIndent(stepResult.Result, "    ", "  ")
+		if marshalError != nil {
+			fmt.Printf("  %s (%s): result could not be rendered: %v\n", step.Name, step.ID, marshalError)
+			continue
+		}
+		fmt.Printf("  %s (%s):\n    %s\n", step.Name, step.ID, encoded)
+	}
 }
 
 func renderExecutionsTable(executions []client.ExecutionSummary) {
@@ -495,6 +575,8 @@ func init() {
 		"Output format: json or yaml (default: human-readable)")
 	clusterOperationsStepsCmd.Flags().StringP("output", "o", "",
 		"Output format: json or yaml (default: human-readable)")
+	clusterOperationsStepsCmd.Flags().Bool("results", false,
+		"Also fetch and show each step's recorded job result (what the step created, deleted, skipped, or failed to reclaim)")
 	registerStructuredOutputFlags(
 		clusterOperationsCancelCmd,
 		clusterOperationsCancelStepCmd,

--- a/cmd/cluster_operation_results_test.go
+++ b/cmd/cluster_operation_results_test.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type stepsResultsMock struct {
+	baseMock
+	resultCalls    int
+	gotExecutionID string
+	resultError    error
+}
+
+func (mock *stepsResultsMock) GetExecution(executionID string) (client.ExecutionDetail, error) {
+	name := "upcloud_delete_network"
+	return client.ExecutionDetail{
+		Execution: client.ExecutionSummary{ID: executionID, DisplayName: "Reconcile 2 resources", Status: "success"},
+		Steps: []client.ExecutionStep{
+			{ID: "step-1", Name: name, Status: "success"},
+			{ID: "step-2", Name: "upcloud_delete_router", Status: "pending"},
+		},
+	}, nil
+}
+
+func (mock *stepsResultsMock) EnrichExecutionDetailWithDrift(_ *client.ExecutionDetail) error { return nil }
+
+func (mock *stepsResultsMock) GetExecutionResult(executionID string) (client.ExecutionResultResponse, error) {
+	mock.resultCalls++
+	mock.gotExecutionID = executionID
+	if mock.resultError != nil {
+		return client.ExecutionResultResponse{}, mock.resultError
+	}
+	return client.ExecutionResultResponse{
+		ExecutionID: executionID,
+		Results: []client.StepResult{{
+			StepID: "step-1",
+			Result: map[string]any{
+				"status":                        "success",
+				"force_cleanup_storage_deleted": []any{"uuid-v1"},
+			},
+		}},
+	}, nil
+}
+
+// TestOperationsSteps_ResultsFlagFetchesAndMergesStepResults pins the new
+// --results lane: the result endpoint is called once, and the -o json shape
+// carries each finished step's result under step_results in step order,
+// while a step without a result row is simply absent from that list.
+func TestOperationsSteps_ResultsFlagFetchesAndMergesStepResults(t *testing.T) {
+	resetConfirmFlag(t, clusterOperationsStepsCmd)
+	mock := &stepsResultsMock{}
+	var runError error
+	output := captureStdout(t, func() {
+		_, runError = runWithInput(t, mock, "", "cluster", "operations", "steps", "exec-1", "--results", "-o", "json")
+	})
+	if runError != nil {
+		t.Fatalf("execute failed: %v", runError)
+	}
+	if mock.resultCalls != 1 || mock.gotExecutionID != "exec-1" {
+		t.Fatalf("expected one result fetch for exec-1, got calls=%d id=%q", mock.resultCalls, mock.gotExecutionID)
+	}
+	var decoded struct {
+		Steps       []map[string]any `json:"steps"`
+		StepResults []struct {
+			StepID string         `json:"step_id"`
+			Result map[string]any `json:"result"`
+		} `json:"step_results"`
+	}
+	if unmarshalError := json.Unmarshal([]byte(output), &decoded); unmarshalError != nil {
+		t.Fatalf("output must be JSON, got %v: %s", unmarshalError, output)
+	}
+	if len(decoded.Steps) != 2 {
+		t.Fatalf("expected the two steps in the payload, got %d", len(decoded.Steps))
+	}
+	if len(decoded.StepResults) != 1 || decoded.StepResults[0].StepID != "step-1" {
+		t.Fatalf("expected exactly the finished step's result, got %+v", decoded.StepResults)
+	}
+	deleted, _ := decoded.StepResults[0].Result["force_cleanup_storage_deleted"].([]any)
+	if len(deleted) != 1 || deleted[0] != "uuid-v1" {
+		t.Fatalf("result payload drifted: %+v", decoded.StepResults[0].Result)
+	}
+}
+
+// TestOperationsSteps_WithoutResultsFlagSkipsResultFetch pins the default:
+// plain `steps` never calls the result endpoint and its JSON keeps the
+// existing shape (no step_results member).
+func TestOperationsSteps_WithoutResultsFlagSkipsResultFetch(t *testing.T) {
+	resetConfirmFlag(t, clusterOperationsStepsCmd)
+	mock := &stepsResultsMock{}
+	var runError error
+	output := captureStdout(t, func() {
+		_, runError = runWithInput(t, mock, "", "cluster", "operations", "steps", "exec-1", "-o", "json")
+	})
+	if runError != nil {
+		t.Fatalf("execute failed: %v", runError)
+	}
+	if mock.resultCalls != 0 {
+		t.Fatalf("plain steps must not fetch results, got %d calls", mock.resultCalls)
+	}
+	if strings.Contains(output, "step_results") {
+		t.Fatalf("plain steps JSON must keep its shape, got: %s", output)
+	}
+}
+
+// TestOperationsSteps_ResultsFetchFailureIsAnError pins that a failed result
+// fetch surfaces as the command's error instead of a silently partial view.
+func TestOperationsSteps_ResultsFetchFailureIsAnError(t *testing.T) {
+	resetConfirmFlag(t, clusterOperationsStepsCmd)
+	mock := &stepsResultsMock{resultError: errors.New("boom")}
+	var runError error
+	captureStdout(t, func() {
+		_, runError = runWithInput(t, mock, "", "cluster", "operations", "steps", "exec-1", "--results")
+	})
+	if runError == nil || !strings.Contains(runError.Error(), "fetching execution results") {
+		t.Fatalf("expected the result fetch failure to surface, got %v", runError)
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -315,6 +315,10 @@ func (m baseMock) GetExecution(executionID string) (client.ExecutionDetail, erro
 	return client.ExecutionDetail{}, errors.New("not implemented")
 }
 
+func (m baseMock) GetExecutionResult(executionID string) (client.ExecutionResultResponse, error) {
+	return client.ExecutionResultResponse{}, errors.New("not implemented")
+}
+
 func (m baseMock) EnrichExecutionDetailWithDrift(detail *client.ExecutionDetail) error {
 	return nil
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -44,6 +44,7 @@ type APIClient interface {
 
 	ListExecutions(opts client.ListExecutionsOptions) (client.ExecutionListResponse, error)
 	GetExecution(executionID string) (client.ExecutionDetail, error)
+	GetExecutionResult(executionID string) (client.ExecutionResultResponse, error)
 	EnrichExecutionDetailWithDrift(detail *client.ExecutionDetail) error
 	ListExecutionSteps(executionID string) ([]client.ExecutionStep, error)
 	CancelExecution(ctx context.Context, executionID string) (*client.CancelExecutionResponse, error)

--- a/internal/client/kubernetes.go
+++ b/internal/client/kubernetes.go
@@ -10,21 +10,22 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 type PodSummary struct {
-	UID              string  `json:"uid"`
-	Name             string  `json:"name"`
-	Namespace        *string `json:"namespace"`
-	Phase            string  `json:"phase"`
-	Ready            string  `json:"ready"`
-	Restarts         int     `json:"restarts"`
-	LastRestartTime  *string `json:"last_restart_time"`
-	StartTime        *string `json:"start_time"`
-	PodIP            *string `json:"pod_ip"`
-	NodeName         *string `json:"node_name"`
-	NominatedNode    *string `json:"nominated_node_name"`
-	ReadinessGates   *string `json:"readiness_gates"`
+	UID             string  `json:"uid"`
+	Name            string  `json:"name"`
+	Namespace       *string `json:"namespace"`
+	Phase           string  `json:"phase"`
+	Ready           string  `json:"ready"`
+	Restarts        int     `json:"restarts"`
+	LastRestartTime *string `json:"last_restart_time"`
+	StartTime       *string `json:"start_time"`
+	PodIP           *string `json:"pod_ip"`
+	NodeName        *string `json:"node_name"`
+	NominatedNode   *string `json:"nominated_node_name"`
+	ReadinessGates  *string `json:"readiness_gates"`
 }
 
 type CacheInfo struct {
@@ -105,14 +106,14 @@ type GetResourcesRequest struct {
 }
 
 type ResourceResponseItem struct {
-	Status       string        `json:"status"`
-	Group        *string       `json:"group"`
-	Items        []interface{} `json:"items"`
-	Kind         string        `json:"kind"`
-	Name         *string       `json:"name"`
-	Namespace    *string       `json:"namespace"`
-	Version      string        `json:"version"`
-	TotalCount   *int          `json:"total_count"`
+	Status     string        `json:"status"`
+	Group      *string       `json:"group"`
+	Items      []interface{} `json:"items"`
+	Kind       string        `json:"kind"`
+	Name       *string       `json:"name"`
+	Namespace  *string       `json:"namespace"`
+	Version    string        `json:"version"`
+	TotalCount *int          `json:"total_count"`
 }
 
 type GetResourcesResponse struct {
@@ -164,7 +165,18 @@ type PodLogOptions struct {
 	ContainerName string
 	TailLines     int
 	SinceSeconds  int
+	// Follow keeps the stream open for new lines (kubectl logs -f). When
+	// false the client returns once the backlog has drained: the platform's
+	// log route only follows, so the drain is detected client-side as an
+	// idle gap after the first batch (or the server's keepalive comment,
+	// which it only sends once it has nothing buffered).
+	Follow bool
 }
+
+// podLogsDrainIdle is how long a non-follow read waits for another line
+// after the last one before deciding the backlog is drained. The agent
+// pushes the backlog in quick batches, so a genuine gap means it is done.
+const podLogsDrainIdle = 2 * time.Second
 
 func (c *Client) StreamPodLogs(ctx context.Context, clusterID string, opts PodLogOptions, writer io.Writer) error {
 	params := url.Values{}
@@ -213,24 +225,107 @@ func (c *Client) StreamPodLogs(ctx context.Context, clusterID string, opts PodLo
 
 	scanner := bufio.NewScanner(resp.Body)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "event: error" {
-			if scanner.Scan() {
-				errLine := strings.TrimPrefix(scanner.Text(), "data:")
-				errLine = strings.TrimPrefix(errLine, " ")
-				return fmt.Errorf("%s", errLine)
+	if opts.Follow {
+		for scanner.Scan() {
+			if done, lineError := writePodLogLine(scanner, writer); done || lineError != nil {
+				return lineError
 			}
 		}
-		if strings.HasPrefix(line, "data:") {
-			data := strings.TrimPrefix(line, "data:")
-			data = strings.TrimPrefix(data, " ")
-			if _, err := fmt.Fprintln(writer, data); err != nil {
-				return fmt.Errorf("write output: %w", err)
-			}
+		return scanner.Err()
+	}
+	return drainPodLogs(ctx, scanner, resp, writer)
+}
+
+// writePodLogLine handles one SSE line: an error event surfaces as the
+// error, a data line is written. done reports an error event was consumed.
+func writePodLogLine(scanner *bufio.Scanner, writer io.Writer) (bool, error) {
+	line := scanner.Text()
+	if line == "event: error" {
+		if scanner.Scan() {
+			errLine := strings.TrimPrefix(scanner.Text(), "data:")
+			errLine = strings.TrimPrefix(errLine, " ")
+			return true, fmt.Errorf("%s", errLine)
+		}
+		return true, nil
+	}
+	if strings.HasPrefix(line, "data:") {
+		data := strings.TrimPrefix(line, "data:")
+		data = strings.TrimPrefix(data, " ")
+		if _, err := fmt.Fprintln(writer, data); err != nil {
+			return false, fmt.Errorf("write output: %w", err)
 		}
 	}
-	return scanner.Err()
+	return false, nil
+}
+
+// drainPodLogs reads the follow stream until the backlog is drained - the
+// first idle gap after at least one line, or a server keepalive comment
+// (sent only when nothing is buffered) - then closes the response so the
+// server tears the stream down. A stream that ends on its own returns its
+// scanner error, if any.
+func drainPodLogs(ctx context.Context, scanner *bufio.Scanner, resp *http.Response, writer io.Writer) error {
+	lines := make(chan string)
+	scanErrors := make(chan error, 1)
+	go func() {
+		defer close(lines)
+		for scanner.Scan() {
+			select {
+			case lines <- scanner.Text():
+			case <-ctx.Done():
+				return
+			}
+		}
+		scanErrors <- scanner.Err()
+	}()
+	idle := time.NewTimer(podLogsDrainIdle)
+	defer idle.Stop()
+	sawLine := false
+	pendingError := false
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-idle.C:
+			if sawLine {
+				closeBody(resp)
+				return nil
+			}
+			idle.Reset(podLogsDrainIdle)
+		case line, open := <-lines:
+			if !open {
+				select {
+				case scanError := <-scanErrors:
+					return scanError
+				default:
+					return nil
+				}
+			}
+			switch {
+			case pendingError:
+				errLine := strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " ")
+				return fmt.Errorf("%s", errLine)
+			case line == "event: error":
+				pendingError = true
+				continue
+			case strings.HasPrefix(line, ":") && sawLine:
+				closeBody(resp)
+				return nil
+			case strings.HasPrefix(line, "data:"):
+				data := strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " ")
+				if _, err := fmt.Fprintln(writer, data); err != nil {
+					return fmt.Errorf("write output: %w", err)
+				}
+				sawLine = true
+			}
+			if !idle.Stop() {
+				select {
+				case <-idle.C:
+				default:
+				}
+			}
+			idle.Reset(podLogsDrainIdle)
+		}
+	}
 }
 
 type HelmReleasesRequestItem struct {
@@ -363,8 +458,8 @@ func (c *Client) UninstallHelmRelease(clusterID, releaseName, namespace string) 
 }
 
 type ApiErrorResponse struct {
-	ErrorCode string  `json:"error_code"`
-	Detail    string  `json:"detail"`
+	ErrorCode  string `json:"error_code"`
+	Detail     string `json:"detail"`
 	RetryAfter *int   `json:"retry_after"`
 }
 

--- a/internal/client/kubernetes_logs_follow_test.go
+++ b/internal/client/kubernetes_logs_follow_test.go
@@ -1,0 +1,109 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestStreamPodLogsFollowFalseDrainsAndReturns pins the --follow=false lane
+// against a server that never closes the stream (the platform log route only
+// follows): the client prints the backlog burst, then returns once the idle
+// gap passes, instead of hanging until the caller kills it.
+func TestStreamPodLogsFollowFalseDrainsAndReturns(t *testing.T) {
+	handlerDone := make(chan struct{})
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		defer close(handlerDone)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		_, _ = fmt.Fprintln(w, "data: backlog one")
+		_, _ = fmt.Fprintln(w, "data: backlog two")
+		flusher.Flush()
+		// Hold the stream open like the real route does; the client must
+		// leave on its own. Give up after a bound so a regression cannot
+		// hang the test suite.
+		select {
+		case <-r.Context().Done():
+		case <-time.After(15 * time.Second):
+			t.Error("client never closed the non-follow stream")
+		}
+	}
+	testClient := newTestClient(t, handler)
+	var buf bytes.Buffer
+	started := time.Now()
+	err := testClient.StreamPodLogs(context.Background(), "cluster-id",
+		PodLogOptions{Namespace: "default", PodName: "nginx-abc", Follow: false}, &buf)
+	if err != nil {
+		t.Fatalf("StreamPodLogs() error = %v", err)
+	}
+	if buf.String() != "backlog one\nbacklog two\n" {
+		t.Fatalf("output = %q", buf.String())
+	}
+	if elapsed := time.Since(started); elapsed > 10*time.Second {
+		t.Fatalf("drain took %s; expected to return shortly after the idle gap", elapsed)
+	}
+	<-handlerDone
+}
+
+// TestStreamPodLogsFollowFalseStopsOnKeepalive pins the fast path: the
+// server's keepalive comment after a batch means nothing is buffered, so the
+// client returns immediately without waiting out the idle gap.
+func TestStreamPodLogsFollowFalseStopsOnKeepalive(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		_, _ = fmt.Fprintln(w, "data: only line")
+		_, _ = fmt.Fprintln(w, ": keepalive")
+		flusher.Flush()
+		select {
+		case <-r.Context().Done():
+		case <-time.After(15 * time.Second):
+			t.Error("client never closed the non-follow stream after keepalive")
+		}
+	}
+	testClient := newTestClient(t, handler)
+	var buf bytes.Buffer
+	started := time.Now()
+	err := testClient.StreamPodLogs(context.Background(), "cluster-id",
+		PodLogOptions{Namespace: "default", PodName: "nginx-abc", Follow: false}, &buf)
+	if err != nil {
+		t.Fatalf("StreamPodLogs() error = %v", err)
+	}
+	if buf.String() != "only line\n" {
+		t.Fatalf("output = %q", buf.String())
+	}
+	if elapsed := time.Since(started); elapsed > podLogsDrainIdle {
+		t.Fatalf("keepalive should end the drain before the idle gap, took %s", elapsed)
+	}
+}
+
+// TestStreamPodLogsFollowTrueReadsUntilStreamEnds pins the default: with
+// Follow set the client keeps reading and only returns when the server
+// closes the stream.
+func TestStreamPodLogsFollowTrueReadsUntilStreamEnds(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		_, _ = fmt.Fprintln(w, "data: first")
+		flusher.Flush()
+		time.Sleep(3 * podLogsDrainIdle)
+		_, _ = fmt.Fprintln(w, "data: late arrival")
+		flusher.Flush()
+	}
+	testClient := newTestClient(t, handler)
+	var buf bytes.Buffer
+	err := testClient.StreamPodLogs(context.Background(), "cluster-id",
+		PodLogOptions{Namespace: "default", PodName: "nginx-abc", Follow: true}, &buf)
+	if err != nil {
+		t.Fatalf("StreamPodLogs() error = %v", err)
+	}
+	if buf.String() != "first\nlate arrival\n" {
+		t.Fatalf("follow mode must read past idle gaps, got %q", buf.String())
+	}
+}


### PR DESCRIPTION
Bead: ankra-tycp (surfaced while diagnosing the wedged `upcloud-event-verify-3` teardown; backend fix in ankraio/cluster#1272).

Two CLI gaps hit while dogfooding an incident purely through `ankra` (no kubectl, no psql):

## 1. `ankra cluster operations steps <id> --results`

`steps` only showed a status and a truncated error excerpt. The platform already records a per-step **result payload** — what a teardown deleted/skipped/failed to reclaim (`force_cleanup_*` from cluster#1246/#1260), or the full error body — at `GET /executions/{id}/result`, and `internal/client` even had `GetExecutionResult` wired. Nothing exposed it, so job forensics meant kubectl or the DB.

- `--results` fetches the payload and prints each step's result as indented JSON under the table. Steps that never finished are listed as `no result recorded` rather than silently omitted.
- `-o json|yaml` gains a `step_results` list in step order; without the flag the shape is unchanged.
- `GetExecutionResult` added to `APIClient` + `baseMock` (was dead code).

Verified live against the wedged execution:
```
Step results:
  upcloud_delete_router (57131da1-…):
    { "error": "UpCloud API 409: Router change conflict. Try again later.", … }
  upcloud_delete_credential (ff1ae305-…): no result recorded
```

## 2. `ankra cluster logs --follow=false`

`logs` always followed the platform's SSE log route, so `ankra cluster logs … | grep` hung until killed — useless in a script. `--follow` (`-f`) now defaults to true (unchanged `kubectl logs -f` behaviour); `--follow=false` drains the backlog client-side and exits: it returns on the first idle gap after a batch, or immediately on the server keepalive comment (which only arrives once nothing is buffered). The route is untouched (it only follows; the frozen SSE contract is not modified) — this is purely a client-side drain.

Verified live: `--follow=false` against a busy scheduler pod returned 34–50 lines and exit 0 on its own; a follow-mode read of the same pod over 25s returned the same lines +2 that arrived meanwhile, so the drain is faithful.

## Tests
- steps: `--results` calls the endpoint once and merges `step_results` in step order; plain `steps` never calls it and keeps its JSON shape; a failed result fetch surfaces as the command error.
- logs: non-follow drain returns in exactly the idle gap against a never-closing server (2.00s); keepalive ends the drain immediately (0.00s); follow mode reads past a 6s gap. Existing `TestStreamPodLogs` table (zero-value `Follow`) still passes.
- Full `go test ./...` + `golangci-lint` clean.