### PR TITLE
feat(cluster): add --include-dns to every provider create command (ankra-4cva)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@
 - **`ankra application publish-addon` and `published-addon`** publish the
   application's generated manifests to the organisation catalogue as a
   manifest add-on and read the published state back.
+- **`--include-dns` on every `ankra cluster <provider> create`** (UpCloud,
+  DigitalOcean, Hetzner, OVH, Proxmox, Morpheus) completes the create flag
+  trio beside `--external-cloud-provider` and `--include-networking`. The
+  platform gives a new cluster its own subdomain under `ankra.cc` and installs
+  external-dns unless asked not to, and the CLI had no way to ask: every
+  CLI-created cluster took the delegated subzone whether or not it wanted one.
+  It stays on by default, matching the portal wizards and the server, and is
+  independent of the other two — `--include-dns=false` keeps the ingress
+  stack.
 
 ### Fixed
 

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -37,6 +37,18 @@ func isLikelyClusterID(value string) bool {
 	return clusterIDPattern.MatchString(value)
 }
 
+// registerIncludeDNSFlag adds --include-dns to a provider create command. The
+// server defaults include_dns to true on every provider lane, so the flag
+// exists to opt out; the delegated subzone is what makes an ingress hostname
+// resolve and get a certificate without bringing your own domain. external-dns
+// itself ships inside the networking stack, so opting out of that stack leaves
+// the zone delegated but unused.
+func registerIncludeDNSFlag(cmds ...*cobra.Command) {
+	for _, cmd := range cmds {
+		cmd.Flags().Bool("include-dns", true, "Give the cluster its own subdomain under ankra.cc and install external-dns, so an ingress hostname gets its DNS record and TLS certificate with no manual setup (default on; pass --include-dns=false to skip)")
+	}
+}
+
 // resolveCloudProviderNetworking reconciles the --external-cloud-provider and
 // --include-networking flags. Ingress networking (the Traefik LoadBalancer) is
 // provisioned by the cloud controller manager, so --include-networking requires

--- a/cmd/cluster_test.go
+++ b/cmd/cluster_test.go
@@ -14,6 +14,45 @@ func newCloudProviderNetworkingCommand() *cobra.Command {
 	return cmd
 }
 
