### PR TITLE
fix(cluster): apply must read a manifest's manifest_base64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,18 @@
   Because apply also prunes what the file does not declare, a config-only
   apply used to mis-configure and wipe in the same run.
 
+- **`ankra cluster apply` can now read a manifest's `manifest_base64`, so an
+  exported ImportCluster applies as exported.** The platform's IaC export
+  writes a stack's manifests as `manifest_base64`, but apply only ever read
+  the inline `manifest` or a `from_file` path and rejected anything else with
+  "a manifest must set either 'manifest' (inline YAML) or 'from_file'" — so
+  the ordinary clone-edit-apply loop failed on every exported file until each
+  manifest was hand-decoded back into YAML. Unlike the addon values drop above
+  this at least failed loudly, and nothing was ever mis-deployed. Apply now
+  accepts the encoded form and passes the same string through to the platform,
+  refusing content that is not base64 or does not decode to valid YAML.
+  `manifest` and `from_file` keep precedence where a file sets more than one.
+
 - **`ankra cluster logs --follow=false` now asks the platform for a bounded
   read instead of guessing when the backlog ended.** The route only ever
   followed, so the CLI had to infer the end of the tail from a two-second gap

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -681,8 +681,13 @@ func buildManifest(mm map[string]interface{}, baseDir string) (client.Manifest, 
 
 	var content []byte
 	var contentSource string
+	// encoded is what actually goes to the platform. When the manifest arrived
+	// already base64-encoded it is that same string, passed straight through,
+	// so an export -> apply round trip sends back byte-for-byte what it read.
+	var encoded string
 	if inline, ok := mm["manifest"].(string); ok && inline != "" {
 		content = []byte(inline)
+		encoded = base64.StdEncoding.EncodeToString(content)
 		contentSource = "the inline 'manifest' content"
 	} else if fileRef, ok := mm["from_file"].(string); ok {
 		full, err := resolveSafePath(baseDir, fileRef)
@@ -694,16 +699,29 @@ func buildManifest(mm map[string]interface{}, baseDir string) (client.Manifest, 
 			return client.Manifest{}, fmt.Errorf("could not read the file referenced by 'from_file' (%q): %w", full, err)
 		}
 		content = b
+		encoded = base64.StdEncoding.EncodeToString(content)
 		contentSource = fmt.Sprintf("the file referenced by 'from_file' (%q)", full)
+	} else if b64, ok := mm["manifest_base64"].(string); ok && b64 != "" {
+		// This is the form the platform's own IaC export emits (ManifestSpec),
+		// so it is what an export/clone -> apply round trip carries. Until
+		// ankra-62cvj nothing read it and every such manifest was rejected as
+		// having no content at all - loudly, unlike the ankra-yxxa addon drop,
+		// but it made an exported ImportCluster unappliable without hand-editing.
+		decoded, err := base64.StdEncoding.DecodeString(b64)
+		if err != nil {
+			return client.Manifest{}, fmt.Errorf("the manifest 'manifest_base64' is not valid base64: %w", err)
+		}
+		content = decoded
+		encoded = b64
+		contentSource = "the 'manifest_base64' content"
 	} else {
-		return client.Manifest{}, errors.New("a manifest must set either 'manifest' (inline YAML) or 'from_file' (path to a YAML file)")
+		return client.Manifest{}, errors.New("a manifest must set either 'manifest' (inline YAML), 'from_file' (path to a YAML file) or 'manifest_base64' (base64-encoded YAML)")
 	}
 
 	if err := validateYAMLDocuments(content); err != nil {
 		return client.Manifest{}, fmt.Errorf("%s is not valid YAML: %w", contentSource, err)
 	}
 
-	encoded := base64.StdEncoding.EncodeToString(content)
 	ns, _ := mm["namespace"].(string)
 	parents := parseParentList(mm["parents"])
 

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -304,6 +304,110 @@ func TestBuildManifest(t *testing.T) {
 			t.Errorf("expected error naming the file and YAML problem, got: %v", err)
 		}
 	})
