### PR TITLE
feat: add --sort/--order to the main list commands (ankra-9bkp5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Added
 
+- **`--sort <column>` and `--order asc|desc` on the main list commands**
+  (`cluster list`, `cluster addons list`, `org list`, `credentials list`,
+  `tokens list`) let you order the output by any rendered column — e.g.
+  `ankra cluster list --sort created --order desc` puts the newest clusters
+  first. Sorting happens on the raw values, so timestamp columns order
+  chronologically rather than by their "2 days ago" display text, and the
+  same order applies to `-o json|yaml`. Without `--sort` the server order is
+  unchanged, and an unknown column exits with the usage code and lists the
+  valid ones. (`helm registries list` keeps its existing server-side
+  `--sort-by`/`--sort-order` flags.)
 - **`ankra stack-profiles` now carries the profile's whole life, not just the
   read half.** The portal could create a profile from a deployed stack, edit
   its catalogue metadata, snapshot new versions, roll the current-version

--- a/cmd/cluster_addon.go
+++ b/cmd/cluster_addon.go
@@ -23,11 +23,26 @@ var clusterAddonsCmd = &cobra.Command{
 	Long:  "Commands to list, manage settings, and uninstall addons.",
 }
 
+var clusterAddonSortFields = []sortField[client.ClusterAddonListItem]{
+	{"name", func(a, b client.ClusterAddonListItem) int { return compareFold(a.Name, b.Name) }},
+	{"chart", func(a, b client.ClusterAddonListItem) int { return compareFold(a.ChartName, b.ChartName) }},
+	{"version", func(a, b client.ClusterAddonListItem) int { return compareFold(a.ChartVersion, b.ChartVersion) }},
+	{"namespace", func(a, b client.ClusterAddonListItem) int { return compareFold(a.Namespace, b.Namespace) }},
+	{"health", func(a, b client.ClusterAddonListItem) int { return compareFoldPtr(a.Health, b.Health) }},
+	{"state", func(a, b client.ClusterAddonListItem) int { return compareFoldPtr(a.State, b.State) }},
+	{"created", func(a, b client.ClusterAddonListItem) int { return compareTimePtrs(a.CreatedAt, b.CreatedAt) }},
+	{"updated", func(a, b client.ClusterAddonListItem) int { return compareTimePtrs(a.UpdatedAt, b.UpdatedAt) }},
+}
+
 var clusterAddonsListCmd = &cobra.Command{
 	Use:   "list [addon name]",
 	Short: "List addons for the active cluster; or show details for a single addon",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		sortAddons, err := resolveSort(cmd, clusterAddonSortFields)
+		if err != nil {
+			return err
+		}
 		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
 			return err
@@ -37,6 +52,7 @@ var clusterAddonsListCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("listing addons: %w", err)
 		}
+		sortAddons(addons)
 		if len(args) == 0 {
 			if addons == nil {
 				addons = []client.ClusterAddonListItem{}
@@ -667,6 +683,7 @@ func init() {
 	clusterAddonsUpgradeCmd.Flags().Bool("yes", false, "Skip the confirmation prompt for destructive changes (--namespace)")
 	clusterAddonsUpgradeCmd.Flags().StringP("output", "o", "", "Output format: json or yaml (default: human-readable)")
 	registerStructuredOutputFlags(clusterAddonsListCmd, clusterAddonsAvailableCmd, clusterAddonsSettingsCmd)
+	registerSortFlags(clusterAddonsListCmd, clusterAddonSortFields)
 
 	clusterAddonsValuesCmd.Flags().String("cluster", "", "Target cluster (name or ID); defaults to the active selection")
 	clusterAddonsValuesCmd.Flags().StringP("output", "o", "", "Output format: yaml (decoded, default) or raw (base64)")

--- a/cmd/credentials.go
+++ b/cmd/credentials.go
@@ -19,10 +19,25 @@ var credentialsCmd = &cobra.Command{
 	Long:    "Commands to list, view, validate, and delete credentials.",
 }
 
+var credentialSortFields = []sortField[client.Credential]{
+	{"id", func(a, b client.Credential) int { return compareFold(a.ID, b.ID) }},
+	{"name", func(a, b client.Credential) int { return compareFold(a.Name, b.Name) }},
+	{"provider", func(a, b client.Credential) int { return compareFold(a.Provider, b.Provider) }},
+	{"state", func(a, b client.Credential) int { return compareFoldPtr(a.State, b.State) }},
+	{"available", func(a, b client.Credential) int { return compareBools(a.Available, b.Available) }},
+	{"repos", func(a, b client.Credential) int { return compareIntPtrs(a.RepositoryCount, b.RepositoryCount) }},
+	{"last-synced", func(a, b client.Credential) int { return compareTimeStringPtrs(a.LastSyncedAt, b.LastSyncedAt) }},
+	{"created", func(a, b client.Credential) int { return compareTimeStrings(a.CreatedAt, b.CreatedAt) }},
+}
+
 var credentialsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all credentials",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		sortCreds, err := resolveSort(cmd, credentialSortFields)
+		if err != nil {
+			return err
+		}
 		provider, _ := cmd.Flags().GetString("provider")
 		var providerPtr *string
 		if provider != "" {
@@ -37,6 +52,7 @@ var credentialsListCmd = &cobra.Command{
 		if creds == nil {
 			creds = []client.Credential{}
 		}
+		sortCreds(creds)
 		if rendered, err := renderStructured(cmd, creds); rendered || err != nil {
 			return err
 		}
@@ -266,6 +282,7 @@ func init() {
 	credentialsDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
 	registerStructuredOutputFlags(credentialsListCmd, credentialsGetCmd)
+	registerSortFlags(credentialsListCmd, credentialSortFields)
 
 	credentialsCmd.AddCommand(credentialsListCmd)
 	credentialsCmd.AddCommand(credentialsValidateCmd)

--- a/cmd/organisation.go
+++ b/cmd/organisation.go
@@ -31,10 +31,22 @@ var orgCmd = &cobra.Command{
 	Long:    "Commands to list, switch, create, and manage organisations.",
 }
 
+var orgSortFields = []sortField[client.OrganisationSummary]{
+	{"id", func(a, b client.OrganisationSummary) int { return compareFold(a.OrganisationID, b.OrganisationID) }},
+	{"name", func(a, b client.OrganisationSummary) int { return compareFoldPtr(a.Name, b.Name) }},
+	{"slug", func(a, b client.OrganisationSummary) int { return compareFoldPtr(a.Slug, b.Slug) }},
+	{"role", func(a, b client.OrganisationSummary) int { return compareFoldPtr(a.Role, b.Role) }},
+	{"status", func(a, b client.OrganisationSummary) int { return compareFoldPtr(a.Status, b.Status) }},
+}
+
 var orgListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all organisations you belong to",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		sortOrgs, err := resolveSort(cmd, orgSortFields)
+		if err != nil {
+			return err
+		}
 		orgs, err := apiClient.ListOrganisations()
 		if err != nil {
 			return fmt.Errorf("listing organisations: %w", err)
@@ -43,6 +55,7 @@ var orgListCmd = &cobra.Command{
 		if orgs == nil {
 			orgs = []client.OrganisationSummary{}
 		}
+		sortOrgs(orgs)
 		if rendered, err := renderStructured(cmd, orgs); rendered || err != nil {
 			return err
 		}
@@ -616,6 +629,7 @@ func init() {
 	orgRemoveCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
 
 	registerStructuredOutputFlags(orgListCmd, orgCurrentCmd, orgCreateCmd, orgMembersCmd)
+	registerSortFlags(orgListCmd, orgSortFields)
 
 	orgCmd.AddCommand(orgListCmd)
 	orgCmd.AddCommand(orgSwitchCmd)

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"os"
@@ -29,10 +30,30 @@ var clusterCmd = &cobra.Command{
 	Long:  `Commands for managing and operating on clusters.`,
 }
 
+var clusterSortFields = []sortField[client.ClusterListItem]{
+	{"name", func(a, b client.ClusterListItem) int { return compareFold(a.Name, b.Name) }},
+	{"environment", func(a, b client.ClusterListItem) int { return compareFold(a.Environment, b.Environment) }},
+	{"kube-version", func(a, b client.ClusterListItem) int { return compareFold(a.KubeVersion, b.KubeVersion) }},
+	{"nodes", func(a, b client.ClusterListItem) int { return cmp.Compare(a.Nodes, b.Nodes) }},
+	{"control-planes", func(a, b client.ClusterListItem) int { return cmp.Compare(a.ControlPlanes, b.ControlPlanes) }},
+	{"state", func(a, b client.ClusterListItem) int { return compareFold(a.State, b.State) }},
+	{"kind", func(a, b client.ClusterListItem) int { return compareFold(a.Kind, b.Kind) }},
+	{"created", func(a, b client.ClusterListItem) int { return compareTimeStrings(a.CreatedAt, b.CreatedAt) }},
+}
+
 var clusterListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all clusters",
+	Example: `  # newest clusters first
+  ankra cluster list --sort created --order desc
+
+  # alphabetical by name
+  ankra cluster list --sort name`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		sortClusters, err := resolveSort(cmd, clusterSortFields)
+		if err != nil {
+			return err
+		}
 		clusters, err := listAllClusters()
 		if err != nil {
 			return fmt.Errorf("listing clusters: %w", err)
@@ -40,6 +61,7 @@ var clusterListCmd = &cobra.Command{
 		if clusters == nil {
 			clusters = []client.ClusterListItem{}
 		}
+		sortClusters(clusters)
 		if rendered, err := renderStructured(cmd, clusters); rendered || err != nil {
 			return err
 		}
@@ -515,6 +537,7 @@ func init() {
 		clusterProvisionCmd,
 		clusterDeprovisionCmd,
 	)
+	registerSortFlags(clusterListCmd, clusterSortFields)
 
 	clusterCmd.AddCommand(clusterListCmd)
 	clusterCmd.AddCommand(clusterInfoCmd)

--- a/cmd/sort.go
+++ b/cmd/sort.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// sortField describes one sortable column of a list command: the key the
+// user passes to --sort, and a comparator over the raw, unformatted items —
+// so "created" orders by timestamp, not by the rendered "2 days ago" text.
+type sortField[T any] struct {
+	key     string
+	compare func(a, b T) int
+}
+
+func sortFieldKeys[T any](fields []sortField[T]) []string {
+	keys := make([]string, len(fields))
+	for i, field := range fields {
+		keys[i] = field.key
+	}
+	return keys
+}
+
+// registerSortFlags adds the shared --sort/--order flags to a list command.
+func registerSortFlags[T any](cmd *cobra.Command, fields []sortField[T]) {
+	cmd.Flags().String("sort", "", "Sort by column: "+strings.Join(sortFieldKeys(fields), ", ")+" (default: server order)")
+	cmd.Flags().String("order", "asc", "Sort direction with --sort: asc or desc")
+}
+
+// resolveSort validates --sort/--order and returns the sort to run on the
+// fetched items. Call it before any API work so a bad flag fails fast with
+// the usage code instead of after a wasted request. The returned function
+// stably sorts in place — before any rendering, so tables and -o json|yaml
+// agree on the order — and is a no-op without --sort, preserving the server
+// order.
+func resolveSort[T any](cmd *cobra.Command, fields []sortField[T]) (func(items []T), error) {
+	noop := func([]T) {}
+	key, _ := cmd.Flags().GetString("sort")
+	key = strings.ToLower(strings.TrimSpace(key))
+	order, _ := cmd.Flags().GetString("order")
+	order = strings.ToLower(strings.TrimSpace(order))
+	if order != "asc" && order != "desc" {
+		return noop, withExitCode(exitUsage, fmt.Errorf("invalid --order %q (valid: asc, desc)", order))
+	}
+	if key == "" {
+		if cmd.Flags().Changed("order") {
+			return noop, withExitCode(exitUsage, fmt.Errorf("--order requires --sort"))
+		}
+		return noop, nil
+	}
+	for _, field := range fields {
+		if field.key != key {
+			continue
+		}
+		compare := field.compare
+		if order == "desc" {
+			asc := compare
+			compare = func(a, b T) int { return -asc(a, b) }
+		}
+		return func(items []T) { slices.SortStableFunc(items, compare) }, nil
+	}
+	return noop, withExitCode(exitUsage,
+		fmt.Errorf("invalid --sort %q (valid: %s)", key, strings.Join(sortFieldKeys(fields), ", ")))
+}
+
+// compareFold orders strings case-insensitively, breaking ties with the
+// case-sensitive comparison so the order stays deterministic.
+func compareFold(a, b string) int {
+	if c := strings.Compare(strings.ToLower(a), strings.ToLower(b)); c != 0 {
+		return c
+	}
+	return strings.Compare(a, b)
+}
+
+// compareFoldPtr is compareFold over nullable strings; nil sorts like "".
+func compareFoldPtr(a, b *string) int {
+	return compareFold(derefString(a), derefString(b))
+}
+
+// compareTimeStrings orders the API's RFC3339 timestamp strings
+// chronologically. Values that do not parse (including "") sort before every
+// parseable timestamp and lexicographically among themselves, mirroring
+// formatTimeAgo's tolerance of malformed values.
+func compareTimeStrings(a, b string) int {
+	ta, errA := time.Parse(time.RFC3339, a)
+	tb, errB := time.Parse(time.RFC3339, b)
+	switch {
+	case errA == nil && errB == nil:
+		return ta.Compare(tb)
+	case errA == nil:
+		return 1
+	case errB == nil:
+		return -1
+	default:
+		return strings.Compare(a, b)
+	}
+}
+
+// compareTimeStringPtrs is compareTimeStrings over nullable timestamps
+// (e.g. last-used "Never"); nil sorts like "", before every real timestamp.
+func compareTimeStringPtrs(a, b *string) int {
+	return compareTimeStrings(derefString(a), derefString(b))
+}
+
+// compareTimePtrs orders nullable time.Time values; nil sorts first.
+func compareTimePtrs(a, b *time.Time) int {
+	switch {
+	case a == nil && b == nil:
+		return 0
+	case a == nil:
+		return -1
+	case b == nil:
+		return 1
+	default:
+		return a.Compare(*b)
+	}
+}
+
+// compareBools orders false before true.
+func compareBools(a, b bool) int {
+	switch {
+	case a == b:
+		return 0
+	case b:
+		return -1
+	default:
+		return 1
+	}
+}
+
+// compareIntPtrs orders nullable ints; nil sorts first.
+func compareIntPtrs(a, b *int) int {
+	switch {
+	case a == nil && b == nil:
+		return 0
+	case a == nil:
+		return -1
+	case b == nil:
+		return 1
+	default:
+		return cmp.Compare(*a, *b)
+	}
+}

--- a/cmd/sort_test.go
+++ b/cmd/sort_test.go
@@ -1,0 +1,212 @@
+package cmd
+
+import (
+	"cmp"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+func newSortTestCommand() (*cobra.Command, []sortField[int]) {
+	fields := []sortField[int]{
+		{"value", func(a, b int) int { return cmp.Compare(a, b) }},
+		{"other", func(a, b int) int { return 0 }},
+	}
+	command := &cobra.Command{Use: "sorttest"}
+	registerSortFlags(command, fields)
+	return command, fields
+}
+
+func TestResolveSort(t *testing.T) {
+	tests := []struct {
+		name     string
+		sort     string
+		order    string
+		want     []int
+		wantCode int
+	}{
+		{name: "no flags keeps server order", want: []int{3, 1, 2}},
+		{name: "ascending", sort: "value", want: []int{1, 2, 3}},
+		{name: "descending", sort: "value", order: "desc", want: []int{3, 2, 1}},
+		{name: "key is case-insensitive", sort: "VALUE", want: []int{1, 2, 3}},
+		{name: "unknown key is a usage error", sort: "bogus", wantCode: exitUsage},
+		{name: "unknown order is a usage error", sort: "value", order: "sideways", wantCode: exitUsage},
+		{name: "order without sort is a usage error", order: "desc", wantCode: exitUsage},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			command, fields := newSortTestCommand()
+			if testCase.sort != "" {
+				if err := command.Flags().Set("sort", testCase.sort); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if testCase.order != "" {
+				if err := command.Flags().Set("order", testCase.order); err != nil {
+					t.Fatal(err)
+				}
+			}
+			items := []int{3, 1, 2}
+			sortItems, err := resolveSort(command, fields)
+			if testCase.wantCode != 0 {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				if code := exitCodeFor(err); code != testCase.wantCode {
+					t.Fatalf("expected exit code %d, got %d (%v)", testCase.wantCode, code, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			sortItems(items)
+			for i := range testCase.want {
+				if items[i] != testCase.want[i] {
+					t.Fatalf("expected %v, got %v", testCase.want, items)
+				}
+			}
+		})
+	}
+}
+
+func TestSortComparators(t *testing.T) {
+	if compareTimeStrings("2024-01-01T00:00:00Z", "2024-02-01T00:00:00Z") >= 0 {
+		t.Error("expected January to sort before February")
+	}
+	// Chronological, not lexicographic: the offset timestamp is the later
+	// instant even though it compares smaller as a string.
+	if compareTimeStrings("2024-01-02T00:00:00Z", "2024-01-01T23:30:00-02:00") >= 0 {
+		t.Error("expected instants to be compared in UTC, not as strings")
+	}
+	if compareTimeStrings("", "2024-01-01T00:00:00Z") >= 0 {
+		t.Error("expected unparseable values to sort before timestamps")
+	}
+	if compareTimeStrings("abc", "abd") >= 0 {
+		t.Error("expected unparseable values to compare lexicographically")
+	}
+	if compareBools(false, true) >= 0 {
+		t.Error("expected false to sort before true")
+	}
+	earlier := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	later := earlier.Add(time.Hour)
+	if compareTimePtrs(nil, &earlier) >= 0 || compareTimePtrs(&earlier, &later) >= 0 {
+		t.Error("expected nil first, then chronological order")
+	}
+	three, four := 3, 4
+	if compareIntPtrs(nil, &three) >= 0 || compareIntPtrs(&three, &four) >= 0 {
+		t.Error("expected nil first, then numeric order")
+	}
+	name := "Zed"
+	if compareFoldPtr(nil, &name) >= 0 {
+		t.Error("expected nil to sort like the empty string")
+	}
+	if compareFold("apple", "Banana") >= 0 {
+		t.Error("expected case-insensitive ordering")
+	}
+}
+
+// resetSortFlags restores a shared command's sort flags after a test.
+// Resetting Changed matters: applySort treats an explicit --order without
+// --sort as a usage error, so a leaked Changed bit would fail later tests.
+func resetSortFlags(t *testing.T, command *cobra.Command, extra ...string) {
+	t.Helper()
+	t.Cleanup(func() {
+		flags := command.Flags()
+		for _, flagName := range append([]string{"sort", "order"}, extra...) {
+			flag := flags.Lookup(flagName)
+			if flag == nil {
+				continue
+			}
+			_ = flags.Set(flagName, flag.DefValue)
+			flag.Changed = false
+		}
+	})
+}
+
+func sortTestClusters() []client.ClusterListItem {
+	// Server order (bravo, alpha, charlie) differs from both the name order
+	// and the created order so a passing test proves a re-sort happened.
+	return []client.ClusterListItem{
+		{ID: "id-2", Name: "bravo-cluster", State: "online", Kind: "imported", CreatedAt: "2024-03-01T00:00:00Z"},
+		{ID: "id-1", Name: "alpha-cluster", State: "online", Kind: "imported", CreatedAt: "2024-01-01T00:00:00Z"},
+		{ID: "id-3", Name: "charlie-cluster", State: "offline", Kind: "imported", CreatedAt: "2024-02-01T00:00:00Z"},
+	}
+}
+
+func assertOrder(t *testing.T, output string, names ...string) {
+	t.Helper()
+	previous := -1
+	for _, name := range names {
+		index := strings.Index(output, name)
+		if index < 0 {
+			t.Fatalf("expected output to contain %q, got: %s", name, output)
+		}
+		if index < previous {
+			t.Fatalf("expected order %v, got: %s", names, output)
+		}
+		previous = index
+	}
+}
+
+func TestClusterListSortByName(t *testing.T) {
+	setMockClient(t, &clusterListMock{clusters: sortTestClusters()})
+	resetSortFlags(t, clusterListCmd)
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("cluster", "list", "--sort", "name")
+	})
+	assertOrder(t, stdoutOutput, "alpha-cluster", "bravo-cluster", "charlie-cluster")
+}
+
+func TestClusterListSortByCreatedDesc(t *testing.T) {
+	setMockClient(t, &clusterListMock{clusters: sortTestClusters()})
+	resetSortFlags(t, clusterListCmd)
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("cluster", "list", "--sort", "created", "--order", "desc")
+	})
+	assertOrder(t, stdoutOutput, "bravo-cluster", "charlie-cluster", "alpha-cluster")
+}
+
+func TestClusterListSortAppliesToStructuredOutput(t *testing.T) {
+	setMockClient(t, &clusterListMock{clusters: sortTestClusters()})
+	resetSortFlags(t, clusterListCmd, "output")
+
+	output, err := executeCommand("cluster", "list", "--sort", "name", "-o", "json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var clusters []client.ClusterListItem
+	if err := json.Unmarshal([]byte(output), &clusters); err != nil {
+		t.Fatalf("expected JSON output, got %q: %v", output, err)
+	}
+	if len(clusters) != 3 || clusters[0].Name != "alpha-cluster" ||
+		clusters[1].Name != "bravo-cluster" || clusters[2].Name != "charlie-cluster" {
+		t.Errorf("expected JSON sorted by name, got: %+v", clusters)
+	}
+}
+
+func TestClusterListInvalidSortIsUsageError(t *testing.T) {
+	setMockClient(t, &clusterListMock{clusters: sortTestClusters()})
+	resetSortFlags(t, clusterListCmd)
+
+	var err error
+	captureStdout(t, func() {
+		_, err = executeCommand("cluster", "list", "--sort", "bogus")
+	})
+	if err == nil {
+		t.Fatal("expected an error for an unknown --sort value")
+	}
+	if code := exitCodeFor(err); code != exitUsage {
+		t.Errorf("expected exit code %d, got %d (%v)", exitUsage, code, err)
+	}
+	if !strings.Contains(err.Error(), "created") {
+		t.Errorf("expected the error to list valid keys, got: %v", err)
+	}
+}

--- a/cmd/tokens.go
+++ b/cmd/tokens.go
@@ -18,10 +18,23 @@ var tokensCmd = &cobra.Command{
 	Long:    "Commands to list, create, revoke, and delete API tokens.",
 }
 
+var tokenSortFields = []sortField[client.APIToken]{
+	{"id", func(a, b client.APIToken) int { return compareFold(a.ID, b.ID) }},
+	{"name", func(a, b client.APIToken) int { return compareFold(a.Name, b.Name) }},
+	{"status", func(a, b client.APIToken) int { return compareBools(a.Revoked, b.Revoked) }},
+	{"created", func(a, b client.APIToken) int { return compareTimeStrings(a.CreatedAt, b.CreatedAt) }},
+	{"expires", func(a, b client.APIToken) int { return compareTimeStrings(a.ExpiresAt, b.ExpiresAt) }},
+	{"last-used", func(a, b client.APIToken) int { return compareTimeStringPtrs(a.LastUsedAt, b.LastUsedAt) }},
+}
+
 var tokensListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all API tokens",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		sortTokens, err := resolveSort(cmd, tokenSortFields)
+		if err != nil {
+			return err
+		}
 		tokens, err := apiClient.ListAPITokens()
 		if err != nil {
 			return fmt.Errorf("listing tokens: %w", err)
@@ -30,6 +43,7 @@ var tokensListCmd = &cobra.Command{
 		if tokens == nil {
 			tokens = []client.APIToken{}
 		}
+		sortTokens(tokens)
 		if rendered, err := renderStructured(cmd, tokens); rendered || err != nil {
 			return err
 		}
@@ -166,6 +180,7 @@ func init() {
 		"MCP access scopes: mcp:read or mcp:read,mcp:write; omitted creates a REST-only token")
 
 	registerStructuredOutputFlags(tokensListCmd, tokensCreateCmd)
+	registerSortFlags(tokensListCmd, tokenSortFields)
 
 	tokensCmd.AddCommand(tokensListCmd)
 	tokensCmd.AddCommand(tokensCreateCmd)


### PR DESCRIPTION
## What & why

The list commands always printed rows in server order; the only way to reorder them was piping `-o json` through `jq`. This adds `--sort <column>` and `--order asc|desc` to the main list commands — `cluster list`, `cluster addons list`, `org list`, `credentials list`, and `tokens list` — so e.g. `ankra cluster list --sort created --order desc` puts the newest clusters first.

Design points:

- A small generic helper (`cmd/sort.go`) holds the flag registration, validation, and comparators; each command declares its sortable columns as a `[]sortField[T]` next to the command.
- Sorting runs on the **raw values before rendering**, so timestamp columns order chronologically rather than by their "2 days ago" display text, and `-o json|yaml` comes out in the same order as the table.
- Flags are validated **before any API call**: an unknown `--sort` column or `--order` direction exits with the usage code (2) and names the valid values, without a wasted request. `--order` without `--sort` is also a usage error.
- Without `--sort`, the server order is preserved (stable sort keeps ties in server order too).
- Commands that page server-side (`charts list`, `cluster operations list`) are deliberately left out — a client-side sort of one page would be misleading. `helm registries list` keeps its existing server-side `--sort-by`/`--sort-order`.

Bead: ankra-9bkp5

## Test plan

- New `cmd/sort_test.go`: unit tests for `resolveSort` validation (unknown key/direction, `--order` without `--sort`, case-insensitive keys, asc/desc) and for every comparator (chronological vs lexicographic timestamps, nil-pointer ordering, bool ordering); e2e tests through the shared `rootCmd` covering table order for `--sort name` and `--sort created --order desc`, JSON output order, and the exit-2 contract for an invalid column. Test cleanup resets the leaked flag `Changed` state on the shared command (same gotcha as `TestHelmRegistriesListFlagsForwarded`).
- `go test -race -count=1 ./...` green; `golangci-lint run` 0 issues; `go vet` clean.
- Manual: built the binary; `ankra cluster list --help` renders the new flags and examples; `--sort bogus` exits 2 instantly against an unroutable base URL (proves validation precedes the fetch).

## Docs checklist

- [ ] No user-facing command/flag changes — no docs needed
- [x] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); ensure `Short`/`Long`/`Example` on new commands are written for docs readers
- [ ] Broader behaviour changes — docs updated in [ankra-docs](https://github.com/ankraio/ankra-docs) (link the PR): <!-- PR link -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
