### PR TITLE
fix(cluster): apply must stop dropping addon values and stack variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,10 @@
   add-ons then ran unconfigured and the manifests reached the cluster with
   `${VAR}` still in them, failing typed fields outright. Apply now sends both,
   and a `configuration:` block it cannot turn into values is an error naming
-  the keys it did find, rather than a silent fall back to chart defaults.
+  what it did find, rather than a silent fall back to chart defaults — both
+  when the block uses a key this CLI does not read and when it gives a key
+  the CLI does read the wrong type, such as a nested map where
+  `values_base64` takes a string.
   Because apply also prunes what the file does not declare, a config-only
   apply used to mis-configure and wipe in the same run.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,9 @@
   what it did find, rather than a silent fall back to chart defaults — both
   when the block uses a key this CLI does not read and when it gives a key
   the CLI does read the wrong type, such as a nested map where
-  `values_base64` takes a string.
+  `values_base64` takes a string. A key it cannot read sitting *beside* one it
+  can is a warning on stderr naming the ignored key rather than an error, so a
+  file from a newer Ankra still applies.
   Because apply also prunes what the file does not declare, a config-only
   apply used to mis-configure and wipe in the same run.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,20 @@
 
 ### Fixed
 
+- **`ankra cluster apply` no longer drops an addon's values or a stack's
+  variables on the way to the platform.** Two keys of the ImportCluster
+  dialect were never read: `configuration.values_base64` on an addon, and the
+  stack-level `variables` map. Both are what the platform's own IaC export
+  emits, so applying an exported file — the ordinary clone-edit-apply loop —
+  installed every addon with chart defaults and left the stack with no
+  variables at all, while `apply` and `validate` both reported success. The
+  add-ons then ran unconfigured and the manifests reached the cluster with
+  `${VAR}` still in them, failing typed fields outright. Apply now sends both,
+  and a `configuration:` block it cannot turn into values is an error naming
+  the keys it did find, rather than a silent fall back to chart defaults.
+  Because apply also prunes what the file does not declare, a config-only
+  apply used to mis-configure and wipe in the same run.
+
 - **`ankra cluster logs --follow=false` now asks the platform for a bounded
   read instead of guessing when the backlog ended.** The route only ever
   followed, so the CLI had to infer the end of the tail from a two-second gap

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -270,6 +270,32 @@ func unknownConfigurationKeys(conf map[string]interface{}) []string {
 	return unknown
 }
 
+// checkConfigurationTypes rejects a recognised addon 'configuration' key whose
+// value is not the type that key is read as. Without it the read below simply
+// fails its type assertion and the block collapses to no configuration at all,
+// which is the ankra-yxxa failure: the addon installs on chart defaults, over
+// whatever it was running, and apply reports success.
+//
+// A key present but explicitly nil is left alone - 'values:' with nothing
+// after it means the same deliberate "no configuration" as 'values: ""'.
+func checkConfigurationTypes(conf map[string]interface{}) error {
+	for _, key := range []string{"from_file", "values", "values_base64"} {
+		value, present := conf[key]
+		if !present || value == nil {
+			continue
+		}
+		if _, ok := value.(string); !ok {
+			return fmt.Errorf("addon 'configuration.%s' must be a string, got %T", key, value)
+		}
+	}
+	if value, present := conf["encrypted_paths"]; present && value != nil {
+		if _, ok := value.([]interface{}); !ok {
+			return fmt.Errorf("addon 'configuration.encrypted_paths' must be a list of strings, got %T", value)
+		}
+	}
+	return nil
+}
+
 // sortedKeys returns a map's keys in a stable order, so an error message that
 // lists what a block did contain reads the same on every run.
 func sortedKeys(m map[string]interface{}) []string {
@@ -725,12 +751,27 @@ func buildAddon(am map[string]interface{}, baseDir string) (client.Addon, error)
 
 	var cfg interface{}
 	if conf, ok := am["configuration"].(map[string]interface{}); ok {
+		// A key we DO read, holding the wrong type, used to fail its type
+		// assertion and fall through to a nil configuration - the ankra-yxxa
+		// silent drop again, entered through a malformed value rather than an
+		// unread key, and invisible to unknownConfigurationKeys because the
+		// key itself is recognised. An explicit nil ('values:' with nothing
+		// after it) stays equivalent to the deliberately-empty 'values: ""'.
+		if err := checkConfigurationTypes(conf); err != nil {
+			return client.Addon{}, err
+		}
+
 		var encryptedPaths []string
 		if rawPaths, ok := conf["encrypted_paths"].([]interface{}); ok {
-			for _, p := range rawPaths {
-				if s, ok := p.(string); ok {
-					encryptedPaths = append(encryptedPaths, s)
+			for i, p := range rawPaths {
+				s, ok := p.(string)
+				if !ok {
+					// Skipping one silently would ship the secret it names
+					// unencrypted.
+					return client.Addon{}, fmt.Errorf(
+						"addon 'configuration.encrypted_paths' entry %d must be a string, got %T", i+1, p)
 				}
+				encryptedPaths = append(encryptedPaths, s)
 			}
 		}
 
@@ -775,16 +816,22 @@ func buildAddon(am map[string]interface{}, baseDir string) (client.Addon, error)
 				ValuesBase64:   encoded,
 				EncryptedPaths: encryptedPaths,
 			}
-		} else if len(encryptedPaths) > 0 {
-			return client.Addon{}, errors.New("addon 'configuration.encrypted_paths' is set but there is nothing to decrypt (set 'from_file', 'values' or 'values_base64')")
 		} else if unknown := unknownConfigurationKeys(conf); len(unknown) > 0 {
 			// Keys we do not read are either a typo or a dialect newer than
 			// this CLI. Either way, say so - a configuration block that turns
 			// into nothing means the addon deploys with chart defaults over
 			// whatever it is running, which is how this went unnoticed.
+			//
+			// This runs ahead of the encrypted_paths complaint below because
+			// a block with both a typo'd key and encrypted_paths is better
+			// served by the message that names the typo. Neither branch is
+			// reached unless the block yielded no values at all, so the set
+			// of files that apply is unchanged either way.
 			return client.Addon{}, fmt.Errorf(
 				"addon 'configuration' has no values this CLI can read: set 'from_file', 'values' or 'values_base64' (unrecognised: %s)",
 				strings.Join(unknown, ", "))
+		} else if len(encryptedPaths) > 0 {
+			return client.Addon{}, errors.New("addon 'configuration.encrypted_paths' is set but there is nothing to decrypt (set 'from_file', 'values' or 'values_base64')")
 		}
 	}
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 
 	"ankra/internal/client"
@@ -246,6 +248,39 @@ func buildImportRequest(path string) (client.CreateImportClusterRequest, error) 
 	}, nil
 }
 
