### PR TITLE
feat(node-group): --user-data-file on node-group add (ankra-6srv8)

### DIFF
--- a/cmd/cluster_node_group.go
+++ b/cmd/cluster_node_group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 
 	"ankra/internal/client"
@@ -244,6 +245,28 @@ var clusterNodeGroupListCmd = &cobra.Command{
 	},
 }
 
+// maxNodeGroupUserDataBytes mirrors the platform's refusal cap (the
+// OpenStack instance user-data limit); checking client-side turns a
+// round-trip rejection into an immediate, clearer error.
+const maxNodeGroupUserDataBytes = 65535
+
+// readNodeGroupUserDataFile loads the cloud-init document named by
+// --user-data-file; an empty path means the flag was not set.
+func readNodeGroupUserDataFile(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	content, readError := os.ReadFile(path)
+	if readError != nil {
+		return "", fmt.Errorf("reading --user-data-file: %w", readError)
+	}
+	if len(content) > maxNodeGroupUserDataBytes {
+		return "", fmt.Errorf("--user-data-file %s is %d bytes; the platform caps node-group user data at %d bytes",
+			path, len(content), maxNodeGroupUserDataBytes)
+	}
+	return string(content), nil
+}
+
 var clusterNodeGroupAddCmd = &cobra.Command{
 	Use:   "add <cluster_id>",
 	Short: "Add a node group",
@@ -258,12 +281,18 @@ var clusterNodeGroupAddCmd = &cobra.Command{
 		instanceType, _ := cmd.Flags().GetString("instance-type")
 		count, _ := cmd.Flags().GetInt("count")
 		availabilityZone, _ := cmd.Flags().GetString("availability-zone")
+		userDataFile, _ := cmd.Flags().GetString("user-data-file")
+		userData, userDataError := readNodeGroupUserDataFile(userDataFile)
+		if userDataError != nil {
+			return userDataError
+		}
 
 		req := client.AddNodeGroupRequest{
 			Name:             name,
 			InstanceType:     instanceType,
 			Count:            count,
 			AvailabilityZone: availabilityZone,
+			UserData:         userData,
 		}
 
 		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
@@ -658,6 +687,7 @@ func init() {
 	clusterNodeGroupAddCmd.Flags().String("instance-type", "", "Server type / flavor / plan for nodes (required)")
 	clusterNodeGroupAddCmd.Flags().Int("count", 1, "Number of nodes")
 	clusterNodeGroupAddCmd.Flags().String("availability-zone", "", "Pin every node of the group to one availability zone, on OVH 3-AZ regions (e.g. eu-west-par-b). See 'ankra cluster ovh regions --with-zones'. Pin the group when it runs zonal storage: an OVH volume cannot attach from another zone")
+	clusterNodeGroupAddCmd.Flags().String("user-data-file", "", "Path to a cloud-init user-data file for the group (OVH clusters only). Applied verbatim at first boot by every instance the group ever creates, replacements included; Ankra sends no cloud-init of its own, so the document is not merged with anything. Max 65535 bytes. Use for provision-time disk layouts, e.g. carving a partition for LUKS before growpart runs")
 	_ = clusterNodeGroupAddCmd.MarkFlagRequired("name")
 	_ = clusterNodeGroupAddCmd.MarkFlagRequired("instance-type")
 

--- a/cmd/cluster_node_group_test.go
+++ b/cmd/cluster_node_group_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadNodeGroupUserDataFileEmptyPathMeansUnset(t *testing.T) {
+	userData, err := readNodeGroupUserDataFile("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if userData != "" {
+		t.Fatalf("userData = %q, want empty for an unset flag", userData)
+	}
+}
+
+func TestReadNodeGroupUserDataFileLoadsTheDocumentVerbatim(t *testing.T) {
+	document := "#cloud-config\ngrowpart:\n  mode: 'off'\n"
+	path := filepath.Join(t.TempDir(), "user-data.yaml")
+	if err := os.WriteFile(path, []byte(document), 0o600); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+	userData, err := readNodeGroupUserDataFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if userData != document {
+		t.Fatalf("userData = %q, want the file content verbatim", userData)
+	}
+}
+
+func TestReadNodeGroupUserDataFileErrorsOnMissingFile(t *testing.T) {
+	_, err := readNodeGroupUserDataFile(filepath.Join(t.TempDir(), "absent.yaml"))
+	if err == nil {
+		t.Fatal("expected an error for a missing file")
+	}
+}
+
+func TestReadNodeGroupUserDataFileRefusesOversizedDocuments(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "oversized.yaml")
+	if err := os.WriteFile(path, []byte(strings.Repeat("x", maxNodeGroupUserDataBytes+1)), 0o600); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+	_, err := readNodeGroupUserDataFile(path)
+	if err == nil || !strings.Contains(err.Error(), "65535") {
+		t.Fatalf("error = %v, want the size-cap refusal naming the limit", err)
+	}
+}

--- a/internal/client/hetzner_clusters.go
+++ b/internal/client/hetzner_clusters.go
@@ -242,6 +242,11 @@ type AddNodeGroupRequest struct {
 	// regions. Omitted spreads the group across the cluster's zone pool when
 	// it has one, and leaves placement to the provider when it does not.
 	AvailabilityZone string `json:"availability_zone,omitempty"`
+	// UserData is the group's opaque cloud-init document (OVH clusters
+	// only), applied verbatim at first boot by every instance the group
+	// ever creates, replacements included. The platform sends no cloud-init
+	// of its own, and refuses documents over 65535 bytes.
+	UserData string `json:"user_data,omitempty"`
 }
 
 type AddNodeGroupResult struct {

--- a/internal/client/ovh_clusters_test.go
+++ b/internal/client/ovh_clusters_test.go
@@ -459,10 +459,17 @@ func TestAddOvhNodeGroup_Success(t *testing.T) {
 		if r.URL.Path != expectedPath {
 			t.Errorf("path = %s, want %s", r.URL.Path, expectedPath)
 		}
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decoding request body: %v", err)
+		}
+		if payload["user_data"] != "#cloud-config\n" {
+			t.Errorf("payload user_data = %v, want the document under the user_data wire field", payload["user_data"])
+		}
 		jsonResponse(t, w, http.StatusCreated, expectedResponse)
 	}
 	testClient := newTestClient(t, handler)
-	req := AddNodeGroupRequest{Name: "gpu-pool", InstanceType: "b2-7", Count: 2}
+	req := AddNodeGroupRequest{Name: "gpu-pool", InstanceType: "b2-7", Count: 2, UserData: "#cloud-config\n"}
 	result, _, err := testClient.AddOvhNodeGroup(context.Background(), clusterID, req, true)
 	if err != nil {
 		t.Fatalf("AddOvhNodeGroup: %v", err)


### PR DESCRIPTION
## What

`--user-data-file` on `ankra cluster node-group add`: reads a cloud-init document from a file and sends it as `user_data` on `AddNodeGroupRequest`.

Bead: ankra-6srv8

## Why

The platform shipped per-node-group cloud-init `user_data` (cluster#1316); the CLI had no flag for it, so the first customer to use the feature (Depict, Linear PLA-765/PLA-762) discovered it only by reading `/openapi.json`. Their explicit ask was a FILE flag rather than a string flag: the document is multi-KB YAML and inline passing is quoting-hostile.

## Behaviour

- Reads the file verbatim; no merging, no templating.
- Client-side refusal over the platform's 65535-byte cap (immediate and clearer than the server's 409).
- OVH clusters only; other providers refuse server-side with "User data is not supported for X clusters".
- Help text carries the semantics (verbatim at first boot, every instance the group ever creates, replacements included) so the generated docs answer the cattle-node question directly.

## Testing

Unit tests for the file reader (unset flag, verbatim load, missing file, size cap) and the client test now decodes the request body asserting the `user_data` wire field. Pre-commit `go test ./...` + `golangci-lint run` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
