### PR TITLE
fix(cluster): ask the platform for a bounded log read on --follow=false (ankra-v54hx)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@
 
 ### Fixed
 
+- **`ankra cluster logs --follow=false` now asks the platform for a bounded
+  read instead of guessing when the backlog ended.** The route only ever
+  followed, so the CLI had to infer the end of the tail from a two-second gap
+  with no new line — which cost every scripted `--follow=false` run those two
+  seconds, and cut the tail short whenever a busy pod happened to pause.
+  The request now carries `follow=false`: the cluster snapshots the selected
+  tail and closes the stream itself, and the CLI exits on that. Against a
+  platform that predates the parameter nothing changes — the old idle-gap
+  drain still ends the read. The stream's terminating frames ("stream
+  complete", "stream idle timeout") also stop being printed as though they
+  were log lines, in both follow and non-follow mode.
+
 - **`ankra application add` no longer inspects the wrong repository when it is
   run from inside a Git hook.** `git commit` exports `GIT_DIR`,
   `GIT_INDEX_FILE` and friends into every hook it runs, and those variables

--- a/internal/client/kubernetes.go
+++ b/internal/client/kubernetes.go
@@ -166,10 +166,12 @@ type PodLogOptions struct {
 	TailLines     int
 	SinceSeconds  int
 	// Follow keeps the stream open for new lines (kubectl logs -f). When
-	// false the client returns once the backlog has drained: the platform's
-	// log route only follows, so the drain is detected client-side as an
-	// idle gap after the first batch (or the server's keepalive comment,
-	// which it only sends once it has nothing buffered).
+	// false the request carries follow=false, so the route snapshots the
+	// selected tail and closes the response on the agent's end frame. A
+	// platform that predates that parameter ignores it and keeps following,
+	// so the client still detects the drain itself - an idle gap after the
+	// first batch, or the server's keepalive comment, which it only sends
+	// once it has nothing buffered.
 	Follow bool
 }
 
@@ -190,6 +192,12 @@ func (c *Client) StreamPodLogs(ctx context.Context, clusterID string, opts PodLo
 	}
 	if opts.SinceSeconds > 0 {
 		params.Set("since_seconds", fmt.Sprintf("%d", opts.SinceSeconds))
+	}
+	if !opts.Follow {
+		// The route defaults to follow=true; only the bounded read has to
+		// say so, which keeps the following request byte-identical to what
+		// every released CLI has always sent.
+		params.Set("follow", "false")
 	}
 
 	endpoint := fmt.Sprintf("%s/api/v1/clusters/%s/kubernetes/pod/logs?%s",
@@ -236,33 +244,44 @@ func (c *Client) StreamPodLogs(ctx context.Context, clusterID string, opts PodLo
 	return drainPodLogs(ctx, scanner, resp, writer)
 }
 
+// sseData strips the "data:" prefix and its optional space from an SSE
+// line, leaving the payload.
+func sseData(line string) string {
+	return strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " ")
+}
+
 // writePodLogLine handles one SSE line: an error event surfaces as the
