### PR TITLE
feat(bastion): report the resize operation instead of claiming the node is resized (ankra-ukodb)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Ankra CLI Changelog
 
+## Unreleased
+
+### Changed
+
+- **`ankra cluster <provider> bastion resize` no longer claims the node is
+  resized before the cloud has touched it.** The command reported
+  "resized to '<type>'" as soon as the platform had recorded the new instance
+  type, while the provider's update job — the power-off, the resize, the
+  power-on — had not started. The platform now hands back the operation
+  carrying that job, so the confirmation says the instance type was *set*,
+  names the operation, warns that SSH and NAT drop while the node cycles, and
+  points at `ankra cluster operations list <operation_id>` for the part that is
+  still running. A write that scheduled no cloud work (a stopped cluster, whose
+  new type applies on start, or a resize already in flight) says so instead of
+  printing an id there is nothing to poll for. `-o json|yaml` gains the
+  matching `operation_id` field.
+
 ## v0.12.0 — 2026-08-18
 
 Closes the loop on node-group cloud-init. A node group could already carry a

--- a/cmd/cluster_bastion.go
+++ b/cmd/cluster_bastion.go
@@ -88,8 +88,26 @@ func runBastionResize(cmd *cobra.Command, opsFn func() bastionOps, clusterID, in
 	} else if handled {
 		return nil
 	}
-	fmt.Printf("Bastion/gateway '%s' resized to '%s'.\n", result.Name, result.InstanceType)
+	printBastionResized(result)
 	return nil
+}
+
+// printBastionResized reports the write, not the cloud resize: the platform
+// records the new instance type and dispatches the provider's bastion update
+// job, which powers the node off, resizes it and powers it back on long after
+// this command has returned. The operation it hands back is the only thing
+// that says when that has finished, so the confirmation names it and points at
+// the poller instead of claiming the node is already resized.
+func printBastionResized(result *client.UpdateBastionInstanceTypeResult) {
+	if result.OperationID != nil && *result.OperationID != "" {
+		fmt.Printf("Bastion/gateway '%s' instance type set to '%s' (operation %s).\n", result.Name, result.InstanceType, *result.OperationID)
+		fmt.Println("The provider powers the node off, resizes it and powers it back on; SSH and NAT for the cluster are briefly unavailable until it is back.")
+		fmt.Printf("Track progress with: ankra cluster operations list %s\n", *result.OperationID)
+		return
+	}
+	fmt.Printf("Bastion/gateway '%s' instance type set to '%s'.\n", result.Name, result.InstanceType)
+	fmt.Println("The platform returned no operation to track for this write - a stopped cluster applies the new type on start, and a resize already running keeps its own operation.")
+	fmt.Println("List what is running with: ankra cluster operations list")
 }
 
 // runBastionStatus reports the verdict the platform's bastion health loop
@@ -233,7 +251,10 @@ Find its node ID with 'nodes list'.`,
 		Short: "Change the bastion/gateway instance type",
 		Long: `Resize the bastion/gateway node. The provider's bastion/gateway update job
 powers it off, resizes it, and powers it back on, causing brief SSH/NAT
-downtime for the cluster.`,
+downtime for the cluster.
+
+--wait covers the platform write only; the cloud resize runs as the operation
+reported on success. Follow it with 'ankra cluster operations list <operation_id>'.`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runBastionResize(cmd, opsFn, args[0], args[1])

