### PR TITLE
docs(cli): the Ankra domain is the organisation's own custom domain (ankra-rktx)

### DIFF
--- a/cmd/cluster_domain.go
+++ b/cmd/cluster_domain.go
@@ -13,9 +13,8 @@ var clusterDomainCmd = &cobra.Command{
 	Short: "Show the cluster's generated public domain, enabling it if needed",
 	Long: `Show the cluster's generated public domain, queueing the zone if the
 cluster does not have one yet. The domain nests under the organisation's
-Ankra-managed root (ankra.cc by default; organisations may select another
-offered root, such as smartoptics.dev, in the organisation's AI environment
-settings).
+Ankra-managed root (ankra.cc by default; an organisation may register its
+own custom domain in the AI environment settings).
 
 The call is idempotent: a cluster that already has a zone reports its
 existing domain unchanged, so this doubles as a lookup. A fresh zone reads


### PR DESCRIPTION
Help-text follow-up to the custom-domain rework (bead ankra-rktx): the alternate root is the organisation's own registered domain, not a platform-offered list.

Bead: ankra-rktx
