### PR TITLE
fix(upcloud): stop pinning a colliding default network range on create (ankra-st3f2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,17 @@
 
 ### Fixed
 
+- **`ankra cluster upcloud create` no longer pins a network range that the
+  platform refuses.** `--network-ip-range` defaulted to the literal
+  `10.0.0.0/16` and the CLI always sent it, so on any UpCloud account that
+  already holds a `10.0.x` private network the create came back
+  `400 ... Network address 10.0.0.0/16 overlaps with an existing private
+  network`. The guide's terminal equivalent of the create wizard broke exactly
+  as printed. The flag now defaults to unset and an unset range is left out of
+  the request, so Ankra derives a range that is free in the account — what the
+  API, AI and portal lanes already do. Pass `--network-ip-range` only to pin a
+  specific range.
+
 - **`ankra cluster apply` no longer drops an addon's values or a stack's
   variables on the way to the platform.** Two keys of the ImportCluster
   dialect were never read: `configuration.values_base64` on an addon, and the

--- a/cmd/upcloud_cluster.go
+++ b/cmd/upcloud_cluster.go
@@ -524,7 +524,7 @@ func init() {
 	upcloudCreateCmd.Flags().String("credential-id", "", "UpCloud API credential ID (required)")
 	upcloudCreateCmd.Flags().String("ssh-key-credential-id", "", "SSH key credential ID (required)")
 	upcloudCreateCmd.Flags().String("zone", "", "UpCloud zone (required)")
-	upcloudCreateCmd.Flags().String("network-ip-range", "10.0.0.0/16", "Network IP range")
+	upcloudCreateCmd.Flags().String("network-ip-range", "", "Private network IP range (optional). Left unset, Ankra picks a range that is free in your UpCloud account; pass one only to pin it (a range overlapping an existing network in the zone is refused)")
 	upcloudCreateCmd.Flags().String("bastion-plan", "1xCPU-2GB", "Bastion plan")
 	upcloudCreateCmd.Flags().Int("control-plane-count", 1, "Number of control plane nodes")
 	upcloudCreateCmd.Flags().String("control-plane-plan", "2xCPU-4GB", "Control plane plan")

--- a/cmd/upcloud_cluster_test.go
+++ b/cmd/upcloud_cluster_test.go
@@ -87,3 +87,48 @@ func TestUpcloudNodeGroupDelete_YesProceeds(t *testing.T) {
 		t.Errorf("got cluster=%q group=%q, want uc-123/workers", mock.gotClusterID, mock.gotGroupName)
 	}
 }
+
+type upcloudCreateMock struct {
+	baseMock
+	gotRequest client.CreateUpcloudClusterRequest
+}
+
+func (m *upcloudCreateMock) CreateUpcloudCluster(req client.CreateUpcloudClusterRequest) (*client.CreateUpcloudClusterResponse, error) {
+	m.gotRequest = req
+	return &client.CreateUpcloudClusterResponse{ClusterID: "uc-123", Name: req.Name}, nil
+}
+
+// The flag used to default to the literal 10.0.0.0/16, so every CLI create
+// pinned the same range and the platform refused it as overlapping the
+// account's existing private network. Unset now means "let Ankra pick".
+func TestUpcloudCreate_NetworkIPRangeDefaultsToAuto(t *testing.T) {
+	mock := &upcloudCreateMock{}
+	resetConfirmFlag(t, upcloudCreateCmd)
+	_ = captureStdout(t, func() {
+		if _, err := runWithInput(t, mock, "", "cluster", "upcloud", "create",
+			"--name", "gpu-chat", "--credential-id", "cred-1",
+			"--ssh-key-credential-id", "ssh-1", "--zone", "fi-hel2"); err != nil {
+			t.Fatalf("execute failed: %v", err)
+		}
+	})
+	if mock.gotRequest.NetworkIPRange != "" {
+		t.Errorf("NetworkIPRange = %q, want empty so the platform picks a free range",
+			mock.gotRequest.NetworkIPRange)
+	}
+}
+
+func TestUpcloudCreate_NetworkIPRangeFlagPinsTheRange(t *testing.T) {
+	mock := &upcloudCreateMock{}
+	resetConfirmFlag(t, upcloudCreateCmd)
+	_ = captureStdout(t, func() {
+		if _, err := runWithInput(t, mock, "", "cluster", "upcloud", "create",
+			"--name", "gpu-chat", "--credential-id", "cred-1",
+			"--ssh-key-credential-id", "ssh-1", "--zone", "fi-hel2",
+			"--network-ip-range", "10.90.0.0/24"); err != nil {
+			t.Fatalf("execute failed: %v", err)
+		}
+	})
+	if mock.gotRequest.NetworkIPRange != "10.90.0.0/24" {
+		t.Errorf("NetworkIPRange = %q, want 10.90.0.0/24", mock.gotRequest.NetworkIPRange)
+	}
+}

--- a/internal/client/upcloud_clusters.go
+++ b/internal/client/upcloud_clusters.go
@@ -15,7 +15,7 @@ type CreateUpcloudClusterRequest struct {
 	CredentialID          string  `json:"credential_id"`
 	SSHKeyCredentialID    string  `json:"ssh_key_credential_id"`
 	Zone                  string  `json:"zone"`
-	NetworkIPRange        string  `json:"network_ip_range"`
+	NetworkIPRange        string  `json:"network_ip_range,omitempty"`
 	BastionPlan           string  `json:"bastion_plan"`
 	ControlPlaneCount     int     `json:"control_plane_count"`
 	ControlPlanePlan      string  `json:"control_plane_plan"`

--- a/internal/client/upcloud_clusters_test.go
+++ b/internal/client/upcloud_clusters_test.go
@@ -478,3 +478,52 @@ func TestDeleteUpcloudNodeGroup_Error(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 }
+
+func TestCreateUpcloudCluster_OmitsUnsetNetworkIPRange(t *testing.T) {
+	expectedResponse := CreateUpcloudClusterResponse{ClusterID: "upcloud-cluster-789", Name: "gpu-chat"}
+	var receivedBody map[string]any
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&receivedBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		jsonResponse(t, w, http.StatusCreated, expectedResponse)
+	})
+	req := CreateUpcloudClusterRequest{
+		Name: "gpu-chat", CredentialID: "cred-1", SSHKeyCredentialID: "ssh-1",
+		Zone: "fi-hel2", BastionPlan: "1xCPU-1GB",
+		ControlPlaneCount: 1, ControlPlanePlan: "2xCPU-4GB",
+		WorkerCount: 1, WorkerPlan: "2xCPU-4GB", Distribution: "k3s",
+	}
+	if _, err := testClient.CreateUpcloudCluster(req); err != nil {
+		t.Fatalf("CreateUpcloudCluster: %v", err)
+	}
+	// An unset range has to be absent from the body, not empty in it: the
+	// platform only derives a free range when the key is missing, and any
+	// literal range collides with the account's existing networks.
+	if value, present := receivedBody["network_ip_range"]; present {
+		t.Errorf("network_ip_range must be omitted when unset, got %v", value)
+	}
+}
+
+func TestCreateUpcloudCluster_SendsExplicitNetworkIPRange(t *testing.T) {
+	expectedResponse := CreateUpcloudClusterResponse{ClusterID: "upcloud-cluster-789", Name: "gpu-chat"}
+	var receivedBody map[string]any
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&receivedBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		jsonResponse(t, w, http.StatusCreated, expectedResponse)
+	})
+	req := CreateUpcloudClusterRequest{
+		Name: "gpu-chat", CredentialID: "cred-1", SSHKeyCredentialID: "ssh-1",
+		Zone: "fi-hel2", NetworkIPRange: "10.90.0.0/24", BastionPlan: "1xCPU-1GB",
+		ControlPlaneCount: 1, ControlPlanePlan: "2xCPU-4GB",
+		WorkerCount: 1, WorkerPlan: "2xCPU-4GB", Distribution: "k3s",
+	}
+	if _, err := testClient.CreateUpcloudCluster(req); err != nil {
+		t.Fatalf("CreateUpcloudCluster: %v", err)
+	}
+	if got, ok := receivedBody["network_ip_range"].(string); !ok || got != "10.90.0.0/24" {
+		t.Errorf("network_ip_range = %v, want 10.90.0.0/24", receivedBody["network_ip_range"])
+	}
+}