+
+	t.Run("manifest_base64 round trip", func(t *testing.T) {
+		manifestContent := "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: exported"
+		encoded := base64.StdEncoding.EncodeToString([]byte(manifestContent))
+		mm := map[string]interface{}{
+			"name":            "exported-ns",
+			"namespace":       "default",
+			"manifest_base64": encoded,
+		}
+		m, err := buildManifest(mm, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// The encoded string is passed straight through, not re-encoded, so
+		// what the platform stores is what its own export emitted.
+		if m.ManifestBase64 != encoded {
+			t.Errorf("manifest_base64 = %q, want the encoded string passed through (%q)", m.ManifestBase64, encoded)
+		}
+		decoded, _ := base64.StdEncoding.DecodeString(m.ManifestBase64)
+		if string(decoded) != manifestContent {
+			t.Errorf("decoded content = %q, want %q", string(decoded), manifestContent)
+		}
+	})
+
+	t.Run("manifest_base64 that is not base64 is refused", func(t *testing.T) {
+		mm := map[string]interface{}{
+			"name":            "not-base64",
+			"manifest_base64": "apiVersion: v1\nkind: Namespace",
+		}
+		_, err := buildManifest(mm, "")
+		if err == nil {
+			t.Fatal("expected error for non-base64 manifest_base64")
+		}
+		if !strings.Contains(err.Error(), "not valid base64") {
+			t.Errorf("expected a base64 error naming the field, got: %v", err)
+		}
+	})
+
+	t.Run("manifest_base64 that does not decode to YAML is refused", func(t *testing.T) {
+		mm := map[string]interface{}{
+			"name":            "not-yaml",
+			"manifest_base64": base64.StdEncoding.EncodeToString([]byte("key: value\n\tbad-tab-indent: x")),
+		}
+		_, err := buildManifest(mm, "")
+		if err == nil {
+			t.Fatal("expected error for manifest_base64 decoding to invalid YAML")
+		}
+		if !strings.Contains(err.Error(), "manifest_base64") || !strings.Contains(err.Error(), "not valid YAML") {
+			t.Errorf("expected a YAML error naming the field, got: %v", err)
+		}
+	})
+
+	t.Run("inline manifest wins over manifest_base64", func(t *testing.T) {
+		inline := "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: inline-wins"
+		mm := map[string]interface{}{
+			"name":            "precedence",
+			"manifest":        inline,
+			"manifest_base64": base64.StdEncoding.EncodeToString([]byte("apiVersion: v1\nkind: Namespace\nmetadata:\n  name: loser")),
+		}
+		m, err := buildManifest(mm, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		decoded, _ := base64.StdEncoding.DecodeString(m.ManifestBase64)
+		if string(decoded) != inline {
+			t.Errorf("decoded content = %q, want the inline 'manifest' content", string(decoded))
+		}
+	})
+
+	t.Run("from_file wins over manifest_base64", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		fileContent := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: file-wins"
+		if err := os.WriteFile(filepath.Join(tmpDir, "cm.yaml"), []byte(fileContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+		mm := map[string]interface{}{
+			"name":            "precedence-file",
+			"from_file":       "cm.yaml",
+			"manifest_base64": base64.StdEncoding.EncodeToString([]byte("apiVersion: v1\nkind: Namespace\nmetadata:\n  name: loser")),
+		}
+		m, err := buildManifest(mm, tmpDir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		decoded, _ := base64.StdEncoding.DecodeString(m.ManifestBase64)
+		if string(decoded) != fileContent {
+			t.Errorf("decoded content = %q, want the 'from_file' content", string(decoded))
+		}
+	})
+
+	t.Run("no content at all names every accepted key", func(t *testing.T) {
+		mm := map[string]interface{}{
+			"name": "no-content",
+		}
+		_, err := buildManifest(mm, "")
+		if err == nil {
+			t.Fatal("expected error for missing content")
+		}
+		for _, key := range []string{"manifest", "from_file", "manifest_base64"} {
+			if !strings.Contains(err.Error(), key) {
+				t.Errorf("error should name %q so the user can fix the file, got: %v", key, err)
+			}
+		}
+	})
 }
 
 func TestBuildAddon(t *testing.T) {

--- a/testing/validation/README.md
+++ b/testing/validation/README.md
@@ -36,7 +36,7 @@ addons are identified by name when present, otherwise by 1-based position
 | `missing-spec.yaml` | `the 'spec' section is missing (it must contain 'stacks' and optionally 'git_repository')` |
 | `stack-missing-name.yaml` | `stack #1: every stack needs a 'name'` |
 | `manifest-missing-name.yaml` | `stack "logging": manifest #1: every manifest needs a 'name'` |
-| `manifest-no-source.yaml` | `stack "logging": manifest "namespace-fluent-bit": a manifest must set either 'manifest' (inline YAML) or 'from_file' (path to a YAML file)` |
+| `manifest-no-source.yaml` | `stack "logging": manifest "namespace-fluent-bit": a manifest must set either 'manifest' (inline YAML), 'from_file' (path to a YAML file) or 'manifest_base64' (base64-encoded YAML)` |
 | `manifest-missing-file.yaml` | `stack "logging": manifest "namespace-fluent-bit": could not read the file referenced by 'from_file' ("..."): ... no such file or directory` |
 | `addon-missing-name.yaml` | `stack "logging": addon #1: every addon needs a 'name'` |
 | `stack-without-manifests-key.yaml` | Passes validation. A stack that omits the `manifests` key (and likewise `addons`) is handled gracefully - `cmd/apply.go` guards the map access, so no panic. |


### PR DESCRIPTION
Bead: ankra-62cvj

## What was wrong

The platform's IaC export emits a stack's manifests as `ManifestSpec`
(`internal/client/iac.go`), which carries the YAML in `manifest_base64`. But
`buildManifest` in `cmd/apply.go` only read the inline `manifest` key or a
`from_file` path, and rejected anything else:

```
stack "logging": manifest "namespace-fluent-bit": a manifest must set either
'manifest' (inline YAML) or 'from_file' (path to a YAML file)
```

So an exported ImportCluster whose manifests are inline base64 could not be
applied at all — the ordinary clone → edit → apply loop needed every manifest
hand-decoded back into YAML first — even though the backend's `Manifest` schema
accepts `manifest_base64` (openapi.json).

This is the manifest half of the gap [#114](https://github.com/ankraio/ankra-cli/pull/114)
(ankra-yxxa) closed for addon `configuration.values_base64`, and was found while
fixing it. Unlike that one it always failed **loudly**, so nothing was ever
silently mis-deployed by it.

## What changed

`buildManifest` gains a third content branch, in the same shape #114 used for
addons: decode the base64, validate the result parses as YAML, and pass the
caller's **encoded string straight through** rather than re-encoding, so an
export → apply round trip sends back byte-for-byte what the export emitted.

- `manifest` and `from_file` keep precedence — a file setting more than one
  behaves exactly as before.
- Content that is not base64 → `the manifest 'manifest_base64' is not valid
  base64: ...`
- Base64 that does not decode to YAML → `the 'manifest_base64' content is not
  valid YAML: ...`
- The "no content" error now names all three accepted keys.

Also updated: the `CHANGELOG.md` Unreleased entry, and the one line in
`testing/validation/README.md` that quotes the old error string verbatim.

## Verification

Reproduced first — the four new `TestBuildManifest` subtests fail on `master`
with the old "must set either 'manifest' … or 'from_file'" message, and pass
with the fix.

- `go test -race -count=1 ./...` — all packages pass
- `golangci-lint run ./cmd/...` — 0 issues
- End-to-end `--dry-run` against a hand-built export-shaped file:
  - valid `manifest_base64` → `Validation succeeded`
  - garbage `manifest_base64` → exit 1, base64 error naming the field
  - no content key → exit 1, error naming all three keys (matches the README
    line updated here)

## Where to look hardest

The pass-through of the caller's encoded string instead of re-encoding the
decoded bytes. `base64.StdEncoding.DecodeString` rejects embedded newlines, so
for anything it accepts the two are byte-identical — but passing it through is
what makes the round trip exact and matches the addon path in #114.

Nothing on pr-shepherd's scary list: no schema migration, no values/GitOps,
ingress, auth or agent-protocol surface. It is CLI-local input parsing that
strictly widens what `apply` accepts.