--- a/cmd/cluster_bastion_test.go
+++ b/cmd/cluster_bastion_test.go
@@ -36,8 +36,9 @@ func (m *bastionResizeMock) UpdateHetznerBastionInstanceType(ctx context.Context
 
 func TestClusterBastionResizeCommandWithWait(t *testing.T) {
 	writeSelectedClusterJSON(t)
+	operationID := "op-77"
 	mock := &bastionResizeMock{
-		result: &client.UpdateBastionInstanceTypeResult{NodeID: "node-9", Kind: "hetzner_bastion", Name: "bastion", InstanceType: "cx31"},
+		result: &client.UpdateBastionInstanceTypeResult{NodeID: "node-9", Kind: "hetzner_bastion", Name: "bastion", InstanceType: "cx31", OperationID: &operationID},
 	}
 	setMockClient(t, mock)
 
@@ -48,8 +49,40 @@ func TestClusterBastionResizeCommandWithWait(t *testing.T) {
 	if len(mock.resizeCalls) != 1 || mock.resizeCalls[0] != "cluster-1:cx31:true" {
 		t.Fatalf("expected one resize call with wait=true, got %v", mock.resizeCalls)
 	}
-	if !strings.Contains(stdoutOutput, "resized to 'cx31'") {
-		t.Errorf("expected resize confirmation, got: %s", stdoutOutput)
+	if !strings.Contains(stdoutOutput, "instance type set to 'cx31' (operation op-77)") {
+		t.Errorf("expected the write confirmation to name the operation, got: %s", stdoutOutput)
+	}
+	if !strings.Contains(stdoutOutput, "ankra cluster operations list op-77") {
+		t.Errorf("expected the operations-list hint, got: %s", stdoutOutput)
+	}
+	if strings.Contains(stdoutOutput, "resized to") {
+		t.Errorf("the cloud resize has not happened yet, so it must not be reported as done: %s", stdoutOutput)
+	}
+}
+
+// A platform that scheduled no cloud work (stopped cluster, resize already in
+// flight) - and any platform older than the release that added the field -
+// answers without an operation_id. The write is still confirmed, but nothing
+// is claimed about a resize and no unpollable id is printed.
+func TestClusterBastionResizeCommandWithoutOperationID(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	mock := &bastionResizeMock{
+		result: &client.UpdateBastionInstanceTypeResult{NodeID: "node-9", Kind: "hetzner_bastion", Name: "bastion", InstanceType: "cx31"},
+	}
+	setMockClient(t, mock)
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("cluster", "hetzner", "bastion", "resize", "cluster-1", "cx31", "--wait")
+	})
+
+	if !strings.Contains(stdoutOutput, "instance type set to 'cx31'") {
+		t.Errorf("expected the write confirmation, got: %s", stdoutOutput)
+	}
+	if !strings.Contains(stdoutOutput, "no operation to track") {
+		t.Errorf("expected the missing-operation explanation, got: %s", stdoutOutput)
+	}
+	if strings.Contains(stdoutOutput, "(operation ") {
+		t.Errorf("expected no operation id, got: %s", stdoutOutput)
 	}
 }
 

--- a/internal/client/bastion.go
+++ b/internal/client/bastion.go
@@ -11,11 +11,17 @@ import (
 )
 
 // UpdateBastionInstanceTypeResult reports the mutated bastion/gateway node.
+// OperationID carries the execution the platform dispatched to perform the
+// cloud resize; it is null when the write scheduled no cloud work (a stopped
+// cluster applies the new type on start, and a resize already in flight keeps
+// its own operation) and absent altogether on platforms older than the release
+// that added the field.
 type UpdateBastionInstanceTypeResult struct {
-	NodeID       string `json:"node_id"`
-	Kind         string `json:"kind"`
-	Name         string `json:"name"`
-	InstanceType string `json:"instance_type"`
+	NodeID       string  `json:"node_id"`
+	Kind         string  `json:"kind"`
+	Name         string  `json:"name"`
+	InstanceType string  `json:"instance_type"`
+	OperationID  *string `json:"operation_id"`
 }
 
 func (c *Client) UpdateHetznerBastionInstanceType(ctx context.Context, clusterID, instanceType string, wait bool) (*UpdateBastionInstanceTypeResult, bool, error) {

--- a/internal/client/bastion_test.go
+++ b/internal/client/bastion_test.go
@@ -43,11 +43,13 @@ func TestUpdateHetznerBastionInstanceType_SubmittedWithoutWait(t *testing.T) {
 }
 
 func TestUpdateHetznerBastionInstanceType_WaitReturnsResult(t *testing.T) {
+	operationID := "op-77"
 	expectedResponse := UpdateBastionInstanceTypeResult{
 		NodeID:       "node-789",
 		Kind:         "hetzner_bastion",
 		Name:         "bastion",
 		InstanceType: "cx31",
+		OperationID:  &operationID,
 	}
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		if got := r.URL.Query().Get("wait"); got != "true" {
@@ -65,6 +67,32 @@ func TestUpdateHetznerBastionInstanceType_WaitReturnsResult(t *testing.T) {
 	}
 	if result == nil || result.Name != "bastion" || result.InstanceType != "cx31" {
 		t.Errorf("result = %+v, want bastion resized to cx31", result)
+	}
+	if result.OperationID == nil || *result.OperationID != "op-77" {
+		t.Errorf("OperationID = %v, want op-77", result.OperationID)
+	}
+}
+
+// operation_id is additive and nullable: the platform omits it when the write
+// scheduled no cloud work, and a platform older than the release that added it
+// never sends the key at all. Both must decode to a nil OperationID rather
+// than failing the resize.
+func TestUpdateHetznerBastionInstanceType_MissingOperationIDDecodes(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(t, w, http.StatusOK, map[string]string{
+			"node_id":       "node-789",
+			"kind":          "hetzner_bastion",
+			"name":          "bastion",
+			"instance_type": "cx31",
+		})
+	}
+	testClient := newTestClient(t, handler)
+	result, _, err := testClient.UpdateHetznerBastionInstanceType(context.Background(), "cluster-123", "cx31", true)
+	if err != nil {
+		t.Fatalf("UpdateHetznerBastionInstanceType: %v", err)
+	}
+	if result == nil || result.OperationID != nil {
+		t.Errorf("result = %+v, want a decoded result with a nil OperationID", result)
 	}
 }
 


### PR DESCRIPTION
Bead: ankra-ukodb

## What & why

`ankra cluster <provider> bastion resize` printed

```
Bastion/gateway 'bastion' resized to 'cx31'.
```

as soon as the platform had written the new instance type. The provider's
bastion update job — power the node off, resize it, power it back on — had not
started at that point, so the line was untrue for as long as the resize really
took, and the output carried nothing to follow it with.

cluster#1386 (ankra-uwii) makes that write dispatch the job inline and answer
with an additive, nullable `operation_id`. This consumes it:

- `client.UpdateBastionInstanceTypeResult` gains `OperationID *string`
  (`operation_id`), so `-o json|yaml` carries it too;
- the human confirmation follows `nodes restart` in `cmd/cluster_nodes.go`:
  names the operation, states that SSH/NAT for the cluster drop while the node
  cycles, and points at `ankra cluster operations list <operation_id>`;
- "resized to" becomes "instance type set to" — the write is what has
  happened when the command returns.

### Safe to merge ahead of the platform release

The field is additive and nullable, so this does not depend on #1386 shipping
first. With no `operation_id` in the response — an older platform, or the
branches where the platform schedules no cloud work: a stopped cluster (the new
type applies on start) and a resize already in flight — the command confirms
the write, explains that there is no operation to track, and prints no id
nobody could poll.

### What this deliberately does not do

The bead also asks whether `--wait` should poll the operation to completion.
That is the same CLI-contract question as **ankra-6j2w** (`apply --wait`), which
is parked on a product decision (change `--wait`'s meaning vs. add a new flag),
so deciding it unattended here would fix the contract for one command and split
it from the rest. `--wait` behaviour is unchanged; the resize help text now says
plainly that it covers the platform write only and that the cloud resize is the
returned operation. Follow-up filed: ankra-13mx7.

## How I verified it

- `go build ./...`, `gofmt` clean on the touched files.
- `lint-lock -- go test -race -count=1 ./cmd/... ./internal/client/...` — pass.
  New coverage: the confirmation names the operation and the poll hint and no
  longer says "resized"; the no-operation branch confirms the write without an
  id; the client decodes a response with `operation_id` absent to a nil field.
- `golangci-lint` is not installed on this machine — CI's lint job covers it.

## Reviewer attention

- The wording of the no-operation branch: it has to be honest both for an older
  platform (field absent) and for #1386's null cases, without asserting which
  one happened.
- Nothing on pr-shepherd's scary list: CLI-only, no schema, deploy, ingress,
  auth or agent-protocol surface.