+// addonConfigurationKeys is every key an addon's 'configuration' block may
+// carry. Anything else in there is a key this CLI would drop on the floor, so
+// buildAddon refuses the file rather than deploying chart defaults.
+var addonConfigurationKeys = map[string]bool{
+	"from_file":       true,
+	"values":          true,
+	"values_base64":   true,
+	"encrypted_paths": true,
+}
+
+// unknownConfigurationKeys lists, in a stable order, the keys of an addon
+// configuration block that this CLI does not read.
+func unknownConfigurationKeys(conf map[string]interface{}) []string {
+	unknown := make([]string, 0)
+	for _, key := range sortedKeys(conf) {
+		if !addonConfigurationKeys[key] {
+			unknown = append(unknown, key)
+		}
+	}
+	return unknown
+}
+
+// sortedKeys returns a map's keys in a stable order, so an error message that
+// lists what a block did contain reads the same on every run.
+func sortedKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 func optString(m map[string]interface{}, key string) string {
 	value, ok := m[key]
 	if !ok || value == nil {
@@ -474,13 +509,61 @@ func buildStack(sm map[string]interface{}, baseDir string) (client.Stack, error)
 		return client.Stack{}, err
 	}
 
+	variables, err := parseStackVariables(sm["variables"])
+	if err != nil {
+		return client.Stack{}, err
+	}
+
 	return client.Stack{
 		Name:        name,
 		Description: desc,
 		Manifests:   manifests,
 		Addons:      addons,
 		DeployWave:  deployWave,
+		Variables:   variables,
 	}, nil
+}
+
+// parseStackVariables reads the optional stack-level 'variables' map, the
+// scope that shadows cluster and organisation variables when this stack's
+// manifests and addons are rendered. Apply used to drop it (ankra-yxxa): the
+// stack came back with no variables at all and every '${VAR}' reached the
+// cluster as a literal token, so string fields got nonsense and numeric ones
+// failed the typed patch outright.
+//
+// The backend stores variables as strings. Integers and booleans are written
+// out as their literal text because that conversion is exact; anything a
+// conversion would mangle - a float such as 1.20, a nested structure, a key
+// with no value - is rejected with a hint to quote it, the same guard
+// requiredAddonString applies to chart_version.
+func parseStackVariables(raw interface{}) (map[string]string, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	rawMap, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("'variables' must be a map of name to value, got %v", raw)
+	}
+	variables := make(map[string]string, len(rawMap))
+	for _, key := range sortedKeys(rawMap) {
+		switch typed := rawMap[key].(type) {
+		case string:
+			variables[key] = typed
+		case int:
+			variables[key] = strconv.Itoa(typed)
+		case int64:
+			variables[key] = strconv.FormatInt(typed, 10)
+		case uint64:
+			variables[key] = strconv.FormatUint(typed, 10)
+		case bool:
+			variables[key] = strconv.FormatBool(typed)
+		default:
+			return nil, fmt.Errorf(
+				"variable %q must be a string (got %v - quote it, as variables are stored as strings and an unquoted value like 1.20 would be rewritten to \"1.2\")",
+				key, rawMap[key])
+		}
+	}
+	return variables, nil
 }
 
 // parseDeployWave validates the optional 'deploy_wave' stack field: a
@@ -669,8 +752,33 @@ func buildAddon(am map[string]interface{}, baseDir string) (client.Addon, error)
 				ValuesBase64:   base64.StdEncoding.EncodeToString([]byte(inline)),
 				EncryptedPaths: encryptedPaths,
 			}
