### PR TITLE
fix(cluster): apply must stop dropping a manifest's or addon's group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,16 @@
 
 ### Fixed
 
+- **`ankra cluster apply` no longer drops a manifest's or addon's `group`
+  label.** The platform's IaC export writes an organizational `group` on
+  manifests and addons, but `apply` never read the key and the request it
+  built had nowhere to put it. Applying an exported ImportCluster therefore
+  flattened every group in the stack — silently, with `apply` and `validate`
+  both reporting success, and permanently, because apply also prunes what the
+  file no longer declares. Groups now survive the clone-edit-apply round trip,
+  and a `group:` that is not a quoted string is rejected instead of quietly
+  becoming no group at all.
+
 - **`ankra cluster upcloud create` no longer pins a network range that the
   platform refuses.** `--network-ip-range` defaulted to the literal
   `10.0.0.0/16` and the CLI always sent it, so on any UpCloud account that

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -673,6 +673,28 @@ func parseAgentsMdFields(m map[string]interface{}, baseDir string) (*string, *st
 	return agentsMd, agentsMdFromFile, nil
 }
 
+// parseGroupField extracts the optional 'group' organizational label shared
+// by manifests and addons - the key the platform's own IaC export writes to
+// record which group a resource sits in within its stack.
+//
+// A non-string value is an error rather than an empty string: the platform
+// types 'group' as a string and would answer 422, and quietly turning a
+// mistyped value into "no group" is the same silent drop that made the label
+// disappear from applied exports in the first place (ankra-o0k2f). An absent
+// key stays "ungrouped", which apply then prunes server-side like any other
+// value the file no longer declares.
+func parseGroupField(m map[string]interface{}) (string, error) {
+	raw, present := m["group"]
+	if !present || raw == nil {
+		return "", nil
+	}
+	group, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("'group' must be a quoted string (got %v)", raw)
+	}
+	return group, nil
+}
+
 func buildManifest(mm map[string]interface{}, baseDir string) (client.Manifest, error) {
 	name, _ := mm["name"].(string)
 	if name == "" {
@@ -735,6 +757,11 @@ func buildManifest(mm map[string]interface{}, baseDir string) (client.Manifest, 
 		}
 	}
 
+	group, err := parseGroupField(mm)
+	if err != nil {
+		return client.Manifest{}, err
+	}
+
 	agentsMd, agentsMdFromFile, err := parseAgentsMdFields(mm, baseDir)
 	if err != nil {
 		return client.Manifest{}, err
@@ -746,6 +773,7 @@ func buildManifest(mm map[string]interface{}, baseDir string) (client.Manifest, 
 		Namespace:        ns,
 		Parents:          parents,
 		EncryptedPaths:   encryptedPaths,
+		Group:            group,
 		AgentsMd:         agentsMd,
 		AgentsMdFromFile: agentsMdFromFile,
 	}, nil
@@ -889,6 +917,11 @@ func buildAddon(am map[string]interface{}, baseDir string) (client.Addon, error)
 		}
 	}
 
+	group, err := parseGroupField(am)
+	if err != nil {
+		return client.Addon{}, err
+	}
+
 	agentsMd, agentsMdFromFile, err := parseAgentsMdFields(am, baseDir)
 	if err != nil {
 		return client.Addon{}, err
@@ -906,6 +939,7 @@ func buildAddon(am map[string]interface{}, baseDir string) (client.Addon, error)
 		RegistryURL:            registryURL,
 		RegistryCredentialName: registryCredentialName,
 		Settings:               settings,
+		Group:                  group,
 		AgentsMd:               agentsMd,
 		AgentsMdFromFile:       agentsMdFromFile,
 	}, nil

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -182,6 +182,53 @@ func TestBuildManifest(t *testing.T) {
 		}
 	})
 
