### PR TITLE
fix(application): stop inheriting the caller's Git repository environment (ankra-ykqvz)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Fixed
+
+- **`ankra application add` no longer inspects the wrong repository when it is
+  run from inside a Git hook.** `git commit` exports `GIT_DIR`,
+  `GIT_INDEX_FILE` and friends into every hook it runs, and those variables
+  outrank the directory the CLI addresses, so the command run from a
+  pre-commit hook — or from `git rebase --exec`, or a CI step wrapped in one —
+  read the hook's repository instead of the path it was given: the wrong
+  owner/name, the wrong branch, and no error for a path that is not in a
+  repository at all. Git invocations now drop the inherited
+  repository-binding variables while keeping the user's SSH, credential and
+  proxy settings.
+
 ### Changed
 
 - **`ankra cluster <provider> bastion resize` no longer claims the node is

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -360,6 +360,39 @@ func inspectLocalApplicationRepository(
 	}, nil
 }
 
+// Variables through which Git binds a command to one specific repository,
+// index or work tree. `git commit` exports them into every hook it runs, so a
+// CLI invoked from a hook — or from `git rebase --exec`, or a CI step wrapped
+// in one — would silently address the hook's repository instead of the
+// directory named with -C.
+var gitRepositoryEnvironmentVariables = map[string]struct{}{
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES": {},
+	"GIT_COMMON_DIR":                   {},
+	"GIT_DIR":                          {},
+	"GIT_INDEX_FILE":                   {},
+	"GIT_NAMESPACE":                    {},
+	"GIT_OBJECT_DIRECTORY":             {},
+	"GIT_PREFIX":                       {},
+	"GIT_WORK_TREE":                    {},
+}
+
+// gitEnvironment is the process environment with those repository-binding
+// variables removed and the C locale forced, so a Git invocation addresses the
+// directory it was given and its output stays parseable. Everything else the
+// user configured (GIT_SSH_COMMAND, credential helpers, proxies) is preserved.
+func gitEnvironment() []string {
+	processEnvironment := os.Environ()
+	gitCommandEnvironment := make([]string, 0, len(processEnvironment)+1)
+	for _, environmentEntry := range processEnvironment {
+		variableName, _, _ := strings.Cut(environmentEntry, "=")
+		if _, isRepositoryBinding := gitRepositoryEnvironmentVariables[variableName]; isRepositoryBinding {
+			continue
+		}
+		gitCommandEnvironment = append(gitCommandEnvironment, environmentEntry)
+	}
+	return append(gitCommandEnvironment, "LC_ALL=C")
+}
+
 func executeGit(
 	requestContext context.Context,
 	directory string,
@@ -367,7 +400,7 @@ func executeGit(
 ) (string, error) {
 	commandArguments := append([]string{"-C", directory}, arguments...)
 	gitCommand := exec.CommandContext(requestContext, "git", commandArguments...)
-	gitCommand.Env = append(os.Environ(), "LC_ALL=C")
+	gitCommand.Env = gitEnvironment()
 	commandOutput, commandError := gitCommand.CombinedOutput()
 	if commandError != nil {
 		errorDetail := strings.TrimSpace(string(commandOutput))

--- a/cmd/application_test.go
+++ b/cmd/application_test.go
@@ -161,6 +161,57 @@ func TestInspectLocalApplicationRepositoryUsesRemoteDefaultBranch(t *testing.T) 
 	}
 }
 
+func TestInspectLocalApplicationRepositoryIgnoresInheritedGitEnvironment(t *testing.T) {
+	repositoryPath := createTestGitRepository(
+		t,
+		"main",
+		"git@github.com:acme/payments.git",
+	)
+	hookRepositoryPath := createTestGitRepository(
+		t,
+		"master",
+		"git@github.com:acme/unrelated.git",
+	)
+
+	// What `git commit` exports into .githooks/pre-commit: without stripping
+	// these, every Git invocation below addresses the hook's repository no
+	// matter which directory it was pointed at.
+	t.Setenv("GIT_DIR", filepath.Join(hookRepositoryPath, ".git"))
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(hookRepositoryPath, ".git", "index"))
+	t.Setenv("GIT_PREFIX", "")
+
+	repository, inspectError := inspectLocalApplicationRepository(
+		context.Background(),
+		repositoryPath,
+		"origin",
+		"",
+	)
+	if inspectError != nil {
+		t.Fatalf("inspectLocalApplicationRepository() error = %v", inspectError)
+	}
+	if repository.Owner != "acme" || repository.Name != "payments" {
+		t.Errorf("repository = %s/%s, want acme/payments", repository.Owner, repository.Name)
+	}
+	if repository.Branch != "main" {
+		t.Errorf("branch = %q, want main", repository.Branch)
+	}
+
+	_, outsideError := inspectLocalApplicationRepository(
+		context.Background(),
+		t.TempDir(),
+		"origin",
+		"",
+	)
+	if exitCodeFor(outsideError) != exitUsage {
+		t.Errorf(
+			"exit code outside a repository = %d, want %d: %v",
+			exitCodeFor(outsideError),
+			exitUsage,
+			outsideError,
+		)
+	}
+}
+
 func TestInspectLocalApplicationRepositoryExitCodes(t *testing.T) {
 	t.Run("missing_path", func(t *testing.T) {
 		_, inspectError := inspectLocalApplicationRepository(
@@ -570,6 +621,10 @@ func runExternalCommand(
 ) {
 	t.Helper()
 	command := exec.Command(commandName, arguments...)
+	// Without this the temp repository these helpers build would be created
+	// and mutated inside whatever repository the test runner inherited from —
+	// `git commit` exports GIT_DIR and GIT_INDEX_FILE into the pre-commit hook.
+	command.Env = gitEnvironment()
 	if commandOutput, commandError := command.CombinedOutput(); commandError != nil {
 		t.Fatalf("%s failed: %v\n%s", commandName, commandError, commandOutput)
 	}


### PR DESCRIPTION
Bead: ankra-ykqvz

## What was wrong

`git commit` exports its per-hook environment — `GIT_DIR`, `GIT_INDEX_FILE`,
`GIT_PREFIX` and friends — into `.githooks/pre-commit`. Those variables outrank
the directory a git command addresses with `-C`, and `executeGit` in
`cmd/application.go` passed the whole process environment straight through:

```go
gitCommand.Env = append(os.Environ(), "LC_ALL=C")
```

Two consequences.

**Product bug.** `ankra application add <path>` run from inside a git hook —
or from `git rebase --exec`, or a CI step wrapped in one — inspects the *hook's*
repository instead of the path it was given. It reports the wrong owner/name,
the wrong branch, and returns success for a path that is not in a repository at
all (the `exitUsage` "not inside a Git repository" arm never fires).

**This repo's pre-commit gate could not pass.** The hook runs `go test ./...`;
the tests that build a temp repository and shell out to git inherited the same
environment, so six of them failed under `git commit` while passing everywhere
else — leaving anyone committing here with a red gate unrelated to their change,
or `--no-verify`, which `CLAUDE.md` forbids.

Reproduced deterministically on `master` by exporting what a worktree's
`git commit` exports (absolute `GIT_DIR`), which fails exactly the set the bead
names:

```
--- FAIL: TestInspectLocalApplicationRepositoryUsesRemoteDefaultBranch
--- FAIL: TestInspectLocalApplicationRepositoryExitCodes/not_a_repository
--- FAIL: TestApplicationAddCommand
--- FAIL: TestApplicationAddCommandStructuredOutput
--- FAIL: TestApplicationAddCommandMapsEveryRegistryFlag
--- FAIL: TestApplicationAddCommandOmitsTheRegistryWhenUndeclared
```

## What changed

- `cmd/application.go`: new `gitEnvironment()` builds the child environment with
  the repository-binding variables removed (`GIT_DIR`, `GIT_COMMON_DIR`,
  `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_PREFIX`, `GIT_OBJECT_DIRECTORY`,
  `GIT_ALTERNATE_OBJECT_DIRECTORIES`, `GIT_NAMESPACE`) and `LC_ALL=C` kept.
  `executeGit` uses it. Everything else the user configured — `GIT_SSH_COMMAND`,
  credential helpers, proxies — is preserved deliberately.
- `cmd/application_test.go`: the temp-repo helper (`runExternalCommand`) uses the
  same environment, so the fixtures are hermetic too. Without it, `git init
  <tmpdir>` under a hook environment does not even build the repository the test
  thinks it built.
- New regression test
  `TestInspectLocalApplicationRepositoryIgnoresInheritedGitEnvironment`: builds a
  second "hook" repository, exports `GIT_DIR`/`GIT_INDEX_FILE` at it, and asserts
  the inspection still resolves the repository it was pointed at *and* still
  reports `exitUsage` for a path outside any repository. Against the unfixed
  `executeGit` it fails with `repository = acme/unrelated, want acme/payments`.

The bead suggested fixing this in the tests alone. That is not sufficient: the
`not_a_repository` and `application add` failures run through production
`executeGit`, so the inheritance has to be cut there — which also fixes the
product bug rather than only the gate. The hook itself is unchanged.

## Verification

- Reproduced on `master` with the hook environment: the six tests above fail.
- `go test -race -count=1 ./cmd/` — pass, plain and with the hook environment
  exported.
- New test fails against the unfixed `executeGit`, passes with it.
- The **real gate under a real `git commit`** in a linked worktree (the exact
  configuration the bead reproduced against):
  `git -c core.hooksPath=.githooks commit` → `go test ./...` all packages ok,
  `golangci-lint run` 0 issues, "Pre-commit checks passed."
- `golangci-lint run ./cmd/...` — 0 issues. `gofmt -l` clean for both touched
  files (three unrelated files are already unformatted on `master`).

## Worth a closer look

The variable list is a deliberate allow-most/deny-few: it strips what binds git
to a repository and keeps what configures how git talks to the network. If you
think a name is missing (`GIT_CEILING_DIRECTORIES`,
`GIT_DISCOVERY_ACROSS_FILESYSTEM`) say so — they change discovery behaviour but
do not redirect an explicit `-C`, so I left them.

Nothing here touches schema, deploy surfaces, auth, or the agent protocol.