+		} else if encoded, ok := conf["values_base64"].(string); ok && encoded != "" {
+			// This is the form the platform's own IaC export emits, so it is
+			// what a clone/export -> apply round trip carries. Reading it was
+			// missing until ankra-yxxa: the block fell through to a nil
+			// configuration and every addon in the file installed with chart
+			// defaults, silently and with validate passing.
+			decoded, err := base64.StdEncoding.DecodeString(encoded)
+			if err != nil {
+				return client.Addon{}, fmt.Errorf("the addon 'configuration.values_base64' is not valid base64: %w", err)
+			}
+			if err := validateYAMLDocuments(decoded); err != nil {
+				return client.Addon{}, fmt.Errorf("the addon 'configuration.values_base64' does not decode to valid YAML: %w", err)
+			}
+			cfg = client.AddonStandaloneConfiguration{
+				ValuesBase64:   encoded,
+				EncryptedPaths: encryptedPaths,
+			}
 		} else if len(encryptedPaths) > 0 {
-			return client.Addon{}, errors.New("addon 'configuration.encrypted_paths' is set but there is nothing to decrypt (set 'from_file' or 'values')")
+			return client.Addon{}, errors.New("addon 'configuration.encrypted_paths' is set but there is nothing to decrypt (set 'from_file', 'values' or 'values_base64')")
+		} else if unknown := unknownConfigurationKeys(conf); len(unknown) > 0 {
+			// Keys we do not read are either a typo or a dialect newer than
+			// this CLI. Either way, say so - a configuration block that turns
+			// into nothing means the addon deploys with chart defaults over
+			// whatever it is running, which is how this went unnoticed.
+			return client.Addon{}, fmt.Errorf(
+				"addon 'configuration' has no values this CLI can read: set 'from_file', 'values' or 'values_base64' (unrecognised: %s)",
+				strings.Join(unknown, ", "))
 		}
 	}
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -536,6 +536,12 @@ func buildStack(sm map[string]interface{}, baseDir string) (client.Stack, error)
 // conversion would mangle - a float such as 1.20, a nested structure, a key
 // with no value - is rejected with a hint to quote it, the same guard
 // requiredAddonString applies to chart_version.
+//
+// The int cases carry the common path, not the rare one: this file is decoded
+// by gopkg.in/yaml.v3, which yields a Go int for an unquoted 'REPLICAS: 2'.
+// A decoder that round-trips through JSON would hand every number over as a
+// float64 and send plain integers down the reject branch instead, so that
+// contract is pinned by a test rather than assumed.
 func parseStackVariables(raw interface{}) (map[string]string, error) {
 	if raw == nil {
 		return nil, nil

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -833,6 +833,22 @@ func buildAddon(am map[string]interface{}, baseDir string) (client.Addon, error)
 		} else if len(encryptedPaths) > 0 {
 			return client.Addon{}, errors.New("addon 'configuration.encrypted_paths' is set but there is nothing to decrypt (set 'from_file', 'values' or 'values_base64')")
 		}
+
+		// A key we cannot read alongside one we can: the values do reach the
+		// addon, so this is not the ankra-yxxa drop, but whatever the extra
+		// key meant to say is still being ignored. Warn rather than fail -
+		// the platform's own IaC export writes these files, and erroring
+		// would mean a dialect that gains a key breaks every older CLI on a
+		// file whose values it reads perfectly. Stderr keeps '-o json|yaml'
+		// parseable.
+		if cfg != nil {
+			if unknown := unknownConfigurationKeys(conf); len(unknown) > 0 {
+				_, _ = fmt.Fprintf(os.Stderr,
+					"Warning: addon %q has 'configuration' keys this CLI does not read, so they are ignored: %s. "+
+						"Check the spelling, or upgrade if the file came from a newer Ankra.\n",
+					name, strings.Join(unknown, ", "))
+			}
+		}
 	}
 
 	agentsMd, agentsMdFromFile, err := parseAgentsMdFields(am, baseDir)

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -270,6 +270,19 @@ func unknownConfigurationKeys(conf map[string]interface{}) []string {
 	return unknown
 }
 
+// describeVariableValue renders a rejected variable for an error message: the
+// value itself when it is a scalar (the hint only lands if you can see the
+// 1.20 that provoked it), the type alone when it is a map or a list, whose
+// contents may be a credential and whose shape is the actual problem anyway.
+func describeVariableValue(value interface{}) string {
+	switch value.(type) {
+	case map[string]interface{}, []interface{}, map[interface{}]interface{}:
+		return fmt.Sprintf("a %T", value)
+	default:
+		return fmt.Sprintf("%v", value)
+	}
+}
+
 // checkConfigurationTypes rejects a recognised addon 'configuration' key whose
 // value is not the type that key is read as. Without it the read below simply
 // fails its type assertion and the block collapses to no configuration at all,
@@ -590,9 +603,13 @@ func parseStackVariables(raw interface{}) (map[string]string, error) {
 		case bool:
 			variables[key] = strconv.FormatBool(typed)
 		default:
+			// Echo a scalar, because seeing 1.20 is what makes the hint land,
+			// but describe a map or a list by type only: a nested block is
+			// where a credential would be hiding, and this error travels into
+			// CI logs.
 			return nil, fmt.Errorf(
-				"variable %q must be a string (got %v - quote it, as variables are stored as strings and an unquoted value like 1.20 would be rewritten to \"1.2\")",
-				key, rawMap[key])
+				"variable %q must be a string (got %s - quote it, as variables are stored as strings and an unquoted value like 1.20 would be rewritten to \"1.2\")",
+				key, describeVariableValue(rawMap[key]))
 		}
 	}
 	return variables, nil
@@ -761,6 +778,11 @@ func buildAddon(am map[string]interface{}, baseDir string) (client.Addon, error)
 			return client.Addon{}, err
 		}
 