+	// ankra-o0k2f: the 'group' key the platform's IaC export writes was not
+	// read at all, so a clone-edit-apply round trip flattened the stack's
+	// grouping while apply and validate both reported success.
+	t.Run("group passes through", func(t *testing.T) {
+		mm := map[string]interface{}{
+			"name":     "fluent-bit",
+			"manifest": "apiVersion: v1\nkind: Namespace",
+			"group":    "observability",
+		}
+		m, err := buildManifest(mm, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m.Group != "observability" {
+			t.Errorf("group = %q, want %q", m.Group, "observability")
+		}
+	})
+
+	t.Run("group absent stays empty", func(t *testing.T) {
+		mm := map[string]interface{}{
+			"name":     "ungrouped",
+			"manifest": "apiVersion: v1\nkind: Namespace",
+		}
+		m, err := buildManifest(mm, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m.Group != "" {
+			t.Errorf("group = %q, want empty for an ungrouped manifest", m.Group)
+		}
+	})
+
+	t.Run("non-string group is rejected", func(t *testing.T) {
+		mm := map[string]interface{}{
+			"name":     "numeric-group",
+			"manifest": "apiVersion: v1\nkind: Namespace",
+			"group":    7,
+		}
+		_, err := buildManifest(mm, "")
+		if err == nil {
+			t.Fatal("expected error for a non-string group")
+		}
+		if !strings.Contains(err.Error(), "'group'") {
+			t.Errorf("error should name the field, got: %v", err)
+		}
+	})
+
 	t.Run("agents_md absent leaves both fields nil", func(t *testing.T) {
 		mm := map[string]interface{}{
 			"name":     "plain",
@@ -738,6 +785,54 @@ func TestBuildAddon(t *testing.T) {
 		}
 		if a.Settings == nil {
 			t.Error("expected settings to be populated")
+		}
+	})
+
+	// ankra-o0k2f, the addon half: same unread 'group' key, same silent drop.
+	t.Run("group passes through", func(t *testing.T) {
+		am := map[string]interface{}{
+			"name":          "cert-manager",
+			"chart_name":    "cert-manager",
+			"chart_version": "1.0.0",
+			"group":         "platform services",
+		}
+		a, err := buildAddon(am, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a.Group != "platform services" {
+			t.Errorf("group = %q, want %q", a.Group, "platform services")
+		}
+	})
+
+	t.Run("group absent stays empty", func(t *testing.T) {
+		am := map[string]interface{}{
+			"name":          "ungrouped",
+			"chart_name":    "ungrouped",
+			"chart_version": "1.0.0",
+		}
+		a, err := buildAddon(am, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a.Group != "" {
+			t.Errorf("group = %q, want empty for an ungrouped addon", a.Group)
+		}
+	})
+
+	t.Run("non-string group is rejected", func(t *testing.T) {
+		am := map[string]interface{}{
+			"name":          "numeric-group",
+			"chart_name":    "numeric-group",
+			"chart_version": "1.0.0",
+			"group":         1.20,
+		}
+		_, err := buildAddon(am, "")
+		if err == nil {
+			t.Fatal("expected error for a non-string group")
+		}
+		if !strings.Contains(err.Error(), "'group'") {
+			t.Errorf("error should name the field, got: %v", err)
 		}
 	})
 
@@ -1368,6 +1463,54 @@ spec:
 		}
 		if string(decoded) != values {
 			t.Errorf("decoded addon values = %q, want %q", string(decoded), values)
+		}
+	})
+
+	// ankra-o0k2f: apply also prunes what the file does not declare, so
+	// dropping the unread 'group' key flattened the stack's grouping on every
+	// clone-edit-apply round trip. The platform's write schema does take it
+	// (importedapi/specparse.go parses 'group' on manifests and addons), so
+	// the fix is to carry it rather than to warn about it.
+	t.Run("exported dialect keeps manifest and addon groups", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		manifestB64 := base64.StdEncoding.EncodeToString([]byte("apiVersion: v1\nkind: Namespace\nmetadata:\n  name: obs"))
+		yamlContent := `kind: ImportCluster
+metadata:
+  name: grouped-cluster
+spec:
+  stacks:
+    - name: platform
+      manifests:
+        - name: namespaces
+          manifest_base64: ` + manifestB64 + `
+          group: bootstrap
+      addons:
+        - name: cert-manager
+          chart_name: cert-manager
+          chart_version: "1.14.5"
+          group: platform services
+        - name: ungrouped-addon
+          chart_name: nginx
+          chart_version: "1.0.0"
+`
+		yamlPath := filepath.Join(tmpDir, "cluster.yaml")
+		if err := os.WriteFile(yamlPath, []byte(yamlContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		req, err := buildImportRequest(yamlPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		stack := req.Spec.Stacks[0]
+		if stack.Manifests[0].Group != "bootstrap" {
+			t.Errorf("manifest group = %q, want %q", stack.Manifests[0].Group, "bootstrap")
+		}
+		if stack.Addons[0].Group != "platform services" {
+			t.Errorf("addon group = %q, want %q", stack.Addons[0].Group, "platform services")
+		}
+		if stack.Addons[1].Group != "" {
+			t.Errorf("ungrouped addon group = %q, want empty", stack.Addons[1].Group)
 		}
 	})
 

--- a/internal/client/clusters.go
+++ b/internal/client/clusters.go
@@ -276,6 +276,10 @@ type Addon struct {
 	RegistryURL            string                 `json:"registry_url,omitempty"`
 	RegistryCredentialName string                 `json:"registry_credential_name,omitempty"`
 	Settings               map[string]interface{} `json:"settings,omitempty"`
+	// Group is the optional organizational grouping label within the stack,
+	// the same field AddonSpec carries in the exported IaC. Omitted when
+	// empty: apply is declarative, so an absent key means "ungrouped".
+	Group string `json:"group,omitempty"`
 	// AgentsMd is the addon's AGENTS.md content (operational learnings in
 	// plain markdown). Pointer semantics matter: nil = field absent, the
 	// backend preserves the stored value; pointer to "" = explicit clear.
@@ -291,6 +295,8 @@ type Manifest struct {
 	Namespace      string   `json:"namespace,omitempty"`
 	Parents        []Parent `json:"parents"`
 	EncryptedPaths []string `json:"encrypted_paths,omitempty"`
+	// Group: see the Addon field of the same name.
+	Group string `json:"group,omitempty"`
 	// AgentsMd / AgentsMdFromFile: see the Addon fields of the same name.
 	// nil = preserve stored value, pointer to "" = clear.
 	AgentsMd         *string `json:"agents_md,omitempty"`

--- a/internal/client/clusters_test.go
+++ b/internal/client/clusters_test.go
@@ -391,6 +391,52 @@ func TestApplyCluster(t *testing.T) {
 	}
 }
 
+// TestApplyClusterSendsGroupLabels pins the wire half of ankra-o0k2f: the
+// organizational 'group' label reaches the import body for the manifests and
+// addons that carry one, and is omitted entirely for the ones that do not, so
+// an ungrouped resource sends the same bytes it always did.
+func TestApplyClusterSendsGroupLabels(t *testing.T) {
+	request := CreateImportClusterRequest{
+		Name: "grouped-cluster",
+		Spec: CreateResourceSpec{
+			Stacks: []Stack{{
+				Name:      "platform",
+				Manifests: []Manifest{{Name: "namespaces", Group: "bootstrap"}},
+				Addons: []Addon{
+					{Name: "cert-manager", ChartName: "cert-manager", ChartVersion: "1.14.5", Group: "platform services"},
+					{Name: "nginx", ChartName: "nginx", ChartVersion: "1.0.0"},
+				},
+			}},
+		},
+	}
+
+	var body map[string]any
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decoding request body: %v", err)
+		}
+		jsonResponse(t, w, http.StatusOK, ImportResponse{Name: "grouped-cluster", ClusterId: "cluster-123"})
+	}
+
+	testClient := newTestClient(t, handler)
+	if _, _, err := testClient.ApplyCluster(context.Background(), request, true); err != nil {
+		t.Fatalf("ApplyCluster() error = %v", err)
+	}
+
+	stack := body["spec"].(map[string]any)["stacks"].([]any)[0].(map[string]any)
+	manifest := stack["manifests"].([]any)[0].(map[string]any)
+	if manifest["group"] != "bootstrap" {
+		t.Errorf("manifest group = %v, want %q", manifest["group"], "bootstrap")
+	}
+	addons := stack["addons"].([]any)
+	if grouped := addons[0].(map[string]any); grouped["group"] != "platform services" {
+		t.Errorf("addon group = %v, want %q", grouped["group"], "platform services")
+	}
+	if ungrouped := addons[1].(map[string]any); ungrouped["group"] != nil {
+		t.Errorf("ungrouped addon must omit the key, got %v", ungrouped["group"])
+	}
+}
+
 func TestValidateCluster(t *testing.T) {
 	spec := CreateResourceSpec{Stacks: []Stack{{Name: "stack1"}}}
 

--- a/internal/skills/embedded/skills/ankra-import-cluster/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-import-cluster/SKILL.md
@@ -53,6 +53,7 @@ spec:
 - `manifests[]` — raw Kubernetes YAML. Use `from_file: "path.yaml"` to reference a file, or `manifest: |-` for inline content.
 - `addons[]` — Helm releases. Required: `chart_name`, `chart_version`, `repository_url`, `namespace`. Configure via `configuration.values: |-` (inline) or `configuration.from_file:`.
 - `agents_md` / `agents_md_from_file` — optional per-manifest and per-addon AGENTS.md: operational learnings in plain markdown, stored as a sibling file in the GitOps repo (e.g. `agents_md_from_file: "manifests/fluent-bit.AGENTS.md"`). Omitting the field preserves the stored content, an explicit empty string clears it, and editing it never triggers a redeploy. Plaintext only — never put secrets in it. After any non-obvious operation (a values quirk, an upgrade pitfall, a dependency gotcha), record what you learned here so future agents working on the same addon or manifest benefit.
+- `group` — optional per-manifest and per-addon organizational label within the stack (a quoted string, e.g. `group: "platform services"`). Purely organizational: it never triggers a redeploy. Keep whatever the exported file carries — apply prunes what the file no longer declares, so removing the key removes the resource from its group.
 - `parents` — the dependency edges that control deployment order. A resource only deploys after its parents succeed. Reference a parent as `- manifest: <name>` or `- addon: <name>`.
 
 ## Workflow


### PR DESCRIPTION
Bead: ankra-o0k2f

## What was wrong

The platform's IaC export writes an organizational `group` label on manifests and
addons (`AddonSpec.Group` / `ManifestSpec.Group` in `internal/client/iac.go`), but
`cmd/apply.go` never read the key — `group` did not appear in the file at all — and
neither `client.Manifest` nor `client.Addon` had a field to carry it.

Applying an exported ImportCluster therefore dropped every group label:

- **silently** — `apply` and `validate` both reported success (the same class as
  ankra-yxxa's `values_base64`, not the loud failure of ankra-62cvj), and
- **permanently** — apply prunes what the file no longer declares, so the ordinary
  clone-edit-apply round trip flattened the stack's grouping.

## Why pass-through is the right fix

The bead asked to check first whether the write schema accepts `group` at all. It
does. `go/internal/importedapi/specparse.go` parses `group` for manifests (`:462`),
addons (`:529`) and applications (`:602`) into `APIManifest`/`APIAddon.Group`, and
`enginekit/clusterengine` stores it via `setDefinitionGroup` and emits it again in
the IaC dump (`iac.go:328/:362`). It is absent from `openapi.json` for the same
reason `agents_md` is — both are Go-side contract extensions over the frozen
pydantic models, and the CLI already passes `agents_md` through. So the correct fix
is to carry the key, not to reject or warn on it.

## What changed

- `client.Addon` and `client.Manifest` gain `Group string` with `json:"group,omitempty"`
  — an ungrouped resource sends the same bytes it always did.
- `buildManifest` / `buildAddon` read the key through a shared `parseGroupField`.
- A non-string `group` is now an error rather than an empty string. The platform
  types it as a string and would answer 422, and quietly turning a mistyped value
  into "no group" is the same silent drop entered through a malformed value instead
  of an unread key — the treatment `chart_version` already gets.
- CHANGELOG entry, and one line in the embedded `ankra-import-cluster` skill's field
  reference (that file documents this dialect; `../ankra-skills` is not present in
  this repo, so the embedded copy is canonical and `make verify-skills` is a no-op).

## Verification

- `go test -race -count=1 ./cmd/ ./internal/client/ ./internal/skills/` — pass.
- `golangci-lint run ./cmd/... ./internal/client/...` — 0 issues.
- New tests: `buildManifest`/`buildAddon` group pass-through, absent-stays-empty and
  non-string-rejected; a `buildImportRequest` round trip over an exported-dialect
  file carrying `group` on a manifest and on one of two addons; and
  `TestApplyClusterSendsGroupLabels`, which asserts over the wire that the label
  reaches the import body and that an ungrouped addon omits the key entirely.

## Worth a closer look

- **The omitempty / prune semantics.** Absent `group` means ungrouped, and the
  backend clears the group when the request carries no key. That is what apply's
  declarative prune should do — removing the key from the file removes the resource
  from its group — but it is the one behaviour worth agreeing on deliberately.
- **The new hard error on a non-string `group`.** It rejects a file that used to
  apply (dropping the label). That is the point, but it is a behaviour change.

## Follow-up filed, not fixed here

`ankra-pgib9`: `applyAddonMutations` (`cmd/cluster_partial.go`) rebuilds its
`AddonSpec` field by field and copies everything except `Group`, so
`ankra cluster addon upgrade` sends a partial patch with no `group` key — which the
backend treats as "clear", not "preserve". Same bug, different command; kept out of
this PR to keep it reviewable. The sibling paths are fine: `cluster_manifests.go:328`
and `cluster_encrypt.go:908` both copy the struct whole.