-// error, a data line is written. done reports an error event was consumed.
+// error, an end event stops the read, a data line is written. done reports
+// the stream is over. Both terminating events carry their own data line
+// ("stream complete", "stream idle timeout") - that is protocol text, so it
+// is consumed with the event rather than printed as if it were a log line.
 func writePodLogLine(scanner *bufio.Scanner, writer io.Writer) (bool, error) {
 	line := scanner.Text()
-	if line == "event: error" {
+	switch line {
+	case "event: error":
 		if scanner.Scan() {
-			errLine := strings.TrimPrefix(scanner.Text(), "data:")
-			errLine = strings.TrimPrefix(errLine, " ")
-			return true, fmt.Errorf("%s", errLine)
+			return true, fmt.Errorf("%s", sseData(scanner.Text()))
 		}
+		return true, nil
+	case "event: end":
+		scanner.Scan()
 		return true, nil
 	}
 	if strings.HasPrefix(line, "data:") {
-		data := strings.TrimPrefix(line, "data:")
-		data = strings.TrimPrefix(data, " ")
-		if _, err := fmt.Fprintln(writer, data); err != nil {
+		if _, err := fmt.Fprintln(writer, sseData(line)); err != nil {
 			return false, fmt.Errorf("write output: %w", err)
 		}
 	}
 	return false, nil
 }
 
-// drainPodLogs reads the follow stream until the backlog is drained - the
-// first idle gap after at least one line, or a server keepalive comment
-// (sent only when nothing is buffered) - then closes the response so the
-// server tears the stream down. A stream that ends on its own returns its
-// scanner error, if any.
+// drainPodLogs reads a non-follow stream until the backlog is drained. A
+// route that honours follow=false ends it with its own "end" frame; against
+// an older one the drain is inferred client-side from the first idle gap
+// after at least one line, or from a server keepalive comment (sent only
+// when nothing is buffered), and the response is closed so the server tears
+// the stream down. A stream that ends on its own returns its scanner error,
+// if any.
 func drainPodLogs(ctx context.Context, scanner *bufio.Scanner, resp *http.Response, writer io.Writer) error {
 	lines := make(chan string)
 	scanErrors := make(chan error, 1)
@@ -281,6 +300,7 @@ func drainPodLogs(ctx context.Context, scanner *bufio.Scanner, resp *http.Respon
 	defer idle.Stop()
 	sawLine := false
 	pendingError := false
+	pendingEnd := false
 	for {
 		select {
 		case <-ctx.Done():
@@ -302,17 +322,23 @@ func drainPodLogs(ctx context.Context, scanner *bufio.Scanner, resp *http.Respon
 			}
 			switch {
 			case pendingError:
-				errLine := strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " ")
-				return fmt.Errorf("%s", errLine)
+				return fmt.Errorf("%s", sseData(line))
+			case pendingEnd:
+				// The end frame's payload ("stream complete", "stream idle
+				// timeout") is protocol text, not a log line: swallow it and
+				// leave, the server has already closed its side.
+				return nil
 			case line == "event: error":
 				pendingError = true
+				continue
+			case line == "event: end":
+				pendingEnd = true
 				continue
 			case strings.HasPrefix(line, ":") && sawLine:
 				closeBody(resp)
 				return nil
 			case strings.HasPrefix(line, "data:"):
-				data := strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " ")
-				if _, err := fmt.Fprintln(writer, data); err != nil {
+				if _, err := fmt.Fprintln(writer, sseData(line)); err != nil {
 					return fmt.Errorf("write output: %w", err)
 				}
 				sawLine = true

--- a/internal/client/kubernetes_logs_follow_test.go
+++ b/internal/client/kubernetes_logs_follow_test.go
@@ -107,3 +107,76 @@ func TestStreamPodLogsFollowTrueReadsUntilStreamEnds(t *testing.T) {
 		t.Fatalf("follow mode must read past idle gaps, got %q", buf.String())
 	}
 }
+
+// TestStreamPodLogsFollowFalseEndsOnServerEndFrame pins the bounded read
+// against a route that honours follow=false: the request says so, the end
+// frame stops the read at once instead of waiting out the idle gap, and the
+// frame's "stream complete" payload never reaches the log output.
+func TestStreamPodLogsFollowFalseEndsOnServerEndFrame(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("follow"); got != "false" {
+			t.Errorf("follow query = %q, want %q", got, "false")
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		_, _ = fmt.Fprint(w, "data: backlog one\n\n")
+		_, _ = fmt.Fprint(w, "event: end\ndata: stream complete\n\n")
+		flusher.Flush()
+		// Hold the response open: the client must leave on the frame, not
+		// because the stream closed under it.
+		select {
+		case <-r.Context().Done():
+		case <-time.After(15 * time.Second):
+			t.Error("client never left on the end frame")
+		}
+	}
+	testClient := newTestClient(t, handler)
+	var buf bytes.Buffer
+	started := time.Now()
+	err := testClient.StreamPodLogs(context.Background(), "cluster-id",
+		PodLogOptions{Namespace: "default", PodName: "nginx-abc", Follow: false}, &buf)
+	if err != nil {
+		t.Fatalf("StreamPodLogs() error = %v", err)
+	}
+	if buf.String() != "backlog one\n" {
+		t.Fatalf("output = %q; the end frame's payload is protocol text", buf.String())
+	}
+	if elapsed := time.Since(started); elapsed >= podLogsDrainIdle {
+		t.Fatalf("end frame should end the read before the idle gap, took %s", elapsed)
+	}
+}
+
+// TestStreamPodLogsFollowTrueEndsOnEndFrame pins the follow lane's own
+// terminator: the route ends a stream it has stopped hearing from with
+// "event: end" + "stream idle timeout", which is protocol text and must not
+// be printed as if it were a log line. Following requests leave the follow
+// parameter off, keeping them byte-identical to older releases.
+func TestStreamPodLogsFollowTrueEndsOnEndFrame(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Has("follow") {
+			t.Errorf("follow query = %q, want it absent", r.URL.Query().Get("follow"))
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		_, _ = fmt.Fprint(w, "data: first\n\n")
+		_, _ = fmt.Fprint(w, "event: end\ndata: stream idle timeout\n\n")
+		flusher.Flush()
+		select {
+		case <-r.Context().Done():
+		case <-time.After(15 * time.Second):
+			t.Error("client never left on the end frame")
+		}
+	}
+	testClient := newTestClient(t, handler)
+	var buf bytes.Buffer
+	err := testClient.StreamPodLogs(context.Background(), "cluster-id",
+		PodLogOptions{Namespace: "default", PodName: "nginx-abc", Follow: true}, &buf)
+	if err != nil {
+		t.Fatalf("StreamPodLogs() error = %v", err)
+	}
+	if buf.String() != "first\n" {
+		t.Fatalf("output = %q; the end frame's payload is protocol text", buf.String())
+	}
+}


### PR DESCRIPTION
## What & why

Bead: ankra-v54hx

`ankra cluster logs --follow=false` shipped before the platform could serve a
bounded read. The pod-logs route only ever followed, so the CLI opened the
ordinary stream and inferred the end of the backlog client-side: two seconds
with no new line meant "drained". That costs every scripted run those two
seconds, and it cuts the tail short whenever a busy pod pauses mid-backlog.

cluster #1313 (ankra-7g7p, merged 2026-08-18) put `follow=` on both pod-logs
SSE routes. This PR uses it:

- A non-follow read sends `follow=false`. The agent snapshots the selected
  tail and the route closes the response on the agent's end frame, so the CLI
  exits on that instead of on a timer.
- A **following** request omits the parameter entirely, so it stays
  byte-identical to what every released CLI sends.
- The client-side idle-gap drain is untouched. Against a platform that
  predates the parameter the unknown query param is ignored, the stream keeps
  following, and the drain is still what ends the read — so this is safe to
  release ahead of the deploy, it is simply inert until then.
- The SSE reader printed every `data:` line verbatim, so it would have echoed
  the new frame's `stream complete` payload as if it were a log line. The
  pre-existing `stream idle timeout` frame (the follow lane's terminator) has
  the same wart and lands in the middle of a piped log file. Both terminating
  events are now consumed with their payload and stop the read.

### One deliberate deviation from the bead

The bead asked for a new `--no-follow` flag. **It is not added**: `--follow`
(bool, default true, `-f`) already exists and `--follow=false` is exactly that
mode — it shipped in ankra-tycp / #96, after this bead was written. A second
flag for the same boolean would need conflict handling for
`--follow --no-follow` and would leave the command with two spellings of one
thing, so `cmd/cluster_k8s.go` is unchanged; its `Long` text already documents
`--follow=false`. Say so on the PR if you would rather have the alias and I
will add it.

## Test plan

- `go test -race -count=1 ./cmd/... ./internal/client/...` — pass.
- `golangci-lint run ./internal/client/...` — 0 issues.
- Two new tests in `internal/client/kubernetes_logs_follow_test.go`, both
  against a handler that holds the response open so a pass proves the client
  left on the frame rather than on the stream closing:
  - `TestStreamPodLogsFollowFalseEndsOnServerEndFrame` — asserts
    `follow=false` is on the request, that the read ends *before* the idle
    gap, and that `stream complete` is not printed.
  - `TestStreamPodLogsFollowTrueEndsOnEndFrame` — asserts the follow request
    omits `follow`, and that `stream idle timeout` is not printed.
- Not run: a live `ankra cluster logs` against a deployed cluster (no cluster
  credentials in this environment). The wire contract is pinned against the
  frames cluster emits in `go/internal/kubeproxyapi/kubernetes.go`
  (`event: end\ndata: stream complete` / `data: stream idle timeout`).

### Worth a closer look

`drainPodLogs` now has two "the next line belongs to the event before it"
flags (`pendingError`, `pendingEnd`). They are mutually exclusive in practice
— the route emits one terminating frame and returns — but the ordering of the
switch arms is what makes that true, so it is the part to read twice.

Not on the scary list: no schema, deploy surface, ingress, auth, or agent
protocol change. The agent↔platform wire is untouched; this only changes the
query string the CLI sends and how it reads frames the route already emits.

## Docs checklist

- [x] No user-facing command/flag changes — no docs needed
- [ ] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); ensure `Short`/`Long`/`Example` on new commands are written for docs readers
- [ ] Broader behaviour changes — docs updated in [ankra-docs](https://github.com/ankraio/ankra-docs) (link the PR): <!-- PR link -->
