### PR TITLE
fix(reconcile): parse the platform's actual response shape (ankra-5thl5)

### DIFF
--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -196,13 +196,10 @@ If a cluster name is provided, reconciles that specific cluster.`,
 			return encodeStructured(cmd.OutOrStdout(), format, result)
 		}
 
-		if result.Success {
-			fmt.Println("Reconciliation triggered successfully!")
+		if result.CreatedOperations > 0 {
+			fmt.Printf("Reconciliation triggered: %d operation(s) created\n", result.CreatedOperations)
 		} else {
-			fmt.Printf("Reconciliation request completed: %s\n", result.Message)
-		}
-		if result.Message != "" {
-			fmt.Printf("Message: %s\n", result.Message)
+			fmt.Println("Reconciliation triggered: no operations created - stored state is already in sync")
 		}
 		return nil
 	},

--- a/internal/client/clusters.go
+++ b/internal/client/clusters.go
@@ -361,9 +361,13 @@ type ImportResponse struct {
 	Errors        []ImportResponseResourceError `json:"errors,omitempty"`
 }
 
+// TriggerReconcileResult mirrors the platform's reconcile response (openapi
+// TriggerReconcileResult): the number of operations the manual reconcile
+// planned. Zero is a success too - stored state was already in sync. The
+// route works for every cluster kind; "imported" in its path is historical
+// naming.
 type TriggerReconcileResult struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
+	CreatedOperations int `json:"created_operations"`
 }
 
 func (c *Client) TriggerReconcile(ctx context.Context, clusterID string) (*TriggerReconcileResult, error) {

--- a/internal/client/clusters_test.go
+++ b/internal/client/clusters_test.go
@@ -163,7 +163,7 @@ func TestTriggerReconcile(t *testing.T) {
 					w.WriteHeader(http.StatusMethodNotAllowed)
 					return
 				}
-				jsonResponse(t, w, http.StatusOK, TriggerReconcileResult{Success: true, Message: "reconciling"})
+				jsonResponse(t, w, http.StatusOK, TriggerReconcileResult{CreatedOperations: 2})
 			},
 			wantErr: false,
 		},
@@ -184,8 +184,8 @@ func TestTriggerReconcile(t *testing.T) {
 				t.Errorf("TriggerReconcile() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !tt.wantErr && !got.Success {
-				t.Errorf("TriggerReconcile() got.Success = %v, want true", got.Success)
+			if !tt.wantErr && got.CreatedOperations != 2 {
+				t.Errorf("TriggerReconcile() got.CreatedOperations = %d, want 2 - the wire field is created_operations", got.CreatedOperations)
 			}
 		})
 	}


### PR DESCRIPTION
## What

`ankra cluster reconcile` now parses the platform's actual response shape and reports it: `Reconciliation triggered: N operation(s) created`, or the explicit zero case `no operations created - stored state is already in sync`.

Bead: ankra-5thl5

## Why

The endpoint returns `200 {"created_operations": N}` (openapi `TriggerReconcileResult`). The CLI deserialized into `{success, message}` — fields the API never returns — so **every** reconcile, on **every** cluster kind, printed `Reconciliation request completed: ` with zero values and exit 0. During the 2026-08-18 Depict cinder outage the customer read that as "reconcile doesn't work for ovh-kind clusters" (Linear PLA-761/PLA-763) and lost hours to it. The route in fact works for all cluster kinds — `imported` in its path is historical naming; verified against `importedapi.reconcileClusterHandler` → `providers.TriggerReconcile` (org gate only) and the frozen contract.

## Notes

- Structured output (`--output json|yaml`) now carries `created_operations`.
- Client test asserts the real wire field; the e2e base mock is shape-compatible unchanged.
- Reaches customers with the next release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