+		// Computed once: the same list decides the hard error below (when the
+		// block yielded nothing) and the warning at the end (when it yielded
+		// values anyway), and two call sites would be free to drift apart.
+		unknownKeys := unknownConfigurationKeys(conf)
+
 		var encryptedPaths []string
 		if rawPaths, ok := conf["encrypted_paths"].([]interface{}); ok {
 			for i, p := range rawPaths {
@@ -816,7 +838,7 @@ func buildAddon(am map[string]interface{}, baseDir string) (client.Addon, error)
 				ValuesBase64:   encoded,
 				EncryptedPaths: encryptedPaths,
 			}
-		} else if unknown := unknownConfigurationKeys(conf); len(unknown) > 0 {
+		} else if len(unknownKeys) > 0 {
 			// Keys we do not read are either a typo or a dialect newer than
 			// this CLI. Either way, say so - a configuration block that turns
 			// into nothing means the addon deploys with chart defaults over
@@ -829,7 +851,7 @@ func buildAddon(am map[string]interface{}, baseDir string) (client.Addon, error)
 			// of files that apply is unchanged either way.
 			return client.Addon{}, fmt.Errorf(
 				"addon 'configuration' has no values this CLI can read: set 'from_file', 'values' or 'values_base64' (unrecognised: %s)",
-				strings.Join(unknown, ", "))
+				strings.Join(unknownKeys, ", "))
 		} else if len(encryptedPaths) > 0 {
 			return client.Addon{}, errors.New("addon 'configuration.encrypted_paths' is set but there is nothing to decrypt (set 'from_file', 'values' or 'values_base64')")
 		}
@@ -841,13 +863,11 @@ func buildAddon(am map[string]interface{}, baseDir string) (client.Addon, error)
 		// would mean a dialect that gains a key breaks every older CLI on a
 		// file whose values it reads perfectly. Stderr keeps '-o json|yaml'
 		// parseable.
-		if cfg != nil {
-			if unknown := unknownConfigurationKeys(conf); len(unknown) > 0 {
-				_, _ = fmt.Fprintf(os.Stderr,
-					"Warning: addon %q has 'configuration' keys this CLI does not read, so they are ignored: %s. "+
-						"Check the spelling, or upgrade if the file came from a newer Ankra.\n",
-					name, strings.Join(unknown, ", "))
-			}
+		if cfg != nil && len(unknownKeys) > 0 {
+			_, _ = fmt.Fprintf(os.Stderr,
+				"Warning: addon %q has 'configuration' keys this CLI does not read, so they are ignored: %s. "+
+					"Check the spelling, or upgrade if the file came from a newer Ankra.\n",
+				name, strings.Join(unknownKeys, ", "))
 		}
 	}
 

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -515,6 +515,41 @@ func TestBuildAddon(t *testing.T) {
 		}
 	})
 
