### PR TITLE
fix(upcloud create): default --network-ip-range to platform auto-assignment (ankra-st3f2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@
 
 ### Fixed
 
+- **`ankra cluster upcloud create` no longer hard-codes `10.0.0.0/16` as the
+  private network range.** The flag defaulted to that CIDR and always sent it,
+  so on any account that already holds a `10.0.0.0/x` network the create was
+  refused with `400 Invalid cluster configuration` before a single server was
+  ordered. `--network-ip-range` is now optional: leave it blank and the
+  platform assigns a free `/16` that does not overlap your existing networks
+  (the same auto-assignment the portal wizard uses); an explicit CIDR is still
+  sent unchanged.
+
 - **`ankra cluster apply` no longer drops an addon's values or a stack's
   variables on the way to the platform.** Two keys of the ImportCluster
   dialect were never read: `configuration.values_base64` on an addon, and the

--- a/cmd/upcloud_cluster.go
+++ b/cmd/upcloud_cluster.go
@@ -524,7 +524,7 @@ func init() {
 	upcloudCreateCmd.Flags().String("credential-id", "", "UpCloud API credential ID (required)")
 	upcloudCreateCmd.Flags().String("ssh-key-credential-id", "", "SSH key credential ID (required)")
 	upcloudCreateCmd.Flags().String("zone", "", "UpCloud zone (required)")
-	upcloudCreateCmd.Flags().String("network-ip-range", "10.0.0.0/16", "Network IP range")
+	upcloudCreateCmd.Flags().String("network-ip-range", "", "Private network CIDR (optional; leave blank and the platform assigns a free /16 that does not overlap the networks already in your UpCloud account)")
 	upcloudCreateCmd.Flags().String("bastion-plan", "1xCPU-2GB", "Bastion plan")
 	upcloudCreateCmd.Flags().Int("control-plane-count", 1, "Number of control plane nodes")
 	upcloudCreateCmd.Flags().String("control-plane-plan", "2xCPU-4GB", "Control plane plan")

--- a/cmd/upcloud_cluster_test.go
+++ b/cmd/upcloud_cluster_test.go
@@ -8,6 +8,58 @@ import (
 	"ankra/internal/client"
 )
 
+type upcloudCreateMock struct {
+	baseMock
+	called     bool
+	gotRequest client.CreateUpcloudClusterRequest
+}
+
+func (m *upcloudCreateMock) CreateUpcloudCluster(req client.CreateUpcloudClusterRequest) (*client.CreateUpcloudClusterResponse, error) {
+	m.called = true
+	m.gotRequest = req
+	return &client.CreateUpcloudClusterResponse{ClusterID: "uc-cluster-123", Name: req.Name}, nil
+}
+
+// The platform assigns a free private range when none is sent; a baked-in
+// 10.0.0.0/16 default collided with the networks most accounts already hold
+// and was refused at create time, so the flag now defaults to "let the
+// platform pick" while an explicit CIDR still travels unchanged.
+func TestUpcloudCreateNetworkRangeDefaultsToPlatformAssignment(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantRange string
+	}{
+		{name: "default is unset so the platform assigns a free range"},
+		{name: "explicit range is honoured", args: []string{"--network-ip-range", "10.84.0.0/16"}, wantRange: "10.84.0.0/16"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetConfirmFlag(t, upcloudCreateCmd)
+			mock := &upcloudCreateMock{}
+			args := append([]string{"cluster", "upcloud", "create",
+				"--name", "range-test",
+				"--credential-id", "cred-1",
+				"--ssh-key-credential-id", "ssh-1",
+				"--zone", "fi-hel2"}, tt.args...)
+			out, err := runWithInput(t, mock, "", args...)
+			if err != nil {
+				t.Fatalf("execute failed: %v\noutput: %s", err, out)
+			}
+			if !mock.called {
+				t.Fatal("expected CreateUpcloudCluster call")
+			}
+			if mock.gotRequest.NetworkIPRange != tt.wantRange {
+				t.Errorf("network_ip_range = %q, want %q", mock.gotRequest.NetworkIPRange, tt.wantRange)
+			}
+		})
+	}
+	if flag := upcloudCreateCmd.Flags().Lookup("network-ip-range"); flag == nil || flag.DefValue != "" {
+		t.Fatalf("--network-ip-range must default to empty (platform-assigned), got %+v", flag)
+	}
+}
+
 type upcloudDeprovisionMock struct {
 	baseMock
 	called       bool

--- a/internal/client/upcloud_clusters.go
+++ b/internal/client/upcloud_clusters.go
@@ -15,7 +15,7 @@ type CreateUpcloudClusterRequest struct {
 	CredentialID          string  `json:"credential_id"`
 	SSHKeyCredentialID    string  `json:"ssh_key_credential_id"`
 	Zone                  string  `json:"zone"`
-	NetworkIPRange        string  `json:"network_ip_range"`
+	NetworkIPRange        string  `json:"network_ip_range,omitempty"`
 	BastionPlan           string  `json:"bastion_plan"`
 	ControlPlaneCount     int     `json:"control_plane_count"`
 	ControlPlanePlan      string  `json:"control_plane_plan"`

--- a/internal/client/upcloud_clusters_test.go
+++ b/internal/client/upcloud_clusters_test.go
@@ -66,6 +66,9 @@ func TestCreateUpcloudCluster_SendsCloudProviderNetworkingAndGitopsFields(t *tes
 	if got, ok := receivedBody["include_dns"].(bool); !ok || !got {
 		t.Errorf("include_dns = %v, want true", receivedBody["include_dns"])
 	}
+	if got, _ := receivedBody["network_ip_range"].(string); got != "10.0.0.0/16" {
+		t.Errorf("network_ip_range = %v, want 10.0.0.0/16", receivedBody["network_ip_range"])
+	}
 	if got, _ := receivedBody["gitops_credential_name"].(string); got != "github-cred" {
 		t.Errorf("gitops_credential_name = %q, want github-cred", got)
 	}
@@ -111,6 +114,30 @@ func TestCreateUpcloudCluster_OmitsGitopsWhenUnset(t *testing.T) {
 	}
 	if _, present := receivedBody["gitops_repository"]; present {
 		t.Errorf("gitops_repository should be omitted when unset")
+	}
+}
+
+// A blank network range must leave network_ip_range off the wire entirely:
+// the platform treats an absent key as "assign a free private range", but an
+// empty string would be validated as a CIDR and refused.
+func TestCreateUpcloudCluster_OmitsNetworkRangeWhenUnset(t *testing.T) {
+	expectedResponse := CreateUpcloudClusterResponse{ClusterID: "upcloud-cluster-123", Name: "upcloud-test"}
+	var receivedBody map[string]any
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&receivedBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		jsonResponse(t, w, http.StatusCreated, expectedResponse)
+	})
+	req := CreateUpcloudClusterRequest{
+		Name: "upcloud-test", CredentialID: "cred-1", SSHKeyCredentialID: "ssh-1",
+		Zone: "fi-hel2", Distribution: "kubeadm",
+	}
+	if _, err := testClient.CreateUpcloudCluster(req); err != nil {
+		t.Fatalf("CreateUpcloudCluster: %v", err)
+	}
+	if _, present := receivedBody["network_ip_range"]; present {
+		t.Errorf("network_ip_range should be omitted when unset, got %v", receivedBody["network_ip_range"])
 	}
 }
 


