### PR TITLE
fix(cluster): resolve --cluster names to ids in cluster validate (ankra-1qx3)

### DIFF
--- a/cmd/cluster_validate.go
+++ b/cmd/cluster_validate.go
@@ -20,7 +20,7 @@ offline checks cannot perform:
   - plaintext Kubernetes Secret / unencrypted addon value detection
   - parent references resolved against a cluster's existing resources
 
-Nothing is applied. Use --cluster <id> to validate the spec against an
+Nothing is applied. Use --cluster <name|id> to validate the spec against an
 existing cluster's deployed resources, and --strict-secrets to treat
 plaintext secrets as errors instead of warnings.`,
 	Args: cobra.NoArgs,
@@ -30,7 +30,7 @@ plaintext secrets as errors instead of warnings.`,
 func init() {
 	clusterValidateCmd.Flags().StringP("file", "f", "", "Path to the ImportCluster YAML file to validate")
 	clusterValidateCmd.Flags().Bool("strict-secrets", false, "Treat plaintext secrets as errors instead of warnings")
-	clusterValidateCmd.Flags().String("cluster", "", "Validate against an existing cluster's resources (cluster ID)")
+	clusterValidateCmd.Flags().String("cluster", "", "Validate against an existing cluster's resources (cluster name or ID)")
 	registerStructuredOutputFlags(clusterValidateCmd)
 	_ = clusterValidateCmd.MarkFlagRequired("file")
 	clusterCmd.AddCommand(clusterValidateCmd)
@@ -42,7 +42,15 @@ func runClusterValidate(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("reading --file: %w", err)
 	}
 	strictSecrets, _ := cmd.Flags().GetBool("strict-secrets")
-	clusterID, _ := cmd.Flags().GetString("cluster")
+	clusterFlagValue, _ := cmd.Flags().GetString("cluster")
+	clusterID := ""
+	if clusterFlagValue != "" {
+		resolvedClusterID, resolveError := resolveClusterID(clusterFlagValue)
+		if resolveError != nil {
+			return fmt.Errorf("resolving --cluster %q: %w", clusterFlagValue, resolveError)
+		}
+		clusterID = resolvedClusterID
+	}
 
 	importRequest, err := buildImportRequest(filePath)
 	if err != nil {

--- a/cmd/cluster_validate_test.go
+++ b/cmd/cluster_validate_test.go
@@ -32,14 +32,32 @@ func newValidateTestServer(t *testing.T, receivedClusterID *string) *httptest.Se
 	}))
 }
 
