### PR TITLE
chore: add `make hooks` so a clone actually installs the pre-commit gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,16 +7,21 @@ template in `.github/pull_request_template.md`.
 ## Build, test, lint
 
 ```bash
+make hooks        # once per clone: git config core.hooksPath .githooks
 make build        # go build ./...
 make test         # go test -race -count=1 ./...
 make lint         # golangci-lint run
 ./build.sh        # dist/ankra with release-identical ldflags (--install → /usr/local/bin)
 ```
 
-A pre-commit hook (`core.hooksPath` → `.githooks/`) runs `go test ./...` and
-`golangci-lint run` on every commit, so commits take ~30s and a red test
-blocks the commit. Do not bypass it with `--no-verify` unless explicitly
-asked.
+The pre-commit gate is opt-in per clone: git ignores `.githooks/` until
+`core.hooksPath` points at it, and nothing sets that automatically, so a clone
+that never ran `make hooks` commits with no gate and says nothing. Check with
+`git config core.hooksPath` — empty output means the gate is not installed.
+
+Once installed, the hook runs `go test ./...` and `golangci-lint run` on every
+commit, so commits take ~30s and a red test blocks the commit. Do not bypass
+it with `--no-verify` unless explicitly asked.
 
 The version string is injected at build time via `-X main.version` →
 `cmd.SetVersion`. The `version = "0.3.0"` constant in `cmd/root.go` is only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,15 +28,22 @@ You need Go (the version pinned by the `toolchain` directive in `go.mod` —
 git clone https://github.com/ankraio/ankra-cli.git
 cd ankra-cli
 
+make hooks        # once per clone: git config core.hooksPath .githooks
 make build        # go build ./...
 make test         # go test -race -count=1 ./...
 make lint         # golangci-lint run
 ./build.sh        # dist/ankra with release-identical ldflags (--install → /usr/local/bin)
 ```
 
-A pre-commit hook (`core.hooksPath` → `.githooks/`) runs `go test ./...` and
-`golangci-lint run` on every commit, so commits take ~30s and a red test
-blocks the commit. Please don't bypass it with `--no-verify`.
+`make hooks` installs the pre-commit gate, and it is the step people miss:
+git does not read `.githooks/` unless `core.hooksPath` points at it, so until
+you run it your commits go through with no gate and no warning. Run it once
+per clone (it is idempotent, and `git config core.hooksPath` tells you whether
+a clone already has it).
+
+The hook then runs `go test ./...` and `golangci-lint run` on every commit, so
+commits take ~30s and a red test blocks the commit. Please don't bypass it
+with `--no-verify`.
 
 ## Making changes
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint generate verify-skills
+.PHONY: build test lint hooks generate verify-skills
 
 # Path to the canonical ankra-skills project (monorepo sibling). In the split
 # ankra-cli repo this does not exist and the vendored embedded copy is canonical.
@@ -14,6 +14,14 @@ test:
 
 lint:
 	golangci-lint run
+
+# hooks points this clone at the committed .githooks/ so the pre-commit gate
+# actually runs. git never sets core.hooksPath for you, so a fresh clone
+# commits with no gate at all and says nothing about it — run this once after
+# cloning. Idempotent.
+hooks:
+	@git config core.hooksPath .githooks
+	@echo "core.hooksPath = $$(git config core.hooksPath) (pre-commit gate active)"
 
 # generate vendors the canonical skills into the CLI for //go:embed and
 # regenerates the ankra-skills catalog. No-op when the sibling is absent.


### PR DESCRIPTION
## What & why

The repo documents a pre-commit gate (`core.hooksPath` → `.githooks/`, running
`go test ./...` and `golangci-lint run`) in both CONTRIBUTING.md and CLAUDE.md,
but nothing ever installs it. git does not read `.githooks/` unless
`core.hooksPath` points at it, and neither document told you to set it — so a
fresh clone commits with **no gate at all and no warning**. The documented
quality gate is opt-in by accident: whoever wired it by hand once has it, a new
clone does not, and nobody is told. (This is the follow-up filed from #108.)

- **`make hooks`** runs `git config core.hooksPath .githooks` and echoes the
  resulting value. Idempotent. Because linked worktrees share the repository
  config, running it once covers every worktree — the relative path resolves
  against each worktree's own root.
- **CONTRIBUTING.md / CLAUDE.md**: `make hooks` is now the first line of the
  setup block, and the paragraph describing the hook says plainly that the gate
  does nothing until it is run, with `git config core.hooksPath` (empty output =
  not installed) as the way to check.

No CHANGELOG entry: this is contributor tooling, not a user-visible CLI change.
No Go code is touched.

## Test plan

Verified in a throwaway clone rather than in the workspace checkout — `git
config core.hooksPath` writes to the shared repository config, and this machine
has other agents committing in sibling worktrees of this repo who should not
suddenly acquire a 30s `go test` + `golangci-lint` gate mid-flight.

In that clone:

- Fresh clone of this branch: `git config core.hooksPath` printed nothing —
  the bug reproduces exactly as reported.
- `make hooks` → `core.hooksPath = .githooks (pre-commit gate active)`; re-running
  it is a no-op with the same output.
- Replaced `.githooks/pre-commit` with a stub that touches a marker file, then
  committed: the stub ran and the marker appeared — git really does resolve the
  hook afterwards.
- Repeated the commit from a linked worktree of that clone: `core.hooksPath` is
  inherited and the hook fired there too, confirming the relative path resolves
  per-worktree.
- `make -n build test lint verify-skills` all still resolve (Makefile intact).

Go tests and `golangci-lint` were **not** run locally: no Go source changed, and
CI's lint-test-build job covers them on this PR.

## Docs checklist

- [x] No user-facing command/flag changes — no docs needed

Nothing on the risky list here (no schema, deploy, ingress, auth or agent
protocol surface). The one thing worth a reviewer's eye is that `make hooks`
mutates local git config, so it is deliberately a target you opt into rather
than a prerequisite of `make build`/`make test`.

Bead: ankra-blrfl
