### PR TITLE
feat(demo): per-component deploy flags and component-aware demo output (ankra-7ade)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,31 @@
   keeps the cluster's volumes (previously it always deleted them, so a
   stopped Hetzner cluster restarted with empty storage); pass `--force` to
   get the old reclaim-everything behaviour.
+- **`ankra application demo` speaks multi-component.** A monorepo demo runs
+  every component as its own pod, and the CLI could neither steer that nor
+  show it. `demo deploy` gains `--component` (repeatable) to narrow a launch
+  to the components you name, `--component-tag`, `--component-port` and
+  `--component-path` to tune one component each as `NAME=VALUE`, and
+  `--entry-component` to say which one owns the demo host's root path
+  instead of leaving it to the entry heuristic. Because the selection and
+  the overrides ride the same request field, an override may only name a
+  component `--component` selects, and the CLI says so rather than letting
+  the launch silently narrow to that one component. `demo list` and
+  `demo detail` now print a summary — every demo's components, which one is
+  the entry, and each component's port, ingress path, image tag and pod —
+  instead of a raw JSON document; `-o json` and `-o yaml` still emit the
+  untouched payload, including the resource inventory and events the
+  summary leaves out. `demo logs` gains `--component` to read the pod
+  belonging to one component of a multi-component demo (and `--pod` to name
+  one directly), so reading the API's logs no longer means finding its pod
+  by hand.
+
+### Fixed
+
+- **`ankra application demo logs --tail` is no longer ignored.** The flag
+  was sent as `tail`, but the endpoint reads `tail_lines`, so every demo log
+  fetch silently returned the backend's default tail no matter what you
+  asked for.
 
 ## v0.11.0-rc4 — 2026-08-17
 

--- a/cmd/application_demo.go
+++ b/cmd/application_demo.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strconv"
 	"strings"
 
 	"ankra/internal/client"
