### PR TITLE
fix(ci): create TMPDIR before setup-go so the lifecycle system test can start (ankra-2k1al)

### DIFF
--- a/.github/workflows/systemtest.yml
+++ b/.github/workflows/systemtest.yml
@@ -56,6 +56,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      # TMPDIR (set job-wide above) lives inside the workspace so the test's
+      # temp files survive for the log upload, but checkout starts from a
+      # clean workspace. It must exist before anything invokes Go: setup-go
+      # runs `go env`, and Go refuses to start with a missing TMPDIR.
+      - name: Create TMPDIR
+        run: mkdir -p "$TMPDIR"
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -66,7 +73,6 @@ jobs:
 
       - name: Run lifecycle system test
         run: |
-          mkdir -p "$TMPDIR"
           # "none" lets a dispatch skip a whole family (an empty input would
           # fall back to the default matrix instead).
           if [ "$ANKRA_SYSTEMTEST_PROVIDERS" = "none" ]; then export ANKRA_SYSTEMTEST_PROVIDERS=""; fi


### PR DESCRIPTION
## What & why

The scheduled Lifecycle system test (Mon/Wed/Fri 03:00 UTC) has failed on every run since at least 2026-08-12 (runs 31564055260, 31770693882, 31991920217, 32212851335, 32444301131), so the CLI has had **zero lifecycle e2e coverage for over a week** — and the failure is in setup, not in any test:

- The job sets `TMPDIR: ${{ github.workspace }}/systemtest-artifacts` job-wide so the test's temp files survive for the log-upload step.
- But nothing created that directory until the "Run lifecycle system test" step, and `actions/setup-go` runs `go env` first. Go aborts outright when `TMPDIR` doesn't exist: `go: creating work dir: stat .../systemtest-artifacts: no such file or directory`.

Fix: create the directory in its own step immediately after checkout — before anything invokes Go — and drop the now-redundant `mkdir` from the test step. One file, +7/−1.

Reviewer note: the exact upgrade that turned this fatal is unpinnable from here (`TMPDIR` was added 2026-06-19 and runs passed until early August; the go1.26.6 toolchain bump landed Aug 16, *after* the first failure, so the trigger was likely a setup-go or runner-image update around Aug 10–12). The mechanism is unambiguous from the failed logs either way, and the fix is correct regardless of trigger.

Bead: ankra-2k1al

## Test plan

- YAML parses (`ruby -ryaml`); repo pre-commit hook (go test + golangci-lint) passed on commit.
- The real gate can't run on a PR: the workflow is `schedule` + `workflow_dispatch` only, and a dispatch provisions real, billable cloud infrastructure. After merge, verify cheaply with a manual dispatch using `providers: none` and `managed_providers: none` — that exercises checkout → **Create TMPDIR** → setup-go → build (the exact path that has been dying) without spinning up any cloud clusters.

## Docs checklist

- [x] No user-facing command/flag changes — no docs needed
- [ ] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); ensure `Short`/`Long`/`Example` on new commands are written for docs readers
- [ ] Broader behaviour changes — docs updated in [ankra-docs](https://github.com/ankraio/ankra-docs) (link the PR): <!-- PR link -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