+	// A typo next to a key that does work: the values still reach the addon,
+	// so failing the apply would be wrong (the platform's export writes these
+	// files, and a dialect that gains a key must not break older CLIs), but
+	// the ignored key has to be said out loud rather than dropped in silence.
+	t.Run("an unrecognised key beside a working one warns without failing", func(t *testing.T) {
+		am := map[string]interface{}{
+			"name":          "cert-manager",
+			"chart_name":    "cert-manager",
+			"chart_version": "1.14.0",
+			"configuration": map[string]interface{}{
+				"values": "replicaCount: 3",
+				"valuez": "replicaCount: 9",
+			},
+		}
+		var a client.Addon
+		var err error
+		warning := captureStderr(t, func() {
+			a, err = buildAddon(am, "")
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		cfg, ok := a.Configuration.(client.AddonStandaloneConfiguration)
+		if !ok {
+			t.Fatalf("configuration type = %T, want the values to still be sent", a.Configuration)
+		}
+		decoded, decodeErr := base64.StdEncoding.DecodeString(cfg.ValuesBase64)
+		if decodeErr != nil || string(decoded) != "replicaCount: 3" {
+			t.Errorf("values = %q (err %v), want the readable key to still win", string(decoded), decodeErr)
+		}
+		if !strings.Contains(warning, "valuez") {
+			t.Errorf("stderr = %q, want a warning naming the ignored key", warning)
+		}
+	})
+
 	// Both diagnostics only fire for a block that yielded no values, so the
 	// question is only which one you get: the typo is the actionable half.
 	t.Run("an unrecognised key is named even when encrypted_paths is set", func(t *testing.T) {
@@ -979,6 +1014,27 @@ func TestBuildStack(t *testing.T) {
 		}
 		if _, ok := raw["DEBUG"].(bool); !ok {
 			t.Fatalf("DEBUG decoded as %T, want bool", raw["DEBUG"])
+		}
+	})
+
+	// An integer above int64's range decodes as uint64 rather than int, which
+	// is the whole reason parseStackVariables carries a uint64 case. Verified
+	// against the decoder rather than assumed, so the branch is not mistaken
+	// for dead code and deleted.
+	t.Run("integers too large for int64 decode to uint64 and survive", func(t *testing.T) {
+		var raw map[string]interface{}
+		if err := yaml.Unmarshal([]byte("MAX_BYTES: 18446744073709551615\n"), &raw); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := raw["MAX_BYTES"].(uint64); !ok {
+			t.Fatalf("MAX_BYTES decoded as %T, want uint64", raw["MAX_BYTES"])
+		}
+		s, err := buildStack(map[string]interface{}{"name": "gpu-chat", "variables": raw}, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if s.Variables["MAX_BYTES"] != "18446744073709551615" {
+			t.Errorf("MAX_BYTES = %q, want it carried through exactly", s.Variables["MAX_BYTES"])
 		}
 	})
 

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -467,11 +467,79 @@ func TestBuildAddon(t *testing.T) {
 		}
 	})
 
+	// A recognised key holding the wrong type failed its type assertion and
+	// left the block worth nothing, so the addon installed on chart defaults
+	// with apply reporting success - ankra-yxxa reached through a malformed
+	// value instead of an unread key, and invisible to the unrecognised-key
+	// error because the key itself is one this CLI reads.
+	t.Run("configuration keys holding the wrong type are rejected", func(t *testing.T) {
+		for label, conf := range map[string]map[string]interface{}{
+			"values_base64 as a map":  {"values_base64": map[string]interface{}{"replicaCount": 3}},
+			"values as a map":         {"values": map[string]interface{}{"replicaCount": 3}},
+			"values as a number":      {"values": 3},
+			"from_file as a list":     {"from_file": []interface{}{"values.yaml"}},
+			"encrypted_paths as text": {"encrypted_paths": "secrets.password"},
+		} {
+			am := map[string]interface{}{
+				"name":          "cert-manager",
+				"chart_name":    "cert-manager",
+				"chart_version": "1.14.0",
+				"configuration": conf,
+			}
+			a, err := buildAddon(am, "")
+			if err == nil {
+				t.Errorf("%s: expected an error, got configuration = %v", label, a.Configuration)
+				continue
+			}
+			if !strings.Contains(err.Error(), "must be a") {
+				t.Errorf("%s: error = %v, want it to name the expected type", label, err)
+			}
+		}
+	})
+
+	// Dropping a single non-string entry silently would ship the secret it
+	// names unencrypted.
+	t.Run("encrypted_paths entries that are not strings are rejected", func(t *testing.T) {
+		am := map[string]interface{}{
+			"name":          "cert-manager",
+			"chart_name":    "cert-manager",
+			"chart_version": "1.14.0",
+			"configuration": map[string]interface{}{
+				"values":          "replicaCount: 3",
+				"encrypted_paths": []interface{}{"secrets.password", map[string]interface{}{"secrets": "token"}},
+			},
+		}
+		_, err := buildAddon(am, "")
+		if err == nil || !strings.Contains(err.Error(), "encrypted_paths") {
+			t.Errorf("error = %v, want an error naming encrypted_paths", err)
+		}
+	})
+
+	// Both diagnostics only fire for a block that yielded no values, so the
+	// question is only which one you get: the typo is the actionable half.
+	t.Run("an unrecognised key is named even when encrypted_paths is set", func(t *testing.T) {
+		am := map[string]interface{}{
+			"name":          "cert-manager",
+			"chart_name":    "cert-manager",
+			"chart_version": "1.14.0",
+			"configuration": map[string]interface{}{
+				"valuez":          "replicaCount: 3",
+				"encrypted_paths": []interface{}{"secrets.password"},
+			},
+		}
+		_, err := buildAddon(am, "")
+		if err == nil || !strings.Contains(err.Error(), "valuez") {
+			t.Errorf("error = %v, want it to name the unrecognised key rather than the generic encrypted_paths message", err)
+		}
+	})
+
 	t.Run("configuration blocks that deliberately carry nothing stay configuration-free", func(t *testing.T) {
 		for label, conf := range map[string]map[string]interface{}{
-			"empty block":         {},
-			"empty values":        {"values": ""},
-			"empty values_base64": {"values_base64": ""},
+			"empty block":          {},
+			"empty values":         {"values": ""},
+			"empty values_base64":  {"values_base64": ""},
+			"null values":          {"values": nil},
+			"null encrypted_paths": {"encrypted_paths": nil},
 		} {
 			am := map[string]interface{}{
 				"name":          "cert-manager",

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -1049,6 +1049,29 @@ func TestBuildStack(t *testing.T) {
 		}
 	})
 
+	// The rejection message travels into CI logs, so a nested block - the one
+	// shape that could be hiding a credential - is described by type rather
+	// than printed. A scalar is still echoed: seeing the 1.20 is what makes
+	// the "quote it" hint land.
+	t.Run("rejecting a structured variable does not echo its contents", func(t *testing.T) {
+		sm := map[string]interface{}{
+			"name": "gpu-chat",
+			"variables": map[string]interface{}{
+				"DB": map[string]interface{}{"password": "hunter2-should-not-appear"},
+			},
+		}
+		_, err := buildStack(sm, "")
+		if err == nil {
+			t.Fatal("expected an error for a structured variable")
+		}
+		if !strings.Contains(err.Error(), "DB") {
+			t.Errorf("error = %v, want it to name the variable", err)
+		}
+		if strings.Contains(err.Error(), "hunter2") {
+			t.Errorf("error = %v, want the nested value described by type, not echoed", err)
+		}
+	})
+
 	t.Run("variables must be a map", func(t *testing.T) {
 		sm := map[string]interface{}{
 			"name":      "gpu-chat",

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -367,6 +367,127 @@ func TestBuildAddon(t *testing.T) {
 		}
 	})
 
+	// values_base64 is the form the platform's IaC export emits, so these
+	// cover the round trip that installed every addon with chart defaults
+	// before the CLI read the key at all (ankra-yxxa).
+	t.Run("standalone config values_base64", func(t *testing.T) {
+		valuesContent := "replicaCount: 3\nimage:\n  tag: latest"
+		encoded := base64.StdEncoding.EncodeToString([]byte(valuesContent))
+
+		am := map[string]interface{}{
+			"name":          "cert-manager",
+			"chart_name":    "cert-manager",
+			"chart_version": "1.14.0",
+			"configuration": map[string]interface{}{
+				"values_base64":   encoded,
+				"encrypted_paths": []interface{}{"secrets.token"},
+			},
+		}
+		a, err := buildAddon(am, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		cfg, ok := a.Configuration.(client.AddonStandaloneConfiguration)
+		if !ok {
+			t.Fatalf("configuration type = %T, want AddonStandaloneConfiguration", a.Configuration)
+		}
+		if cfg.ValuesBase64 != encoded {
+			t.Errorf("values_base64 = %q, want %q", cfg.ValuesBase64, encoded)
+		}
+		if len(cfg.EncryptedPaths) != 1 || cfg.EncryptedPaths[0] != "secrets.token" {
+			t.Errorf("encrypted_paths = %v, want [secrets.token]", cfg.EncryptedPaths)
+		}
+	})
+
+	t.Run("from_file and values still win over values_base64", func(t *testing.T) {
+		inline := "replicaCount: 1"
+		am := map[string]interface{}{
+			"name":          "cert-manager",
+			"chart_name":    "cert-manager",
+			"chart_version": "1.14.0",
+			"configuration": map[string]interface{}{
+				"values":        inline,
+				"values_base64": base64.StdEncoding.EncodeToString([]byte("replicaCount: 9")),
+			},
+		}
+		a, err := buildAddon(am, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		cfg := a.Configuration.(client.AddonStandaloneConfiguration)
+		decoded, _ := base64.StdEncoding.DecodeString(cfg.ValuesBase64)
+		if string(decoded) != inline {
+			t.Errorf("decoded values = %q, want the inline values %q", string(decoded), inline)
+		}
+	})
+
+	t.Run("values_base64 rejects undecodable content", func(t *testing.T) {
+		am := map[string]interface{}{
+			"name":          "cert-manager",
+			"chart_name":    "cert-manager",
+			"chart_version": "1.14.0",
+			"configuration": map[string]interface{}{"values_base64": "not base64!!"},
+		}
+		_, err := buildAddon(am, "")
+		if err == nil || !strings.Contains(err.Error(), "not valid base64") {
+			t.Errorf("error = %v, want a 'not valid base64' error", err)
+		}
+	})
+
+	t.Run("values_base64 rejects content that is not YAML", func(t *testing.T) {
+		am := map[string]interface{}{
+			"name":          "cert-manager",
+			"chart_name":    "cert-manager",
+			"chart_version": "1.14.0",
+			"configuration": map[string]interface{}{
+				"values_base64": base64.StdEncoding.EncodeToString([]byte("key: [unclosed")),
+			},
+		}
+		_, err := buildAddon(am, "")
+		if err == nil || !strings.Contains(err.Error(), "valid YAML") {
+			t.Errorf("error = %v, want a 'valid YAML' error", err)
+		}
+	})
+
+	t.Run("configuration with a key this CLI cannot read is rejected", func(t *testing.T) {
+		am := map[string]interface{}{
+			"name":          "cert-manager",
+			"chart_name":    "cert-manager",
+			"chart_version": "1.14.0",
+			"configuration": map[string]interface{}{"valuez": "replicaCount: 3"},
+		}
+		_, err := buildAddon(am, "")
+		if err == nil || !strings.Contains(err.Error(), "no values this CLI can read") {
+			t.Fatalf("error = %v, want an error about values the CLI cannot read", err)
+		}
+		if !strings.Contains(err.Error(), "valuez") {
+			t.Errorf("error = %v, want it to name the unrecognised key", err)
+		}
+	})
+
+	t.Run("configuration blocks that deliberately carry nothing stay configuration-free", func(t *testing.T) {
+		for label, conf := range map[string]map[string]interface{}{
+			"empty block":         {},
+			"empty values":        {"values": ""},
+			"empty values_base64": {"values_base64": ""},
+		} {
+			am := map[string]interface{}{
+				"name":          "cert-manager",
+				"chart_name":    "cert-manager",
+				"chart_version": "1.14.0",
+				"configuration": conf,
+			}
+			a, err := buildAddon(am, "")
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", label, err)
+				continue
+			}
+			if a.Configuration != nil {
+				t.Errorf("%s: configuration = %v, want nil", label, a.Configuration)
+			}
+		}
+	})
+
 	t.Run("registry fields", func(t *testing.T) {
 		am := map[string]interface{}{
 			"name":                     "custom-chart",
@@ -739,6 +860,57 @@ func TestBuildStack(t *testing.T) {
 		if s.DeployWave != nil {
 			t.Errorf("deploy wave = %v, want nil for a stack without deploy_wave", *s.DeployWave)
 		}
+		if s.Variables != nil {
+			t.Errorf("variables = %v, want nil for a stack without variables", s.Variables)
+		}
+	})
+
+	// Apply dropped the stack-level variables map entirely, so an applied
+	// stack came back with none and every '${VAR}' reached the cluster as a
+	// literal token (ankra-yxxa).
+	t.Run("variables are parsed", func(t *testing.T) {
+		sm := map[string]interface{}{
+			"name": "gpu-chat",
+			"variables": map[string]interface{}{
+				"STORAGE_CLASS": "longhorn",
+				"REPLICAS":      2,
+				"DEBUG":         false,
+			},
+		}
+		s, err := buildStack(sm, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := map[string]string{"STORAGE_CLASS": "longhorn", "REPLICAS": "2", "DEBUG": "false"}
+		if len(s.Variables) != len(want) {
+			t.Fatalf("variables = %v, want %v", s.Variables, want)
+		}
+		for key, value := range want {
+			if s.Variables[key] != value {
+				t.Errorf("variable %q = %q, want %q", key, s.Variables[key], value)
+			}
+		}
+	})
+
+	t.Run("variables reject values a string conversion would mangle", func(t *testing.T) {
+		sm := map[string]interface{}{
+			"name":      "gpu-chat",
+			"variables": map[string]interface{}{"CHART_VERSION": 1.20},
+		}
+		_, err := buildStack(sm, "")
+		if err == nil || !strings.Contains(err.Error(), "CHART_VERSION") {
+			t.Errorf("error = %v, want an error naming the unquoted variable", err)
+		}
+	})
+
+	t.Run("variables must be a map", func(t *testing.T) {
+		sm := map[string]interface{}{
+			"name":      "gpu-chat",
+			"variables": []interface{}{"STORAGE_CLASS=longhorn"},
+		}
+		if _, err := buildStack(sm, ""); err == nil {
+			t.Error("expected an error for a non-map 'variables'")
+		}
 	})
 
 	t.Run("deploy_wave is parsed", func(t *testing.T) {
@@ -863,6 +1035,58 @@ spec:
 		}
 		if len(req.Spec.Stacks) != 1 {
 			t.Errorf("stacks count = %d, want 1", len(req.Spec.Stacks))
+		}
+	})
+
+	// The gpu-chat-rag incident file (ankra-yxxa): an exported ImportCluster
+	// whose addons carry configuration.values_base64 and whose stack carries a
+	// variables map. Both used to be dropped on the way to the API, so the
+	// apply installed chart defaults and cleared the stack's variables while
+	// reporting success.
+	t.Run("exported dialect keeps addon values and stack variables", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		values := "resources:\n  limits:\n    nvidia.com/gpu: 1"
+		encoded := base64.StdEncoding.EncodeToString([]byte(values))
+		yamlContent := `kind: ImportCluster
+metadata:
+  name: gpu-chat-rag
+spec:
+  stacks:
+    - name: gpu-chat
+      variables:
+        STORAGE_CLASS: longhorn
+        MODEL_REPLICAS: "3"
+      manifests: []
+      addons:
+        - name: vllm
+          chart_name: vllm
+          chart_version: "0.9.1"
+          configuration:
+            values_base64: ` + encoded + `
+`
+		yamlPath := filepath.Join(tmpDir, "cluster.yaml")
+		if err := os.WriteFile(yamlPath, []byte(yamlContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		req, err := buildImportRequest(yamlPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		stack := req.Spec.Stacks[0]
+		if stack.Variables["STORAGE_CLASS"] != "longhorn" || stack.Variables["MODEL_REPLICAS"] != "3" {
+			t.Errorf("variables = %v, want STORAGE_CLASS=longhorn and MODEL_REPLICAS=3", stack.Variables)
+		}
+		cfg, ok := stack.Addons[0].Configuration.(client.AddonStandaloneConfiguration)
+		if !ok {
+			t.Fatalf("addon configuration type = %T, want AddonStandaloneConfiguration", stack.Addons[0].Configuration)
+		}
+		decoded, decodeErr := base64.StdEncoding.DecodeString(cfg.ValuesBase64)
+		if decodeErr != nil {
+			t.Fatalf("decoding the addon values: %v", decodeErr)
+		}
+		if string(decoded) != values {
+			t.Errorf("decoded addon values = %q, want %q", string(decoded), values)
 		}
 	})
 

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"ankra/internal/client"
 )
 
@@ -892,6 +894,26 @@ func TestBuildStack(t *testing.T) {
 		}
 	})
 
+	// The int/int64/uint64 cases above only matter if the file decoder hands
+	// unquoted YAML integers over as Go ints. gopkg.in/yaml.v3 does; a decoder
+	// that round-trips through JSON (sigs.k8s.io/yaml, encoding/json) would
+	// instead yield float64 for every number, drop each one into the default
+	// branch and reject 'REPLICAS: 2' as unquotable - the ankra-yxxa symptom
+	// again, in a new coat. Pin that contract here so swapping the decoder
+	// fails loudly rather than at apply time.
+	t.Run("unquoted YAML scalars decode to Go ints and bools", func(t *testing.T) {
+		var raw map[string]interface{}
+		if err := yaml.Unmarshal([]byte("REPLICAS: 2\nDEBUG: false\n"), &raw); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := raw["REPLICAS"].(int); !ok {
+			t.Fatalf("REPLICAS decoded as %T, want int - parseStackVariables would reject it", raw["REPLICAS"])
+		}
+		if _, ok := raw["DEBUG"].(bool); !ok {
+			t.Fatalf("DEBUG decoded as %T, want bool", raw["DEBUG"])
+		}
+	})
+
 	t.Run("variables reject values a string conversion would mangle", func(t *testing.T) {
 		sm := map[string]interface{}{
 			"name":      "gpu-chat",
@@ -1055,7 +1077,8 @@ spec:
     - name: gpu-chat
       variables:
         STORAGE_CLASS: longhorn
-        MODEL_REPLICAS: "3"
+        MODEL_REPLICAS: 3
+        DEBUG_LOGGING: false
       manifests: []
       addons:
         - name: vllm
@@ -1074,8 +1097,15 @@ spec:
 			t.Fatalf("unexpected error: %v", err)
 		}
 		stack := req.Spec.Stacks[0]
-		if stack.Variables["STORAGE_CLASS"] != "longhorn" || stack.Variables["MODEL_REPLICAS"] != "3" {
-			t.Errorf("variables = %v, want STORAGE_CLASS=longhorn and MODEL_REPLICAS=3", stack.Variables)
+		wantVariables := map[string]string{
+			"STORAGE_CLASS":  "longhorn",
+			"MODEL_REPLICAS": "3",
+			"DEBUG_LOGGING":  "false",
+		}
+		for key, value := range wantVariables {
+			if stack.Variables[key] != value {
+				t.Errorf("variable %q = %q, want %q", key, stack.Variables[key], value)
+			}
 		}
 		cfg, ok := stack.Addons[0].Configuration.(client.AddonStandaloneConfiguration)
 		if !ok {

--- a/internal/client/clusters.go
+++ b/internal/client/clusters.go
@@ -305,6 +305,12 @@ type Stack struct {
 	// DeployWave orders stacks against each other: stacks in wave N deploy
 	// only after every stack in a lower wave finished. Nil = unordered.
 	DeployWave *int `json:"deploy_wave,omitempty"`
+	// Variables are the stack-scoped rendering variables, the same map the
+	// partial-stack PATCH carries as StackSpec.Variables. The backend replaces
+	// the stored map with whatever apply sends, so omitting it clears the
+	// stack's variables - which is what happened before the CLI read them
+	// (ankra-yxxa).
+	Variables map[string]string `json:"variables,omitempty"`
 }
 
 type GitRepository struct {


### PR DESCRIPTION
## What & why

Bead: ankra-yxxa

`ankra cluster apply` read neither `configuration.values_base64` on an addon nor
the stack-level `variables` map. Both are exactly what the platform's own IaC
export emits, so applying an exported file — the ordinary clone / edit / apply
loop — silently sent a stack with no addon values and no variables, and the API
happily accepted it.

Reproduced on gpu-chat-rag (prod, 2026-08-19): a full ImportCluster with four
addons each carrying `configuration.values_base64` installed all four Helm
releases on chart defaults ("Default Helm values … generated by Ankra"), and the
same run left the stack with no variables at all, so every manifest reached the
cluster with `${VAR}` still in it — string fields got the literal token (an
invalid PVC `storageClassName`) and numeric ones failed the typed patch
(`.spec.replicas: expected numeric, got string`). `apply` and `validate` both
reported success throughout. Because apply also **prunes** whatever the file does
not declare, a configuration-only apply mis-configured and wiped in the same run.

The drop was purely on the CLI's parse side — the API has accepted
`AddonStandaloneConfiguration.values_base64` and `Stack.variables` all along
(both are in `openapi.json`, on the `Stack` and `FrontendStack` branches alike),
and the CLI already *sends* `values_base64` when the file used `values` or
`from_file`.

What changed:

- `buildAddon` reads `configuration.values_base64`, rejecting content that is not
  base64 or does not decode to valid YAML. `from_file` and `values` keep
  precedence, so nothing about the hand-authored dialect moves.
- `buildStack` reads and sends the stack `variables` map (new
  `client.Stack.Variables`, the same map the partial-stack PATCH already carries
  as `StackSpec.Variables`).
- A `configuration:` block carrying a key this CLI cannot read is now an error
  naming the key, instead of falling through to a nil configuration. That silence
  is the whole reason this went unnoticed in two incidents. A block that
  deliberately carries nothing (`{}`, `values: ""`) still parses as
  "no configuration".
- Variables are stored as strings server-side, so integers and booleans are
  written out as their literal text (that conversion is exact) and anything a
  conversion would mangle — a float like `1.20`, a nested structure, a key with
  no value — is rejected with a hint to quote it, matching the guard
  `requiredAddonString` already applies to `chart_version`.

`ankra cluster validate` shares `buildImportRequest`, so it stops passing these
files silently too.

## Test plan

- New tests in `cmd/apply_test.go` cover the addon `values_base64` path
  (round trip, `encrypted_paths` alongside it, precedence, bad base64, non-YAML),
  the unreadable-configuration error, the deliberately-empty blocks, and stack
  `variables` (strings/ints/bools, mangling rejection, non-map).
  `TestBuildImportRequest/exported_dialect_keeps_addon_values_and_stack_variables`
  is the incident file end to end.
- Verified they reproduce the bug first: against pre-fix `cmd/apply.go` they fail
  with exactly the reported symptom — `addon configuration type = <nil>` and
  `variables = map[]`.
- `go test -count=1 ./cmd/... ./internal/...` — pass.
- `golangci-lint run ./cmd/... ./internal/client/...` — 0 issues.
- Commit went through the repo's `.githooks` pre-commit gate (full `go test ./...`
  + `golangci-lint run`) — green.
- Not exercised against a live platform; no credentials in this environment.

Worth a careful look: the new "configuration has no values this CLI can read"
error is the one behaviour change that can reject a file that used to apply. It
fires only on keys outside `{from_file, values, values_base64, encrypted_paths}`,
so a file that hits it was already having its values dropped — but it does mean
an older CLI meeting a newer dialect now fails loudly instead of quietly.

## Docs checklist

- [x] No user-facing command/flag changes — no docs needed

Behaviour change is in the ImportCluster file dialect, not in any command or
flag; the repo carries no schema documentation for it. `CHANGELOG.md` has a
`### Fixed` entry under `## Unreleased`.