### PR DESCRIPTION
Bead: ankra-st3f2

## What changed

`ankra cluster upcloud create` shipped `--network-ip-range` with a literal
`10.0.0.0/16` default and always sent it. Since cluster#1353 (ankra-qmq3) taught
the platform to preflight the requested range against the private networks the
UpCloud account already owns in the zone, that default is refused at request
time:

```
400 ... Network address 10.0.0.0/16 overlaps with an existing private network
10.0.0.0/24 - pick a network_ip_range that is free in this UpCloud account
```

Every UpCloud account that has provisioned once holds a `10.0.x` network, so the
CLI create path is broken for them, and the GPU Chat guide's terminal equivalent
of the wizard fails exactly as printed (found in the v10 clean-room walkthrough,
epic ankra-l23lp). Before the preflight the same command was *accepted* and then
wedged forever in reconcile on UpCloud's own 409 — so this is the create failing
loudly instead of silently, not a new refusal.

- `--network-ip-range` now defaults to unset, and `network_ip_range` carries
  `omitempty`, so an unset range is absent from the body rather than empty in
  it. The platform only derives a free range (`deriveUpcloudNodeNetworkCIDR`)
  when the key is missing — which is what the API, AI and portal lanes already
  get.
- Passing `--network-ip-range` still pins a range; the help text now says what
  unset means and that an overlapping range is refused.

Scope is UpCloud only, matching the bead. `--cni` and `--include-dns` parity are
deliberately not here.

## How I verified it

- `go test -race -count=1 ./cmd/... ./internal/client/...` — pass. New tests pin
  both halves: the client omits `network_ip_range` from the JSON when unset and
  sends it when set, and the command leaves the request field empty with the
  flag unset while `--network-ip-range` still reaches the request.
- `golangci-lint run ./cmd/... ./internal/client/...` — 0 issues. `gofmt` clean.
- Reproduced on `master` first: `cmd/upcloud_cluster.go:527` pinned the literal,
  `internal/client/upcloud_clusters.go:18` had no `omitempty`, and
  `providers.CreateUpcloudCluster` on cluster `main` only derives a free range
  when the field is nil or empty.
- Not run: a live UpCloud create (needs a funded credential and provisions real
  servers). The wire shape is covered by the tests above.

## Where to look hardest

- The `omitempty` on `NetworkIPRange` is what actually fixes it — an empty
  string still in the body would also be treated as unset by the usecase today,
  but omission is what the portal fix (ankra-cxp6) and the API lane do, and it
  keeps the request honest against the OpenAPI contract.
- **Overlaps with the older, unmerged #88**, which fixes the same default while
  also adding `--cni` and `--include-dns`. That branch is 28 commits behind
  `master` and its `--include-dns` half was superseded by #110, so it needs a
  rebase or a close — I did not touch it (a bot may not close another author's
  PR). If #88 is rebased instead of this, close this one.

Nothing on pr-shepherd's scary list: no migration, no values/GitOps, no ingress,
no auth, no agent protocol. It is a CLI flag default and one wire field.