+// The create flag trio (--external-cloud-provider, --include-networking,
+// --include-dns) is the CLI's half of a contract the server defaults on: a
+// provider create command that is missing one of them silently opts the user
+// into it with no way to say no.
+func TestProviderCreateCommandsExposeTheFlagTrio(t *testing.T) {
+	tests := []struct {
+		name                  string
+		cmd                   *cobra.Command
+		externalCloudProvider bool
+	}{
+		{name: "upcloud", cmd: upcloudCreateCmd, externalCloudProvider: true},
+		{name: "digitalocean", cmd: digitaloceanCreateCmd, externalCloudProvider: true},
+		{name: "hetzner", cmd: hetznerCreateCmd, externalCloudProvider: true},
+		{name: "ovh", cmd: ovhCreateCmd, externalCloudProvider: true},
+		{name: "proxmox", cmd: proxmoxCreateCmd},
+		{name: "morpheus", cmd: morpheusCreateCmd},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, flagName := range []string{"include-networking", "include-dns"} {
+				flag := tt.cmd.Flags().Lookup(flagName)
+				if flag == nil {
+					t.Fatalf("%s create must expose --%s", tt.name, flagName)
+				}
+				if flag.DefValue != "true" {
+					t.Errorf("--%s default = %q, want true (the server defaults it on)", flagName, flag.DefValue)
+				}
+			}
+			// Proxmox and Morpheus have no CCM; the backend refuses the flag
+			// for them, which TestProxmoxCreate_HasNoExternalCloudProviderFlag
+			// pins for its own command.
+			if got := tt.cmd.Flags().Lookup("external-cloud-provider") != nil; got != tt.externalCloudProvider {
+				t.Errorf("--external-cloud-provider present = %v, want %v", got, tt.externalCloudProvider)
+			}
+		})
+	}
+}
+
 func TestResolveCloudProviderNetworking(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/cmd/digitalocean_cluster.go
+++ b/cmd/digitalocean_cluster.go
@@ -41,6 +41,7 @@ var digitaloceanCreateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		includeDNS, _ := cmd.Flags().GetBool("include-dns")
 		gitopsCredentialName, _ := cmd.Flags().GetString("gitops-credential-name")
 		gitopsRepository, _ := cmd.Flags().GetString("gitops-repository")
 		gitopsBranch, _ := cmd.Flags().GetString("gitops-branch")
@@ -49,7 +50,7 @@ var digitaloceanCreateCmd = &cobra.Command{
 			Name:                  name,
 			CredentialID:          credentialID,
 			SSHKeyCredentialID:    sshKeyCredentialID,
-			Region:                  region,
+			Region:                region,
 			NetworkIPRange:        networkIPRange,
 			BastionSize:           bastionSize,
 			ControlPlaneCount:     cpCount,
@@ -62,6 +63,7 @@ var digitaloceanCreateCmd = &cobra.Command{
 			EtcdSize:              etcdSize,
 			ExternalCloudProvider: externalCloudProvider,
 			IncludeNetworking:     includeNetworking,
+			IncludeDNS:            includeDNS,
 		}
 		if kubeVersion != "" {
 			req.KubernetesVersion = &kubeVersion
@@ -598,6 +600,7 @@ func init() {
 	digitaloceanCreateCmd.Flags().String("etcd-size", "s-2vcpu-4gb", "Droplet size for dedicated etcd nodes when --etcd-topology=external")
 	digitaloceanCreateCmd.Flags().Bool("external-cloud-provider", true, "Install the DigitalOcean CCM and CSI (cloud-provider=external) for LoadBalancers and persistent volumes (default on; pass --external-cloud-provider=false to skip, which also disables --include-networking)")
 	digitaloceanCreateCmd.Flags().Bool("include-networking", true, "Install Traefik + cert-manager for ingress (default on; pass --include-networking=false to skip). Requires --external-cloud-provider (the ingress LoadBalancer is provisioned by the cloud controller manager)")
+	registerIncludeDNSFlag(digitaloceanCreateCmd)
 	digitaloceanCreateCmd.Flags().String("gitops-credential-name", "", "GitOps GitHub credential name; when set with --gitops-repository, the generated digitalocean-cloud-provider stack is committed to Git (optional)")
 	digitaloceanCreateCmd.Flags().String("gitops-repository", "", "GitOps repository (e.g. org/repo) to commit the generated stack to (optional)")
 	digitaloceanCreateCmd.Flags().String("gitops-branch", "master", "GitOps branch to commit to")

--- a/cmd/digitalocean_cluster_test.go
+++ b/cmd/digitalocean_cluster_test.go
@@ -8,6 +8,61 @@ import (
 	"ankra/internal/client"
 )
 
+type digitaloceanCreateMock struct {
+	baseMock
+	called     bool
+	gotRequest client.CreateDigitaloceanClusterRequest
+}
+
+func (m *digitaloceanCreateMock) CreateDigitaloceanCluster(req client.CreateDigitaloceanClusterRequest) (*client.CreateDigitaloceanClusterResponse, error) {
+	m.called = true
+	m.gotRequest = req
+	return &client.CreateDigitaloceanClusterResponse{ClusterID: "do-cluster-123", Name: req.Name}, nil
+}
+
+// --include-dns has to reach the wire on every provider lane, not just the
+// three that grew their own flag tests: the field carries no omitempty
+// precisely so an explicit false survives the round trip instead of being
+// re-defaulted to true server-side. It is also independent of the
+// cloud-provider/networking pair in both directions.
+func TestDigitaloceanCreateSendsIncludeDNS(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		wantDNS        bool
+		wantNetworking bool
+	}{
+		{name: "default", wantDNS: true, wantNetworking: true},
+		{name: "dns off", args: []string{"--include-dns=false"}, wantNetworking: true},
+		{name: "networking off keeps dns", args: []string{"--include-networking=false"}, wantDNS: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetConfirmFlag(t, digitaloceanCreateCmd)
+			mock := &digitaloceanCreateMock{}
+			args := append([]string{"cluster", "digitalocean", "create",
+				"--name", "dns-test",
+				"--credential-id", "cred-1",
+				"--ssh-key-credential-id", "ssh-1",
+				"--region", "fra1"}, tt.args...)
+			out, err := runWithInput(t, mock, "", args...)
+			if err != nil {
+				t.Fatalf("execute failed: %v\noutput: %s", err, out)
+			}
+			if !mock.called {
+				t.Fatal("expected CreateDigitaloceanCluster call")
+			}
+			if mock.gotRequest.IncludeDNS != tt.wantDNS {
+				t.Errorf("include_dns = %v, want %v", mock.gotRequest.IncludeDNS, tt.wantDNS)
+			}
+			if mock.gotRequest.IncludeNetworking != tt.wantNetworking {
+				t.Errorf("include_networking = %v, want %v", mock.gotRequest.IncludeNetworking, tt.wantNetworking)
+			}
+		})
+	}
+}
+
 type digitaloceanDeprovisionMock struct {
 	baseMock
 	called       bool

--- a/cmd/hetzner_cluster.go
+++ b/cmd/hetzner_cluster.go
@@ -42,6 +42,7 @@ var hetznerCreateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		includeDNS, _ := cmd.Flags().GetBool("include-dns")
 		gitopsCredentialName, _ := cmd.Flags().GetString("gitops-credential-name")
 		gitopsRepository, _ := cmd.Flags().GetString("gitops-repository")
 		gitopsBranch, _ := cmd.Flags().GetString("gitops-branch")
@@ -68,6 +69,7 @@ var hetznerCreateCmd = &cobra.Command{
 			EtcdServerType:         etcdServerType,
 			ExternalCloudProvider:  externalCloudProvider,
 			IncludeNetworking:      includeNetworking,
+			IncludeDNS:             includeDNS,
 		}
 		if kubeVersion != "" {
 			req.KubernetesVersion = &kubeVersion
@@ -615,6 +617,7 @@ func init() {
 	hetznerCreateCmd.Flags().String("etcd-server-type", "cx33", "Server type for dedicated etcd nodes when --etcd-topology=external")
 	hetznerCreateCmd.Flags().Bool("external-cloud-provider", true, "Install the Hetzner CCM and CSI (cloud-provider=external) for LoadBalancers and persistent volumes (default on; pass --external-cloud-provider=false to skip, which also disables --include-networking)")
 	hetznerCreateCmd.Flags().Bool("include-networking", true, "Install Traefik + cert-manager for ingress (default on; pass --include-networking=false to skip). Requires --external-cloud-provider (the ingress LoadBalancer is provisioned by the cloud controller manager)")
+	registerIncludeDNSFlag(hetznerCreateCmd)
 	hetznerCreateCmd.Flags().String("gitops-credential-name", "", "GitOps GitHub credential name; when set with --gitops-repository, the generated hcloud stack is committed to Git (optional)")
 	hetznerCreateCmd.Flags().String("gitops-repository", "", "GitOps repository (e.g. org/repo) to commit the generated stack to (optional)")
 	hetznerCreateCmd.Flags().String("gitops-branch", "master", "GitOps branch to commit to")

--- a/cmd/hetzner_cluster_test.go
+++ b/cmd/hetzner_cluster_test.go
@@ -12,6 +12,59 @@ import (
 	"github.com/spf13/pflag"
 )
 
+type hetznerCreateMock struct {
+	baseMock
+	called     bool
+	gotRequest client.CreateHetznerClusterRequest
+}
+
+func (m *hetznerCreateMock) CreateHetznerCluster(req client.CreateHetznerClusterRequest) (*client.CreateHetznerClusterResponse, error) {
+	m.called = true
+	m.gotRequest = req
+	return &client.CreateHetznerClusterResponse{ClusterID: "hz-cluster-123", Name: req.Name}, nil
+}
+
+// The same wire guarantee the digitalocean and ovh lanes pin: include_dns
+// travels without omitempty so an explicit false is not dropped and
+// re-defaulted to true, and it does not move include_networking with it.
+func TestHetznerCreateSendsIncludeDNS(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		wantDNS        bool
+		wantNetworking bool
+	}{
+		{name: "default", wantDNS: true, wantNetworking: true},
+		{name: "dns off", args: []string{"--include-dns=false"}, wantNetworking: true},
+		{name: "networking off keeps dns", args: []string{"--include-networking=false"}, wantDNS: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetConfirmFlag(t, hetznerCreateCmd)
+			mock := &hetznerCreateMock{}
+			args := append([]string{"cluster", "hetzner", "create",
+				"--name", "dns-test",
+				"--credential-id", "cred-1",
+				"--ssh-key-credential-id", "ssh-1",
+				"--location", "fsn1"}, tt.args...)
+			out, err := runWithInput(t, mock, "", args...)
+			if err != nil {
+				t.Fatalf("execute failed: %v\noutput: %s", err, out)
+			}
+			if !mock.called {
+				t.Fatal("expected CreateHetznerCluster call")
+			}
+			if mock.gotRequest.IncludeDNS != tt.wantDNS {
+				t.Errorf("include_dns = %v, want %v", mock.gotRequest.IncludeDNS, tt.wantDNS)
+			}
+			if mock.gotRequest.IncludeNetworking != tt.wantNetworking {
+				t.Errorf("include_networking = %v, want %v", mock.gotRequest.IncludeNetworking, tt.wantNetworking)
+			}
+		})
+	}
+}
+
 type hetznerDeprovisionMock struct {
 	baseMock
 	called       bool

--- a/cmd/morpheus_cluster.go
+++ b/cmd/morpheus_cluster.go
@@ -41,6 +41,7 @@ var morpheusCreateCmd = &cobra.Command{
 		etcdPlanID, _ := cmd.Flags().GetInt64("etcd-plan-id")
 		cni, _ := cmd.Flags().GetString("cni")
 		includeNetworking, _ := cmd.Flags().GetBool("include-networking")
+		includeDNS, _ := cmd.Flags().GetBool("include-dns")
 
 		request := client.CreateMorpheusClusterRequest{
 			Name:               name,
@@ -60,6 +61,7 @@ var morpheusCreateCmd = &cobra.Command{
 			EtcdNodeCount:      etcdNodeCount,
 			CNI:                cni,
 			IncludeNetworking:  includeNetworking,
+			IncludeDNS:         includeDNS,
 		}
 		if description != "" {
 			request.Description = &description
@@ -363,6 +365,7 @@ func init() {
 	morpheusCreateCmd.Flags().Int64("etcd-plan-id", 0, "Service plan ID for dedicated etcd nodes when --etcd-topology=external (optional)")
 	morpheusCreateCmd.Flags().String("cni", "", "CNI plugin (optional; the platform default is used when omitted)")
 	morpheusCreateCmd.Flags().Bool("include-networking", true, "Install Traefik + cert-manager as Ankra-managed stacks for ingress (exposed via the built-in k3s service load balancer; default on)")
+	registerIncludeDNSFlag(morpheusCreateCmd)
 
 	_ = morpheusCreateCmd.MarkFlagRequired("name")
 	_ = morpheusCreateCmd.MarkFlagRequired("credential-id")

--- a/cmd/morpheus_cluster_test.go
+++ b/cmd/morpheus_cluster_test.go
@@ -74,6 +74,9 @@ func TestMorpheusCreate_MapsFlagsToRequest(t *testing.T) {
 	if !request.IncludeNetworking {
 		t.Error("include_networking should default to true")
 	}
+	if !request.IncludeDNS {
+		t.Error("include_dns should default to true")
+	}
 	if request.VirtualImageID != nil || request.EtcdPlanID != nil {
 		t.Errorf("optional ids should be omitted when unset, got virtual_image_id=%v etcd_plan_id=%v",
 			request.VirtualImageID, request.EtcdPlanID)
@@ -109,6 +112,39 @@ func TestMorpheusCreate_SendsOptionalNumericIDs(t *testing.T) {
 	}
 	if mock.gotRequest.EtcdPlanID == nil || *mock.gotRequest.EtcdPlanID != 9 {
 		t.Errorf("etcd_plan_id = %v, want 9", mock.gotRequest.EtcdPlanID)
+	}
+}
+
+func TestMorpheusCreate_IncludeDNSCanBeDisabled(t *testing.T) {
+	// Cobra flag values live on the shared command, so put --include-dns back
+	// on its default rather than leaking the opt-out into later tests.
+	t.Cleanup(func() {
+		_ = morpheusCreateCmd.Flags().Set("include-dns", "true")
+		morpheusCreateCmd.Flags().Lookup("include-dns").Changed = false
+	})
+	mock := &morpheusCreateMock{}
+	out, runError := runWithInput(t, mock, "",
+		"cluster", "morpheus", "create",
+		"--name", "morpheus-test",
+		"--credential-id", "cred-1",
+		"--ssh-key-credential-id", "ssh-1",
+		"--group-id", "1",
+		"--cloud-id", "2",
+		"--network-id", "3",
+		"--layout-id", "4",
+		"--bastion-plan-id", "5",
+		"--control-plane-plan-id", "6",
+		"--worker-plan-id", "7",
+		"--include-dns=false",
+	)
+	if runError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", runError, out)
+	}
+	if mock.gotRequest.IncludeDNS {
+		t.Error("include_dns should be false when disabled")
+	}
+	if !mock.gotRequest.IncludeNetworking {
+		t.Error("opting out of the delegated subzone must not drop the ingress stack")
 	}
 }
 

--- a/cmd/ovh_cluster.go
+++ b/cmd/ovh_cluster.go
@@ -45,6 +45,7 @@ var ovhCreateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		includeDNS, _ := cmd.Flags().GetBool("include-dns")
 		gitopsCredentialName, _ := cmd.Flags().GetString("gitops-credential-name")
 		gitopsRepository, _ := cmd.Flags().GetString("gitops-repository")
 		gitopsBranch, _ := cmd.Flags().GetString("gitops-branch")
@@ -70,6 +71,7 @@ var ovhCreateCmd = &cobra.Command{
 			EtcdFlavorID:          etcdFlavorID,
 			ExternalCloudProvider: externalCloudProvider,
 			IncludeNetworking:     includeNetworking,
+			IncludeDNS:            includeDNS,
 		}
 		if kubeVersion != "" {
 			req.KubernetesVersion = &kubeVersion
@@ -903,6 +905,7 @@ func init() {
 	ovhCreateCmd.Flags().String("etcd-flavor-id", "b2-15", "Instance flavor for dedicated etcd nodes when --etcd-topology=external")
 	ovhCreateCmd.Flags().Bool("external-cloud-provider", true, "Install the OpenStack CCM and Cinder CSI (cloud-provider=external) for LoadBalancers and persistent volumes (default on; pass --external-cloud-provider=false to skip, which also disables --include-networking)")
 	ovhCreateCmd.Flags().Bool("include-networking", true, "Install Traefik + cert-manager for ingress (default on; pass --include-networking=false to skip). Requires --external-cloud-provider (the ingress LoadBalancer is provisioned by the cloud controller manager)")
+	registerIncludeDNSFlag(ovhCreateCmd)
 	ovhCreateCmd.Flags().String("gitops-credential-name", "", "GitOps GitHub credential name; when set with --gitops-repository, the generated ovh-cloud stack is committed to Git (optional)")
 	ovhCreateCmd.Flags().String("gitops-repository", "", "GitOps repository (e.g. org/repo) to commit the generated stack to (optional)")
 	ovhCreateCmd.Flags().String("gitops-branch", "master", "GitOps branch to commit to")

--- a/cmd/ovh_cluster_test.go
+++ b/cmd/ovh_cluster_test.go
@@ -528,6 +528,45 @@ func TestOvhCreateOmitsAvailabilityZonesWhenNotAsked(t *testing.T) {
 	}
 }
 
+// --include-dns is independent of the cloud-provider/networking pair: opting
+// out of the delegated ankra.cc subzone must not quietly drop the ingress
+// stack that the other two flags govern.
+func TestOvhCreateSendsIncludeDNS(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		wantDNS        bool
+		wantNetworking bool
+	}{
+		{name: "default", wantDNS: true, wantNetworking: true},
+		{name: "dns off", args: []string{"--include-dns=false"}, wantNetworking: true},
+		{name: "networking off keeps dns", args: []string{"--include-networking=false"}, wantDNS: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetOvhCommandFlags(t, ovhCreateCmd)
+			mock := &ovhCreateZonesMock{}
+			setMockClient(t, mock)
+
+			args := append([]string{"cluster", "ovh", "create",
+				"--name", "dns-test",
+				"--credential-id", "credential-1",
+				"--ssh-key-credential-id", "ssh-1",
+				"--region", "GRA"}, tt.args...)
+			if _, err := executeCommand(args...); err != nil {
+				t.Fatalf("creating the cluster: %v", err)
+			}
+			if mock.gotRequest.IncludeDNS != tt.wantDNS {
+				t.Errorf("include_dns = %v, want %v", mock.gotRequest.IncludeDNS, tt.wantDNS)
+			}
+			if mock.gotRequest.IncludeNetworking != tt.wantNetworking {
+				t.Errorf("include_networking = %v, want %v", mock.gotRequest.IncludeNetworking, tt.wantNetworking)
+			}
+		})
+	}
+}
+
 type ovhNodeGroupZoneMock struct {
 	baseMock
 	gotRequest client.AddNodeGroupRequest

--- a/cmd/proxmox_cluster.go
+++ b/cmd/proxmox_cluster.go
@@ -42,6 +42,7 @@ var proxmoxCreateCmd = &cobra.Command{
 		etcdInstanceType, _ := cmd.Flags().GetString("etcd-instance-type")
 		cni, _ := cmd.Flags().GetString("cni")
 		includeNetworking, _ := cmd.Flags().GetBool("include-networking")
+		includeDNS, _ := cmd.Flags().GetBool("include-dns")
 
 		request := client.CreateProxmoxClusterRequest{
 			Name:                     name,
@@ -63,6 +64,7 @@ var proxmoxCreateCmd = &cobra.Command{
 			EtcdInstanceType:         etcdInstanceType,
 			CNI:                      cni,
 			IncludeNetworking:        includeNetworking,
+			IncludeDNS:               includeDNS,
 		}
 		if description != "" {
 			request.Description = &description
@@ -352,6 +354,7 @@ func init() {
 	proxmoxCreateCmd.Flags().String("etcd-instance-type", "px-medium", "Instance-size preset for dedicated etcd nodes when --etcd-topology=external")
 	proxmoxCreateCmd.Flags().String("cni", "", "CNI plugin (optional; the platform default is used when omitted)")
 	proxmoxCreateCmd.Flags().Bool("include-networking", true, "Install Traefik + cert-manager as Ankra-managed stacks for ingress (exposed via the built-in k3s service load balancer; default on)")
+	registerIncludeDNSFlag(proxmoxCreateCmd)
 
 	_ = proxmoxCreateCmd.MarkFlagRequired("name")
 	_ = proxmoxCreateCmd.MarkFlagRequired("credential-id")

--- a/cmd/proxmox_cluster_test.go
+++ b/cmd/proxmox_cluster_test.go
@@ -88,6 +88,9 @@ func TestProxmoxCreate_MapsFlagsToRequest(t *testing.T) {
 	if !request.IncludeNetworking {
 		t.Error("include_networking should default to true")
 	}
+	if !request.IncludeDNS {
+		t.Error("include_dns should default to true")
+	}
 	if request.Description != nil || request.KubernetesVersion != nil {
 		t.Errorf("optional fields should be omitted when unset, got description=%v kubernetes_version=%v",
 			request.Description, request.KubernetesVersion)
@@ -110,6 +113,31 @@ func TestProxmoxCreate_IncludeNetworkingCanBeDisabled(t *testing.T) {
 	}
 	if mock.gotRequest.IncludeNetworking {
 		t.Error("include_networking should be false when disabled")
+	}
+}
+
+func TestProxmoxCreate_IncludeDNSCanBeDisabled(t *testing.T) {
+	// Cobra flag values live on the shared command, so put --include-dns back
+	// on its default rather than leaking the opt-out into later tests.
+	t.Cleanup(func() {
+		_ = proxmoxCreateCmd.Flags().Set("include-dns", "true")
+		proxmoxCreateCmd.Flags().Lookup("include-dns").Changed = false
+	})
+	mock := &proxmoxCreateMock{}
+	out, runError := runWithInput(t, mock, "",
+		"cluster", "proxmox", "create",
+		"--name", "pve-test",
+		"--credential-id", "cred-1",
+		"--ssh-key-credential-id", "ssh-1",
+		"--node", "pve1",
+		"--bridge", "vmbr0",
+		"--include-dns=false",
+	)
+	if runError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", runError, out)
+	}
+	if mock.gotRequest.IncludeDNS {
+		t.Error("include_dns should be false when disabled")
 	}
 }
 

--- a/cmd/upcloud_cluster.go
+++ b/cmd/upcloud_cluster.go
@@ -40,6 +40,7 @@ var upcloudCreateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		includeDNS, _ := cmd.Flags().GetBool("include-dns")
 		gitopsCredentialName, _ := cmd.Flags().GetString("gitops-credential-name")
 		gitopsRepository, _ := cmd.Flags().GetString("gitops-repository")
 		gitopsBranch, _ := cmd.Flags().GetString("gitops-branch")
@@ -61,6 +62,7 @@ var upcloudCreateCmd = &cobra.Command{
 			EtcdPlan:              etcdPlan,
 			ExternalCloudProvider: externalCloudProvider,
 			IncludeNetworking:     includeNetworking,
+			IncludeDNS:            includeDNS,
 		}
 		if kubeVersion != "" {
 			req.KubernetesVersion = &kubeVersion
@@ -535,6 +537,7 @@ func init() {
 	upcloudCreateCmd.Flags().String("etcd-plan", "2xCPU-4GB", "Plan for dedicated etcd nodes when --etcd-topology=external")
 	upcloudCreateCmd.Flags().Bool("external-cloud-provider", true, "Install the UpCloud CCM and CSI (cloud-provider=external) for LoadBalancers and persistent volumes (default on; pass --external-cloud-provider=false to skip, which also disables --include-networking)")
 	upcloudCreateCmd.Flags().Bool("include-networking", true, "Install Traefik + cert-manager for ingress (default on; pass --include-networking=false to skip). Requires --external-cloud-provider (the ingress LoadBalancer is provisioned by the cloud controller manager)")
+	registerIncludeDNSFlag(upcloudCreateCmd)
 	upcloudCreateCmd.Flags().String("gitops-credential-name", "", "GitOps GitHub credential name; when set with --gitops-repository, the generated upcloud-cloud-provider stack is committed to Git (optional)")
 	upcloudCreateCmd.Flags().String("gitops-repository", "", "GitOps repository (e.g. org/repo) to commit the generated stack to (optional)")
 	upcloudCreateCmd.Flags().String("gitops-branch", "master", "GitOps branch to commit to")

--- a/internal/client/digitalocean_clusters.go
+++ b/internal/client/digitalocean_clusters.go
@@ -28,6 +28,7 @@ type CreateDigitaloceanClusterRequest struct {
 	EtcdSize              string  `json:"etcd_size,omitempty"`
 	ExternalCloudProvider bool    `json:"external_cloud_provider"`
 	IncludeNetworking     bool    `json:"include_networking"`
+	IncludeDNS            bool    `json:"include_dns"`
 	GitopsCredentialName  *string `json:"gitops_credential_name,omitempty"`
 	GitopsRepository      *string `json:"gitops_repository,omitempty"`
 	GitopsBranch          *string `json:"gitops_branch,omitempty"`

--- a/internal/client/hetzner_clusters.go
+++ b/internal/client/hetzner_clusters.go
@@ -65,6 +65,7 @@ type CreateHetznerClusterRequest struct {
 	NodeGroups             []CreateNodeGroupRequest `json:"node_groups,omitempty"`
 	ExternalCloudProvider  bool                     `json:"external_cloud_provider"`
 	IncludeNetworking      bool                     `json:"include_networking"`
+	IncludeDNS             bool                     `json:"include_dns"`
 	GitopsCredentialName   *string                  `json:"gitops_credential_name,omitempty"`
 	GitopsRepository       *string                  `json:"gitops_repository,omitempty"`
 	GitopsBranch           *string                  `json:"gitops_branch,omitempty"`

--- a/internal/client/morpheus_clusters.go
+++ b/internal/client/morpheus_clusters.go
@@ -31,6 +31,7 @@ type CreateMorpheusClusterRequest struct {
 	EtcdPlanID         *int64  `json:"etcd_plan_id,omitempty"`
 	CNI                string  `json:"cni,omitempty"`
 	IncludeNetworking  bool    `json:"include_networking"`
+	IncludeDNS         bool    `json:"include_dns"`
 }
 
 type CreateMorpheusClusterResponse struct {

--- a/internal/client/ovh_clusters.go
+++ b/internal/client/ovh_clusters.go
@@ -46,6 +46,7 @@ type CreateOvhClusterRequest struct {
 	EtcdFlavorID          string  `json:"etcd_flavor_id,omitempty"`
 	ExternalCloudProvider bool    `json:"external_cloud_provider"`
 	IncludeNetworking     bool    `json:"include_networking"`
+	IncludeDNS            bool    `json:"include_dns"`
 	GitopsCredentialName  *string `json:"gitops_credential_name,omitempty"`
 	GitopsRepository      *string `json:"gitops_repository,omitempty"`
 	GitopsBranch          *string `json:"gitops_branch,omitempty"`

--- a/internal/client/proxmox_clusters.go
+++ b/internal/client/proxmox_clusters.go
@@ -31,6 +31,7 @@ type CreateProxmoxClusterRequest struct {
 	EtcdInstanceType         string   `json:"etcd_instance_type,omitempty"`
 	CNI                      string   `json:"cni,omitempty"`
 	IncludeNetworking        bool     `json:"include_networking"`
+	IncludeDNS               bool     `json:"include_dns"`
 }
 
 type CreateProxmoxClusterResponse struct {

--- a/internal/client/upcloud_clusters.go
+++ b/internal/client/upcloud_clusters.go
@@ -28,6 +28,7 @@ type CreateUpcloudClusterRequest struct {
 	EtcdPlan              string  `json:"etcd_plan,omitempty"`
 	ExternalCloudProvider bool    `json:"external_cloud_provider"`
 	IncludeNetworking     bool    `json:"include_networking"`
+	IncludeDNS            bool    `json:"include_dns"`
 	GitopsCredentialName  *string `json:"gitops_credential_name,omitempty"`
 	GitopsRepository      *string `json:"gitops_repository,omitempty"`
 	GitopsBranch          *string `json:"gitops_branch,omitempty"`

--- a/internal/client/upcloud_clusters_test.go
+++ b/internal/client/upcloud_clusters_test.go
@@ -49,6 +49,7 @@ func TestCreateUpcloudCluster_SendsCloudProviderNetworkingAndGitopsFields(t *tes
 		WorkerCount: 2, WorkerPlan: "2xCPU-4GB", Distribution: "k3s",
 		ExternalCloudProvider: true,
 		IncludeNetworking:     true,
+		IncludeDNS:            true,
 		GitopsCredentialName:  strPtr("github-cred"),
 		GitopsRepository:      strPtr("acme/infra"),
 		GitopsBranch:          &branch,
@@ -61,6 +62,9 @@ func TestCreateUpcloudCluster_SendsCloudProviderNetworkingAndGitopsFields(t *tes
 	}
 	if got, ok := receivedBody["include_networking"].(bool); !ok || !got {
 		t.Errorf("include_networking = %v, want true", receivedBody["include_networking"])
+	}
+	if got, ok := receivedBody["include_dns"].(bool); !ok || !got {
+		t.Errorf("include_dns = %v, want true", receivedBody["include_dns"])
 	}
 	if got, _ := receivedBody["gitops_credential_name"].(string); got != "github-cred" {
 		t.Errorf("gitops_credential_name = %q, want github-cred", got)
@@ -96,6 +100,11 @@ func TestCreateUpcloudCluster_OmitsGitopsWhenUnset(t *testing.T) {
 	}
 	if got, ok := receivedBody["include_networking"].(bool); !ok || got {
 		t.Errorf("include_networking = %v, want false", receivedBody["include_networking"])
+	}
+	// No omitempty on include_dns: a dropped false would be decoded as the
+	// server's default true and provision the subzone the user opted out of.
+	if got, ok := receivedBody["include_dns"].(bool); !ok || got {
+		t.Errorf("include_dns = %v, want false", receivedBody["include_dns"])
 	}
 	if _, present := receivedBody["gitops_credential_name"]; present {
 		t.Errorf("gitops_credential_name should be omitted when unset")


### PR DESCRIPTION
## What

Adds `--include-dns` to every provider `create` command — `upcloud`,
`digitalocean`, `hetzner`, `ovh`, `proxmox`, `morpheus` — completing the create
flag trio beside `--external-cloud-provider` and `--include-networking`. It
defaults to `true` and is sent on every create request.

Bead: ankra-4cva

## Why

The capability shipped server-side and was invisible to CLI users:

- `providerapi/lifecycle.go` decodes `include_dns` with `optionalBool(..., true)`
  on all seven provider create lanes, and `resolveCreateFlags` resolves a nil
  pointer to `DefaultCreateIncludeDNS = true`.
- `queuePendingClusterDNSZone` inserts the pending `dns_zones` row from it, and
  the scheduler's `dns_zone_reconciler` drives that to a delegated
  `<cluster>.<org>.ankra.cc` zone with external-dns wired into the networking
  stack.

So every CLI-created cluster took the delegated subzone whether or not it wanted
one, with no flag to decline. The portal wizards already surface all three
(Scaleway always did; UpCloud since portal#1288).

## Notes for review

- **No `omitempty` on the new `include_dns` JSON field.** That is deliberate and
  is what the second UpCloud client test pins: a dropped `false` would be
  decoded as the server's default `true` and provision the subzone the user
  explicitly opted out of. It matches the existing `include_networking` /
  `external_cloud_provider` tags.
- **The flag is independent of the other two**, matching both the portal wizards
  and the server, which apply no cross-flag rule: `--include-dns=false` keeps the
  ingress stack, and `--include-networking=false` keeps the subzone (the zone is
  delegated but external-dns, which ships inside the networking stack, is not
  installed). No new `resolveCloudProviderNetworking`-style validation was added.
- The help text lives in one shared `registerIncludeDNSFlag` helper in
  `cmd/cluster.go` rather than six copies, since the wording is not
  provider-specific.
- `cmd/digitalocean_cluster.go` carries a one-line `Region:` realignment that
  `gofmt` applied to the struct literal being edited; the file was already
  gofmt-dirty on `master`.
- Scaleway has no CLI `create` command, so it is not in the list.

## Verification

- `go test -count=1 ./cmd/... ./internal/client/...` — pass
- `lint-lock -- golangci-lint run ./cmd/... ./internal/client/...` — 0 issues
- `go vet ./cmd/... ./internal/client/...` — clean
- Built the binary and confirmed `--include-dns` appears in `--help` for all six
  provider create commands.
- `go build ./...` without `-buildvcs=false` reports `error obtaining VCS status`
  on this machine, in the shared checkout too — a pre-existing local git/Go
  stamping condition, not from this change. CI builds normally.

New tests:

- `TestProviderCreateCommandsExposeTheFlagTrio` — table over all six create
  commands asserting `--include-networking` and `--include-dns` exist and default
  to `true`, and that only the CCM-backed four expose
  `--external-cloud-provider`. This is the regression guard for the next provider
  added.
- `TestOvhCreateSendsIncludeDNS` — the flag reaches the request, and DNS and
  networking are independent in both directions.
- `TestProxmoxCreate_IncludeDNSCanBeDisabled` plus a default-on assertion in the
  existing proxmox mapping test.
- `include_dns` wire assertions (true and false) in the UpCloud client tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