+// useTestClient points the command at the test server and satisfies the root
+// command's auth gate, which reads the token rather than the client: without
+// it the command fails with "not logged in" wherever no real credentials
+// exist, which is every CI runner.
+func useTestClient(t *testing.T, serverURL string) {
+	t.Helper()
+	previousClient := apiClient
+	previousToken := apiToken
+	previousBaseURL := baseURL
+	apiClient = client.New("test-token", serverURL)
+	apiToken = "test-token"
+	baseURL = serverURL
+	t.Setenv("ANKRA_API_TOKEN", "test-token")
+	t.Cleanup(func() {
+		apiClient = previousClient
+		apiToken = previousToken
+		baseURL = previousBaseURL
+	})
+}
+
 func TestClusterValidateResolvesClusterNameToID(t *testing.T) {
 	receivedClusterID := ""
 	server := newValidateTestServer(t, &receivedClusterID)
 	defer server.Close()
 
-	previousClient := apiClient
-	apiClient = client.New("test-token", server.URL)
-	t.Cleanup(func() { apiClient = previousClient })
+	useTestClient(t, server.URL)
 
 	_, err := executeCommand("cluster", "validate", "--file", writeMinimalImportCluster(t), "--cluster", "chat-ai-l4")
 	if err != nil {
@@ -55,9 +73,7 @@ func TestClusterValidatePassesClusterIDThrough(t *testing.T) {
 	server := newValidateTestServer(t, &receivedClusterID)
 	defer server.Close()
 
-	previousClient := apiClient
-	apiClient = client.New("test-token", server.URL)
-	t.Cleanup(func() { apiClient = previousClient })
+	useTestClient(t, server.URL)
 
 	_, err := executeCommand("cluster", "validate", "--file", writeMinimalImportCluster(t), "--cluster", validateTestClusterID)
 	if err != nil {

--- a/cmd/cluster_validate_test.go
+++ b/cmd/cluster_validate_test.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+const validateTestClusterID = "bb549585-5bd3-49e5-87d7-b7f7fa258dcd"
+
+func newValidateTestServer(t *testing.T, receivedClusterID *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.Method == http.MethodGet && request.URL.Path == "/api/v1/clusters":
+			_ = json.NewEncoder(responseWriter).Encode(client.ClusterListResponse{
+				Result: []client.ClusterListItem{{
+					ID:   validateTestClusterID,
+					Name: "chat-ai-l4",
+				}},
+				Pagination: client.Pagination{TotalPages: 1},
+			})
+		case request.Method == http.MethodPost && request.URL.Path == "/api/v1/clusters/validate":
+			*receivedClusterID = request.URL.Query().Get("cluster_id")
+			_ = json.NewEncoder(responseWriter).Encode(client.ValidateClusterResponse{})
+		default:
+			responseWriter.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestClusterValidateResolvesClusterNameToID(t *testing.T) {
+	receivedClusterID := ""
+	server := newValidateTestServer(t, &receivedClusterID)
+	defer server.Close()
+
+	previousClient := apiClient
+	apiClient = client.New("test-token", server.URL)
+	t.Cleanup(func() { apiClient = previousClient })
+
+	_, err := executeCommand("cluster", "validate", "--file", writeMinimalImportCluster(t), "--cluster", "chat-ai-l4")
+	if err != nil {
+		t.Fatalf("cluster validate: %v", err)
+	}
+	if receivedClusterID != validateTestClusterID {
+		t.Errorf("cluster_id query = %q, want the resolved UUID %q", receivedClusterID, validateTestClusterID)
+	}
+}
+
+func TestClusterValidatePassesClusterIDThrough(t *testing.T) {
+	receivedClusterID := ""
+	server := newValidateTestServer(t, &receivedClusterID)
+	defer server.Close()
+
+	previousClient := apiClient
+	apiClient = client.New("test-token", server.URL)
+	t.Cleanup(func() { apiClient = previousClient })
+
+	_, err := executeCommand("cluster", "validate", "--file", writeMinimalImportCluster(t), "--cluster", validateTestClusterID)
+	if err != nil {
+		t.Fatalf("cluster validate: %v", err)
+	}
+	if receivedClusterID != validateTestClusterID {
+		t.Errorf("cluster_id query = %q, want %q untouched", receivedClusterID, validateTestClusterID)
+	}
+}


### PR DESCRIPTION
## Summary
`ankra cluster validate -f x.yaml --cluster <name>` sent the cluster NAME verbatim as the `cluster_id` query parameter, and the API rejected it with a 422 `uuid_parsing` error — while every other cluster command accepts a name or an ID. Hit live on 2026-08-18 validating a stack change against `chat-ai-l4`.

## Change
- `cluster validate` resolves its local `--cluster` flag through the existing `resolveClusterID` helper (names resolve via the clusters list; 36-char UUIDs pass through untouched).
- Flag help and long help now say `name or ID`.

## Tests
- `TestClusterValidateResolvesClusterNameToID` — name in, resolved UUID on the wire.
- `TestClusterValidatePassesClusterIDThrough` — UUID in, unchanged on the wire.
- `make build`, `go vet`, `make test`, `make lint` all green.

Bead: ankra-1qx3

🤖 Generated with [Claude Code](https://claude.com/claude-code)