### PR TITLE
ci: run ankra-cli workflows on Depot instead of ubuntu-latest (ankra-lo47s)

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   sync-docs:
     name: Generate and PR CLI reference
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout ankra-cli
         uses: actions/checkout@v6

--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   lint-test-build:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Create release
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -67,16 +67,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: depot-ubuntu-24.04
             goos: linux
             goarch: amd64
-          - os: ubuntu-latest
+          - os: depot-ubuntu-24.04
             goos: linux
             goarch: arm64
-          - os: ubuntu-latest
+          - os: depot-ubuntu-24.04
             goos: windows
             goarch: amd64
-          - os: ubuntu-latest
+          - os: depot-ubuntu-24.04
             goos: windows
             goarch: arm64
           - os: macos-latest
@@ -156,7 +156,7 @@ jobs:
     if: ${{ !contains(github.ref_name, '-') }}
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/systemtest.yml
+++ b/.github/workflows/systemtest.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   lifecycle-system-test:
     name: Cloud lifecycle system test
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     timeout-minutes: 240
     env:
       ANKRA_SYSTEMTEST_CONFIRM: 'yes'


### PR DESCRIPTION
Bead: ankra-lo47s

## Problem

The org-wide GitHub Actions billing failure (ankra-m5m9d) blocks any job on a
GitHub-hosted runner — the job never starts:

> The job was not started because recent account payments have failed or your spending limit needs to be increased.

`ankra-cli` had 0 of 6 `runs-on` lines on Depot, so lint/build, systemtest,
docs-sync and releases are all dead. cluster, portal, agent, admin-portal and
(as of beads#17) beads already run on Depot, which is billed outside GitHub
Actions and is unaffected.

## Change

Every plain `ubuntu-latest` → `depot-ubuntu-24.04`, including the four
linux/windows entries in the release matrix — those are pure Go cross-compiles
(`CGO_ENABLED: 0`, `GOOS`/`GOARCH`), so the host OS is irrelevant to the artifact.

## What is deliberately NOT changed

The two `macos-latest` matrix entries (darwin/amd64, darwin/arm64) stay.

The build itself would cross-compile from Linux happily — but the job also runs
`codesign --force --sign -` to ad-hoc sign the darwin binaries, and `codesign` is
macOS-only. Moving them to Linux would silently drop that signing and add Gatekeeper
friction for every macOS CLI user, which is a product decision rather than an
infrastructure one.

No `depot-macos` label is used anywhere in the org, so that label is unproven here;
guessing it risks a job that queues forever instead of failing loudly. **The two
darwin release jobs therefore remain billing-blocked** — called out in the bead with
the real options (enable Depot macOS, or configure proper Developer ID notarization,
which is the actual fix the existing code comment already anticipates).

## Verification

All four workflow files parse as valid YAML. Being release/CI workflows, the real
proof is the next run on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

## ⚠️ BLOCKED — do not merge yet

Verified on this PR's own CI: the jobs are accepted but **never picked up**.

```
status=queued  conclusion=-  runner=(none)  labels=depot-ubuntu-24.04
```

Compare a Depot job in `ankraio/beads`, which works:

```
status=completed  conclusion=success  runner=depot-0tz55m0140  labels=depot-ubuntu-24.04
```

**Depot runners are enabled per repository**, and this repo is not connected. Merging
as-is would replace a fast, clearly-worded billing failure (~2-4s, with an annotation
explaining exactly what is wrong) with a job that hangs in the queue indefinitely —
strictly worse, and much harder to diagnose.

**Required first:** connect this repository in the Depot organisation settings so the
`depot-ubuntu-24.04` label resolves. Once that is done this PR is correct as written and
its own CI becomes the proof — the checks here will go green instead of queueing.

The queued runs from this PR have been cancelled so they do not sit forever.