### PR DESCRIPTION
## What & why

`ankra cluster upcloud create` hard-coded `10.0.0.0/16` as the default `--network-ip-range` and always sent it. The platform now refuses a range that overlaps a private network already in the account (`400 Invalid cluster configuration`), and most accounts hold a `10.0.0.0/x` network, so the documented one-liner in the GPU Chat guide failed before a single server was ordered (reproduced 2026-08-20 on `upcloud-workspace`). The portal wizard already leaves the field blank and lets the platform assign a free `/16`.

- `--network-ip-range` now defaults to empty; help text says the platform assigns a non-overlapping `/16`.
- `CreateUpcloudClusterRequest.NetworkIPRange` gains `omitempty`, so a blank flag drops the key from the body instead of sending `""` (which would be validated as a CIDR). An explicit CIDR is sent unchanged.
- CHANGELOG `Unreleased → Fixed` entry.

Bead: ankra-st3f2

## Test plan

- New `TestUpcloudCreateNetworkRangeDefaultsToPlatformAssignment` (cmd level, mock client): default sends no range, explicit `10.84.0.0/16` is honoured, flag `DefValue == ""`.
- New `TestCreateUpcloudCluster_OmitsNetworkRangeWhenUnset` (client level): `network_ip_range` absent from the JSON body when unset; existing payload test now also asserts the explicit value travels.
- `go test -race ./...`, `golangci-lint run ./...` (0 issues).

## Docs checklist

- [ ] No user-facing command/flag changes — no docs needed
- [x] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); ensure `Short`/`Long`/`Example` on new commands are written for docs readers
- [ ] Broader behaviour changes — docs updated in ankra-docs