@@ -36,7 +38,11 @@ func newApplicationDemoDetailCommand() *cobra.Command {
 	detailCommand := &cobra.Command{
 		Use:   "detail <application-id> <workspace-id>",
 		Short: "Show a demo workspace's record, provisioning steps, and failure detail",
-		Args:  cobra.ExactArgs(2),
+		Long: `Show a demo workspace's record, its components, provisioning steps, and
+failure detail. The default rendering summarises the demo; -o json or
+-o yaml emit the full payload, including the resource inventory and the
+Kubernetes events behind a stalled step.`,
+		Args: cobra.ExactArgs(2),
 		RunE: func(command *cobra.Command, arguments []string) error {
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
 				return formatError
@@ -46,7 +52,7 @@ func newApplicationDemoDetailCommand() *cobra.Command {
 			if detailError != nil {
 				return detailError
 			}
-			return renderApplicationPayload(command, payload)
+			return renderApplicationDemoDetail(command, payload)
 		},
 	}
 	registerStructuredOutputFlags(detailCommand)
@@ -57,15 +63,39 @@ func newApplicationDemoLogsCommand() *cobra.Command {
 	logsCommand := &cobra.Command{
 		Use:   "logs <application-id> <workspace-id>",
 		Short: "Fetch a bounded tail of the demo container's logs",
-		Long:  "Fetch a bounded tail of the demo container's logs. One-shot: the command returns after the fetch instead of following the stream.",
-		Args:  cobra.ExactArgs(2),
+		Long: `Fetch a bounded tail of the demo container's logs. One-shot: the command
+returns after the fetch instead of following the stream.
+
+A multi-component demo runs one pod per component, and without a selector
+the backend reads whichever pod it finds first. --component picks the pod
+belonging to that component; --pod addresses one by name (from
+` + "`ankra application demo detail`" + `) when a component has more than one.`,
+		Example: `  ankra application demo logs <app-id> <workspace-id> --tail 500
+  ankra application demo logs <app-id> <workspace-id> --component crm-api`,
+		Args: cobra.ExactArgs(2),
 		RunE: func(command *cobra.Command, arguments []string) error {
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
 				return formatError
 			}
+			applicationID := strings.TrimSpace(arguments[0])
+			workspaceID := strings.TrimSpace(arguments[1])
 			tailLines, _ := command.Flags().GetInt("tail")
+			componentName, _ := command.Flags().GetString("component")
+			componentName = strings.TrimSpace(componentName)
+			podName, _ := command.Flags().GetString("pod")
+			podName = strings.TrimSpace(podName)
+			if componentName != "" && podName != "" {
+				return withExitCode(exitUsage, errors.New("--component and --pod are mutually exclusive"))
+			}
+			if componentName != "" {
+				resolved, resolveError := resolveDemoComponentPod(command, applicationID, workspaceID, componentName)
+				if resolveError != nil {
+					return resolveError
+				}
+				podName = resolved
+			}
 			payload, logsError := apiClient.GetApplicationDemoLogs(command.Context(),
-				strings.TrimSpace(arguments[0]), strings.TrimSpace(arguments[1]), tailLines)
+				applicationID, workspaceID, podName, tailLines)
 			if logsError != nil {
 				return logsError
 			}
@@ -73,8 +103,61 @@ func newApplicationDemoLogsCommand() *cobra.Command {
 		},
 	}
 	logsCommand.Flags().Int("tail", 200, "Number of log lines from the end")
+	logsCommand.Flags().String("component", "", "Read the pod belonging to this component of a multi-component demo")
+	logsCommand.Flags().String("pod", "", "Read this pod by name (default: the demo's own pod)")
 	registerStructuredOutputFlags(logsCommand)
 	return logsCommand
+}
+
+// resolveDemoComponentPod maps a component name to the pod whose logs to
+// read. The logs endpoint addresses pods, not components, so the selector is
+// resolved here from the detail payload's inventory, whose Pod entries carry
+// the component they belong to. A ready pod wins over a present one: a
+// redeploy leaves the previous rollout's pods in the inventory, and their
+// logs describe the code that was replaced.
+func resolveDemoComponentPod(command *cobra.Command, applicationID string,
+	workspaceID string, componentName string) (string, error) {
+	payload, detailError := apiClient.GetApplicationDemoDetail(command.Context(), applicationID, workspaceID)
+	if detailError != nil {
+		return "", detailError
+	}
+	var detail demoDetailDocument
+	if unmarshalError := json.Unmarshal(payload, &detail); unmarshalError != nil {
+		return "", fmt.Errorf("parsing demo detail: %w", unmarshalError)
+	}
+
+	candidate := ""
+	componentHasPod := false
+	for _, resource := range detail.Inspection.Resources {
+		if resource.Kind != "Pod" || !strings.EqualFold(resource.Component, componentName) {
+			continue
+		}
+		componentHasPod = true
+		if !resource.Present {
+			continue
+		}
+		if resource.Status == "ready" {
+			return resource.Name, nil
+		}
+		if candidate == "" {
+			candidate = resource.Name
+		}
+	}
+	if candidate != "" {
+		return candidate, nil
+	}
+	if componentHasPod {
+		return "", withExitCode(exitNotFound, fmt.Errorf(
+			"component %q has no pod on the cluster yet; run 'ankra application demo detail %s %s' for its provisioning state",
+			componentName, applicationID, workspaceID))
+	}
+	known := detail.Demo.componentNames()
+	if len(known) == 0 {
+		return "", withExitCode(exitNotFound, fmt.Errorf(
+			"this demo records no components, so --component %q cannot be resolved", componentName))
+	}
+	return "", withExitCode(exitNotFound, fmt.Errorf(
+		"component %q is not part of this demo; it runs: %s", componentName, strings.Join(known, ", ")))
 }
 
 func newApplicationDemoConfigCommand() *cobra.Command {
@@ -235,7 +318,10 @@ func newApplicationDemoListCommand() *cobra.Command {
 	listCommand := &cobra.Command{
 		Use:   "list <application-id>",
 		Short: "List the application's active demo workspaces",
-		Args:  cobra.ExactArgs(1),
+		Long: `List the application's active demo workspaces, one row each, with the
+components every demo runs. -o json or -o yaml emit the full payload,
+including the TTL policy and the staging cluster's status.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(command *cobra.Command, arguments []string) error {
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
 				return formatError
@@ -244,7 +330,7 @@ func newApplicationDemoListCommand() *cobra.Command {
 			if listError != nil {
 				return listError
 			}
-			return renderApplicationPayload(command, payload)
+			return renderApplicationDemoList(command, payload)
 		},
 	}
 	registerStructuredOutputFlags(listCommand)
@@ -284,9 +370,20 @@ func newApplicationDemoDeployCommand() *cobra.Command {
 		Long: `Deploy a short-lived demo workspace for a branch or pull request.
 
 All flags are optional; only the flags you set are sent, so the backend
-applies its own defaults for the rest.`,
+applies its own defaults for the rest.
+
+A monorepo demo runs every recorded component as its own pod by default.
+--component narrows that to the components you name, and the per-component
+override flags (--component-tag, --component-port, --component-path) tune
+one component each. Because selection and overrides ride the same request
+field, an override may only name a component that --component selects: to
+tune one component of a full launch, list them all.`,
 		Example: `  ankra application demo deploy <app-id> --branch feature/login
-  ankra application demo deploy <app-id> --pr-number 42 --ttl-hours 8`,
+  ankra application demo deploy <app-id> --pr-number 42 --ttl-hours 8
+  ankra application demo deploy <app-id> --branch main \
+    --component crm-frontend --component crm-api \
+    --component-port crm-api=8090 --component-path crm-api=/api \
+    --entry-component crm-frontend`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(command *cobra.Command, arguments []string) error {
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
@@ -313,6 +410,15 @@ applies its own defaults for the rest.`,
 				containerPort, _ := command.Flags().GetInt("container-port")
 				demoRequest.ContainerPort = &containerPort
 			}
+			components, componentsError := demoComponentsFromFlags(command)
+			if componentsError != nil {
+				return componentsError
+			}
+			demoRequest.Components = components
+			if command.Flags().Changed("entry-component") {
+				entryComponent, _ := command.Flags().GetString("entry-component")
+				demoRequest.EntryComponent = &entryComponent
+			}
 			payload, deployError := apiClient.DeployApplicationDemo(command.Context(), strings.TrimSpace(arguments[0]), demoRequest)
 			if deployError != nil {
 				return deployError
@@ -325,8 +431,115 @@ applies its own defaults for the rest.`,
 	deployCommand.Flags().String("image-tag", "", "Explicit container image tag to deploy")
 	deployCommand.Flags().Int("ttl-hours", 0, "Lifetime of the demo workspace in hours")
 	deployCommand.Flags().Int("container-port", 0, "Container port to expose")
+	deployCommand.Flags().StringArray("component", nil,
+		"Component of a monorepo to deploy (repeatable; omitted deploys every component)")
+	deployCommand.Flags().StringArray("component-tag", nil,
+		"Image tag for one selected component as NAME=TAG (repeatable)")
+	deployCommand.Flags().StringArray("component-port", nil,
+		"Container port for one selected component as NAME=PORT (repeatable)")
+	deployCommand.Flags().StringArray("component-path", nil,
+		"Ingress path prefix for one selected component as NAME=/prefix (repeatable; empty keeps it in-cluster only)")
+	deployCommand.Flags().String("entry-component", "",
+		"Component that owns the demo host's root path (default: the backend's entry heuristic)")
 	registerStructuredOutputFlags(deployCommand)
 	return deployCommand
+}
+
+// demoComponentsFromFlags builds the request's components[] from --component
+// and the per-component override flags. It returns nil when no component was
+// named, which is how the backend is told to deploy every recorded one.
+//
+// The overrides are keyed by component name rather than positionally so the
+// flags read the same way in any order, and every override must name a
+// selected component: components[] carries the selection as well as the
+// overrides, so an override for an unlisted component would silently narrow
+// the launch to that component alone.
+func demoComponentsFromFlags(command *cobra.Command) ([]client.DeployApplicationDemoComponent, error) {
+	names, _ := command.Flags().GetStringArray("component")
+	imageTags, tagError := demoComponentOverrides(command, "component-tag")
+	if tagError != nil {
+		return nil, tagError
+	}
+	ports, portError := demoComponentOverrides(command, "component-port")
+	if portError != nil {
+		return nil, portError
+	}
+	paths, pathError := demoComponentOverrides(command, "component-path")
+	if pathError != nil {
+		return nil, pathError
+	}
+
+	positionByName := map[string]int{}
+	components := make([]client.DeployApplicationDemoComponent, 0, len(names))
+	for _, rawName := range names {
+		name := strings.TrimSpace(rawName)
+		if name == "" {
+			return nil, withExitCode(exitUsage, errors.New("--component cannot be empty"))
+		}
+		if _, duplicate := positionByName[name]; duplicate {
+			return nil, withExitCode(exitUsage, fmt.Errorf("--component %q is listed more than once", name))
+		}
+		positionByName[name] = len(components)
+		components = append(components, client.DeployApplicationDemoComponent{Name: name})
+	}
+
+	for _, override := range []struct {
+		flagName string
+		values   map[string]string
+		apply    func(*client.DeployApplicationDemoComponent, string) error
+	}{
+		{"component-tag", imageTags, func(component *client.DeployApplicationDemoComponent, value string) error {
+			component.ImageTag = &value
+			return nil
+		}},
+		{"component-port", ports, func(component *client.DeployApplicationDemoComponent, value string) error {
+			port, conversionError := strconv.Atoi(strings.TrimSpace(value))
+			if conversionError != nil {
+				return fmt.Errorf("--component-port %q is not a number", value)
+			}
+			component.ContainerPort = &port
+			return nil
+		}},
+		{"component-path", paths, func(component *client.DeployApplicationDemoComponent, value string) error {
+			component.IngressPath = &value
+			return nil
+		}},
+	} {
+		for name, value := range override.values {
+			position, selected := positionByName[name]
+			if !selected {
+				return nil, withExitCode(exitUsage, fmt.Errorf(
+					"--%s names component %q, which --component does not select; add --component %s",
+					override.flagName, name, name))
+			}
+			if applyError := override.apply(&components[position], value); applyError != nil {
+				return nil, withExitCode(exitUsage, applyError)
+			}
+		}
+	}
+	if len(components) == 0 {
+		return nil, nil
+	}
+	return components, nil
+}
+
+// demoComponentOverrides parses one repeatable NAME=VALUE override flag.
+// A repeated name overrides by name, matching --env on `demo config set`.
+func demoComponentOverrides(command *cobra.Command, flagName string) (map[string]string, error) {
+	entries, _ := command.Flags().GetStringArray(flagName)
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	values := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		name, value, found := strings.Cut(entry, "=")
+		name = strings.TrimSpace(name)
+		if !found || name == "" {
+			return nil, withExitCode(exitUsage, fmt.Errorf("--%s entries must be NAME=VALUE", flagName))
+		}
+		values[name] = value
+	}
+	return values, nil
 }
 
 func newApplicationDemoStopCommand() *cobra.Command {

--- a/cmd/application_demo_render.go
+++ b/cmd/application_demo_render.go
@@ -1,0 +1,361 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+// The demo list and detail payloads are the only application subresources the
+// CLI renders itself rather than dumping. A multi-component demo runs one pod
+// per component, and the components array — which one owns the demo host's
+// root path, which port and ingress path each got, which image tag each is
+// running — is the part a human actually reads; scrolling a nested JSON
+// document to find it is not reading.
+//
+// These documents decode only the fields the rendering needs. Everything else
+// on the wire is reachable untouched through -o json|yaml, so the backend can
+// add fields without this file caring, and a payload it cannot decode falls
+// back to the raw JSON rather than failing a read.
+
+// demoComponentDocument is one entry of a demo record's components array.
+type demoComponentDocument struct {
+	Name          string `json:"name"`
+	ImageTag      string `json:"image_tag"`
+	ContainerPort int    `json:"container_port"`
+	IngressPath   string `json:"ingress_path"`
+	Entry         bool   `json:"entry"`
+}
+
+// demoDocument is the demo record as list and detail both carry it.
+type demoDocument struct {
+	ID            string                  `json:"id"`
+	Status        string                  `json:"status"`
+	Branch        *string                 `json:"branch"`
+	PRNumber      *int                    `json:"pr_number"`
+	Namespace     string                  `json:"namespace"`
+	PreviewURL    *string                 `json:"preview_url"`
+	ImageTag      *string                 `json:"image_tag"`
+	Component     *string                 `json:"component"`
+	ContainerPort *int                    `json:"container_port"`
+	Components    []demoComponentDocument `json:"components"`
+	LastError     *string                 `json:"last_error"`
+	ExpiresAt     string                  `json:"expires_at"`
+	CreatedAt     string                  `json:"created_at"`
+	DemoStackName *string                 `json:"demo_stack_name"`
+}
+
+// demoListDocument is the GET /demos payload. Demos is a pointer so an
+// absent key is distinguishable from an empty list: "no active demos" is a
+// claim about the application, and a payload that never carried the key must
+// not be summarised into it.
+type demoListDocument struct {
+	Demos *[]demoDocument `json:"demos"`
+}
+
+// demoStepDocument is one provisioning step of the detail payload.
+type demoStepDocument struct {
+	Label  string `json:"label"`
+	Status string `json:"status"`
+	Detail string `json:"detail"`
+}
+
+// demoResourceDocument is one inventory entry of the detail payload. Pod
+// entries carry the component they belong to, which is what resolves
+// `demo logs --component` to a pod name.
+type demoResourceDocument struct {
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Component string `json:"component"`
+	Present   bool   `json:"present"`
+	Status    string `json:"status"`
+}
+
+// demoDetailDocument is the GET /demos/{id}/detail payload.
+type demoDetailDocument struct {
+	Demo       demoDocument `json:"demo"`
+	Inspection struct {
+		ClusterReachable  bool                   `json:"cluster_reachable"`
+		UnreachableReason string                 `json:"unreachable_reason"`
+		Steps             []demoStepDocument     `json:"steps"`
+		Resources         []demoResourceDocument `json:"resources"`
+	} `json:"inspection"`
+}
+
+// componentNames lists the demo's components in record order, degrading to
+// the legacy single-component scalar for rows predating multi-component
+// demos.
+func (demo demoDocument) componentNames() []string {
+	if len(demo.Components) == 0 {
+		if demo.Component != nil && *demo.Component != "" {
+			return []string{*demo.Component}
+		}
+		return nil
+	}
+	names := make([]string, 0, len(demo.Components))
+	for _, component := range demo.Components {
+		names = append(names, component.Name)
+	}
+	return names
+}
+
+// source describes what the demo was launched from: its branch, its pull
+// request, or nothing recorded.
+func (demo demoDocument) source() string {
+	switch {
+	case demo.Branch != nil && *demo.Branch != "":
+		return *demo.Branch
+	case demo.PRNumber != nil && *demo.PRNumber > 0:
+		return "PR #" + strconv.Itoa(*demo.PRNumber)
+	default:
+		return "-"
+	}
+}
+
+// renderApplicationDemoList prints one row per demo with the components it
+// runs. -o json|yaml keep the untouched payload, which also carries the TTL
+// policy and staging-cluster status this summary leaves out.
+func renderApplicationDemoList(command *cobra.Command, payload json.RawMessage) error {
+	format, formatError := structuredFormatFromFlags(command)
+	if formatError != nil {
+		return formatError
+	}
+	if format != outputDefault {
+		return renderApplicationPayload(command, payload)
+	}
+	var document demoListDocument
+	if unmarshalError := json.Unmarshal(payload, &document); unmarshalError != nil || document.Demos == nil {
+		return renderApplicationPayload(command, payload)
+	}
+	demos := *document.Demos
+
+	output := command.OutOrStdout()
+	if len(demos) == 0 {
+		_, _ = fmt.Fprintln(output, "No active demo workspaces.")
+		return nil
+	}
+	writer := table.NewWriter()
+	writer.SetOutputMirror(output)
+	writer.SetStyle(table.StyleRounded)
+	writer.AppendHeader(table.Row{"ID", "Status", "Source", "Components", "URL", "Expires"})
+	entryMarked := false
+	for _, demo := range demos {
+		components, marked := demoComponentSummary(demo)
+		entryMarked = entryMarked || marked
+		previewURL := "-"
+		if demo.PreviewURL != nil && *demo.PreviewURL != "" {
+			previewURL = *demo.PreviewURL
+		}
+		writer.AppendRow(table.Row{
+			demo.ID, demo.Status, demo.source(), components, previewURL,
+			formatDemoExpiry(demo.ExpiresAt),
+		})
+	}
+	writer.Render()
+	if entryMarked {
+		_, _ = fmt.Fprintln(output, "* entry component — owns the demo host's root path")
+	}
+	return nil
+}
+
+// demoComponentSummary is the components column: every component the demo
+// runs, the entry one marked. It reports whether it marked an entry so the
+// caller only prints the legend when there is something to explain.
+func demoComponentSummary(demo demoDocument) (string, bool) {
+	if len(demo.Components) == 0 {
+		if demo.Component != nil && *demo.Component != "" {
+			return *demo.Component, false
+		}
+		return "-", false
+	}
+	marked := false
+	labels := make([]string, 0, len(demo.Components))
+	for _, component := range demo.Components {
+		label := component.Name
+		if component.Entry {
+			label += "*"
+			marked = true
+		}
+		labels = append(labels, label)
+	}
+	return strings.Join(labels, ", "), marked
+}
+
+// renderApplicationDemoDetail prints the demo's record, its components, and
+// its provisioning steps. The resource inventory and the namespace's
+// Kubernetes events stay behind -o json|yaml: they are the deep debugging
+// material, and printing them by default buries the summary a stalled demo
+// is actually read for.
+func renderApplicationDemoDetail(command *cobra.Command, payload json.RawMessage) error {
+	format, formatError := structuredFormatFromFlags(command)
+	if formatError != nil {
+		return formatError
+	}
+	if format != outputDefault {
+		return renderApplicationPayload(command, payload)
+	}
+	var document demoDetailDocument
+	// A payload without a demo record is not the document this summarises —
+	// an error envelope, or a wire shape the CLI has not caught up with.
+	// Either way the raw JSON is more use than a summary of nothing.
+	if unmarshalError := json.Unmarshal(payload, &document); unmarshalError != nil || document.Demo.ID == "" {
+		return renderApplicationPayload(command, payload)
+	}
+
+	output := command.OutOrStdout()
+	demo := document.Demo
+	_, _ = fmt.Fprintf(output, "Demo %s\n", demo.ID)
+	writeDemoField(output, "Status", demo.Status)
+	writeDemoField(output, "Source", demo.source())
+	writeDemoField(output, "Namespace", demo.Namespace)
+	if demo.PreviewURL != nil {
+		writeDemoField(output, "URL", *demo.PreviewURL)
+	}
+	if demo.DemoStackName != nil {
+		writeDemoField(output, "Stack", *demo.DemoStackName)
+	}
+	writeDemoField(output, "Expires", formatDemoExpiry(demo.ExpiresAt))
+	if demo.LastError != nil && *demo.LastError != "" {
+		writeDemoField(output, "Last error", *demo.LastError)
+	}
+	if !document.Inspection.ClusterReachable {
+		reason := document.Inspection.UnreachableReason
+		if reason == "" {
+			reason = "the staging cluster could not be reached, so no live state is available"
+		}
+		writeDemoField(output, "Cluster", reason)
+	}
+
+	renderDemoComponents(output, demo, document.Inspection.Resources)
+	renderDemoSteps(output, document.Inspection.Steps)
+	return nil
+}
+
+// renderDemoComponents prints the components table, one row per workload,
+// with the pod each component's logs come from. A demo predating component
+// records has none, so its single workload is described from the record's
+// own scalars instead.
+func renderDemoComponents(output io.Writer, demo demoDocument, resources []demoResourceDocument) {
+	_, _ = fmt.Fprintln(output)
+	if len(demo.Components) == 0 {
+		_, _ = fmt.Fprintln(output, "Component:")
+		name := "-"
+		if demo.Component != nil && *demo.Component != "" {
+			name = *demo.Component
+		}
+		writeDemoField(output, "Name", name)
+		if demo.ImageTag != nil && *demo.ImageTag != "" {
+			writeDemoField(output, "Image tag", *demo.ImageTag)
+		}
+		if demo.ContainerPort != nil && *demo.ContainerPort > 0 {
+			writeDemoField(output, "Port", strconv.Itoa(*demo.ContainerPort))
+		}
+		return
+	}
+
+	podsByComponent := demoPodsByComponent(resources)
+	_, _ = fmt.Fprintln(output, "Components:")
+	writer := table.NewWriter()
+	writer.SetOutputMirror(output)
+	writer.SetStyle(table.StyleRounded)
+	writer.AppendHeader(table.Row{"Name", "Entry", "Port", "Path", "Image Tag", "Pods"})
+	for _, component := range demo.Components {
+		entry := ""
+		if component.Entry {
+			entry = "yes"
+		}
+		path := component.IngressPath
+		if component.Entry {
+			path = "/"
+		}
+		if path == "" {
+			path = "in-cluster only"
+		}
+		port := "-"
+		if component.ContainerPort > 0 {
+			port = strconv.Itoa(component.ContainerPort)
+		}
+		imageTag := component.ImageTag
+		if imageTag == "" {
+			imageTag = "-"
+		}
+		pods := "-"
+		if names := podsByComponent[component.Name]; len(names) > 0 {
+			pods = strings.Join(names, ", ")
+		}
+		writer.AppendRow(table.Row{component.Name, entry, port, path, imageTag, pods})
+	}
+	writer.Render()
+}
+
+// demoPodsByComponent groups the inventory's live pods by the component that
+// owns them, in a stable order so repeated calls print identically.
+func demoPodsByComponent(resources []demoResourceDocument) map[string][]string {
+	pods := map[string][]string{}
+	for _, resource := range resources {
+		if resource.Kind != "Pod" || resource.Component == "" || !resource.Present {
+			continue
+		}
+		pods[resource.Component] = append(pods[resource.Component], resource.Name)
+	}
+	for component := range pods {
+		sort.Strings(pods[component])
+	}
+	return pods
+}
+
+// renderDemoSteps prints the provisioning steps in order — the part that
+// explains what a demo stuck in provisioning is waiting on.
+func renderDemoSteps(output io.Writer, steps []demoStepDocument) {
+	if len(steps) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintln(output)
+	_, _ = fmt.Fprintln(output, "Steps:")
+	writer := table.NewWriter()
+	writer.SetOutputMirror(output)
+	writer.SetStyle(table.StyleRounded)
+	writer.AppendHeader(table.Row{"Step", "Status", "Detail"})
+	for _, step := range steps {
+		writer.AppendRow(table.Row{step.Label, step.Status, step.Detail})
+	}
+	writer.Render()
+}
+
+func writeDemoField(output io.Writer, label string, value string) {
+	if value == "" {
+		return
+	}
+	_, _ = fmt.Fprintf(output, "  %-12s %s\n", label+":", value)
+}
+
+// formatDemoExpiry renders a TTL deadline as the time left on it, which is
+// the question a demo's expiry is ever asked. An unparseable timestamp is
+// printed as it arrived rather than swallowed.
+func formatDemoExpiry(timestamp string) string {
+	if timestamp == "" {
+		return "-"
+	}
+	expiresAt, parseError := time.Parse(time.RFC3339, timestamp)
+	if parseError != nil {
+		return timestamp
+	}
+	remaining := time.Until(expiresAt)
+	switch {
+	case remaining <= 0:
+		return "expired"
+	case remaining < time.Hour:
+		return fmt.Sprintf("in %dm", int(remaining.Minutes()))
+	case remaining < 24*time.Hour:
+		return fmt.Sprintf("in %dh", int(remaining.Hours()))
+	default:
+		return fmt.Sprintf("in %dd", int(remaining.Hours()/24))
+	}
+}

--- a/cmd/application_demo_test.go
+++ b/cmd/application_demo_test.go
@@ -1,0 +1,327 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+// applicationDemoMock records the demo calls the command family makes, so the
+// tests can assert the request the flags built rather than the rendering.
+type applicationDemoMock struct {
+	baseMock
+	deployPayload json.RawMessage
+	detailPayload json.RawMessage
+	listPayload   json.RawMessage
+	logsPayload   json.RawMessage
+
+	demoRequest client.DeployApplicationDemoRequest
+	demoCalls   int
+	logsPod     string
+	logsTail    int
+	logsCalls   int
+	detailCalls int
+}
+
+func (mock *applicationDemoMock) DeployApplicationDemo(requestContext context.Context,
+	applicationID string, demoRequest client.DeployApplicationDemoRequest) (json.RawMessage, error) {
+	mock.demoCalls++
+	mock.demoRequest = demoRequest
+	return mock.deployPayload, nil
+}
+
+func (mock *applicationDemoMock) GetApplicationDemos(requestContext context.Context,
+	applicationID string) (json.RawMessage, error) {
+	return mock.listPayload, nil
+}
+
+func (mock *applicationDemoMock) GetApplicationDemoDetail(requestContext context.Context,
+	applicationID string, workspaceID string) (json.RawMessage, error) {
+	mock.detailCalls++
+	return mock.detailPayload, nil
+}
+
+func (mock *applicationDemoMock) GetApplicationDemoLogs(requestContext context.Context,
+	applicationID string, workspaceID string, podName string, tailLines int) (json.RawMessage, error) {
+	mock.logsCalls++
+	mock.logsPod = podName
+	mock.logsTail = tailLines
+	return mock.logsPayload, nil
+}
+
+const demoDetailFixture = `{
+  "demo": {
+    "id": "ws-1",
+    "status": "ready",
+    "branch": "main",
+    "namespace": "ankra-demo-br-553ae8f1",
+    "preview_url": "https://demo.example",
+    "expires_at": "2099-01-01T00:00:00Z",
+    "components": [
+      {"name": "crm-frontend", "image_tag": "sha-1363b7d", "container_port": 3000, "entry": true},
+      {"name": "crm-api", "image_tag": "sha-1363b7d", "container_port": 8090, "ingress_path": "/api"}
+    ]
+  },
+  "inspection": {
+    "cluster_reachable": true,
+    "steps": [{"label": "Workload", "status": "done", "detail": "Both deployments applied."}],
+    "resources": [
+      {"kind": "Pod", "name": "crm-api-old", "component": "crm-api", "present": true, "status": "failed"},
+      {"kind": "Pod", "name": "crm-api-new", "component": "crm-api", "present": true, "status": "ready"},
+      {"kind": "Pod", "name": "demo-front", "component": "crm-frontend", "present": true, "status": "ready"},
+      {"kind": "Deployment", "name": "crm-api", "component": "crm-api", "present": true, "status": "ready"}
+    ]
+  }
+}`
+
+func TestApplicationDemoDeployMapsComponentFlags(t *testing.T) {
+	mockClient := &applicationDemoMock{deployPayload: json.RawMessage(`{"workspace_id":"ws-1"}`)}
+	_, executeError := runApplicationCommand(t, mockClient,
+		"demo", "deploy", "app-1",
+		"--branch", "main",
+		"--component", "crm-frontend",
+		"--component", "crm-api",
+		"--component-tag", "crm-api=sha-1363b7d",
+		"--component-port", "crm-api=8090",
+		"--component-path", "crm-api=/api",
+		"--entry-component", "crm-frontend",
+	)
+	if executeError != nil {
+		t.Fatalf("demo deploy error = %v", executeError)
+	}
+	request := mockClient.demoRequest
+	if len(request.Components) != 2 {
+		t.Fatalf("components = %+v, want two", request.Components)
+	}
+	if request.Components[0].Name != "crm-frontend" || request.Components[1].Name != "crm-api" {
+		t.Errorf("components are not in flag order: %+v", request.Components)
+	}
+	if request.Components[0].ImageTag != nil || request.Components[0].ContainerPort != nil ||
+		request.Components[0].IngressPath != nil {
+		t.Errorf("crm-frontend picked up overrides meant for crm-api: %+v", request.Components[0])
+	}
+	api := request.Components[1]
+	if api.ImageTag == nil || *api.ImageTag != "sha-1363b7d" {
+		t.Errorf("crm-api image tag = %v", api.ImageTag)
+	}
+	if api.ContainerPort == nil || *api.ContainerPort != 8090 {
+		t.Errorf("crm-api container port = %v", api.ContainerPort)
+	}
+	if api.IngressPath == nil || *api.IngressPath != "/api" {
+		t.Errorf("crm-api ingress path = %v", api.IngressPath)
+	}
+	if request.EntryComponent == nil || *request.EntryComponent != "crm-frontend" {
+		t.Errorf("entry component = %v", request.EntryComponent)
+	}
+}
+
+func TestApplicationDemoDeployWithoutComponentFlagsSendsNoSelection(t *testing.T) {
+	mockClient := &applicationDemoMock{deployPayload: json.RawMessage(`{"workspace_id":"ws-1"}`)}
+	if _, executeError := runApplicationCommand(t, mockClient,
+		"demo", "deploy", "app-1", "--branch", "main"); executeError != nil {
+		t.Fatalf("demo deploy error = %v", executeError)
+	}
+	if mockClient.demoRequest.Components != nil {
+		t.Errorf("components = %+v, want nil so the backend deploys every component",
+			mockClient.demoRequest.Components)
+	}
+	if mockClient.demoRequest.EntryComponent != nil {
+		t.Errorf("entry component = %v, want nil", mockClient.demoRequest.EntryComponent)
+	}
+}
+
+func TestApplicationDemoDeployRejectsBadComponentFlags(t *testing.T) {
+	for name, arguments := range map[string][]string{
+		"override for an unselected component": {
+			"--component", "crm-frontend", "--component-port", "crm-api=8090"},
+		"override without any selection":   {"--component-tag", "crm-api=sha-1"},
+		"override missing the equals sign": {"--component", "crm-api", "--component-tag", "crm-api"},
+		"override with an empty name":      {"--component", "crm-api", "--component-port", "=8090"},
+		"non-numeric port":                 {"--component", "crm-api", "--component-port", "crm-api=web"},
+		"component listed twice":           {"--component", "crm-api", "--component", "crm-api"},
+		"empty component name":             {"--component", "  "},
+	} {
+		t.Run(name, func(t *testing.T) {
+			mockClient := &applicationDemoMock{}
+			_, executeError := runApplicationCommand(t, mockClient,
+				append([]string{"demo", "deploy", "app-1", "--branch", "main"}, arguments...)...)
+			if exitCodeFor(executeError) != exitUsage {
+				t.Errorf("exit code = %d, want %d: %v", exitCodeFor(executeError), exitUsage, executeError)
+			}
+			if mockClient.demoCalls != 0 {
+				t.Errorf("DeployApplicationDemo calls = %d, want 0", mockClient.demoCalls)
+			}
+		})
+	}
+}
+
+func TestApplicationDemoLogsResolvesComponentToReadyPod(t *testing.T) {
+	mockClient := &applicationDemoMock{
+		detailPayload: json.RawMessage(demoDetailFixture),
+		logsPayload:   json.RawMessage(`{"lines":["listening on 8090"]}`),
+	}
+	if _, executeError := runApplicationCommand(t, mockClient,
+		"demo", "logs", "app-1", "ws-1", "--component", "crm-api", "--tail", "500"); executeError != nil {
+		t.Fatalf("demo logs error = %v", executeError)
+	}
+	if mockClient.logsPod != "crm-api-new" {
+		t.Errorf("pod = %q, want the ready pod crm-api-new", mockClient.logsPod)
+	}
+	if mockClient.logsTail != 500 {
+		t.Errorf("tail = %d, want 500", mockClient.logsTail)
+	}
+}
+
+func TestApplicationDemoLogsWithoutComponentSkipsDetailLookup(t *testing.T) {
+	mockClient := &applicationDemoMock{logsPayload: json.RawMessage(`{"lines":[]}`)}
+	if _, executeError := runApplicationCommand(t, mockClient,
+		"demo", "logs", "app-1", "ws-1"); executeError != nil {
+		t.Fatalf("demo logs error = %v", executeError)
+	}
+	if mockClient.detailCalls != 0 {
+		t.Errorf("detail calls = %d, want 0 without a component selector", mockClient.detailCalls)
+	}
+	if mockClient.logsPod != "" {
+		t.Errorf("pod = %q, want empty so the backend picks the demo's pod", mockClient.logsPod)
+	}
+}
+
+func TestApplicationDemoLogsRejectsUnknownComponent(t *testing.T) {
+	mockClient := &applicationDemoMock{detailPayload: json.RawMessage(demoDetailFixture)}
+	output, executeError := runApplicationCommand(t, mockClient,
+		"demo", "logs", "app-1", "ws-1", "--component", "billing")
+	if exitCodeFor(executeError) != exitNotFound {
+		t.Fatalf("exit code = %d, want %d: %v", exitCodeFor(executeError), exitNotFound, executeError)
+	}
+	if mockClient.logsCalls != 0 {
+		t.Errorf("GetApplicationDemoLogs calls = %d, want 0", mockClient.logsCalls)
+	}
+	if !strings.Contains(output+executeError.Error(), "crm-api") {
+		t.Errorf("error does not name the demo's components: %v", executeError)
+	}
+}
+
+func TestApplicationDemoLogsRejectsComponentWithPod(t *testing.T) {
+	mockClient := &applicationDemoMock{detailPayload: json.RawMessage(demoDetailFixture)}
+	_, executeError := runApplicationCommand(t, mockClient,
+		"demo", "logs", "app-1", "ws-1", "--component", "crm-api", "--pod", "crm-api-new")
+	if exitCodeFor(executeError) != exitUsage {
+		t.Errorf("exit code = %d, want %d: %v", exitCodeFor(executeError), exitUsage, executeError)
+	}
+	if mockClient.logsCalls != 0 {
+		t.Errorf("GetApplicationDemoLogs calls = %d, want 0", mockClient.logsCalls)
+	}
+}
+
+func TestApplicationDemoListRendersComponents(t *testing.T) {
+	mockClient := &applicationDemoMock{listPayload: json.RawMessage(`{
+	  "demos": [{
+	    "id": "ws-1",
+	    "status": "ready",
+	    "branch": "main",
+	    "preview_url": "https://demo.example",
+	    "expires_at": "2099-01-01T00:00:00Z",
+	    "components": [
+	      {"name": "crm-frontend", "entry": true},
+	      {"name": "crm-api", "ingress_path": "/api"}
+	    ]
+	  }]
+	}`)}
+	output, executeError := runApplicationCommand(t, mockClient, "demo", "list", "app-1")
+	if executeError != nil {
+		t.Fatalf("demo list error = %v", executeError)
+	}
+	for _, expected := range []string{"ws-1", "ready", "main", "crm-frontend*", "crm-api", "entry component"} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("output is missing %q:\n%s", expected, output)
+		}
+	}
+}
+
+func TestApplicationDemoListEmpty(t *testing.T) {
+	mockClient := &applicationDemoMock{listPayload: json.RawMessage(`{"demos":[]}`)}
+	output, executeError := runApplicationCommand(t, mockClient, "demo", "list", "app-1")
+	if executeError != nil {
+		t.Fatalf("demo list error = %v", executeError)
+	}
+	if !strings.Contains(output, "No active demo workspaces.") {
+		t.Errorf("output = %q", output)
+	}
+}
+
+func TestApplicationDemoListFallsBackWhenPayloadCarriesNoDemosKey(t *testing.T) {
+	// "No active demo workspaces." is a claim about the application, so a
+	// payload that never carried the list must print raw instead.
+	mockClient := &applicationDemoMock{listPayload: json.RawMessage(`{"detail":"staging cluster missing"}`)}
+	output, executeError := runApplicationCommand(t, mockClient, "demo", "list", "app-1")
+	if executeError != nil {
+		t.Fatalf("demo list error = %v", executeError)
+	}
+	if strings.Contains(output, "No active demo workspaces.") {
+		t.Errorf("a payload without a demos key was summarised as empty:\n%s", output)
+	}
+	if !strings.Contains(output, "staging cluster missing") {
+		t.Errorf("output = %q", output)
+	}
+}
+
+func TestApplicationDemoListStructuredOutputStaysRaw(t *testing.T) {
+	mockClient := &applicationDemoMock{listPayload: json.RawMessage(`{"demos":[],"default_container_port":3000}`)}
+	output, executeError := runApplicationCommand(t, mockClient, "demo", "list", "app-1", "-o", "json")
+	if executeError != nil {
+		t.Fatalf("demo list error = %v", executeError)
+	}
+	if !strings.Contains(output, "\"default_container_port\": 3000") {
+		t.Errorf("-o json dropped payload fields the summary does not render:\n%s", output)
+	}
+}
+
+func TestApplicationDemoDetailRendersComponentsAndSteps(t *testing.T) {
+	mockClient := &applicationDemoMock{detailPayload: json.RawMessage(demoDetailFixture)}
+	output, executeError := runApplicationCommand(t, mockClient, "demo", "detail", "app-1", "ws-1")
+	if executeError != nil {
+		t.Fatalf("demo detail error = %v", executeError)
+	}
+	for _, expected := range []string{
+		"Demo ws-1", "ready", "ankra-demo-br-553ae8f1", "https://demo.example",
+		"crm-frontend", "crm-api", "8090", "/api", "sha-1363b7d", "crm-api-new",
+		"Steps:", "Workload",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("output is missing %q:\n%s", expected, output)
+		}
+	}
+}
+
+func TestApplicationDemoDetailFallsBackToRawJSON(t *testing.T) {
+	// A payload this rendering cannot decode must still print: a wire shape
+	// the CLI has not caught up with is not a reason to fail a read.
+	mockClient := &applicationDemoMock{detailPayload: json.RawMessage(`{"demo":"not-an-object"}`)}
+	output, executeError := runApplicationCommand(t, mockClient, "demo", "detail", "app-1", "ws-1")
+	if executeError != nil {
+		t.Fatalf("demo detail error = %v", executeError)
+	}
+	if !strings.Contains(output, "not-an-object") {
+		t.Errorf("output = %q", output)
+	}
+}
+
+func TestApplicationDemoDetailRendersLegacySingleComponent(t *testing.T) {
+	mockClient := &applicationDemoMock{detailPayload: json.RawMessage(`{
+	  "demo": {"id":"ws-9","status":"ready","pr_number":42,"component":"website",
+	           "image_tag":"sha-abc","container_port":3000,"expires_at":"2099-01-01T00:00:00Z"},
+	  "inspection": {"cluster_reachable": true, "steps": [], "resources": []}
+	}`)}
+	output, executeError := runApplicationCommand(t, mockClient, "demo", "detail", "app-1", "ws-9")
+	if executeError != nil {
+		t.Fatalf("demo detail error = %v", executeError)
+	}
+	for _, expected := range []string{"PR #42", "website", "sha-abc", "3000"} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("output is missing %q:\n%s", expected, output)
+		}
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -243,7 +243,7 @@ func (m baseMock) GetApplicationDemoDetail(requestContext context.Context, appli
 	return nil, errors.New("not implemented")
 }
 
-func (m baseMock) GetApplicationDemoLogs(requestContext context.Context, applicationID string, workspaceID string, tailLines int) (json.RawMessage, error) {
+func (m baseMock) GetApplicationDemoLogs(requestContext context.Context, applicationID string, workspaceID string, podName string, tailLines int) (json.RawMessage, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -134,7 +134,7 @@ type APIClient interface {
 	DeployApplicationDemo(requestContext context.Context, applicationID string, demoRequest client.DeployApplicationDemoRequest) (json.RawMessage, error)
 	StopApplicationDemo(requestContext context.Context, applicationID string, workspaceID string) (json.RawMessage, error)
 	GetApplicationDemoDetail(requestContext context.Context, applicationID string, workspaceID string) (json.RawMessage, error)
-	GetApplicationDemoLogs(requestContext context.Context, applicationID string, workspaceID string, tailLines int) (json.RawMessage, error)
+	GetApplicationDemoLogs(requestContext context.Context, applicationID string, workspaceID string, podName string, tailLines int) (json.RawMessage, error)
 	GetApplicationDemoConfig(requestContext context.Context, applicationID string) (json.RawMessage, error)
 	UpdateApplicationDemoConfig(requestContext context.Context, applicationID string, configuration json.RawMessage) (json.RawMessage, error)
 	FixApplicationDemo(requestContext context.Context, applicationID string, workspaceID string) (json.RawMessage, error)

--- a/internal/client/application_demos_test.go
+++ b/internal/client/application_demos_test.go
@@ -1,0 +1,117 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestGetApplicationDemoLogsSendsTailLinesAndPod(t *testing.T) {
+	testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/v1/org/applications/app-1/demos/ws-1/logs" {
+			t.Errorf("path = %s", request.URL.Path)
+		}
+		// The endpoint reads tail_lines; anything else leaves the tail at
+		// the backend default, which is what `tail` silently did.
+		if got := request.URL.Query().Get("tail_lines"); got != "500" {
+			t.Errorf("tail_lines = %q, want 500", got)
+		}
+		if got := request.URL.Query().Get("pod"); got != "crm-api-abc" {
+			t.Errorf("pod = %q, want crm-api-abc", got)
+		}
+		jsonResponse(t, writer, http.StatusOK, map[string]any{"lines": []string{"ok"}})
+	})
+
+	if _, logsError := testClient.GetApplicationDemoLogs(context.Background(),
+		"app-1", "ws-1", "crm-api-abc", 500); logsError != nil {
+		t.Fatalf("GetApplicationDemoLogs error = %v", logsError)
+	}
+}
+
+func TestGetApplicationDemoLogsOmitsUnsetSelectors(t *testing.T) {
+	testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.RawQuery != "" {
+			t.Errorf("query = %q, want empty", request.URL.RawQuery)
+		}
+		jsonResponse(t, writer, http.StatusOK, map[string]any{"lines": []string{}})
+	})
+
+	if _, logsError := testClient.GetApplicationDemoLogs(context.Background(),
+		"app-1", "ws-1", "", 0); logsError != nil {
+		t.Fatalf("GetApplicationDemoLogs error = %v", logsError)
+	}
+}
+
+func TestDeployApplicationDemoSendsComponents(t *testing.T) {
+	imageTag := "sha-1363b7d"
+	containerPort := 8090
+	ingressPath := "/api"
+	entryComponent := "crm-frontend"
+
+	testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		var body map[string]any
+		if decodeError := json.NewDecoder(request.Body).Decode(&body); decodeError != nil {
+			t.Fatalf("decode request: %v", decodeError)
+		}
+		components, isList := body["components"].([]any)
+		if !isList || len(components) != 2 {
+			t.Fatalf("components = %v, want two entries", body["components"])
+		}
+		second, isObject := components[1].(map[string]any)
+		if !isObject {
+			t.Fatalf("components[1] = %v", components[1])
+		}
+		if second["name"] != "crm-api" || second["image_tag"] != imageTag ||
+			second["container_port"] != float64(containerPort) || second["ingress_path"] != ingressPath {
+			t.Errorf("components[1] = %v", second)
+		}
+		first, isObject := components[0].(map[string]any)
+		if !isObject {
+			t.Fatalf("components[0] = %v", components[0])
+		}
+		// Overrides are omitted rather than sent as zero values: the
+		// backend resolves an absent port from the component record.
+		if _, sent := first["container_port"]; sent {
+			t.Errorf("components[0] carries an unset container_port: %v", first)
+		}
+		if body["entry_component"] != entryComponent {
+			t.Errorf("entry_component = %v, want %s", body["entry_component"], entryComponent)
+		}
+		jsonResponse(t, writer, http.StatusOK, map[string]any{"workspace_id": "ws-1"})
+	})
+
+	if _, deployError := testClient.DeployApplicationDemo(context.Background(), "app-1",
+		DeployApplicationDemoRequest{
+			Components: []DeployApplicationDemoComponent{
+				{Name: "crm-frontend"},
+				{Name: "crm-api", ImageTag: &imageTag, ContainerPort: &containerPort, IngressPath: &ingressPath},
+			},
+			EntryComponent: &entryComponent,
+		}); deployError != nil {
+		t.Fatalf("DeployApplicationDemo error = %v", deployError)
+	}
+}
+
+func TestDeployApplicationDemoOmitsComponentsWhenUnset(t *testing.T) {
+	testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		var body map[string]any
+		if decodeError := json.NewDecoder(request.Body).Decode(&body); decodeError != nil {
+			t.Fatalf("decode request: %v", decodeError)
+		}
+		// An absent components key is how the backend is told to deploy
+		// every recorded component; an empty list would not be.
+		if _, sent := body["components"]; sent {
+			t.Errorf("components was sent for an unnarrowed launch: %v", body)
+		}
+		if _, sent := body["entry_component"]; sent {
+			t.Errorf("entry_component was sent unset: %v", body)
+		}
+		jsonResponse(t, writer, http.StatusOK, map[string]any{"workspace_id": "ws-1"})
+	})
+
+	if _, deployError := testClient.DeployApplicationDemo(context.Background(), "app-1",
+		DeployApplicationDemoRequest{}); deployError != nil {
+		t.Fatalf("DeployApplicationDemo error = %v", deployError)
+	}
+}

--- a/internal/client/application_resources.go
+++ b/internal/client/application_resources.go
@@ -42,6 +42,21 @@ type DeployApplicationDemoRequest struct {
 	ImageTag      *string `json:"image_tag,omitempty"`
 	TTLHours      *int    `json:"ttl_hours,omitempty"`
 	ContainerPort *int    `json:"container_port,omitempty"`
+	// Components selects which of a monorepo's components the demo runs,
+	// each with optional overrides; omitted deploys every recorded
+	// component. EntryComponent names the one that owns the demo host's
+	// root path; omitted applies the backend's entry heuristic.
+	Components     []DeployApplicationDemoComponent `json:"components,omitempty"`
+	EntryComponent *string                          `json:"entry_component,omitempty"`
+}
+
+// DeployApplicationDemoComponent is one components[] entry of the deploy-demo
+// body: a selected component plus the overrides that apply to it alone.
+type DeployApplicationDemoComponent struct {
+	Name          string  `json:"name"`
+	ImageTag      *string `json:"image_tag,omitempty"`
+	ContainerPort *int    `json:"container_port,omitempty"`
+	IngressPath   *string `json:"ingress_path,omitempty"`
 }
 
 // UpdateApplicationImageRegistryRequest mirrors the image-registry body. The
@@ -287,10 +302,18 @@ func (client *Client) GetApplicationDemoDetail(requestContext context.Context, a
 	return client.applicationResourceRequest(requestContext, http.MethodGet, applicationPath(applicationID, "/demos/"+workspaceID+"/detail"), nil, nil)
 }
 
-func (client *Client) GetApplicationDemoLogs(requestContext context.Context, applicationID string, workspaceID string, tailLines int) (json.RawMessage, error) {
+// GetApplicationDemoLogs fetches a bounded log tail. An empty podName lets
+// the backend pick the demo's own pod, which is the single-component case;
+// a multi-component demo has one pod per component and must name the one it
+// wants. The tail parameter is `tail_lines` — the endpoint ignores anything
+// else, so a demo's tail size silently defaulted while the CLI sent `tail`.
+func (client *Client) GetApplicationDemoLogs(requestContext context.Context, applicationID string, workspaceID string, podName string, tailLines int) (json.RawMessage, error) {
 	query := url.Values{}
 	if tailLines > 0 {
-		query.Set("tail", strconv.Itoa(tailLines))
+		query.Set("tail_lines", strconv.Itoa(tailLines))
+	}
+	if podName != "" {
+		query.Set("pod", podName)
 	}
 	return client.applicationResourceRequest(requestContext, http.MethodGet, applicationPath(applicationID, "/demos/"+workspaceID+"/logs"), query, nil)
 }


### PR DESCRIPTION
Bead: ankra-7ade

Follow-up to ankra-5i2x (multi-component demos). The backend already deploys
every component of a monorepo demo as its own pod and carries the components
array on the demo record, but the CLI was still single-workload: `demo deploy`
had one global `--image-tag`/`--container-port`, and `demo list`/`demo detail`
dumped the raw JSON document the components are buried in.

## What changed

**`demo deploy` — per-component selection and overrides**

- `--component NAME` (repeatable) narrows a launch to the components you name;
  omitted still deploys every recorded component.
- `--component-tag NAME=TAG`, `--component-port NAME=PORT`,
  `--component-path NAME=/prefix` (all repeatable) tune one component each.
- `--entry-component NAME` names the component that owns the demo host's root
  path instead of leaving it to the backend's entry heuristic.

These map onto the existing `components[]` / `entry_component` wire fields
(`go/internal/appsapi/demos.go`); no backend change is needed.

The one design call worth a look: `components[]` carries **both** the selection
and the per-component overrides, so an override naming a component that
`--component` did not select would silently narrow the launch to that single
component — exactly the failure ankra-5i2x was filed for. The CLI rejects that
combination with the flag to add rather than sending it. The cost is that
tuning one component of a full launch means listing them all; the `Long` help
and the CHANGELOG say so.

**`demo list` / `demo detail` — component-aware human output**

Both now render a summary by default: every demo's components, which one is
the entry (`crm-frontend*` plus a legend), and per component its port, ingress
path, image tag and live pod. `-o json` and `-o yaml` are unchanged and still
emit the untouched payload, including the resource inventory and namespace
events the summary deliberately leaves out.

This is a **user-visible change to the default output** of those two commands
(previously indented JSON). The `-o` help has always advertised
"default: human-readable"; scripts pinned to `-o json` are unaffected. A
payload the summary cannot decode — or one carrying no demo record / no
`demos` key — falls back to printing the raw JSON rather than failing a read
or claiming "no active demos".

**`demo logs` — component selector**

The logs endpoint addresses pods, not components, so `--component` resolves
through the detail payload's inventory (whose `Pod` entries carry their
component). A ready pod wins over a merely present one: a redeploy leaves the
previous rollout's pods in the inventory and their logs describe the code that
was replaced. `--pod` names one directly when a component has several; the two
are mutually exclusive. An unknown component exits 3 and lists the components
the demo actually runs.

**Drive-by fix in the same function:** `--tail` was sent as `tail`, but the
endpoint reads `tail_lines` — so every demo log fetch has silently used the
backend's default tail regardless of the flag. One-line fix, covered by a
client test.

## Verification

- `go test -race -count=1 -timeout=120s ./...` — pass (full suite).
- `lint-lock -- golangci-lint run` (v2.12.2, the version CI pins) — 0 issues.
- `make verify-skills` — skipped by design (`ankra-skills` source not present;
  the embedded copy is canonical in this repo).
- Rendering checked visually against fixtures for a two-component demo, a
  legacy single-component demo, and an empty list.

New tests cover the flag→request mapping, every rejected flag combination,
component→pod resolution (including the ready-pod preference and the unknown
component), the `tail_lines`/`pod` query parameters, and both renderings plus
their raw-JSON fallbacks.

## Where to look hardest

- The override-must-be-selected rule in `demoComponentsFromFlags` — it is a
  deliberate restriction, and the alternative (silently narrowing the launch)
  is the bug that started this line of work.
- The default-output change on `demo list`/`demo detail`.

Nothing here touches schema migrations, values/GitOps, ingress, auth, or the
agent↔platform protocol; it is CLI-only against existing endpoints.

Left for a follow-up (filed separately): the self-heal lane that log-corrects
a container port still only covers the entry component — that is backend work
in `cluster`, not the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
