### PR TITLE
feat(cluster): debugging verbs that replace a kubectl grant (ankra-ymkj8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,12 +35,15 @@
   spellings work — `pod`, `pods`, `po`, `Pod` — and a kind outside the
   built-in set is reachable with `--group`/`--api-version`. `-o json|yaml`
   emits `{object, events}`.
-- **`ankra cluster events --for <kind>/<name>`** (also `ankra cluster get
-  events --for`) scopes an event listing to a single object's
-  `involvedObject` with a server-side field selector, rather than filtering
-  a namespace-wide list by name. That is the difference between "the pod is
-  Pending" and "no node matches the nodeSelector". `--type Normal|Warning`
-  narrows further, and `-o json|yaml` prints the raw events.
+- **`ankra cluster events --for <kind>/<name>`** scopes an event listing to a
+  single object's `involvedObject` with a server-side field selector, rather
+  than filtering a namespace-wide list by name. That is the difference
+  between "the pod is Pending" and "no node matches the nodeSelector".
+  `--type Normal|Warning` narrows further, and `-o json|yaml` prints the raw
+  events. `ankra cluster get events` gains the same two flags while keeping
+  its existing output, its `[name]` argument, and its `resource_responses`
+  envelope under `-o json|yaml`, so nothing already scripted against it
+  changes.
 - **`ankra cluster top pods|nodes`** shows live CPU and memory from the
   Kubernetes metrics API. `cluster metrics` queries Prometheus, which is the
   right tool for trends but the wrong one for "which container just got

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,14 @@
   its exit code, ImagePullBackOff and its registry error, restart counts),
   and the events whose `involvedObject` is that resource. Kubectl's
   spellings work — `pod`, `pods`, `po`, `Pod` — and a kind outside the
-  built-in set is reachable with `--group`/`--api-version`. `-o json|yaml`
-  emits `{object, events}`.
+  built-in set is reachable with `--group`/`--api-version` (both are
+  required, so a custom resource that does not serve `v1` fails with a clear
+  message rather than an empty read). `-o json|yaml` emits
+  `{object, events}`. Describing a Secret redacts its values to byte counts
+  and lists the keys, like `kubectl describe` does: the point of these
+  commands is to need a kubectl grant less often, not to make reading secret
+  material easier than kubectl makes it. Use `cluster get secrets <name> -o
+  yaml` when you actually want the values.
 - **`ankra cluster events --for <kind>/<name>`** scopes an event listing to a
   single object's `involvedObject` with a server-side field selector, rather
   than filtering a namespace-wide list by name. That is the difference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,54 @@
 
 ### Added
 
+- **`ankra cluster logs --previous` reads the log a crash-looping container
+  left behind.** When a container is in CrashLoopBackOff the only output
+  worth reading belongs to the instance that already died, and nothing in
+  the CLI could reach it — the one case where you most want to avoid handing
+  out a kubectl grant was the one case that forced you to. `--previous`
+  (`-p`) asks the platform for that terminated log; because the log is closed
+  it is always a bounded read, so it ends on its own instead of hanging on a
+  stream that can never produce another line. It needs a platform and a
+  cluster agent that carry the parameter; an older agent serves the current
+  container's log instead.
+- **`ankra cluster logs -l <selector>` and `--all-containers`** read more
+  than one container per invocation. A three-replica Deployment used to mean
+  listing pods to learn the hashed names and then three separate commands;
+  now one selector reads them all, and `--all-containers` expands each pod to
+  every container it declares — init and ephemeral containers included, which
+  is where a stuck pod's real error usually is. With more than one target
+  each line is prefixed `[pod]` or `[pod/container]` so the interleaved
+  output stays attributable, and a following read is capped at five
+  concurrent streams rather than silently opening one connection per replica.
+  `logs` also gains `-o json|yaml`, which groups the output per target for a
+  pipeline to parse.
+- **`ankra cluster describe <kind> <name>`** answers "why is this not ready?"
+  in one call. `cluster get` returned lists and manifests, so conditions,
+  per-container state, and the object's events had to be assembled by hand
+  from three commands. `describe` prints the object's conditions, a pod's
+  container statuses with the detail that explains them (CrashLoopBackOff and
+  its exit code, ImagePullBackOff and its registry error, restart counts),
+  and the events whose `involvedObject` is that resource. Kubectl's
+  spellings work — `pod`, `pods`, `po`, `Pod` — and a kind outside the
+  built-in set is reachable with `--group`/`--api-version`. `-o json|yaml`
+  emits `{object, events}`.
+- **`ankra cluster events --for <kind>/<name>`** (also `ankra cluster get
+  events --for`) scopes an event listing to a single object's
+  `involvedObject` with a server-side field selector, rather than filtering
+  a namespace-wide list by name. That is the difference between "the pod is
+  Pending" and "no node matches the nodeSelector". `--type Normal|Warning`
+  narrows further, and `-o json|yaml` prints the raw events.
+- **`ankra cluster top pods|nodes`** shows live CPU and memory from the
+  Kubernetes metrics API. `cluster metrics` queries Prometheus, which is the
+  right tool for trends but the wrong one for "which container just got
+  OOMKilled" — and it needs Prometheus to have been installed at all.
+  `top` reads metrics-server directly, so it works on any cluster that has
+  one. `top pods` takes `--containers` for a per-container breakdown and
+  `--sort-by cpu|memory`; `top nodes` shows usage against each node's
+  allocatable capacity. A measurement is only meaningful live, so the read
+  bypasses Ankra's resource cache, and an answer that comes back from the
+  cache anyway (an offline cluster) is refused rather than rendered as if it
+  were current.
 - **`--sort <column>` and `--order asc|desc` on the main list commands**
   (`cluster list`, `cluster addons list`, `org list`, `credentials list`,
   `tokens list`) let you order the output by any rendered column — e.g.

--- a/cmd/cluster_debug_verbs_test.go
+++ b/cmd/cluster_debug_verbs_test.go
@@ -1527,3 +1527,116 @@ func TestGetEventsNamedLookupFilteredOutDegradesToAnEmptyListing(t *testing.T) {
 		t.Errorf("the empty envelope should still be well-formed, got:\n%s", output)
 	}
 }
+
+// TestDescribeSecretRedactsTheAppliedManifestAnnotation covers the bypass the
+// re-review found: kubectl apply stores the whole submitted manifest, base64
+// values and all, in an annotation, so redacting only data/stringData left
+// the values readable one field away.
+func TestDescribeSecretRedactsTheAppliedManifestAnnotation(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	const secretValue = "c3VwZXItc2VjcmV0LXZhbHVl"
+	mock := newDebugVerbsMock()
+	mock.responses["Secret"] = client.ResourceResponseItem{
+		Items: []interface{}{objectMap(map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name": "db", "namespace": "default",
+				"annotations": map[string]interface{}{
+					lastAppliedConfigurationAnnotation: `{"data":{"password":"` + secretValue + `"}}`,
+					"backup.example/copy":              "password=" + secretValue,
+					"harmless":                         "managed-by=controller",
+				},
+			},
+			"data": map[string]interface{}{"password": secretValue},
+		})},
+	}
+	mock.responses["Event"] = client.ResourceResponseItem{Items: []interface{}{}}
+	setMockClient(t, mock)
+
+	for _, outputFormat := range []string{"table", "json", "yaml"} {
+		resetCommandFlags(t, clusterDescribeCmd)
+		output := captureStdout(t, func() {
+			if _, executeError := executeCommand("cluster", "describe", "secret", "db",
+				"-n", "default", "-o", outputFormat); executeError != nil {
+				t.Fatalf("describe secret -o %s failed: %v", outputFormat, executeError)
+			}
+		})
+		if strings.Contains(output, secretValue) {
+			t.Errorf("-o %s leaked the secret value through an annotation:\n%s", outputFormat, output)
+		}
+		if outputFormat != "table" && !strings.Contains(output, "harmless") {
+			t.Errorf("-o %s should keep annotations that carry no secret material:\n%s", outputFormat, output)
+		}
+	}
+}
+
+func TestDescribeSecretKeyListingUsesTheResolvedKind(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterDescribeCmd)
+	mock := newDebugVerbsMock()
+	// A cached item need not carry its own kind field. Redaction and the key
+	// listing must agree about what this object is, or one fires and the
+	// other silently does not.
+	mock.responses["Secret"] = client.ResourceResponseItem{
+		Items: []interface{}{objectMap(map[string]interface{}{
+			"apiVersion": "v1",
+			"metadata":   map[string]interface{}{"name": "db", "namespace": "default"},
+			"data":       map[string]interface{}{"password": "c3VwZXItc2VjcmV0LXZhbHVl"},
+		})},
+	}
+	mock.responses["Event"] = client.ResourceResponseItem{Items: []interface{}{}}
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand("cluster", "describe", "secret", "db", "-n", "default"); executeError != nil {
+			t.Fatalf("describe secret failed: %v", executeError)
+		}
+	})
+	plain := stripANSICodes(output)
+	if strings.Contains(plain, "c3VwZXItc2VjcmV0LXZhbHVl") {
+		t.Errorf("the value leaked:\n%s", plain)
+	}
+	if !strings.Contains(plain, "password") || !strings.Contains(plain, "redacted") {
+		t.Errorf("the key listing must fire on the resolved kind too:\n%s", plain)
+	}
+}
+
+func TestEventsShowTheInvolvedObjectNamespace(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterEventsCmd)
+	mock := newDebugVerbsMock()
+	// --for omits involvedObject.namespace under --all-namespaces, so a
+	// same-named object elsewhere also matches. The column is what stops one
+	// namespace's events being read as another's.
+	mock.responses["Event"] = client.ResourceResponseItem{
+		Items: []interface{}{
+			scopedEvent(),
+			objectMap(map[string]interface{}{
+				"type": "Warning", "reason": "BackOff", "message": "other namespace",
+				"lastTimestamp": "2026-08-22T09:07:00Z",
+				"involvedObject": map[string]interface{}{
+					"kind": "Pod", "name": "web-7d9f-2xkvp", "namespace": "staging",
+				},
+			}),
+		},
+	}
+	setMockClient(t, mock)
+
+	var output string
+	stderrText := captureStderr(t, func() {
+		output = captureStdout(t, func() {
+			if _, executeError := executeCommand("cluster", "events",
+				"--for", "pod/web-7d9f-2xkvp", "-A"); executeError != nil {
+				t.Fatalf("events --for -A failed: %v", executeError)
+			}
+		})
+	})
+	plain := stripANSICodes(output)
+	if !strings.Contains(plain, "default") || !strings.Contains(plain, "staging") {
+		t.Errorf("both namespaces must be distinguishable in the output:\n%s", plain)
+	}
+	if !strings.Contains(stderrText, "any namespace") {
+		t.Errorf("the cross-namespace match should be called out on stderr, got %q", stderrText)
+	}
+}

--- a/cmd/cluster_debug_verbs_test.go
+++ b/cmd/cluster_debug_verbs_test.go
@@ -1253,3 +1253,277 @@ func TestResolveK8sKindRejectsEmpty(t *testing.T) {
 		t.Fatal("an empty kind must fail")
 	}
 }
+
+// --- review findings ---
+
+// TestDescribeSecretRedactsItsValues is the regression test for the review's
+// one high-severity finding. This command is pitched as the narrower
+// alternative to handing out a kubectl grant, so it must not be an easier way
+// to read secret material than the tool it replaces. kubectl describe redacts
+// a Secret to key lengths; so does this, in the structured output too, which
+// is where the full base64 payload would otherwise land in CI logs.
+func TestDescribeSecretRedactsItsValues(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterDescribeCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["Secret"] = client.ResourceResponseItem{
+		Items: []interface{}{objectMap(map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata":   map[string]interface{}{"name": "db", "namespace": "default"},
+			"data": map[string]interface{}{
+				"password": "c3VwZXItc2VjcmV0LXZhbHVl",
+			},
+			"stringData": map[string]interface{}{"token": "plaintext-token"},
+		})},
+	}
+	mock.responses["Event"] = client.ResourceResponseItem{Items: []interface{}{}}
+	setMockClient(t, mock)
+
+	for _, outputFormat := range []string{"table", "json", "yaml"} {
+		resetCommandFlags(t, clusterDescribeCmd)
+		output := captureStdout(t, func() {
+			if _, executeError := executeCommand("cluster", "describe", "secret", "db",
+				"-n", "default", "-o", outputFormat); executeError != nil {
+				t.Fatalf("describe secret -o %s failed: %v", outputFormat, executeError)
+			}
+		})
+		if strings.Contains(output, "c3VwZXItc2VjcmV0LXZhbHVl") {
+			t.Errorf("-o %s leaked the secret value:\n%s", outputFormat, output)
+		}
+		if strings.Contains(output, "plaintext-token") {
+			t.Errorf("-o %s leaked the stringData value:\n%s", outputFormat, output)
+		}
+		if !strings.Contains(output, "redacted") {
+			t.Errorf("-o %s should say the value was redacted:\n%s", outputFormat, output)
+		}
+		if !strings.Contains(output, "password") {
+			t.Errorf("-o %s should still name the keys:\n%s", outputFormat, output)
+		}
+	}
+}
+
+// TestTopRefusesSandboxDataThatIsNotFlaggedAsCached pins why the cache guard
+// checks the pointer rather than CacheMetadata.ServedFromCache. The platform
+// attaches cache metadata on three paths and the sandbox one sets
+// ServedFromCache false while still returning synthesised objects, so gating
+// on the flag would render a sandbox cluster's fabricated pods as live
+// measurements.
+func TestTopRefusesSandboxDataThatIsNotFlaggedAsCached(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterTopPodsCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["PodMetrics"] = client.ResourceResponseItem{
+		CacheMetadata: &client.ResourceCacheMetadata{
+			ServedFromCache: false, SyncStatus: "sandbox",
+		},
+		Items: []interface{}{podMetrics("fabricated", "100m", "64Mi")},
+	}
+	setMockClient(t, mock)
+
+	_, executeError := executeCommand("cluster", "top", "pods", "-n", "default")
+	if executeError == nil {
+		t.Fatal("sandbox data must not render as a live measurement even though ServedFromCache is false")
+	}
+	if !strings.Contains(executeError.Error(), "sandbox") {
+		t.Errorf("the refusal should name the sandbox, got %q", executeError.Error())
+	}
+}
+
+func TestLogsPreviousRejectsAnExplicitFollow(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterLogsCmd)
+	mock := newDebugVerbsMock()
+	setMockClient(t, mock)
+
+	_, executeError := executeCommand("cluster", "logs", "web-1", "-n", "default", "--previous", "--follow=true")
+	if executeError == nil {
+		t.Fatal("--previous with an explicit --follow=true must be rejected, not silently overridden")
+	}
+	if got := exitCodeFor(executeError); got != exitUsage {
+		t.Errorf("should exit %d, got %d", exitUsage, got)
+	}
+	if len(mock.logOptions) != 0 {
+		t.Error("the contradiction must be caught before any API call")
+	}
+}
+
+func TestLogsPreviousStillWorksWithTheDefaultFollow(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterLogsCmd)
+	mock := newDebugVerbsMock()
+	mock.logOutput["web-1"] = "panic\n"
+	setMockClient(t, mock)
+
+	// --follow defaults to true in this CLI, so rejecting the explicit form
+	// must not reject the ordinary one.
+	if _, executeError := executeCommand("cluster", "logs", "web-1", "-n", "default", "--previous"); executeError != nil {
+		t.Fatalf("--previous without an explicit --follow must work: %v", executeError)
+	}
+}
+
+func TestLogsBoundedReadIsAlsoCapped(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterLogsCmd)
+	mock := newDebugVerbsMock()
+	pods := []interface{}{}
+	for index := 0; index < maxBoundedLogTargets+1; index++ {
+		pods = append(pods, objectMap(map[string]interface{}{
+			"metadata": map[string]interface{}{"name": fmt.Sprintf("web-%03d", index)},
+			"spec": map[string]interface{}{
+				"containers": []interface{}{map[string]interface{}{"name": "web"}},
+			},
+		}))
+	}
+	mock.responses["Pod"] = client.ResourceResponseItem{Items: pods}
+	setMockClient(t, mock)
+
+	// The cap used to apply only to following reads, so a selector matching a
+	// busy namespace fanned out unbounded - and -o json buffered all of it.
+	_, executeError := executeCommand("cluster", "logs", "-l", "app=web", "-n", "default", "--follow=false")
+	if executeError == nil {
+		t.Fatal("an unbounded bounded-mode fan-out must be refused")
+	}
+	if got := exitCodeFor(executeError); got != exitUsage {
+		t.Errorf("should exit %d, got %d", exitUsage, got)
+	}
+	if len(mock.logOptions) != 0 {
+		t.Error("no stream should be opened once the cap is exceeded")
+	}
+}
+
+func TestTopNodesRefusesCachedCapacityRatherThanPairingItWithLiveUsage(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterTopNodesCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["NodeMetrics"] = client.ResourceResponseItem{
+		Items: []interface{}{objectMap(map[string]interface{}{
+			"metadata": map[string]interface{}{"name": "worker-1"},
+			"usage":    map[string]interface{}{"cpu": "500m", "memory": "1Gi"},
+		})},
+	}
+	// Nodes are a cached kind, so the capacity read has to ask for a live
+	// answer; a cached one must drop the percentage rather than pair a live
+	// measurement with a stale denominator.
+	mock.responses["Node"] = client.ResourceResponseItem{
+		CacheMetadata: &client.ResourceCacheMetadata{
+			ServedFromCache: true, SyncStatus: "cluster_offline",
+		},
+		Items: []interface{}{objectMap(map[string]interface{}{
+			"metadata": map[string]interface{}{"name": "worker-1"},
+			"status": map[string]interface{}{
+				"allocatable": map[string]interface{}{"cpu": "2", "memory": "4Gi"},
+			},
+		})},
+	}
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand("cluster", "top", "nodes"); executeError != nil {
+			t.Fatalf("top nodes failed: %v", executeError)
+		}
+	})
+	nodeRow := ""
+	for _, line := range strings.Split(stripANSICodes(output), "\n") {
+		if strings.Contains(line, "worker-1") {
+			nodeRow = line
+		}
+	}
+	if strings.Contains(nodeRow, "%") {
+		t.Errorf("a cached capacity must not become a percentage: %q", nodeRow)
+	}
+	if !strings.Contains(nodeRow, "500m") {
+		t.Errorf("the live measurement should still render: %q", nodeRow)
+	}
+	// The capacity read must have asked for a live answer in the first place.
+	sawSkipCacheNodeRead := false
+	for index, request := range mock.requests {
+		if request.Kind == "Node" && mock.skipCacheSeen[index] {
+			sawSkipCacheNodeRead = true
+		}
+	}
+	if !sawSkipCacheNodeRead {
+		t.Error("the node capacity read must set skip_cache, like the measurement it divides")
+	}
+}
+
+func TestResolveK8sKindKeepsAnIrregularPluralWhenGroupIsOverridden(t *testing.T) {
+	// Clearing the explicit plural on --group handed the platform's heuristic
+	// kinds it cannot pluralise from the name alone, which 404s against a
+	// real object. The plural belongs to the kind, not to the group.
+	for _, spelling := range []string{"ingress", "endpoints", "networkpolicy", "storageclass"} {
+		withoutOverride, _ := resolveK8sKind(spelling, "", "")
+		withOverride, resolveError := resolveK8sKind(spelling, "example.com", "")
+		if resolveError != nil {
+			t.Errorf("resolveK8sKind(%q, group) failed: %v", spelling, resolveError)
+			continue
+		}
+		if withOverride.resource != withoutOverride.resource {
+			t.Errorf("resolveK8sKind(%q) lost its plural under --group: %q vs %q",
+				spelling, withOverride.resource, withoutOverride.resource)
+		}
+		if withOverride.group != "example.com" {
+			t.Errorf("resolveK8sKind(%q) should still take the group override", spelling)
+		}
+	}
+}
+
+func TestResolveK8sKindRequiresBothOverridesForAnUnknownKind(t *testing.T) {
+	// Defaulting an unknown CRD to v1 produces a confusing empty read when the
+	// resource does not serve v1, rather than a clear usage message.
+	if _, resolveError := resolveK8sKind("Widget", "example.com", ""); resolveError == nil {
+		t.Fatal("--group without --api-version must be a usage error for an unknown kind")
+	} else if got := exitCodeFor(resolveError); got != exitUsage {
+		t.Errorf("should exit %d, got %d", exitUsage, got)
+	}
+	if _, resolveError := resolveK8sKind("Widget", "", "v1alpha1"); resolveError == nil {
+		t.Fatal("--api-version without --group must be a usage error for an unknown kind")
+	}
+	if _, resolveError := resolveK8sKind("Widget", "example.com", "v1alpha1"); resolveError != nil {
+		t.Errorf("both overrides together must resolve: %v", resolveError)
+	}
+}
+
+func TestParseKubernetesQuantityRejectsAnUnknownUnit(t *testing.T) {
+	// The review suggested a bare number could fall through for an unknown
+	// unit. ParseFloat rejects the trailing garbage, so it cannot.
+	for _, malformed := range []string{"100x", "12abc", "5Gib", "1..2", "--3"} {
+		if parsed, isValid := parseKubernetesQuantity(malformed); isValid {
+			t.Errorf("parseKubernetesQuantity(%q) = %v, want rejected", malformed, parsed)
+		}
+	}
+}
+
+func TestGetEventsNamedLookupFilteredOutDegradesToAnEmptyListing(t *testing.T) {
+	// The review asked whether a postFilter dropping the only match confuses
+	// the named-lookup path. It does not: the listing renderer reports that
+	// nothing matched, which is exactly what happened.
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, getEventsCommand(t))
+	mock := newDebugVerbsMock()
+	mock.responses["Event"] = client.ResourceResponseItem{
+		Items: []interface{}{objectMap(map[string]interface{}{
+			"type": "Normal", "reason": "Pulled",
+			"metadata":       map[string]interface{}{"name": "web-1.17abc"},
+			"involvedObject": map[string]interface{}{"kind": "Pod", "name": "web-1"},
+		})},
+	}
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand("cluster", "get", "events", "web-1.17abc",
+			"-n", "default", "--type", "Warning"); executeError != nil {
+			t.Fatalf("get events <name> --type failed: %v", executeError)
+		}
+	})
+	// A named get lookup that matches nothing renders the empty envelope,
+	// which is what every other named lookup in the get family already does
+	// when the object is absent - the filter reaches the same place by a
+	// different route rather than a new confusing one.
+	if strings.Contains(output, "Pulled") {
+		t.Errorf("the filtered-out event must not render:\n%s", output)
+	}
+	if !strings.Contains(output, "items: []") {
+		t.Errorf("the empty envelope should still be well-formed, got:\n%s", output)
+	}
+}

--- a/cmd/cluster_debug_verbs_test.go
+++ b/cmd/cluster_debug_verbs_test.go
@@ -1,0 +1,947 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+// debugVerbsMock answers resources/get from a per-kind table and records
+// every request, so the tests can assert what was asked of the platform -
+// the field selectors that scope an event listing, and the explicit
+// resource plural the metrics API needs - not only what was rendered.
+type debugVerbsMock struct {
+	baseMock
+	responses     map[string]client.ResourceResponseItem
+	requests      []client.ResourceRequestItem
+	skipCacheSeen []bool
+	requestError  error
+
+	logOptions []client.PodLogOptions
+	logOutput  map[string]string
+	logError   error
+}
+
+func (mock *debugVerbsMock) GetResources(clusterID string, request client.GetResourcesRequest) (*client.GetResourcesResponse, error) {
+	if mock.requestError != nil {
+		return nil, mock.requestError
+	}
+	response := client.GetResourcesResponse{}
+	for _, item := range request.ResourceRequests {
+		mock.requests = append(mock.requests, item)
+		mock.skipCacheSeen = append(mock.skipCacheSeen, request.SkipCache)
+		response.ResourceResponses = append(response.ResourceResponses, mock.responses[item.Kind])
+	}
+	return &response, nil
+}
+
+func (mock *debugVerbsMock) StreamPodLogs(_ context.Context, _ string, options client.PodLogOptions, writer io.Writer) error {
+	mock.logOptions = append(mock.logOptions, options)
+	if mock.logError != nil {
+		return mock.logError
+	}
+	key := options.PodName
+	if options.ContainerName != "" {
+		key += "/" + options.ContainerName
+	}
+	if _, writeError := io.WriteString(writer, mock.logOutput[key]); writeError != nil {
+		return writeError
+	}
+	return nil
+}
+
+func objectMap(entries map[string]interface{}) map[string]interface{} { return entries }
+
+func newDebugVerbsMock() *debugVerbsMock {
+	return &debugVerbsMock{
+		responses: map[string]client.ResourceResponseItem{},
+		logOutput: map[string]string{},
+	}
+}
+
+func crashLoopingPod() map[string]interface{} {
+	return objectMap(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":              "web-7d9f-2xkvp",
+			"namespace":         "default",
+			"creationTimestamp": "2026-08-22T09:00:00Z",
+			"labels":            map[string]interface{}{"app": "web"},
+		},
+		"spec": map[string]interface{}{
+			"nodeName": "worker-1",
+			"initContainers": []interface{}{
+				map[string]interface{}{"name": "wait-for-db"},
+			},
+			"containers": []interface{}{
+				map[string]interface{}{"name": "web"},
+				map[string]interface{}{"name": "sidecar"},
+			},
+		},
+		"status": map[string]interface{}{
+			"phase": "Running",
+			"conditions": []interface{}{
+				map[string]interface{}{
+					"type": "Ready", "status": "False",
+					"reason":             "ContainersNotReady",
+					"message":            "containers with unready status: [web]",
+					"lastTransitionTime": "2026-08-22T09:05:00Z",
+				},
+			},
+			"containerStatuses": []interface{}{
+				map[string]interface{}{
+					"name": "web", "ready": false, "restartCount": float64(7),
+					"image": "registry.example/web:1.2.3",
+					"state": map[string]interface{}{
+						"waiting": map[string]interface{}{
+							"reason":  "CrashLoopBackOff",
+							"message": "back-off 5m0s restarting failed container",
+						},
+					},
+					"lastState": map[string]interface{}{
+						"terminated": map[string]interface{}{
+							"reason": "Error", "exitCode": float64(1),
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+func scopedEvent() map[string]interface{} {
+	return objectMap(map[string]interface{}{
+		"type":          "Warning",
+		"reason":        "BackOff",
+		"message":       "Back-off restarting failed container web",
+		"count":         float64(12),
+		"lastTimestamp": "2026-08-22T09:06:00Z",
+		"involvedObject": map[string]interface{}{
+			"kind": "Pod", "name": "web-7d9f-2xkvp", "namespace": "default",
+		},
+	})
+}
+
+func fieldSelectorValue(request client.ResourceRequestItem, field string) string {
+	for _, selector := range request.FieldSelectors {
+		if selector.Field == field {
+			return selector.Value
+		}
+	}
+	return ""
+}
+
+// --- describe ---
+
+func TestDescribePodShowsConditionsContainerStateAndScopedEvents(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterDescribeCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["Pod"] = client.ResourceResponseItem{
+		Status: "success", Kind: "Pod", Version: "v1",
+		Items: []interface{}{crashLoopingPod()},
+	}
+	mock.responses["Event"] = client.ResourceResponseItem{
+		Status: "success", Kind: "Event", Version: "v1",
+		Items: []interface{}{scopedEvent()},
+	}
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand(
+			"cluster", "describe", "pod", "web-7d9f-2xkvp", "-n", "default"); executeError != nil {
+			t.Fatalf("describe failed: %v", executeError)
+		}
+	})
+	plain := stripANSICodes(output)
+
+	for _, expected := range []string{
+		"Pod/web-7d9f-2xkvp", "worker-1", "ContainersNotReady",
+		"CrashLoopBackOff", "exit 1", "registry.example/web:1.2.3", "BackOff",
+	} {
+		if !strings.Contains(plain, expected) {
+			t.Errorf("describe output is missing %q\n%s", expected, plain)
+		}
+	}
+
+	if len(mock.requests) != 2 {
+		t.Fatalf("expected a pod read and an event read, got %d requests", len(mock.requests))
+	}
+	eventRequest := mock.requests[1]
+	if eventRequest.Kind != "Event" {
+		t.Fatalf("second request should read Events, got %q", eventRequest.Kind)
+	}
+	if got := fieldSelectorValue(eventRequest, "involvedObject.name"); got != "web-7d9f-2xkvp" {
+		t.Errorf("events must be scoped by involvedObject.name, got %q", got)
+	}
+	if got := fieldSelectorValue(eventRequest, "involvedObject.kind"); got != "Pod" {
+		t.Errorf("events must be scoped by involvedObject.kind, got %q", got)
+	}
+	if got := fieldSelectorValue(eventRequest, "involvedObject.namespace"); got != "default" {
+		t.Errorf("events must be scoped by involvedObject.namespace, got %q", got)
+	}
+}
+
+func TestDescribeJSONCarriesObjectAndEvents(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterDescribeCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["Pod"] = client.ResourceResponseItem{
+		Items: []interface{}{crashLoopingPod()},
+	}
+	mock.responses["Event"] = client.ResourceResponseItem{
+		Items: []interface{}{scopedEvent()},
+	}
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand(
+			"cluster", "describe", "pod", "web-7d9f-2xkvp", "-n", "default", "-o", "json"); executeError != nil {
+			t.Fatalf("describe -o json failed: %v", executeError)
+		}
+	})
+
+	var decoded describeResult
+	if unmarshalError := json.Unmarshal([]byte(output), &decoded); unmarshalError != nil {
+		t.Fatalf("describe -o json must emit parseable JSON: %v\n%s", unmarshalError, output)
+	}
+	if getNestedString(decoded.Object, "metadata", "name") != "web-7d9f-2xkvp" {
+		t.Errorf("object is missing from the structured output: %+v", decoded.Object)
+	}
+	if len(decoded.Events) != 1 {
+		t.Errorf("expected the scoped event in the structured output, got %d", len(decoded.Events))
+	}
+}
+
+func TestDescribeMissingResourceExitsNotFound(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterDescribeCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["Pod"] = client.ResourceResponseItem{Items: []interface{}{}}
+	setMockClient(t, mock)
+
+	_, executeError := executeCommand("cluster", "describe", "pod", "ghost", "-n", "default")
+	if executeError == nil {
+		t.Fatal("describing a missing pod must fail")
+	}
+	if got := exitCodeFor(executeError); got != exitNotFound {
+		t.Errorf("missing resource should exit %d, got %d (%v)", exitNotFound, got, executeError)
+	}
+}
+
+func TestDescribeNamespacedKindRequiresNamespace(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterDescribeCmd)
+	mock := newDebugVerbsMock()
+	setMockClient(t, mock)
+
+	_, executeError := executeCommand("cluster", "describe", "pod", "web-1")
+	if executeError == nil {
+		t.Fatal("a namespaced describe without -n must fail")
+	}
+	if got := exitCodeFor(executeError); got != exitUsage {
+		t.Errorf("missing namespace should exit %d, got %d", exitUsage, got)
+	}
+	if len(mock.requests) != 0 {
+		t.Error("the namespace check must run before any API call")
+	}
+}
+
+func TestDescribeClusterScopedKindNeedsNoNamespace(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterDescribeCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["Node"] = client.ResourceResponseItem{
+		Items: []interface{}{objectMap(map[string]interface{}{
+			"apiVersion": "v1",
+			"metadata":   map[string]interface{}{"name": "worker-1"},
+		})},
+	}
+	mock.responses["Event"] = client.ResourceResponseItem{Items: []interface{}{}}
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand("cluster", "describe", "node", "worker-1"); executeError != nil {
+			t.Fatalf("describing a node failed: %v", executeError)
+		}
+	})
+	if !strings.Contains(stripANSICodes(output), "Node/worker-1") {
+		t.Errorf("node description missing:\n%s", output)
+	}
+	if mock.requests[0].Namespace != "" {
+		t.Errorf("a cluster-scoped read must not carry a namespace, got %q", mock.requests[0].Namespace)
+	}
+}
+
+func TestDescribeUnknownKindWithoutGroupExitsUsage(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterDescribeCmd)
+	mock := newDebugVerbsMock()
+	setMockClient(t, mock)
+
+	_, executeError := executeCommand("cluster", "describe", "widget", "thing", "-n", "default")
+	if executeError == nil {
+		t.Fatal("an unknown kind with no --group must fail")
+	}
+	if got := exitCodeFor(executeError); got != exitUsage {
+		t.Errorf("unknown kind should exit %d, got %d", exitUsage, got)
+	}
+	if !strings.Contains(executeError.Error(), "--group") {
+		t.Errorf("the error should point at --group, got %q", executeError.Error())
+	}
+}
+
+// --- events --for ---
+
+func TestEventsForScopesByInvolvedObject(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterEventsCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["Event"] = client.ResourceResponseItem{
+		Items: []interface{}{scopedEvent()},
+	}
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand(
+			"cluster", "events", "--for", "pod/web-7d9f-2xkvp", "-n", "default"); executeError != nil {
+			t.Fatalf("events --for failed: %v", executeError)
+		}
+	})
+	if !strings.Contains(stripANSICodes(output), "BackOff") {
+		t.Errorf("scoped event missing from output:\n%s", output)
+	}
+	if len(mock.requests) != 1 {
+		t.Fatalf("expected one event read, got %d", len(mock.requests))
+	}
+	if got := fieldSelectorValue(mock.requests[0], "involvedObject.name"); got != "web-7d9f-2xkvp" {
+		t.Errorf("--for must scope by involvedObject.name, got %q", got)
+	}
+	if got := fieldSelectorValue(mock.requests[0], "involvedObject.kind"); got != "Pod" {
+		t.Errorf("--for must scope by involvedObject.kind, got %q", got)
+	}
+}
+
+func TestEventsForIsAlsoReachableUnderGet(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterGetEventsCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["Event"] = client.ResourceResponseItem{Items: []interface{}{scopedEvent()}}
+	setMockClient(t, mock)
+
+	captureStdout(t, func() {
+		if _, executeError := executeCommand(
+			"cluster", "get", "events", "--for", "deployment/web", "-n", "default"); executeError != nil {
+			t.Fatalf("get events --for failed: %v", executeError)
+		}
+	})
+	if got := fieldSelectorValue(mock.requests[0], "involvedObject.kind"); got != "Deployment" {
+		t.Errorf("kind/name must resolve the kind, got %q", got)
+	}
+}
+
+func TestEventsForRejectsBareName(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterEventsCmd)
+	mock := newDebugVerbsMock()
+	setMockClient(t, mock)
+
+	_, executeError := executeCommand("cluster", "events", "--for", "web-7d9f", "-n", "default")
+	if executeError == nil {
+		t.Fatal("--for without a kind must fail")
+	}
+	if got := exitCodeFor(executeError); got != exitUsage {
+		t.Errorf("bad --for should exit %d, got %d", exitUsage, got)
+	}
+	if len(mock.requests) != 0 {
+		t.Error("--for must be validated before any API call")
+	}
+}
+
+func TestEventsRejectsUnknownType(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterEventsCmd)
+	setMockClient(t, newDebugVerbsMock())
+
+	_, executeError := executeCommand("cluster", "events", "-n", "default", "--type", "Critical")
+	if executeError == nil {
+		t.Fatal("an unknown --type must fail")
+	}
+	if got := exitCodeFor(executeError); got != exitUsage {
+		t.Errorf("unknown --type should exit %d, got %d", exitUsage, got)
+	}
+}
+
+func TestEventsEmptyListingSaysSo(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterEventsCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["Event"] = client.ResourceResponseItem{Items: []interface{}{}}
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand("cluster", "events", "-n", "default"); executeError != nil {
+			t.Fatalf("events failed: %v", executeError)
+		}
+	})
+	if !strings.Contains(output, "No events found.") {
+		t.Errorf("an empty listing should say so, got:\n%s", output)
+	}
+}
+
+func TestEventsSurfacesAPIFailure(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterEventsCmd)
+	mock := newDebugVerbsMock()
+	mock.requestError = fmt.Errorf("cluster is offline")
+	setMockClient(t, mock)
+
+	_, executeError := executeCommand("cluster", "events", "-n", "default")
+	if executeError == nil || !strings.Contains(executeError.Error(), "cluster is offline") {
+		t.Fatalf("an API failure must surface, got %v", executeError)
+	}
+}
+
+// --- top ---
+
+func podMetrics(name string, cpu string, memory string) map[string]interface{} {
+	return objectMap(map[string]interface{}{
+		"metadata": map[string]interface{}{"name": name, "namespace": "default"},
+		"containers": []interface{}{
+			map[string]interface{}{
+				"name":  "web",
+				"usage": map[string]interface{}{"cpu": cpu, "memory": memory},
+			},
+		},
+	})
+}
+
+func TestTopPodsRendersLiveUsage(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterTopPodsCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["PodMetrics"] = client.ResourceResponseItem{
+		Items: []interface{}{
+			podMetrics("web-1", "250000000n", "128Mi"),
+			podMetrics("web-2", "1500000000n", "512Mi"),
+		},
+	}
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand("cluster", "top", "pods", "-n", "default"); executeError != nil {
+			t.Fatalf("top pods failed: %v", executeError)
+		}
+	})
+	plain := stripANSICodes(output)
+	for _, expected := range []string{"web-1", "250m", "128Mi", "web-2", "1500m", "512Mi"} {
+		if !strings.Contains(plain, expected) {
+			t.Errorf("top pods output is missing %q\n%s", expected, plain)
+		}
+	}
+	if mock.requests[0].Resource != "pods" || mock.requests[0].Group != metricsAPIGroup {
+		t.Errorf("the metrics read must name group %q and resource \"pods\", got %+v",
+			metricsAPIGroup, mock.requests[0])
+	}
+	if !mock.skipCacheSeen[0] {
+		t.Error("a live measurement must be read with skip_cache")
+	}
+}
+
+func TestTopPodsSortByMemoryOrdersDescending(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterTopPodsCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["PodMetrics"] = client.ResourceResponseItem{
+		Items: []interface{}{
+			podMetrics("small", "100000000n", "64Mi"),
+			podMetrics("large", "100000000n", "1Gi"),
+		},
+	}
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand(
+			"cluster", "top", "pods", "-n", "default", "--sort-by", "memory"); executeError != nil {
+			t.Fatalf("top pods --sort-by memory failed: %v", executeError)
+		}
+	})
+	plain := stripANSICodes(output)
+	if strings.Index(plain, "large") > strings.Index(plain, "small") {
+		t.Errorf("--sort-by memory must put the largest first:\n%s", plain)
+	}
+}
+
+func TestTopRefusesACachedAnswer(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterTopPodsCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["PodMetrics"] = client.ResourceResponseItem{
+		CacheMetadata: &client.ResourceCacheMetadata{
+			ServedFromCache: true, SyncStatus: "cluster_offline",
+		},
+		Items: []interface{}{objectMap(map[string]interface{}{
+			"kind":     "Pod",
+			"metadata": map[string]interface{}{"name": "web-1", "namespace": "default"},
+		})},
+	}
+	setMockClient(t, mock)
+
+	_, executeError := executeCommand("cluster", "top", "pods", "-n", "default")
+	if executeError == nil {
+		t.Fatal("a cached answer must not be rendered as a live measurement")
+	}
+	if !strings.Contains(executeError.Error(), "cluster_offline") {
+		t.Errorf("the refusal should name the cache state, got %q", executeError.Error())
+	}
+}
+
+func TestTopDropsObjectsWithoutUsage(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterTopPodsCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["PodMetrics"] = client.ResourceResponseItem{
+		Items: []interface{}{
+			objectMap(map[string]interface{}{
+				"kind":     "Pod",
+				"metadata": map[string]interface{}{"name": "not-a-measurement"},
+			}),
+		},
+	}
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand("cluster", "top", "pods", "-n", "default"); executeError != nil {
+			t.Fatalf("top pods failed: %v", executeError)
+		}
+	})
+	if strings.Contains(output, "not-a-measurement") {
+		t.Errorf("a plain Pod must never be rendered as usage:\n%s", output)
+	}
+	if !strings.Contains(output, "metrics-server") {
+		t.Errorf("an empty measurement set should explain metrics-server:\n%s", output)
+	}
+}
+
+func TestTopNodesShowsPercentagesAgainstAllocatable(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterTopNodesCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["NodeMetrics"] = client.ResourceResponseItem{
+		Items: []interface{}{objectMap(map[string]interface{}{
+			"metadata": map[string]interface{}{"name": "worker-1"},
+			"usage":    map[string]interface{}{"cpu": "500m", "memory": "1Gi"},
+		})},
+	}
+	mock.responses["Node"] = client.ResourceResponseItem{
+		Items: []interface{}{objectMap(map[string]interface{}{
+			"metadata": map[string]interface{}{"name": "worker-1"},
+			"status": map[string]interface{}{
+				"allocatable": map[string]interface{}{"cpu": "2", "memory": "4Gi"},
+			},
+		})},
+	}
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand("cluster", "top", "nodes"); executeError != nil {
+			t.Fatalf("top nodes failed: %v", executeError)
+		}
+	})
+	plain := stripANSICodes(output)
+	for _, expected := range []string{"worker-1", "500m", "25%", "1024Mi"} {
+		if !strings.Contains(plain, expected) {
+			t.Errorf("top nodes output is missing %q\n%s", expected, plain)
+		}
+	}
+}
+
+func TestTopNodesWithoutCapacityOmitsPercentages(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterTopNodesCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["NodeMetrics"] = client.ResourceResponseItem{
+		Items: []interface{}{objectMap(map[string]interface{}{
+			"metadata": map[string]interface{}{"name": "worker-1"},
+			"usage":    map[string]interface{}{"cpu": "500m", "memory": "1Gi"},
+		})},
+	}
+	mock.responses["Node"] = client.ResourceResponseItem{Items: []interface{}{}}
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand("cluster", "top", "nodes"); executeError != nil {
+			t.Fatalf("top nodes failed: %v", executeError)
+		}
+	})
+	plain := stripANSICodes(output)
+	nodeRow := ""
+	for _, line := range strings.Split(plain, "\n") {
+		if strings.Contains(line, "worker-1") {
+			nodeRow = line
+		}
+	}
+	if nodeRow == "" {
+		t.Fatalf("the node row is missing:\n%s", plain)
+	}
+	if strings.Contains(nodeRow, "%") {
+		t.Errorf("an unknown capacity must not be guessed at as a percentage: %q", nodeRow)
+	}
+	if !strings.Contains(nodeRow, "500m") || !strings.Contains(nodeRow, "1024Mi") {
+		t.Errorf("the measurement itself should still render: %q", nodeRow)
+	}
+}
+
+func TestTopRejectsUnknownSortBy(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterTopPodsCmd)
+	mock := newDebugVerbsMock()
+	setMockClient(t, mock)
+
+	_, executeError := executeCommand("cluster", "top", "pods", "-n", "default", "--sort-by", "disk")
+	if executeError == nil {
+		t.Fatal("an unknown --sort-by must fail")
+	}
+	if got := exitCodeFor(executeError); got != exitUsage {
+		t.Errorf("unknown --sort-by should exit %d, got %d", exitUsage, got)
+	}
+	if len(mock.requests) != 0 {
+		t.Error("--sort-by must be validated before any API call")
+	}
+}
+
+func TestParseKubernetesQuantity(t *testing.T) {
+	cases := []struct {
+		raw      string
+		expected float64
+		isValid  bool
+	}{
+		{"250000000n", 0.25, true},
+		{"500m", 0.5, true},
+		{"2", 2, true},
+		{"128Mi", 128 * 1024 * 1024, true},
+		{"1Gi", 1024 * 1024 * 1024, true},
+		{"1k", 1000, true},
+		{"", 0, false},
+		{"<nil>", 0, false},
+		{"lots", 0, false},
+	}
+	for _, testCase := range cases {
+		parsed, isValid := parseKubernetesQuantity(testCase.raw)
+		if isValid != testCase.isValid {
+			t.Errorf("parseKubernetesQuantity(%q) valid = %v, want %v", testCase.raw, isValid, testCase.isValid)
+			continue
+		}
+		if isValid && parsed != testCase.expected {
+			t.Errorf("parseKubernetesQuantity(%q) = %v, want %v", testCase.raw, parsed, testCase.expected)
+		}
+	}
+}
+
+// --- logs ---
+
+func TestLogsPreviousRequestsTheTerminatedContainerAndBoundsTheRead(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterLogsCmd)
+	mock := newDebugVerbsMock()
+	mock.logOutput["web-1"] = "panic: config missing\n"
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand(
+			"cluster", "logs", "web-1", "-n", "default", "--previous"); executeError != nil {
+			t.Fatalf("logs --previous failed: %v", executeError)
+		}
+	})
+	if !strings.Contains(output, "panic: config missing") {
+		t.Errorf("the previous log should be printed, got:\n%s", output)
+	}
+	if len(mock.logOptions) != 1 {
+		t.Fatalf("expected one log read, got %d", len(mock.logOptions))
+	}
+	if !mock.logOptions[0].Previous {
+		t.Error("--previous must reach the platform as Previous")
+	}
+	if mock.logOptions[0].Follow {
+		t.Error("--previous must bound the read: the terminated log cannot stream")
+	}
+}
+
+func TestLogsSelectorReadsEveryMatchingPodWithPrefixes(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterLogsCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["Pod"] = client.ResourceResponseItem{
+		Items: []interface{}{
+			objectMap(map[string]interface{}{
+				"metadata": map[string]interface{}{"name": "web-b"},
+				"spec": map[string]interface{}{
+					"containers": []interface{}{map[string]interface{}{"name": "web"}},
+				},
+			}),
+			objectMap(map[string]interface{}{
+				"metadata": map[string]interface{}{"name": "web-a"},
+				"spec": map[string]interface{}{
+					"containers": []interface{}{map[string]interface{}{"name": "web"}},
+				},
+			}),
+		},
+	}
+	mock.logOutput["web-a"] = "from a\n"
+	mock.logOutput["web-b"] = "from b\n"
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand(
+			"cluster", "logs", "-l", "app=web", "-n", "default", "--follow=false"); executeError != nil {
+			t.Fatalf("logs -l failed: %v", executeError)
+		}
+	})
+	if !strings.Contains(output, "[web-a] from a") || !strings.Contains(output, "[web-b] from b") {
+		t.Errorf("multi-pod output must be prefixed per pod, got:\n%s", output)
+	}
+	if len(mock.logOptions) != 2 {
+		t.Fatalf("expected one read per matching pod, got %d", len(mock.logOptions))
+	}
+	if mock.requests[0].LabelSelector != "app=web" {
+		t.Errorf("the pod lookup must carry the selector, got %q", mock.requests[0].LabelSelector)
+	}
+}
+
+func TestLogsAllContainersExpandsInitAndAppContainers(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterLogsCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["Pod"] = client.ResourceResponseItem{
+		Items: []interface{}{crashLoopingPod()},
+	}
+	mock.logOutput["web-7d9f-2xkvp/wait-for-db"] = "waiting\n"
+	mock.logOutput["web-7d9f-2xkvp/web"] = "boom\n"
+	mock.logOutput["web-7d9f-2xkvp/sidecar"] = "idle\n"
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand("cluster", "logs", "web-7d9f-2xkvp",
+			"-n", "default", "--all-containers", "--follow=false"); executeError != nil {
+			t.Fatalf("logs --all-containers failed: %v", executeError)
+		}
+	})
+	for _, expected := range []string{
+		"[web-7d9f-2xkvp/wait-for-db] waiting",
+		"[web-7d9f-2xkvp/web] boom",
+		"[web-7d9f-2xkvp/sidecar] idle",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("--all-containers output is missing %q\n%s", expected, output)
+		}
+	}
+}
+
+func TestLogsStructuredOutputGroupsByTarget(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterLogsCmd)
+	mock := newDebugVerbsMock()
+	mock.logOutput["web-1"] = "line one\nline two\n"
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand(
+			"cluster", "logs", "web-1", "-n", "default", "-o", "json"); executeError != nil {
+			t.Fatalf("logs -o json failed: %v", executeError)
+		}
+	})
+	var groups []podLogGroup
+	if unmarshalError := json.Unmarshal([]byte(output), &groups); unmarshalError != nil {
+		t.Fatalf("logs -o json must emit parseable JSON: %v\n%s", unmarshalError, output)
+	}
+	if len(groups) != 1 || groups[0].Pod != "web-1" {
+		t.Fatalf("unexpected structured shape: %+v", groups)
+	}
+	if len(groups[0].Lines) != 2 || groups[0].Lines[1] != "line two" {
+		t.Errorf("lines were not split correctly: %+v", groups[0].Lines)
+	}
+	if mock.logOptions[0].Follow {
+		t.Error("a structured read must be bounded")
+	}
+}
+
+func TestLogsStructuredOutputRefusesExplicitFollow(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterLogsCmd)
+	mock := newDebugVerbsMock()
+	setMockClient(t, mock)
+
+	_, executeError := executeCommand("cluster", "logs", "web-1", "-n", "default", "-o", "json", "--follow=true")
+	if executeError == nil {
+		t.Fatal("-o json with --follow must fail rather than emit an unterminated document")
+	}
+	if got := exitCodeFor(executeError); got != exitUsage {
+		t.Errorf("-o json --follow should exit %d, got %d", exitUsage, got)
+	}
+}
+
+func TestLogsRejectsPodNameAndSelectorTogether(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterLogsCmd)
+	setMockClient(t, newDebugVerbsMock())
+
+	_, executeError := executeCommand("cluster", "logs", "web-1", "-l", "app=web", "-n", "default")
+	if executeError == nil {
+		t.Fatal("a pod name and a selector together must fail")
+	}
+	if got := exitCodeFor(executeError); got != exitUsage {
+		t.Errorf("should exit %d, got %d", exitUsage, got)
+	}
+}
+
+func TestLogsWithoutPodOrSelectorExitsUsage(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterLogsCmd)
+	setMockClient(t, newDebugVerbsMock())
+
+	_, executeError := executeCommand("cluster", "logs", "-n", "default")
+	if executeError == nil {
+		t.Fatal("logs with no target must fail")
+	}
+	if got := exitCodeFor(executeError); got != exitUsage {
+		t.Errorf("should exit %d, got %d", exitUsage, got)
+	}
+}
+
+func TestLogsSelectorWithNoMatchExitsNotFound(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterLogsCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["Pod"] = client.ResourceResponseItem{Items: []interface{}{}}
+	setMockClient(t, mock)
+
+	_, executeError := executeCommand("cluster", "logs", "-l", "app=nothing", "-n", "default", "--follow=false")
+	if executeError == nil {
+		t.Fatal("a selector matching nothing must fail")
+	}
+	if got := exitCodeFor(executeError); got != exitNotFound {
+		t.Errorf("should exit %d, got %d", exitNotFound, got)
+	}
+}
+
+func TestLogsFollowRefusesTooManyTargets(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterLogsCmd)
+	mock := newDebugVerbsMock()
+	pods := []interface{}{}
+	for index := 0; index < maxConcurrentLogFollows+1; index++ {
+		pods = append(pods, objectMap(map[string]interface{}{
+			"metadata": map[string]interface{}{"name": fmt.Sprintf("web-%d", index)},
+			"spec": map[string]interface{}{
+				"containers": []interface{}{map[string]interface{}{"name": "web"}},
+			},
+		}))
+	}
+	mock.responses["Pod"] = client.ResourceResponseItem{Items: pods}
+	setMockClient(t, mock)
+
+	_, executeError := executeCommand("cluster", "logs", "-l", "app=web", "-n", "default")
+	if executeError == nil {
+		t.Fatal("following more targets than the cap must fail")
+	}
+	if got := exitCodeFor(executeError); got != exitUsage {
+		t.Errorf("should exit %d, got %d", exitUsage, got)
+	}
+	if len(mock.logOptions) != 0 {
+		t.Error("no stream should be opened once the cap is exceeded")
+	}
+}
+
+func TestLogsSurfacesAStreamFailureWithItsTarget(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterLogsCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["Pod"] = client.ResourceResponseItem{
+		Items: []interface{}{
+			objectMap(map[string]interface{}{
+				"metadata": map[string]interface{}{"name": "web-a"},
+				"spec": map[string]interface{}{
+					"containers": []interface{}{map[string]interface{}{"name": "web"}},
+				},
+			}),
+			objectMap(map[string]interface{}{
+				"metadata": map[string]interface{}{"name": "web-b"},
+				"spec": map[string]interface{}{
+					"containers": []interface{}{map[string]interface{}{"name": "web"}},
+				},
+			}),
+		},
+	}
+	mock.logError = fmt.Errorf("container gone")
+	setMockClient(t, mock)
+
+	_, executeError := executeCommand("cluster", "logs", "-l", "app=web", "-n", "default", "--follow=false")
+	if executeError == nil {
+		t.Fatal("a failing stream must surface")
+	}
+	if !strings.Contains(executeError.Error(), "web-a") {
+		t.Errorf("the failure should name its target, got %q", executeError.Error())
+	}
+}
+
+func TestLogsRejectsContainerWithAllContainers(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterLogsCmd)
+	setMockClient(t, newDebugVerbsMock())
+
+	_, executeError := executeCommand(
+		"cluster", "logs", "web-1", "-n", "default", "-c", "web", "--all-containers")
+	if executeError == nil {
+		t.Fatal("--container with --all-containers must fail")
+	}
+	if got := exitCodeFor(executeError); got != exitUsage {
+		t.Errorf("should exit %d, got %d", exitUsage, got)
+	}
+}
+
+// --- kind resolution ---
+
+func TestResolveK8sKindAcceptsKubectlSpellings(t *testing.T) {
+	cases := map[string]k8sKind{
+		"pod":         {kind: "Pod", version: "v1"},
+		"pods":        {kind: "Pod", version: "v1"},
+		"po":          {kind: "Pod", version: "v1"},
+		"Pod":         {kind: "Pod", version: "v1"},
+		"deploy":      {kind: "Deployment", group: "apps", version: "v1"},
+		"deployments": {kind: "Deployment", group: "apps", version: "v1"},
+		"ingresses":   {kind: "Ingress", group: "networking.k8s.io", version: "v1", resource: "ingresses"},
+		"endpoints":   {kind: "Endpoints", version: "v1", resource: "endpoints"},
+	}
+	for spelling, expected := range cases {
+		resolved, resolveError := resolveK8sKind(spelling, "", "")
+		if resolveError != nil {
+			t.Errorf("resolveK8sKind(%q) failed: %v", spelling, resolveError)
+			continue
+		}
+		if resolved != expected {
+			t.Errorf("resolveK8sKind(%q) = %+v, want %+v", spelling, resolved, expected)
+		}
+	}
+}
+
+func TestResolveK8sKindHonoursOverrides(t *testing.T) {
+	resolved, resolveError := resolveK8sKind("Widget", "example.com", "v1alpha1")
+	if resolveError != nil {
+		t.Fatalf("an overridden kind must resolve: %v", resolveError)
+	}
+	if resolved.kind != "Widget" || resolved.group != "example.com" || resolved.version != "v1alpha1" {
+		t.Errorf("overrides were not applied: %+v", resolved)
+	}
+}
+
+func TestResolveK8sKindRejectsEmpty(t *testing.T) {
+	if _, resolveError := resolveK8sKind("  ", "", ""); resolveError == nil {
+		t.Fatal("an empty kind must fail")
+	}
+}

--- a/cmd/cluster_debug_verbs_test.go
+++ b/cmd/cluster_debug_verbs_test.go
@@ -1640,3 +1640,37 @@ func TestEventsShowTheInvolvedObjectNamespace(t *testing.T) {
 		t.Errorf("the cross-namespace match should be called out on stderr, got %q", stderrText)
 	}
 }
+
+// TestEventsNameFlagTargetsTheEventResourceNotTheWorkload pins what --name
+// actually does. The platform matches it against the Event resource's own
+// generated name, so a user reaching for it to find a pod's events gets an
+// empty result that reads as "no events" rather than "wrong flag" - which is
+// why the help text now says so and points at --for.
+func TestEventsNameFlagTargetsTheEventResourceNotTheWorkload(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterEventsCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["Event"] = client.ResourceResponseItem{Items: []interface{}{scopedEvent()}}
+	setMockClient(t, mock)
+
+	captureStdout(t, func() {
+		if _, executeError := executeCommand("cluster", "events", "-n", "default",
+			"--name", "web-1.17abc"); executeError != nil {
+			t.Fatalf("events --name failed: %v", executeError)
+		}
+	})
+	if mock.requests[0].Name != "web-1.17abc" {
+		t.Errorf("--name must reach the request as the resource name, got %q", mock.requests[0].Name)
+	}
+	if fieldSelectorValue(mock.requests[0], "involvedObject.name") != "" {
+		t.Error("--name must not masquerade as an involvedObject scope; that is --for")
+	}
+
+	for _, command := range []*cobra.Command{clusterEventsCmd, getEventsCommand(t)} {
+		usage := command.Flags().Lookup("name").Usage
+		if !strings.Contains(usage, "Event resource's own name") || !strings.Contains(usage, "--for") {
+			t.Errorf("%s --name help must say what it matches and point at --for, got %q",
+				command.CommandPath(), usage)
+		}
+	}
+}

--- a/cmd/cluster_debug_verbs_test.go
+++ b/cmd/cluster_debug_verbs_test.go
@@ -1,14 +1,18 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 
 	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
 )
 
 // debugVerbsMock answers resources/get from a per-kind table and records
@@ -22,9 +26,16 @@ type debugVerbsMock struct {
 	skipCacheSeen []bool
 	requestError  error
 
-	logOptions []client.PodLogOptions
-	logOutput  map[string]string
-	logError   error
+	logOptions     []client.PodLogOptions
+	logOptionsLock sync.Mutex
+	logOutput      map[string]string
+	logError       error
+	// failLogsForPod and failContainer fail only the named targets, so a test
+	// can drive a partially broken selector, or a --previous read where only
+	// some containers have a terminated instance, rather than an
+	// all-or-nothing one.
+	failLogsForPod map[string]error
+	failContainer  map[string]error
 }
 
 func (mock *debugVerbsMock) GetResources(clusterID string, request client.GetResourcesRequest) (*client.GetResourcesResponse, error) {
@@ -41,7 +52,15 @@ func (mock *debugVerbsMock) GetResources(clusterID string, request client.GetRes
 }
 
 func (mock *debugVerbsMock) StreamPodLogs(_ context.Context, _ string, options client.PodLogOptions, writer io.Writer) error {
+	mock.logOptionsLock.Lock()
 	mock.logOptions = append(mock.logOptions, options)
+	mock.logOptionsLock.Unlock()
+	if podError, shouldFail := mock.failLogsForPod[options.PodName]; shouldFail {
+		return podError
+	}
+	if containerError, shouldFail := mock.failContainer[options.ContainerName]; shouldFail {
+		return containerError
+	}
 	if mock.logError != nil {
 		return mock.logError
 	}
@@ -328,9 +347,23 @@ func TestEventsForScopesByInvolvedObject(t *testing.T) {
 	}
 }
 
+// getEventsCommand finds the events command the get family generates, so the
+// test can reset its flags without the production code exporting a handle to
+// a command it only ever mounts.
+func getEventsCommand(t *testing.T) *cobra.Command {
+	t.Helper()
+	for _, command := range clusterGetCmd.Commands() {
+		if command.Name() == "events" {
+			return command
+		}
+	}
+	t.Fatal("cluster get events is not registered")
+	return nil
+}
+
 func TestEventsForIsAlsoReachableUnderGet(t *testing.T) {
 	writeSelectedClusterJSON(t)
-	resetCommandFlags(t, clusterGetEventsCmd)
+	resetCommandFlags(t, getEventsCommand(t))
 	mock := newDebugVerbsMock()
 	mock.responses["Event"] = client.ResourceResponseItem{Items: []interface{}{scopedEvent()}}
 	setMockClient(t, mock)
@@ -405,6 +438,88 @@ func TestEventsSurfacesAPIFailure(t *testing.T) {
 	_, executeError := executeCommand("cluster", "events", "-n", "default")
 	if executeError == nil || !strings.Contains(executeError.Error(), "cluster is offline") {
 		t.Fatalf("an API failure must surface, got %v", executeError)
+	}
+}
+
+// TestEventsTypeFiltersInTheCLINotAsAFieldSelector pins the fix for a
+// silently-wrong filter. The platform answers an event listing from its
+// resource cache whenever the cache is fresh, and the cache honours only a
+// whitelist of field selectors, dropping a type selector without saying so.
+// The same command would then have filtered against an unreachable cluster
+// and not filtered against a healthy one.
+func TestEventsTypeFiltersInTheCLINotAsAFieldSelector(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterEventsCmd)
+	normalEvent := objectMap(map[string]interface{}{
+		"type": "Normal", "reason": "Pulled", "message": "pulled image",
+		"lastTimestamp":  "2026-08-22T09:00:00Z",
+		"involvedObject": map[string]interface{}{"kind": "Pod", "name": "web-1"},
+	})
+	mock := newDebugVerbsMock()
+	mock.responses["Event"] = client.ResourceResponseItem{
+		Items: []interface{}{normalEvent, scopedEvent()},
+	}
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand(
+			"cluster", "events", "-n", "default", "--type", "Warning"); executeError != nil {
+			t.Fatalf("events --type failed: %v", executeError)
+		}
+	})
+	plain := stripANSICodes(output)
+	if strings.Contains(plain, "Pulled") {
+		t.Errorf("--type Warning must drop the Normal event:\n%s", plain)
+	}
+	if !strings.Contains(plain, "BackOff") {
+		t.Errorf("--type Warning must keep the Warning event:\n%s", plain)
+	}
+	if got := fieldSelectorValue(mock.requests[0], "type"); got != "" {
+		t.Errorf("type must not ride as a field selector, got %q", got)
+	}
+}
+
+func TestGetEventsKeepsItsEnvelopeAndPositionalName(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, getEventsCommand(t))
+	mock := newDebugVerbsMock()
+	mock.responses["Event"] = client.ResourceResponseItem{
+		Status: "success", Kind: "Event", Version: "v1",
+		Items: []interface{}{scopedEvent()},
+	}
+	setMockClient(t, mock)
+
+	// The get family's structured output is the resource_responses envelope,
+	// and scripts read it. Sharing an implementation with `cluster events`
+	// must not quietly turn it into a bare array.
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand(
+			"cluster", "get", "events", "-n", "default", "-o", "json"); executeError != nil {
+			t.Fatalf("get events -o json failed: %v", executeError)
+		}
+	})
+	var envelope client.GetResourcesResponse
+	if unmarshalError := json.Unmarshal([]byte(output), &envelope); unmarshalError != nil {
+		t.Fatalf("get events -o json must stay parseable: %v\n%s", unmarshalError, output)
+	}
+	if len(envelope.ResourceResponses) != 1 || len(envelope.ResourceResponses[0].Items) != 1 {
+		t.Fatalf("the resource_responses envelope was lost: %s", output)
+	}
+
+	// A positional name still fetches that one object and renders it as a
+	// manifest, like every other get subcommand.
+	resetCommandFlags(t, getEventsCommand(t))
+	manifest := captureStdout(t, func() {
+		if _, executeError := executeCommand(
+			"cluster", "get", "events", "web-1.17abc", "-n", "default"); executeError != nil {
+			t.Fatalf("get events <name> failed: %v", executeError)
+		}
+	})
+	if !strings.Contains(manifest, "involvedObject") {
+		t.Errorf("a named get events should print the manifest, got:\n%s", manifest)
+	}
+	if mock.requests[1].Name != "web-1.17abc" {
+		t.Errorf("the positional name must reach the request, got %q", mock.requests[1].Name)
 	}
 }
 
@@ -613,6 +728,74 @@ func TestTopRejectsUnknownSortBy(t *testing.T) {
 	}
 	if len(mock.requests) != 0 {
 		t.Error("--sort-by must be validated before any API call")
+	}
+}
+
+// TestTopRendersUnmeasuredUsageAsDash pins the fix for a confident zero. A
+// container whose usage is missing or unparseable used to render as 0m/0Mi,
+// which is indistinguishable from a genuinely idle container.
+func TestTopRendersUnmeasuredUsageAsDash(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterTopNodesCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["NodeMetrics"] = client.ResourceResponseItem{
+		Items: []interface{}{objectMap(map[string]interface{}{
+			"metadata": map[string]interface{}{"name": "worker-1"},
+			"usage":    map[string]interface{}{"cpu": "not-a-quantity", "memory": "1Gi"},
+		})},
+	}
+	mock.responses["Node"] = client.ResourceResponseItem{Items: []interface{}{}}
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand("cluster", "top", "nodes"); executeError != nil {
+			t.Fatalf("top nodes failed: %v", executeError)
+		}
+	})
+	plain := stripANSICodes(output)
+	if strings.Contains(plain, "0m") || strings.Contains(plain, "0Mi") {
+		t.Errorf("an unparseable measurement must not render as zero:\n%s", plain)
+	}
+	if !strings.Contains(plain, "worker-1") {
+		t.Errorf("the node should still be listed:\n%s", plain)
+	}
+}
+
+// TestTopSurfacesAnErroredResponseInsteadOfBlamingMetricsServer pins the
+// other silently-wrong path: an errored response carries no items, which
+// looked exactly like "metrics-server is not installed" and exited zero.
+func TestTopSurfacesAnErroredResponseInsteadOfBlamingMetricsServer(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterTopPodsCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["PodMetrics"] = client.ResourceResponseItem{
+		Status: "error", Items: []interface{}{},
+	}
+	setMockClient(t, mock)
+
+	_, executeError := executeCommand("cluster", "top", "pods", "-n", "default")
+	if executeError == nil {
+		t.Fatal("an errored metrics read must not be reported as a missing metrics-server")
+	}
+	if !strings.Contains(executeError.Error(), "could not answer") {
+		t.Errorf("the error should say the read failed, got %q", executeError.Error())
+	}
+}
+
+func TestTopStructuredOutputIsAnArrayWhenEmpty(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterTopPodsCmd)
+	mock := newDebugVerbsMock()
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand(
+			"cluster", "top", "pods", "-n", "default", "-o", "json"); executeError != nil {
+			t.Fatalf("top pods -o json failed: %v", executeError)
+		}
+	})
+	if strings.TrimSpace(output) != "[]" {
+		t.Errorf("an empty structured read must encode as [], got %q", strings.TrimSpace(output))
 	}
 }
 
@@ -890,6 +1073,62 @@ func TestLogsSurfacesAStreamFailureWithItsTarget(t *testing.T) {
 	}
 }
 
+// TestFollowingTargetsReportEachFailureAndSurviveAPartialOne drives the
+// concurrent follow path directly. A following read only ends when the caller
+// interrupts it, so a target that dies must reach stderr immediately rather
+// than being held until interrupt - at which point the cancelled context makes
+// the caller discard it. A target that survives means the command still
+// succeeded.
+func TestFollowingTargetsReportEachFailureAndSurviveAPartialOne(t *testing.T) {
+	mock := newDebugVerbsMock()
+	mock.logOutput["web-a"] = "from a\n"
+	mock.failLogsForPod = map[string]error{"web-b": fmt.Errorf("container gone")}
+	setMockClient(t, mock)
+
+	targets := []logTarget{{podName: "web-a"}, {podName: "web-b"}}
+	var output bytes.Buffer
+	var streamError error
+	stderrText := captureStderr(t, func() {
+		streamError = streamLogTargets(context.Background(), "cluster-1", targets,
+			client.PodLogOptions{Namespace: "default", Follow: true}, true, &output)
+	})
+	if streamError != nil {
+		t.Errorf("a partial failure must not fail the command, got %v", streamError)
+	}
+	if !strings.Contains(stderrText, "web-b") || !strings.Contains(stderrText, "container gone") {
+		t.Errorf("the failing target must be named on stderr, got %q", stderrText)
+	}
+	if !strings.Contains(output.String(), "[web-a] from a") {
+		t.Errorf("the surviving target must still stream, got %q", output.String())
+	}
+	if strings.Contains(output.String(), "container gone") {
+		t.Error("a failure must not be written into the log stream on stdout")
+	}
+}
+
+func TestFollowingTargetsFailWhenEveryTargetFails(t *testing.T) {
+	mock := newDebugVerbsMock()
+	mock.failLogsForPod = map[string]error{
+		"web-a": fmt.Errorf("container gone"),
+		"web-b": fmt.Errorf("container gone"),
+	}
+	setMockClient(t, mock)
+
+	targets := []logTarget{{podName: "web-a"}, {podName: "web-b"}}
+	var output bytes.Buffer
+	var streamError error
+	captureStderr(t, func() {
+		streamError = streamLogTargets(context.Background(), "cluster-1", targets,
+			client.PodLogOptions{Namespace: "default", Follow: true}, true, &output)
+	})
+	if streamError == nil {
+		t.Fatal("no target read anything, so the command must fail")
+	}
+	if !strings.Contains(streamError.Error(), "container gone") {
+		t.Errorf("the failure should carry the cause, got %v", streamError)
+	}
+}
+
 func TestLogsRejectsContainerWithAllContainers(t *testing.T) {
 	writeSelectedClusterJSON(t)
 	resetCommandFlags(t, clusterLogsCmd)
@@ -937,6 +1176,75 @@ func TestResolveK8sKindHonoursOverrides(t *testing.T) {
 	}
 	if resolved.kind != "Widget" || resolved.group != "example.com" || resolved.version != "v1alpha1" {
 		t.Errorf("overrides were not applied: %+v", resolved)
+	}
+}
+
+// TestResolveK8sKindSingularisesACustomResourcePlural pins the fix for a
+// false not-found. The platform derives the API plural from the kind, so a
+// plural spelling became a double plural ("certificates" -> "certificateses")
+// and the read came back empty - reported as "not found" for an object that
+// exists.
+func TestResolveK8sKindSingularisesACustomResourcePlural(t *testing.T) {
+	// The caller's capitalisation is preserved rather than guessed at: the
+	// CamelCase of a multi-word custom resource cannot be reconstructed from
+	// a lowercase plural (clusterissuers is ClusterIssuer, not
+	// Clusterissuer), and the platform lowercases the kind to derive the
+	// plural anyway, so only the singular form is load-bearing.
+	cases := map[string]string{
+		"certificates":   "certificate",
+		"Certificates":   "Certificate",
+		"Certificate":    "Certificate",
+		"ClusterIssuers": "ClusterIssuer",
+		"gateways":       "gateway",
+		"policies":       "policy",
+		"Policies":       "Policy",
+	}
+	for spelling, expected := range cases {
+		resolved, resolveError := resolveK8sKind(spelling, "example.com", "v1")
+		if resolveError != nil {
+			t.Errorf("resolveK8sKind(%q) failed: %v", spelling, resolveError)
+			continue
+		}
+		if resolved.kind != expected {
+			t.Errorf("resolveK8sKind(%q).kind = %q, want %q", spelling, resolved.kind, expected)
+		}
+	}
+}
+
+// TestLogsAllContainersPreviousPrintsTheContainersThatHaveOne pins the fix for
+// the case the --previous flag exists to serve: a container that never
+// terminated has no previous log and the apiserver answers an error, which
+// used to abandon the remaining containers - including the crash-looping one.
+func TestLogsAllContainersPreviousPrintsTheContainersThatHaveOne(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterLogsCmd)
+	mock := newDebugVerbsMock()
+	mock.responses["Pod"] = client.ResourceResponseItem{
+		Items: []interface{}{crashLoopingPod()},
+	}
+	mock.failLogsForPod = map[string]error{}
+	mock.logOutput["web-7d9f-2xkvp/web"] = "panic: config missing\n"
+	mock.failContainer = map[string]error{
+		"wait-for-db": fmt.Errorf("previous terminated container not found"),
+		"sidecar":     fmt.Errorf("previous terminated container not found"),
+	}
+	setMockClient(t, mock)
+
+	var executeError error
+	stderrText := captureStderr(t, func() {
+		output := captureStdout(t, func() {
+			_, executeError = executeCommand("cluster", "logs", "web-7d9f-2xkvp",
+				"-n", "default", "--all-containers", "--previous")
+		})
+		if !strings.Contains(output, "panic: config missing") {
+			t.Errorf("the container that does have a previous log must be printed:\n%s", output)
+		}
+	})
+	if executeError != nil {
+		t.Errorf("a partial failure must not lose the logs that were read: %v", executeError)
+	}
+	if !strings.Contains(stderrText, "wait-for-db") {
+		t.Errorf("the containers with no previous log should be named on stderr, got %q", stderrText)
 	}
 }
 

--- a/cmd/cluster_debug_verbs_test.go
+++ b/cmd/cluster_debug_verbs_test.go
@@ -1674,3 +1674,78 @@ func TestEventsNameFlagTargetsTheEventResourceNotTheWorkload(t *testing.T) {
 		}
 	}
 }
+
+// TestBothEventsMountsScopeForIdentically pins the fix for the divergence
+// risk: the namespace is resolved once by the command that owns the request
+// and handed to the selector builder, rather than re-derived from flags in a
+// second place where the two could drift apart.
+func TestBothEventsMountsScopeForIdentically(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	selectorsFor := func(t *testing.T, args ...string) []client.FieldSelector {
+		t.Helper()
+		mock := newDebugVerbsMock()
+		mock.responses["Event"] = client.ResourceResponseItem{Items: []interface{}{scopedEvent()}}
+		setMockClient(t, mock)
+		captureStdout(t, func() {
+			if _, executeError := executeCommand(args...); executeError != nil {
+				t.Fatalf("%v failed: %v", args, executeError)
+			}
+		})
+		return mock.requests[0].FieldSelectors
+	}
+
+	resetCommandFlags(t, clusterEventsCmd)
+	direct := selectorsFor(t, "cluster", "events", "--for", "pod/web-1", "-n", "default")
+	resetCommandFlags(t, getEventsCommand(t))
+	viaGet := selectorsFor(t, "cluster", "get", "events", "--for", "pod/web-1", "-n", "default")
+
+	if len(direct) != len(viaGet) || len(direct) == 0 {
+		t.Fatalf("the two mounts built different selector sets: %v vs %v", direct, viaGet)
+	}
+	for index := range direct {
+		if direct[index] != viaGet[index] {
+			t.Errorf("selector %d differs between mounts: %+v vs %+v", index, direct[index], viaGet[index])
+		}
+	}
+
+	// And the namespace-required rule fires the same way on both.
+	resetCommandFlags(t, getEventsCommand(t))
+	setMockClient(t, newDebugVerbsMock())
+	if _, executeError := executeCommand("cluster", "get", "events", "--for", "pod/web-1"); executeError == nil {
+		t.Error("get events --for without a namespace must be a usage error, like cluster events")
+	} else if got := exitCodeFor(executeError); got != exitUsage {
+		t.Errorf("should exit %d, got %d", exitUsage, got)
+	}
+}
+
+func TestDescribeSecretRedactsAShortValueFromAnnotations(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	resetCommandFlags(t, clusterDescribeCmd)
+	const shortSecret = "hunter2"
+	mock := newDebugVerbsMock()
+	mock.responses["Secret"] = client.ResourceResponseItem{
+		Items: []interface{}{objectMap(map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name": "db", "namespace": "default",
+				"annotations": map[string]interface{}{
+					"backup.example/copy": "password=" + shortSecret,
+				},
+			},
+			"data": map[string]interface{}{"password": shortSecret},
+		})},
+	}
+	mock.responses["Event"] = client.ResourceResponseItem{Items: []interface{}{}}
+	setMockClient(t, mock)
+
+	output := captureStdout(t, func() {
+		if _, executeError := executeCommand("cluster", "describe", "secret", "db",
+			"-n", "default", "-o", "json"); executeError != nil {
+			t.Fatalf("describe secret failed: %v", executeError)
+		}
+	})
+	if strings.Contains(output, shortSecret) {
+		t.Errorf("a short secret value leaked through an annotation:\n%s", output)
+	}
+}

--- a/cmd/cluster_describe.go
+++ b/cmd/cluster_describe.go
@@ -104,6 +104,16 @@ Examples:
 	},
 }
 
+// lastAppliedConfigurationAnnotation is the annotation kubectl apply writes,
+// containing the entire submitted manifest verbatim - base64 Secret values
+// included.
+const lastAppliedConfigurationAnnotation = "kubectl.kubernetes.io/last-applied-configuration"
+
+// minimumRedactableSecretLength is the shortest secret value worth scanning
+// annotations for. A one- or two-character value would match half the
+// annotations on the object by coincidence and redact them all.
+const minimumRedactableSecretLength = 8
+
 // redactSecretData replaces a Secret's values with their byte lengths, in
 // place, before anything renders the object.
 //
@@ -115,12 +125,21 @@ Examples:
 // CI logs. Reading a Secret's contents deliberately remains the job of
 // `cluster get secrets <name> -o yaml`, which is an explicit request for
 // them rather than a debugging verb.
+//
+// Clearing data and stringData is not sufficient on its own: a Secret
+// created with `kubectl apply` carries the whole original manifest in the
+// last-applied-configuration annotation, which reproduces every value
+// verbatim. That annotation is always redacted for a Secret, and any other
+// annotation that turns out to embed one of the values is redacted too -
+// scanning for the values themselves catches a controller that copies them
+// somewhere this code does not know the name of.
 func redactSecretData(kind string, object map[string]interface{}) {
 	// The resolved kind is authoritative: a cached item is not guaranteed to
 	// carry its own kind field, so keying off the manifest could miss.
 	if kind != "Secret" && getNestedString(object, "kind") != "Secret" {
 		return
 	}
+	secretValues := []string{}
 	for _, field := range []string{"data", "stringData"} {
 		values, isMap := object[field].(map[string]interface{})
 		if !isMap {
@@ -128,9 +147,40 @@ func redactSecretData(kind string, object map[string]interface{}) {
 		}
 		redacted := make(map[string]interface{}, len(values))
 		for key, value := range values {
-			redacted[key] = fmt.Sprintf("<redacted: %d bytes>", len(fmt.Sprintf("%v", value)))
+			rendered := fmt.Sprintf("%v", value)
+			if len(rendered) >= minimumRedactableSecretLength {
+				secretValues = append(secretValues, rendered)
+			}
+			redacted[key] = fmt.Sprintf("<redacted: %d bytes>", len(rendered))
 		}
 		object[field] = redacted
+	}
+	redactSecretAnnotations(object, secretValues)
+}
+
+// redactSecretAnnotations removes the annotations that can reproduce a
+// Secret's values after data and stringData have been redacted.
+func redactSecretAnnotations(object map[string]interface{}, secretValues []string) {
+	metadata, hasMetadata := getNestedMap(object, "metadata")
+	if !hasMetadata {
+		return
+	}
+	annotations, isMap := metadata["annotations"].(map[string]interface{})
+	if !isMap {
+		return
+	}
+	for name, value := range annotations {
+		rendered := fmt.Sprintf("%v", value)
+		if name == lastAppliedConfigurationAnnotation {
+			annotations[name] = "<redacted: contains the applied Secret manifest>"
+			continue
+		}
+		for _, secretValue := range secretValues {
+			if strings.Contains(rendered, secretValue) {
+				annotations[name] = "<redacted: contains Secret data>"
+				break
+			}
+		}
 	}
 }
 
@@ -202,7 +252,7 @@ func renderDescribe(kind string, object map[string]interface{}, events []map[str
 
 	renderConditions(object)
 	renderContainerStatuses(object)
-	renderSecretKeys(object)
+	renderSecretKeys(kind, object)
 	renderObjectEvents(events)
 }
 
@@ -361,8 +411,11 @@ func containerStateSummary(containerStatus map[string]interface{}, key string) (
 // they are already redacted by the time this runs. "Is the mounted secret
 // present, and is it non-empty?" is one of the questions that used to need a
 // shell in the pod, and it is answerable without one.
-func renderSecretKeys(object map[string]interface{}) {
-	if getNestedString(object, "kind") != "Secret" {
+func renderSecretKeys(kind string, object map[string]interface{}) {
+	// Same authoritative check as redactSecretData: a cached item may not
+	// carry its own kind, and redacting a Secret while skipping its key
+	// listing would be a confusing pair of behaviours in one command.
+	if kind != "Secret" && getNestedString(object, "kind") != "Secret" {
 		return
 	}
 	for _, field := range []string{"data", "stringData"} {

--- a/cmd/cluster_describe.go
+++ b/cmd/cluster_describe.go
@@ -1,0 +1,344 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// describeResult is the structured shape of `cluster describe`. The object
+// is the manifest verbatim and the events are the ones whose involvedObject
+// is that manifest, so a script gets exactly what the human rendering was
+// built from.
+type describeResult struct {
+	Object map[string]interface{}   `json:"object" yaml:"object"`
+	Events []map[string]interface{} `json:"events" yaml:"events"`
+}
+
+var clusterDescribeCmd = &cobra.Command{
+	Use:   "describe <kind> <name>",
+	Short: "Show one resource's status, conditions, and its own events",
+	Long: `Show a single Kubernetes resource together with the events scoped to it.
+
+This answers the question a failing workload raises - why is it not ready? -
+in one call: the object's conditions, a pod's per-container state (probe
+failures, image-pull errors, OOMKills, exit codes), and the events whose
+involvedObject is this resource, rather than a namespace-wide event list you
+have to filter by eye.
+
+Kinds outside the built-in set need --group (and sometimes --api-version),
+exactly like 'cluster get resources'.
+
+Examples:
+  ankra cluster describe pod web-7d9f-2xkvp -n default
+  ankra cluster describe deployment web -n default
+  ankra cluster describe node worker-1
+  ankra cluster describe pvc data-web-0 -n default -o json`,
+	Args:        cobra.ExactArgs(2),
+	Annotations: map[string]string{"group": "kubernetes"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		outputFormat, _ := cmd.Flags().GetString("output")
+		if err := validateK8sOutputFormat(outputFormat); err != nil {
+			return err
+		}
+		namespace, _ := cmd.Flags().GetString("namespace")
+		apiGroup, _ := cmd.Flags().GetString("group")
+		apiVersion, _ := cmd.Flags().GetString("api-version")
+
+		resolvedKind, kindError := resolveK8sKind(args[0], apiGroup, apiVersion)
+		if kindError != nil {
+			return kindError
+		}
+		name := args[1]
+		if !resolvedKind.clusterScoped && namespace == "" {
+			return withExitCode(exitUsage, fmt.Errorf(
+				"--namespace (-n) is required to describe a %s", resolvedKind.kind))
+		}
+		if resolvedKind.clusterScoped {
+			namespace = ""
+		}
+
+		cluster, clusterError := resolveActiveCluster(cmd)
+		if clusterError != nil {
+			return clusterError
+		}
+
+		object, objectError := fetchSingleResource(cluster.ID, resolvedKind, namespace, name)
+		if objectError != nil {
+			return objectError
+		}
+		events, eventsError := fetchEventsForObject(cluster.ID, resolvedKind.kind, name, namespace)
+		if eventsError != nil {
+			return eventsError
+		}
+
+		result := describeResult{Object: object, Events: events}
+		switch outputFormat {
+		case "json":
+			encoded, marshalError := json.MarshalIndent(result, "", "  ")
+			if marshalError != nil {
+				return fmt.Errorf("marshalling to JSON: %w", marshalError)
+			}
+			fmt.Println(string(encoded))
+			return nil
+		case "yaml":
+			encoded, marshalError := yaml.Marshal(result)
+			if marshalError != nil {
+				return fmt.Errorf("marshalling to YAML: %w", marshalError)
+			}
+			fmt.Print(string(encoded))
+			return nil
+		}
+		renderDescribe(resolvedKind.kind, object, events)
+		return nil
+	},
+}
+
+// fetchSingleResource reads exactly one named object. The resources/get
+// wire has no distinct not-found status, so an empty item list is the
+// not-found signal and is reported with the not-found exit code rather than
+// rendered as an empty description.
+func fetchSingleResource(clusterID string, resolvedKind k8sKind, namespace string, name string) (map[string]interface{}, error) {
+	request := client.ResourceRequestItem{
+		Kind:     resolvedKind.kind,
+		Group:    resolvedKind.group,
+		Version:  resolvedKind.version,
+		Resource: resolvedKind.resource,
+		Name:     name,
+	}
+	if namespace != "" {
+		request.Namespace = namespace
+	}
+	response, requestError := apiClient.GetResources(clusterID, client.GetResourcesRequest{
+		ResourceRequests: []client.ResourceRequestItem{request},
+	})
+	if requestError != nil {
+		return nil, requestError
+	}
+	if len(response.ResourceResponses) == 0 || len(response.ResourceResponses[0].Items) == 0 {
+		return nil, withExitCode(exitNotFound, fmt.Errorf("%s %q not found%s",
+			resolvedKind.kind, name, namespaceSuffix(namespace)))
+	}
+	object, isObject := response.ResourceResponses[0].Items[0].(map[string]interface{})
+	if !isObject {
+		return nil, fmt.Errorf("unexpected %s payload for %q", resolvedKind.kind, name)
+	}
+	return object, nil
+}
+
+func namespaceSuffix(namespace string) string {
+	if namespace == "" {
+		return ""
+	}
+	return " in namespace " + namespace
+}
+
+// renderDescribe prints the human view: identity, conditions, container
+// states for a pod, then the object's own events.
+func renderDescribe(kind string, object map[string]interface{}, events []map[string]interface{}) {
+	fmt.Printf("%s\n", text.Bold.Sprintf("%s/%s", kind, getNestedString(object, "metadata", "name")))
+	if namespace := getNestedString(object, "metadata", "namespace"); namespace != "" {
+		fmt.Printf("Namespace:    %s\n", namespace)
+	}
+	if apiVersion := getNestedString(object, "apiVersion"); apiVersion != "" {
+		fmt.Printf("API version:  %s\n", apiVersion)
+	}
+	fmt.Printf("Age:          %s\n", formatK8sAge(getNestedString(object, "metadata", "creationTimestamp")))
+	if node := getNestedString(object, "spec", "nodeName"); node != "" {
+		fmt.Printf("Node:         %s\n", node)
+	}
+	if phase := getNestedString(object, "status", "phase"); phase != "" {
+		fmt.Printf("Status:       %s\n", phase)
+	}
+	if reason := getNestedString(object, "status", "reason"); reason != "" {
+		fmt.Printf("Reason:       %s\n", reason)
+	}
+	if message := getNestedString(object, "status", "message"); message != "" {
+		fmt.Printf("Message:      %s\n", message)
+	}
+	if labels := formatStringMap(object, "labels"); labels != "" {
+		fmt.Printf("Labels:       %s\n", labels)
+	}
+
+	renderConditions(object)
+	renderContainerStatuses(object)
+	renderObjectEvents(events)
+}
+
+// formatStringMap renders metadata.<key> as a sorted k=v list.
+func formatStringMap(object map[string]interface{}, key string) string {
+	metadata, hasMetadata := getNestedMap(object, "metadata")
+	if !hasMetadata {
+		return ""
+	}
+	entries, isMap := metadata[key].(map[string]interface{})
+	if !isMap || len(entries) == 0 {
+		return ""
+	}
+	pairs := make([]string, 0, len(entries))
+	for name, value := range entries {
+		pairs = append(pairs, fmt.Sprintf("%s=%v", name, value))
+	}
+	sort.Strings(pairs)
+	return strings.Join(pairs, ", ")
+}
+
+func renderConditions(object map[string]interface{}) {
+	status, hasStatus := getNestedMap(object, "status")
+	if !hasStatus {
+		return
+	}
+	rawConditions, isList := status["conditions"].([]interface{})
+	if !isList || len(rawConditions) == 0 {
+		return
+	}
+	fmt.Printf("\n%s\n", text.Bold.Sprint("Conditions"))
+	conditionsTable := table.NewWriter()
+	conditionsTable.SetOutputMirror(os.Stdout)
+	conditionsTable.SetStyle(table.StyleRounded)
+	conditionsTable.AppendHeader(table.Row{"Type", "Status", "Reason", "Message", "Last Transition"})
+	for _, rawCondition := range rawConditions {
+		condition, isMap := rawCondition.(map[string]interface{})
+		if !isMap {
+			continue
+		}
+		conditionStatus := getNestedString(condition, "status")
+		switch conditionStatus {
+		case "True":
+			conditionStatus = text.FgGreen.Sprint(conditionStatus)
+		case "False":
+			conditionStatus = text.FgRed.Sprint(conditionStatus)
+		}
+		lastTransition := getNestedString(condition, "lastTransitionTime")
+		if lastTransition == "" {
+			lastTransition = getNestedString(condition, "lastProbeTime")
+		}
+		conditionsTable.AppendRow(table.Row{
+			getNestedString(condition, "type"),
+			conditionStatus,
+			getNestedString(condition, "reason"),
+			getNestedString(condition, "message"),
+			formatK8sAge(lastTransition),
+		})
+	}
+	conditionsTable.Render()
+}
+
+// renderContainerStatuses prints the per-container state of a pod. This is
+// where a CrashLoopBackOff names its exit code, an ImagePullBackOff names
+// the registry error, and a failing readiness probe shows up as a not-ready
+// container with a restart count.
+func renderContainerStatuses(object map[string]interface{}) {
+	status, hasStatus := getNestedMap(object, "status")
+	if !hasStatus {
+		return
+	}
+	sections := []struct {
+		title string
+		key   string
+	}{
+		{"Init containers", "initContainerStatuses"},
+		{"Containers", "containerStatuses"},
+		{"Ephemeral containers", "ephemeralContainerStatuses"},
+	}
+	for _, section := range sections {
+		rawStatuses, isList := status[section.key].([]interface{})
+		if !isList || len(rawStatuses) == 0 {
+			continue
+		}
+		fmt.Printf("\n%s\n", text.Bold.Sprint(section.title))
+		containersTable := table.NewWriter()
+		containersTable.SetOutputMirror(os.Stdout)
+		containersTable.SetStyle(table.StyleRounded)
+		containersTable.AppendHeader(table.Row{"Name", "Ready", "Restarts", "State", "Detail", "Image"})
+		for _, rawStatus := range rawStatuses {
+			containerStatus, isMap := rawStatus.(map[string]interface{})
+			if !isMap {
+				continue
+			}
+			ready := getNestedString(containerStatus, "ready")
+			switch ready {
+			case "true":
+				ready = text.FgGreen.Sprint("true")
+			case "false":
+				ready = text.FgRed.Sprint("false")
+			}
+			state, detail := containerStateSummary(containerStatus, "state")
+			lastState, lastDetail := containerStateSummary(containerStatus, "lastState")
+			if lastState != "" {
+				state = fmt.Sprintf("%s (last: %s)", state, lastState)
+				if detail == "" {
+					detail = lastDetail
+				} else if lastDetail != "" {
+					detail = fmt.Sprintf("%s; last: %s", detail, lastDetail)
+				}
+			}
+			containersTable.AppendRow(table.Row{
+				getNestedString(containerStatus, "name"),
+				ready,
+				getNestedString(containerStatus, "restartCount"),
+				state,
+				detail,
+				getNestedString(containerStatus, "image"),
+			})
+		}
+		containersTable.Render()
+	}
+}
+
+// containerStateSummary flattens a ContainerState union into a state name
+// and the reason/exit-code detail that explains it.
+func containerStateSummary(containerStatus map[string]interface{}, key string) (string, string) {
+	state, hasState := getNestedMap(containerStatus, key)
+	if !hasState {
+		return "", ""
+	}
+	for _, stateName := range []string{"waiting", "running", "terminated"} {
+		stateBody, isPresent := state[stateName].(map[string]interface{})
+		if !isPresent {
+			continue
+		}
+		details := []string{}
+		if reason := getNestedString(stateBody, "reason"); reason != "" {
+			details = append(details, reason)
+		}
+		if exitCode := getNestedString(stateBody, "exitCode"); exitCode != "" {
+			details = append(details, "exit "+exitCode)
+		}
+		if signal := getNestedString(stateBody, "signal"); signal != "" && signal != "0" {
+			details = append(details, "signal "+signal)
+		}
+		if message := getNestedString(stateBody, "message"); message != "" {
+			details = append(details, message)
+		}
+		return stateName, strings.Join(details, ": ")
+	}
+	return "", ""
+}
+
+func renderObjectEvents(events []map[string]interface{}) {
+	fmt.Printf("\n%s\n", text.Bold.Sprint("Events"))
+	if len(events) == 0 {
+		fmt.Println("No events found for this resource.")
+		return
+	}
+	renderEventsTable(events)
+}
+
+func init() {
+	clusterDescribeCmd.Flags().StringP("namespace", "n", "", "Kubernetes namespace")
+	clusterDescribeCmd.Flags().StringP("output", "o", "table", "Output format: table, json, yaml")
+	clusterDescribeCmd.Flags().String("group", "", "API group override (e.g. apps, networking.k8s.io)")
+	clusterDescribeCmd.Flags().String("api-version", "", "API version override (e.g. v1, v1beta1)")
+
+	clusterCmd.AddCommand(clusterDescribeCmd)
+}

--- a/cmd/cluster_describe.go
+++ b/cmd/cluster_describe.go
@@ -110,9 +110,15 @@ Examples:
 const lastAppliedConfigurationAnnotation = "kubectl.kubernetes.io/last-applied-configuration"
 
 // minimumRedactableSecretLength is the shortest secret value worth scanning
-// annotations for. A one- or two-character value would match half the
-// annotations on the object by coincidence and redact them all.
-const minimumRedactableSecretLength = 8
+// *other* annotations for. The guaranteed leak vector,
+// last-applied-configuration, is redacted unconditionally at any value
+// length; this gate only bounds the heuristic substring scan, where a very
+// short value would match unrelated annotations by coincidence and redact
+// the lot. Four is low enough to catch a short token and high enough that a
+// coincidental hit is unlikely; a value below it has too little entropy to
+// be worth protecting at the cost of blanking every annotation that happens
+// to contain those bytes.
+const minimumRedactableSecretLength = 4
 
 // redactSecretData replaces a Secret's values with their byte lengths, in
 // place, before anything renders the object.

--- a/cmd/cluster_describe.go
+++ b/cmd/cluster_describe.go
@@ -76,6 +76,7 @@ Examples:
 		if objectError != nil {
 			return objectError
 		}
+		redactSecretData(resolvedKind.kind, object)
 		events, eventsError := fetchEventsForObject(cluster.ID, resolvedKind.kind, name, namespace)
 		if eventsError != nil {
 			return eventsError
@@ -101,6 +102,36 @@ Examples:
 		renderDescribe(resolvedKind.kind, object, events)
 		return nil
 	},
+}
+
+// redactSecretData replaces a Secret's values with their byte lengths, in
+// place, before anything renders the object.
+//
+// kubectl describe redacts a Secret to key lengths for a reason, and this
+// command is pitched as the narrower alternative to handing out a kubectl
+// grant - it must not be an easier way to exfiltrate secret material than
+// the tool it replaces. `describe secret X -o json` would otherwise print
+// the full base64 payload to stdout, and from there into shell history and
+// CI logs. Reading a Secret's contents deliberately remains the job of
+// `cluster get secrets <name> -o yaml`, which is an explicit request for
+// them rather than a debugging verb.
+func redactSecretData(kind string, object map[string]interface{}) {
+	// The resolved kind is authoritative: a cached item is not guaranteed to
+	// carry its own kind field, so keying off the manifest could miss.
+	if kind != "Secret" && getNestedString(object, "kind") != "Secret" {
+		return
+	}
+	for _, field := range []string{"data", "stringData"} {
+		values, isMap := object[field].(map[string]interface{})
+		if !isMap {
+			continue
+		}
+		redacted := make(map[string]interface{}, len(values))
+		for key, value := range values {
+			redacted[key] = fmt.Sprintf("<redacted: %d bytes>", len(fmt.Sprintf("%v", value)))
+		}
+		object[field] = redacted
+	}
 }
 
 // fetchSingleResource reads exactly one named object. The resources/get
@@ -171,6 +202,7 @@ func renderDescribe(kind string, object map[string]interface{}, events []map[str
 
 	renderConditions(object)
 	renderContainerStatuses(object)
+	renderSecretKeys(object)
 	renderObjectEvents(events)
 }
 
@@ -323,6 +355,36 @@ func containerStateSummary(containerStatus map[string]interface{}, key string) (
 		return stateName, strings.Join(details, ": ")
 	}
 	return "", ""
+}
+
+// renderSecretKeys lists a Secret's keys and value sizes, never the values -
+// they are already redacted by the time this runs. "Is the mounted secret
+// present, and is it non-empty?" is one of the questions that used to need a
+// shell in the pod, and it is answerable without one.
+func renderSecretKeys(object map[string]interface{}) {
+	if getNestedString(object, "kind") != "Secret" {
+		return
+	}
+	for _, field := range []string{"data", "stringData"} {
+		values, isMap := object[field].(map[string]interface{})
+		if !isMap || len(values) == 0 {
+			continue
+		}
+		fmt.Printf("\n%s\n", text.Bold.Sprint("Data ("+field+")"))
+		keys := make([]string, 0, len(values))
+		for key := range values {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		secretTable := table.NewWriter()
+		secretTable.SetOutputMirror(os.Stdout)
+		secretTable.SetStyle(table.StyleRounded)
+		secretTable.AppendHeader(table.Row{"Key", "Value"})
+		for _, key := range keys {
+			secretTable.AppendRow(table.Row{key, values[key]})
+		}
+		secretTable.Render()
+	}
 }
 
 func renderObjectEvents(events []map[string]interface{}) {

--- a/cmd/cluster_events.go
+++ b/cmd/cluster_events.go
@@ -80,9 +80,6 @@ func runClusterEvents(cmd *cobra.Command, _ []string) error {
 		}
 		fieldSelectors = involvedObjectSelectors(targetKind.kind, targetName, namespace)
 	}
-	if eventType != "" {
-		fieldSelectors = append(fieldSelectors, client.FieldSelector{Field: "type", Value: eventType})
-	}
 
 	nameFilter, _ := cmd.Flags().GetString("name")
 	labelSelector, _ := cmd.Flags().GetString("selector")
@@ -95,6 +92,7 @@ func runClusterEvents(cmd *cobra.Command, _ []string) error {
 	if eventsError != nil {
 		return eventsError
 	}
+	events = filterEventsByType(events, eventType)
 
 	switch outputFormat {
 	case "json":
@@ -122,6 +120,26 @@ func runClusterEvents(cmd *cobra.Command, _ []string) error {
 
 func isKnownEventType(eventType string) bool {
 	return eventType == "Normal" || eventType == "Warning"
+}
+
+// filterEventsByType applies --type in the CLI rather than as a field
+// selector. The platform answers an event listing from its resource cache
+// whenever the cache is fresh, and the cache honours only a whitelist of
+// field selectors - involvedObject.* and two spec.* fields - dropping
+// anything else without saying so. A type selector would therefore have
+// filtered against an unreachable cluster and silently not filtered against
+// a healthy one, which is the worst of both.
+func filterEventsByType(events []map[string]interface{}, eventType string) []map[string]interface{} {
+	if eventType == "" {
+		return events
+	}
+	filtered := make([]map[string]interface{}, 0, len(events))
+	for _, event := range events {
+		if getNestedString(event, "type") == eventType {
+			filtered = append(filtered, event)
+		}
+	}
+	return filtered
 }
 
 // parseEventTarget accepts the kubectl "kind/name" spelling that --for
@@ -259,16 +277,66 @@ func renderEventsTable(events []map[string]interface{}) {
 	eventsTable.Render()
 }
 
-// The listing is mounted twice from one implementation: `cluster events` is
-// the verb the debugging flow reaches for, `cluster get events` keeps the
-// spelling the rest of the get family uses. Cobra owns a command's flag
-// state, so each mount point needs its own instance.
-var (
-	clusterEventsCmd    = newClusterEventsCommand()
-	clusterGetEventsCmd = newClusterEventsCommand()
-)
+// `cluster events` is the dedicated debugging verb. `cluster get events`
+// keeps the get family's own command, envelope and positional-name form -
+// its --for and --type are wired through the kindConfig hooks below, so both
+// spellings scope by involvedObject without either changing shape.
+var clusterEventsCmd = newClusterEventsCommand()
 
 func init() {
 	clusterCmd.AddCommand(clusterEventsCmd)
-	clusterGetCmd.AddCommand(clusterGetEventsCmd)
+}
+
+// eventFieldSelectorsFromFlags turns `cluster get events --for kind/name`
+// into the involvedObject selectors. It runs on the get-family command, whose
+// namespace flag is absent for a cluster-scoped kind, hence the lookup guard.
+func eventFieldSelectorsFromFlags(command *cobra.Command) ([]client.FieldSelector, error) {
+	forTarget, _ := command.Flags().GetString("for")
+	eventType, _ := command.Flags().GetString("type")
+	if eventType != "" && !isKnownEventType(eventType) {
+		return nil, withExitCode(exitUsage, fmt.Errorf(
+			"unsupported --type %q: use Normal or Warning", eventType))
+	}
+	if forTarget == "" {
+		return nil, nil
+	}
+	targetKind, targetName, parseError := parseEventTarget(forTarget)
+	if parseError != nil {
+		return nil, parseError
+	}
+	namespace := ""
+	if command.Flags().Lookup("namespace") != nil {
+		namespace, _ = command.Flags().GetString("namespace")
+	}
+	allNamespaces := false
+	if command.Flags().Lookup("all-namespaces") != nil {
+		allNamespaces, _ = command.Flags().GetBool("all-namespaces")
+	}
+	if allNamespaces {
+		namespace = ""
+	}
+	if !targetKind.clusterScoped && namespace == "" && !allNamespaces {
+		return nil, withExitCode(exitUsage, fmt.Errorf(
+			"--namespace (-n) is required with --for %s/%s",
+			strings.ToLower(targetKind.kind), targetName))
+	}
+	return involvedObjectSelectors(targetKind.kind, targetName, namespace), nil
+}
+
+// eventTypeFilterFromFlags applies --type in the CLI for the get-family
+// command, for the same reason runClusterEvents does: the platform's cache
+// silently drops a type field selector.
+func eventTypeFilterFromFlags(items []interface{}, command *cobra.Command) []interface{} {
+	eventType, _ := command.Flags().GetString("type")
+	if eventType == "" {
+		return items
+	}
+	filtered := make([]interface{}, 0, len(items))
+	for _, item := range items {
+		event, isEvent := item.(map[string]interface{})
+		if isEvent && getNestedString(event, "type") == eventType {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
 }

--- a/cmd/cluster_events.go
+++ b/cmd/cluster_events.go
@@ -1,0 +1,264 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// newClusterEventsCommand builds the events listing. The same command is
+// mounted twice - as `cluster events` and as `cluster get events` - so both
+// spellings share one implementation and both gain --for.
+func newClusterEventsCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "events",
+		Short: "List cluster events, optionally scoped to one object",
+		Long: `List Kubernetes events from the active cluster.
+
+--for scopes the listing to a single object's involvedObject, which is what
+turns "the pod is Pending" into "no node matches the nodeSelector". This is
+a server-side field selector, not a substring match on the event text, so
+an object whose name is a prefix of another object's name is not conflated
+with it.
+
+Examples:
+  ankra cluster events -n default
+  ankra cluster events --for pod/web-7d9f-2xkvp -n default
+  ankra cluster events --for deployment/web -n default --type Warning
+  ankra cluster events --all-namespaces --type Warning -o json`,
+		Args:        cobra.NoArgs,
+		Annotations: map[string]string{"group": "kubernetes"},
+		RunE:        runClusterEvents,
+	}
+	command.Flags().StringP("namespace", "n", "", "Kubernetes namespace")
+	command.Flags().BoolP("all-namespaces", "A", false, "List across all namespaces")
+	command.Flags().String("for", "", "Scope to one object's events, as kind/name (e.g. pod/web-7d9f-2xkvp)")
+	command.Flags().String("type", "", "Filter by event type: Normal or Warning")
+	command.Flags().String("name", "", "Filter by event object name")
+	command.Flags().StringP("selector", "l", "", "Label selector")
+	command.Flags().StringP("output", "o", "table", "Output format: table, json, yaml")
+	return command
+}
+
+func runClusterEvents(cmd *cobra.Command, _ []string) error {
+	outputFormat, _ := cmd.Flags().GetString("output")
+	if err := validateK8sOutputFormat(outputFormat); err != nil {
+		return err
+	}
+	namespace, _ := cmd.Flags().GetString("namespace")
+	allNamespaces, _ := cmd.Flags().GetBool("all-namespaces")
+	forTarget, _ := cmd.Flags().GetString("for")
+	eventType, _ := cmd.Flags().GetString("type")
+
+	if allNamespaces {
+		namespace = ""
+	}
+	if eventType != "" && !isKnownEventType(eventType) {
+		return withExitCode(exitUsage, fmt.Errorf(
+			"unsupported --type %q: use Normal or Warning", eventType))
+	}
+
+	fieldSelectors := []client.FieldSelector{}
+	if forTarget != "" {
+		targetKind, targetName, parseError := parseEventTarget(forTarget)
+		if parseError != nil {
+			return parseError
+		}
+		if !targetKind.clusterScoped && namespace == "" && !allNamespaces {
+			return withExitCode(exitUsage, fmt.Errorf(
+				"--namespace (-n) is required with --for %s/%s", strings.ToLower(targetKind.kind), targetName))
+		}
+		fieldSelectors = involvedObjectSelectors(targetKind.kind, targetName, namespace)
+	}
+	if eventType != "" {
+		fieldSelectors = append(fieldSelectors, client.FieldSelector{Field: "type", Value: eventType})
+	}
+
+	nameFilter, _ := cmd.Flags().GetString("name")
+	labelSelector, _ := cmd.Flags().GetString("selector")
+
+	cluster, clusterError := resolveActiveCluster(cmd)
+	if clusterError != nil {
+		return clusterError
+	}
+	events, eventsError := fetchEvents(cluster.ID, namespace, fieldSelectors, nameFilter, labelSelector)
+	if eventsError != nil {
+		return eventsError
+	}
+
+	switch outputFormat {
+	case "json":
+		encoded, marshalError := json.MarshalIndent(events, "", "  ")
+		if marshalError != nil {
+			return fmt.Errorf("marshalling to JSON: %w", marshalError)
+		}
+		fmt.Println(string(encoded))
+		return nil
+	case "yaml":
+		encoded, marshalError := yaml.Marshal(events)
+		if marshalError != nil {
+			return fmt.Errorf("marshalling to YAML: %w", marshalError)
+		}
+		fmt.Print(string(encoded))
+		return nil
+	}
+	if len(events) == 0 {
+		fmt.Println("No events found.")
+		return nil
+	}
+	renderEventsTable(events)
+	return nil
+}
+
+func isKnownEventType(eventType string) bool {
+	return eventType == "Normal" || eventType == "Warning"
+}
+
+// parseEventTarget accepts the kubectl "kind/name" spelling that --for
+// takes. A bare name has no kind to scope by, so it is a usage error
+// rather than a silent namespace-wide listing.
+func parseEventTarget(target string) (k8sKind, string, error) {
+	kindPart, namePart, hasSeparator := strings.Cut(target, "/")
+	if !hasSeparator || strings.TrimSpace(kindPart) == "" || strings.TrimSpace(namePart) == "" {
+		return k8sKind{}, "", withExitCode(exitUsage, fmt.Errorf(
+			"--for takes kind/name (e.g. --for pod/web-7d9f-2xkvp), got %q", target))
+	}
+	resolved, resolveError := resolveK8sKind(kindPart, "", "")
+	if resolveError != nil {
+		return k8sKind{}, "", resolveError
+	}
+	return resolved, namePart, nil
+}
+
+// involvedObjectSelectors builds the field selectors that scope an event
+// listing to one object. The namespace selector is only meaningful for a
+// namespaced target; a cluster-scoped object's events carry an empty
+// involvedObject.namespace.
+func involvedObjectSelectors(kind string, name string, namespace string) []client.FieldSelector {
+	selectors := []client.FieldSelector{
+		{Field: "involvedObject.kind", Value: kind},
+		{Field: "involvedObject.name", Value: name},
+	}
+	if namespace != "" {
+		selectors = append(selectors, client.FieldSelector{
+			Field: "involvedObject.namespace", Value: namespace,
+		})
+	}
+	return selectors
+}
+
+// fetchEventsForObject is the describe path's use of the same scoping.
+func fetchEventsForObject(clusterID string, kind string, name string, namespace string) ([]map[string]interface{}, error) {
+	return fetchEvents(clusterID, namespace, involvedObjectSelectors(kind, name, namespace), "", "")
+}
+
+// fetchEvents reads the Event list, newest last, so a terminal rendering
+// reads top-to-bottom in the order the cluster produced them.
+func fetchEvents(
+	clusterID string,
+	namespace string,
+	fieldSelectors []client.FieldSelector,
+	nameFilter string,
+	labelSelector string,
+) ([]map[string]interface{}, error) {
+	request := client.ResourceRequestItem{Kind: "Event", Version: "v1"}
+	if namespace != "" {
+		request.Namespace = namespace
+	}
+	if nameFilter != "" {
+		request.Name = nameFilter
+	}
+	if labelSelector != "" {
+		request.LabelSelector = labelSelector
+	}
+	if len(fieldSelectors) > 0 {
+		request.FieldSelectors = fieldSelectors
+	}
+	response, requestError := apiClient.GetResources(clusterID, client.GetResourcesRequest{
+		ResourceRequests: []client.ResourceRequestItem{request},
+	})
+	if requestError != nil {
+		return nil, requestError
+	}
+	if len(response.ResourceResponses) == 0 {
+		return []map[string]interface{}{}, nil
+	}
+	events := make([]map[string]interface{}, 0, len(response.ResourceResponses[0].Items))
+	for _, item := range response.ResourceResponses[0].Items {
+		if event, isEvent := item.(map[string]interface{}); isEvent {
+			events = append(events, event)
+		}
+	}
+	sort.SliceStable(events, func(first int, second int) bool {
+		return eventTimestamp(events[first]).Before(eventTimestamp(events[second]))
+	})
+	return events, nil
+}
+
+// eventTimestamp picks the most recent time an event carries. Series
+// events report lastTimestamp, single events report eventTime or
+// firstTimestamp, and everything falls back to the creation timestamp.
+func eventTimestamp(event map[string]interface{}) time.Time {
+	for _, key := range []string{"lastTimestamp", "eventTime", "firstTimestamp"} {
+		if parsed, parseError := time.Parse(time.RFC3339, getNestedString(event, key)); parseError == nil {
+			return parsed
+		}
+	}
+	parsed, parseError := time.Parse(time.RFC3339, getNestedString(event, "metadata", "creationTimestamp"))
+	if parseError != nil {
+		return time.Time{}
+	}
+	return parsed
+}
+
+func renderEventsTable(events []map[string]interface{}) {
+	eventsTable := table.NewWriter()
+	eventsTable.SetOutputMirror(os.Stdout)
+	eventsTable.SetStyle(table.StyleRounded)
+	eventsTable.AppendHeader(table.Row{"Last Seen", "Type", "Reason", "Object", "Count", "Message"})
+	for _, event := range events {
+		eventType := getNestedString(event, "type")
+		if eventType == "Warning" {
+			eventType = text.FgYellow.Sprint(eventType)
+		}
+		involvedKind := strings.ToLower(getNestedString(event, "involvedObject", "kind"))
+		involvedName := getNestedString(event, "involvedObject", "name")
+		count := getNestedString(event, "count")
+		if count == "" {
+			count = "1"
+		}
+		eventsTable.AppendRow(table.Row{
+			formatK8sAge(eventTimestamp(event).Format(time.RFC3339)),
+			eventType,
+			getNestedString(event, "reason"),
+			fmt.Sprintf("%s/%s", involvedKind, involvedName),
+			count,
+			getNestedString(event, "message"),
+		})
+	}
+	eventsTable.Render()
+}
+
+// The listing is mounted twice from one implementation: `cluster events` is
+// the verb the debugging flow reaches for, `cluster get events` keeps the
+// spelling the rest of the get family uses. Cobra owns a command's flag
+// state, so each mount point needs its own instance.
+var (
+	clusterEventsCmd    = newClusterEventsCommand()
+	clusterGetEventsCmd = newClusterEventsCommand()
+)
+
+func init() {
+	clusterCmd.AddCommand(clusterEventsCmd)
+	clusterGetCmd.AddCommand(clusterGetEventsCmd)
+}

--- a/cmd/cluster_events.go
+++ b/cmd/cluster_events.go
@@ -221,6 +221,16 @@ func eventTimestamp(event map[string]interface{}) time.Time {
 	return parsed
 }
 
+// formatEventAge renders an event's age, leaving the cell blank when the
+// event carried no parseable timestamp at all - a zero time would otherwise
+// render as two thousand years.
+func formatEventAge(timestamp time.Time) string {
+	if timestamp.IsZero() {
+		return ""
+	}
+	return formatK8sAge(timestamp.Format(time.RFC3339))
+}
+
 func renderEventsTable(events []map[string]interface{}) {
 	eventsTable := table.NewWriter()
 	eventsTable.SetOutputMirror(os.Stdout)
@@ -238,7 +248,7 @@ func renderEventsTable(events []map[string]interface{}) {
 			count = "1"
 		}
 		eventsTable.AppendRow(table.Row{
-			formatK8sAge(eventTimestamp(event).Format(time.RFC3339)),
+			formatEventAge(eventTimestamp(event)),
 			eventType,
 			getNestedString(event, "reason"),
 			fmt.Sprintf("%s/%s", involvedKind, involvedName),

--- a/cmd/cluster_events.go
+++ b/cmd/cluster_events.go
@@ -78,6 +78,11 @@ func runClusterEvents(cmd *cobra.Command, _ []string) error {
 			return withExitCode(exitUsage, fmt.Errorf(
 				"--namespace (-n) is required with --for %s/%s", strings.ToLower(targetKind.kind), targetName))
 		}
+		if !targetKind.clusterScoped && allNamespaces {
+			fmt.Fprintf(os.Stderr,
+				"Note: --for with --all-namespaces matches every %s named %q in any namespace; the Namespace column tells them apart.\n",
+				strings.ToLower(targetKind.kind), targetName)
+		}
 		fieldSelectors = involvedObjectSelectors(targetKind.kind, targetName, namespace)
 	}
 
@@ -253,7 +258,12 @@ func renderEventsTable(events []map[string]interface{}) {
 	eventsTable := table.NewWriter()
 	eventsTable.SetOutputMirror(os.Stdout)
 	eventsTable.SetStyle(table.StyleRounded)
-	eventsTable.AppendHeader(table.Row{"Last Seen", "Type", "Reason", "Object", "Count", "Message"})
+	// The object's namespace is a column rather than an omission: --for
+	// scopes by involvedObject.namespace only when a namespace is known, so
+	// under --all-namespaces a same-named object of the same kind in another
+	// namespace also matches. Showing the namespace makes that visible
+	// instead of letting one namespace's events be read as another's.
+	eventsTable.AppendHeader(table.Row{"Last Seen", "Type", "Reason", "Object", "Namespace", "Count", "Message"})
 	for _, event := range events {
 		eventType := getNestedString(event, "type")
 		if eventType == "Warning" {
@@ -265,11 +275,16 @@ func renderEventsTable(events []map[string]interface{}) {
 		if count == "" {
 			count = "1"
 		}
+		involvedNamespace := getNestedString(event, "involvedObject", "namespace")
+		if involvedNamespace == "" {
+			involvedNamespace = "<cluster>"
+		}
 		eventsTable.AppendRow(table.Row{
 			formatEventAge(eventTimestamp(event)),
 			eventType,
 			getNestedString(event, "reason"),
 			fmt.Sprintf("%s/%s", involvedKind, involvedName),
+			involvedNamespace,
 			count,
 			getNestedString(event, "message"),
 		})

--- a/cmd/cluster_events.go
+++ b/cmd/cluster_events.go
@@ -78,16 +78,11 @@ func runClusterEvents(cmd *cobra.Command, _ []string) error {
 		if parseError != nil {
 			return parseError
 		}
-		if !targetKind.clusterScoped && namespace == "" && !allNamespaces {
-			return withExitCode(exitUsage, fmt.Errorf(
-				"--namespace (-n) is required with --for %s/%s", strings.ToLower(targetKind.kind), targetName))
+		scopedSelectors, selectorError := eventSelectorsForTarget(targetKind, targetName, namespace, allNamespaces)
+		if selectorError != nil {
+			return selectorError
 		}
-		if !targetKind.clusterScoped && allNamespaces {
-			fmt.Fprintf(os.Stderr,
-				"Note: --for with --all-namespaces matches every %s named %q in any namespace; the Namespace column tells them apart.\n",
-				strings.ToLower(targetKind.kind), targetName)
-		}
-		fieldSelectors = involvedObjectSelectors(targetKind.kind, targetName, namespace)
+		fieldSelectors = scopedSelectors
 	}
 
 	nameFilter, _ := cmd.Flags().GetString("name")
@@ -307,9 +302,10 @@ func init() {
 }
 
 // eventFieldSelectorsFromFlags turns `cluster get events --for kind/name`
-// into the involvedObject selectors. It runs on the get-family command, whose
-// namespace flag is absent for a cluster-scoped kind, hence the lookup guard.
-func eventFieldSelectorsFromFlags(command *cobra.Command) ([]client.FieldSelector, error) {
+// into the involvedObject selectors. The namespace arrives already resolved
+// from the command that owns the request, so the get-family mount and
+// `cluster events` cannot end up scoping the same --for differently.
+func eventFieldSelectorsFromFlags(command *cobra.Command, namespace string, allNamespaces bool) ([]client.FieldSelector, error) {
 	forTarget, _ := command.Flags().GetString("for")
 	eventType, _ := command.Flags().GetString("type")
 	if eventType != "" && !isKnownEventType(eventType) {
@@ -323,21 +319,21 @@ func eventFieldSelectorsFromFlags(command *cobra.Command) ([]client.FieldSelecto
 	if parseError != nil {
 		return nil, parseError
 	}
-	namespace := ""
-	if command.Flags().Lookup("namespace") != nil {
-		namespace, _ = command.Flags().GetString("namespace")
-	}
-	allNamespaces := false
-	if command.Flags().Lookup("all-namespaces") != nil {
-		allNamespaces, _ = command.Flags().GetBool("all-namespaces")
-	}
-	if allNamespaces {
-		namespace = ""
-	}
+	return eventSelectorsForTarget(targetKind, targetName, namespace, allNamespaces)
+}
+
+// eventSelectorsForTarget is the single place --for turns into selectors,
+// shared by both mounts.
+func eventSelectorsForTarget(targetKind k8sKind, targetName string, namespace string, allNamespaces bool) ([]client.FieldSelector, error) {
 	if !targetKind.clusterScoped && namespace == "" && !allNamespaces {
 		return nil, withExitCode(exitUsage, fmt.Errorf(
 			"--namespace (-n) is required with --for %s/%s",
 			strings.ToLower(targetKind.kind), targetName))
+	}
+	if !targetKind.clusterScoped && allNamespaces {
+		fmt.Fprintf(os.Stderr,
+			"Note: --for with --all-namespaces matches every %s named %q in any namespace; the Namespace column tells them apart.\n",
+			strings.ToLower(targetKind.kind), targetName)
 	}
 	return involvedObjectSelectors(targetKind.kind, targetName, namespace), nil
 }

--- a/cmd/cluster_events.go
+++ b/cmd/cluster_events.go
@@ -44,7 +44,11 @@ Examples:
 	command.Flags().BoolP("all-namespaces", "A", false, "List across all namespaces")
 	command.Flags().String("for", "", "Scope to one object's events, as kind/name (e.g. pod/web-7d9f-2xkvp)")
 	command.Flags().String("type", "", "Filter by event type: Normal or Warning")
-	command.Flags().String("name", "", "Filter by event object name")
+	// The platform matches this against the Event resource's own generated
+	// name (web-1.17abc...), not the workload the event is about. Saying
+	// "event object name" read as the latter, which returns nothing and
+	// looks like "there are no events" rather than "wrong flag".
+	command.Flags().String("name", "", "Filter by the Event resource's own name; to scope by the object an event is about, use --for")
 	command.Flags().StringP("selector", "l", "", "Label selector")
 	command.Flags().StringP("output", "o", "table", "Output format: table, json, yaml")
 	return command

--- a/cmd/cluster_k8s.go
+++ b/cmd/cluster_k8s.go
@@ -99,7 +99,7 @@ type kindConfig struct {
 	// the generated command and turn them into server-side field selectors.
 	// Only events uses it today, for --for.
 	registerFlags     func(command *cobra.Command)
-	fieldSelectorsFor func(command *cobra.Command) ([]client.FieldSelector, error)
+	fieldSelectorsFor func(command *cobra.Command, namespace string, allNamespaces bool) ([]client.FieldSelector, error)
 	postFilter        func(items []interface{}, command *cobra.Command) []interface{}
 }
 
@@ -600,7 +600,10 @@ func registerKindCommand(cfg kindConfig) *cobra.Command {
 			query := resourceQuery{}
 			if cfg.fieldSelectorsFor != nil {
 				var selectorError error
-				query.fieldSelectors, selectorError = cfg.fieldSelectorsFor(cmd)
+				// The resolved namespace is handed over rather than re-read,
+				// so a kind's selectors cannot scope differently from the
+				// request they travel on.
+				query.fieldSelectors, selectorError = cfg.fieldSelectorsFor(cmd, namespace, allNamespaces)
 				if selectorError != nil {
 					return selectorError
 				}

--- a/cmd/cluster_k8s.go
+++ b/cmd/cluster_k8s.go
@@ -95,6 +95,12 @@ type kindConfig struct {
 	// message. The generic resources command uses it to point at --group
 	// for kinds that live outside the core API group.
 	emptyHint string
+	// registerFlags and fieldSelectorsFor let one kind add its own flags to
+	// the generated command and turn them into server-side field selectors.
+	// Only events uses it today, for --for.
+	registerFlags     func(command *cobra.Command)
+	fieldSelectorsFor func(command *cobra.Command) ([]client.FieldSelector, error)
+	postFilter        func(items []interface{}, command *cobra.Command) []interface{}
 }
 
 var kindConfigs = []kindConfig{
@@ -254,6 +260,33 @@ var kindConfigs = []kindConfig{
 				formatK8sAge(getNestedString(obj, "metadata", "creationTimestamp")),
 			}
 		},
+	},
+	{
+		commandName: "events", kind: "Event", group: "", version: "v1",
+		short:   "List events in the cluster",
+		headers: table.Row{"Last Seen", "Type", "Reason", "Object", "Message"},
+		formatRow: func(obj map[string]interface{}) table.Row {
+			lastSeen := getNestedString(obj, "lastTimestamp")
+			if lastSeen == "" {
+				lastSeen = getNestedString(obj, "metadata", "creationTimestamp")
+			}
+			object := fmt.Sprintf("%s/%s",
+				strings.ToLower(getNestedString(obj, "involvedObject", "kind")),
+				getNestedString(obj, "involvedObject", "name"))
+			return table.Row{
+				formatK8sAge(lastSeen),
+				getNestedString(obj, "type"),
+				getNestedString(obj, "reason"),
+				object,
+				getNestedString(obj, "message"),
+			}
+		},
+		registerFlags: func(command *cobra.Command) {
+			command.Flags().String("for", "", "Scope to one object's events, as kind/name (e.g. pod/web-7d9f-2xkvp)")
+			command.Flags().String("type", "", "Filter by event type: Normal or Warning")
+		},
+		fieldSelectorsFor: eventFieldSelectorsFromFlags,
+		postFilter:        eventTypeFilterFromFlags,
 	},
 	{
 		commandName: "configmaps", kind: "ConfigMap", group: "", version: "v1",
@@ -428,10 +461,13 @@ func renderSingleResource(item interface{}, outputFormat string) error {
 	return nil
 }
 
-func fetchAndRenderResources(clusterID, namespace, nameFilter, labelSelector, outputFormat string, cfg kindConfig) error {
+func fetchAndRenderResources(clusterID, namespace, nameFilter, labelSelector, outputFormat string, cfg kindConfig, fieldSelectors []client.FieldSelector, postFilter func([]interface{}) []interface{}) error {
 	reqItem := client.ResourceRequestItem{
 		Kind:    cfg.kind,
 		Version: cfg.version,
+	}
+	if len(fieldSelectors) > 0 {
+		reqItem.FieldSelectors = fieldSelectors
 	}
 	if cfg.group != "" {
 		reqItem.Group = cfg.group
@@ -456,6 +492,15 @@ func fetchAndRenderResources(clusterID, namespace, nameFilter, labelSelector, ou
 	var items []interface{}
 	if len(response.ResourceResponses) > 0 {
 		items = response.ResourceResponses[0].Items
+	}
+	if postFilter != nil {
+		items = postFilter(items)
+		// Keep the structured envelope and the table showing the same set:
+		// a filter the caller asked for must not be visible in one and
+		// absent from the other.
+		if len(response.ResourceResponses) > 0 {
+			response.ResourceResponses[0].Items = items
+		}
 	}
 
 	isSingleResourceLookup := nameFilter != "" && len(items) == 1
@@ -537,8 +582,23 @@ func registerKindCommand(cfg kindConfig) *cobra.Command {
 				namespace = ""
 			}
 
-			return fetchAndRenderResources(cluster.ID, namespace, nameFilter, labelSelector, outputFormat, cfg)
+			var fieldSelectors []client.FieldSelector
+			if cfg.fieldSelectorsFor != nil {
+				var selectorError error
+				fieldSelectors, selectorError = cfg.fieldSelectorsFor(cmd)
+				if selectorError != nil {
+					return selectorError
+				}
+			}
+			var postFilter func([]interface{}) []interface{}
+			if cfg.postFilter != nil {
+				postFilter = func(items []interface{}) []interface{} { return cfg.postFilter(items, cmd) }
+			}
+			return fetchAndRenderResources(cluster.ID, namespace, nameFilter, labelSelector, outputFormat, cfg, fieldSelectors, postFilter)
 		},
+	}
+	if cfg.registerFlags != nil {
+		cfg.registerFlags(cmd)
 	}
 
 	if !cfg.clusterScoped {
@@ -582,7 +642,7 @@ var clusterPodsCmd = &cobra.Command{
 				kind:        "Pod",
 				version:     "v1",
 			}
-			return fetchAndRenderResources(cluster.ID, namespace, podName, "", outputFormat, podCfg)
+			return fetchAndRenderResources(cluster.ID, namespace, podName, "", outputFormat, podCfg, nil, nil)
 		}
 
 		if allNamespaces {
@@ -906,7 +966,7 @@ Example:
 			},
 		}
 
-		return fetchAndRenderResources(cluster.ID, namespace, nameFilter, labelSelector, outputFormat, genericCfg)
+		return fetchAndRenderResources(cluster.ID, namespace, nameFilter, labelSelector, outputFormat, genericCfg, nil, nil)
 	},
 }
 

--- a/cmd/cluster_k8s.go
+++ b/cmd/cluster_k8s.go
@@ -461,13 +461,22 @@ func renderSingleResource(item interface{}, outputFormat string) error {
 	return nil
 }
 
-func fetchAndRenderResources(clusterID, namespace, nameFilter, labelSelector, outputFormat string, cfg kindConfig, fieldSelectors []client.FieldSelector, postFilter func([]interface{}) []interface{}) error {
+// resourceQuery carries the optional narrowing a kind command can apply.
+// Both members are nil for every command except events, and bundling them
+// keeps two same-shaped optional arguments off the call signature where they
+// could be transposed silently.
+type resourceQuery struct {
+	fieldSelectors []client.FieldSelector
+	postFilter     func([]interface{}) []interface{}
+}
+
+func fetchAndRenderResources(clusterID, namespace, nameFilter, labelSelector, outputFormat string, cfg kindConfig, query resourceQuery) error {
 	reqItem := client.ResourceRequestItem{
 		Kind:    cfg.kind,
 		Version: cfg.version,
 	}
-	if len(fieldSelectors) > 0 {
-		reqItem.FieldSelectors = fieldSelectors
+	if len(query.fieldSelectors) > 0 {
+		reqItem.FieldSelectors = query.fieldSelectors
 	}
 	if cfg.group != "" {
 		reqItem.Group = cfg.group
@@ -493,8 +502,8 @@ func fetchAndRenderResources(clusterID, namespace, nameFilter, labelSelector, ou
 	if len(response.ResourceResponses) > 0 {
 		items = response.ResourceResponses[0].Items
 	}
-	if postFilter != nil {
-		items = postFilter(items)
+	if query.postFilter != nil {
+		items = query.postFilter(items)
 		// Keep the structured envelope and the table showing the same set:
 		// a filter the caller asked for must not be visible in one and
 		// absent from the other.
@@ -582,19 +591,18 @@ func registerKindCommand(cfg kindConfig) *cobra.Command {
 				namespace = ""
 			}
 
-			var fieldSelectors []client.FieldSelector
+			query := resourceQuery{}
 			if cfg.fieldSelectorsFor != nil {
 				var selectorError error
-				fieldSelectors, selectorError = cfg.fieldSelectorsFor(cmd)
+				query.fieldSelectors, selectorError = cfg.fieldSelectorsFor(cmd)
 				if selectorError != nil {
 					return selectorError
 				}
 			}
-			var postFilter func([]interface{}) []interface{}
 			if cfg.postFilter != nil {
-				postFilter = func(items []interface{}) []interface{} { return cfg.postFilter(items, cmd) }
+				query.postFilter = func(items []interface{}) []interface{} { return cfg.postFilter(items, cmd) }
 			}
-			return fetchAndRenderResources(cluster.ID, namespace, nameFilter, labelSelector, outputFormat, cfg, fieldSelectors, postFilter)
+			return fetchAndRenderResources(cluster.ID, namespace, nameFilter, labelSelector, outputFormat, cfg, query)
 		},
 	}
 	if cfg.registerFlags != nil {
@@ -642,7 +650,7 @@ var clusterPodsCmd = &cobra.Command{
 				kind:        "Pod",
 				version:     "v1",
 			}
-			return fetchAndRenderResources(cluster.ID, namespace, podName, "", outputFormat, podCfg, nil, nil)
+			return fetchAndRenderResources(cluster.ID, namespace, podName, "", outputFormat, podCfg, resourceQuery{})
 		}
 
 		if allNamespaces {
@@ -821,6 +829,10 @@ Examples:
 			follow = false
 		}
 		if previous {
+			if cmd.Flags().Changed("follow") && follow {
+				return withExitCode(exitUsage, errors.New(
+					"--previous reads a terminated container's log, which is closed and cannot be followed; drop --follow"))
+			}
 			follow = false
 		}
 
@@ -838,6 +850,11 @@ Examples:
 			return withExitCode(exitUsage, fmt.Errorf(
 				"following %d containers at once exceeds the limit of %d: narrow the selector or pass --follow=false",
 				len(targets), maxConcurrentLogFollows))
+		}
+		if !follow && len(targets) > maxBoundedLogTargets {
+			return withExitCode(exitUsage, fmt.Errorf(
+				"reading %d containers in one command exceeds the limit of %d: narrow the selector with -l, or pass --tail to bound each read",
+				len(targets), maxBoundedLogTargets))
 		}
 
 		opts := client.PodLogOptions{
@@ -966,7 +983,7 @@ Example:
 			},
 		}
 
-		return fetchAndRenderResources(cluster.ID, namespace, nameFilter, labelSelector, outputFormat, genericCfg, nil, nil)
+		return fetchAndRenderResources(cluster.ID, namespace, nameFilter, labelSelector, outputFormat, genericCfg, resourceQuery{})
 	},
 }
 

--- a/cmd/cluster_k8s.go
+++ b/cmd/cluster_k8s.go
@@ -256,27 +256,6 @@ var kindConfigs = []kindConfig{
 		},
 	},
 	{
-		commandName: "events", kind: "Event", group: "", version: "v1",
-		short:   "List events in the cluster",
-		headers: table.Row{"Last Seen", "Type", "Reason", "Object", "Message"},
-		formatRow: func(obj map[string]interface{}) table.Row {
-			lastSeen := getNestedString(obj, "lastTimestamp")
-			if lastSeen == "" {
-				lastSeen = getNestedString(obj, "metadata", "creationTimestamp")
-			}
-			object := fmt.Sprintf("%s/%s",
-				strings.ToLower(getNestedString(obj, "involvedObject", "kind")),
-				getNestedString(obj, "involvedObject", "name"))
-			return table.Row{
-				formatK8sAge(lastSeen),
-				getNestedString(obj, "type"),
-				getNestedString(obj, "reason"),
-				object,
-				getNestedString(obj, "message"),
-			}
-		},
-	},
-	{
 		commandName: "configmaps", kind: "ConfigMap", group: "", version: "v1",
 		short:   "List configmaps in the cluster",
 		headers: table.Row{"Name", "Namespace", "Data", "Age"},
@@ -708,48 +687,124 @@ var clusterPodsCmd = &cobra.Command{
 }
 
 var clusterLogsCmd = &cobra.Command{
-	Use:   "logs <pod_name>",
-	Short: "Stream logs from a pod",
-	Long: `Stream log output from a pod in the active cluster.
+	Use:   "logs [pod_name]",
+	Short: "Stream logs from one pod, a label selector, or every container",
+	Long: `Stream log output from the active cluster.
 
 By default the stream stays open and prints new lines as they arrive, like
 kubectl logs -f. Pass --follow=false to print the current backlog and exit,
 which is what a pipeline into grep or a script wants.
 
-Example:
+--previous reads the log of the container instance that terminated. For a
+pod in CrashLoopBackOff that is the only log with the failure in it, and it
+is the case where reaching for kubectl through a broad access grant used to
+be the only option. A previous log is closed, so --previous always makes a
+bounded read.
+
+-l/--selector reads every pod matching a label selector instead of one pod
+name, and --all-containers expands each pod to all of its containers (init
+and ephemeral containers included). With more than one target each line is
+prefixed with [pod] or [pod/container] so the interleaved output stays
+attributable.
+
+Examples:
   ankra cluster logs my-pod -n default -c my-container --tail 100
-  ankra cluster logs my-pod -n default --since 600 --follow=false | grep ERROR`,
-	Args:        cobra.ExactArgs(1),
+  ankra cluster logs my-pod -n default --previous
+  ankra cluster logs -l app=web -n default --tail 50 --follow=false
+  ankra cluster logs my-pod -n default --all-containers --previous
+  ankra cluster logs -l app=web -n default --follow=false -o json`,
+	Args:        cobra.MaximumNArgs(1),
 	Annotations: map[string]string{"group": "kubernetes"},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		podName := args[0]
 		namespace, _ := cmd.Flags().GetString("namespace")
 		container, _ := cmd.Flags().GetString("container")
 		tailLines, _ := cmd.Flags().GetInt("tail")
 		sinceSeconds, _ := cmd.Flags().GetInt("since")
 		follow, _ := cmd.Flags().GetBool("follow")
+		previous, _ := cmd.Flags().GetBool("previous")
+		labelSelector, _ := cmd.Flags().GetString("selector")
+		allContainers, _ := cmd.Flags().GetBool("all-containers")
+		outputFormat, _ := cmd.Flags().GetString("output")
 
+		if err := validateK8sOutputFormat(outputFormat); err != nil {
+			return err
+		}
 		if namespace == "" {
 			return withExitCode(exitUsage, errors.New("--namespace (-n) is required for logs"))
 		}
+		podName := ""
+		if len(args) == 1 {
+			podName = args[0]
+		}
+		if podName == "" && labelSelector == "" {
+			return withExitCode(exitUsage,
+				errors.New("logs needs a pod name or a label selector (-l)"))
+		}
+		if podName != "" && labelSelector != "" {
+			return withExitCode(exitUsage,
+				errors.New("pass either a pod name or -l/--selector, not both"))
+		}
+		if container != "" && allContainers {
+			return withExitCode(exitUsage,
+				errors.New("--container and --all-containers select different things; pass only one"))
+		}
+
+		// A structured read has to terminate before it can be encoded, so
+		// -o json|yaml is a bounded read. Saying so is better than
+		// emitting a document that never closes.
+		isStructured := outputFormat == "json" || outputFormat == "yaml"
+		if isStructured {
+			if cmd.Flags().Changed("follow") && follow {
+				return withExitCode(exitUsage, errors.New(
+					"-o json|yaml cannot follow a stream; drop --follow or use -o table"))
+			}
+			follow = false
+		}
+		if previous {
+			follow = false
+		}
+
 		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {
 			return err
 		}
 
+		targets, targetsError := resolveLogTargets(
+			cluster.ID, namespace, podName, labelSelector, container, allContainers)
+		if targetsError != nil {
+			return targetsError
+		}
+		if follow && len(targets) > maxConcurrentLogFollows {
+			return withExitCode(exitUsage, fmt.Errorf(
+				"following %d containers at once exceeds the limit of %d: narrow the selector or pass --follow=false",
+				len(targets), maxConcurrentLogFollows))
+		}
+
 		opts := client.PodLogOptions{
 			Namespace:     namespace,
-			PodName:       podName,
 			ContainerName: container,
 			TailLines:     tailLines,
 			SinceSeconds:  sinceSeconds,
 			Follow:        follow,
+			Previous:      previous,
 		}
 
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
 
-		if err := apiClient.StreamPodLogs(ctx, cluster.ID, opts, os.Stdout); err != nil {
+		if isStructured {
+			groups, collectError := collectLogTargets(ctx, cluster.ID, targets, opts)
+			if collectError != nil {
+				if ctx.Err() != nil {
+					return nil
+				}
+				return collectError
+			}
+			return renderLogGroups(groups, outputFormat)
+		}
+
+		showPrefix := len(targets) > 1
+		if err := streamLogTargets(ctx, cluster.ID, targets, opts, showPrefix, os.Stdout); err != nil {
 			if ctx.Err() != nil {
 				return nil
 			}
@@ -879,6 +934,10 @@ func init() {
 	clusterLogsCmd.Flags().Int("tail", 0, "Number of lines from the end of the logs")
 	clusterLogsCmd.Flags().Int("since", 0, "Seconds of logs to retrieve")
 	clusterLogsCmd.Flags().BoolP("follow", "f", true, "Keep the stream open for new lines; --follow=false prints the current backlog and exits")
+	clusterLogsCmd.Flags().BoolP("previous", "p", false, "Read the terminated container's log (the one a CrashLoopBackOff wrote); always a bounded read")
+	clusterLogsCmd.Flags().StringP("selector", "l", "", "Read every pod matching this label selector instead of one pod name")
+	clusterLogsCmd.Flags().Bool("all-containers", false, "Read every container of each selected pod, including init and ephemeral containers")
+	clusterLogsCmd.Flags().StringP("output", "o", "table", "Output format: table, json, yaml")
 
 	clusterGenericResourcesCmd.Flags().StringP("namespace", "n", "", "Kubernetes namespace")
 	clusterGenericResourcesCmd.Flags().BoolP("all-namespaces", "A", false, "List across all namespaces")

--- a/cmd/cluster_k8s.go
+++ b/cmd/cluster_k8s.go
@@ -284,6 +284,12 @@ var kindConfigs = []kindConfig{
 		registerFlags: func(command *cobra.Command) {
 			command.Flags().String("for", "", "Scope to one object's events, as kind/name (e.g. pod/web-7d9f-2xkvp)")
 			command.Flags().String("type", "", "Filter by event type: Normal or Warning")
+			// The get family's shared --name matches the Event resource's own
+			// generated name, not the workload the event is about; --for is
+			// the flag for the latter.
+			if nameFlag := command.Flags().Lookup("name"); nameFlag != nil {
+				nameFlag.Usage = "Filter by the Event resource's own name; to scope by the object an event is about, use --for"
+			}
 		},
 		fieldSelectorsFor: eventFieldSelectorsFromFlags,
 		postFilter:        eventTypeFilterFromFlags,
@@ -605,9 +611,6 @@ func registerKindCommand(cfg kindConfig) *cobra.Command {
 			return fetchAndRenderResources(cluster.ID, namespace, nameFilter, labelSelector, outputFormat, cfg, query)
 		},
 	}
-	if cfg.registerFlags != nil {
-		cfg.registerFlags(cmd)
-	}
 
 	if !cfg.clusterScoped {
 		cmd.Flags().StringP("namespace", "n", "", "Kubernetes namespace")
@@ -616,6 +619,12 @@ func registerKindCommand(cfg kindConfig) *cobra.Command {
 	cmd.Flags().String("name", "", "Filter by resource name")
 	cmd.Flags().StringP("selector", "l", "", "Label selector")
 	cmd.Flags().StringP("output", "o", "table", "Output format: table, json, yaml")
+
+	// After the shared flags, so a kind can both add its own and adjust the
+	// wording of one it inherits.
+	if cfg.registerFlags != nil {
+		cfg.registerFlags(cmd)
+	}
 
 	return cmd
 }

--- a/cmd/cluster_k8s_kinds.go
+++ b/cmd/cluster_k8s_kinds.go
@@ -1,0 +1,157 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// k8sKind is the group/version/scope a resources/get request needs for a
+// kind the user named on the command line. The platform derives the API
+// plural from the kind, so only kinds whose plural is irregular carry an
+// explicit resource.
+type k8sKind struct {
+	kind          string
+	group         string
+	version       string
+	resource      string
+	clusterScoped bool
+}
+
+// builtinK8sKinds resolves the kubectl spellings - singular, plural, and
+// the common short names - for the kinds a debugging session reaches for.
+// Anything outside this table is still reachable by passing --group and
+// --api-version explicitly, exactly like `cluster get resources`.
+var builtinK8sKinds = map[string]k8sKind{
+	"pod":                     {kind: "Pod", version: "v1"},
+	"configmap":               {kind: "ConfigMap", version: "v1"},
+	"secret":                  {kind: "Secret", version: "v1"},
+	"service":                 {kind: "Service", version: "v1"},
+	"endpoints":               {kind: "Endpoints", version: "v1", resource: "endpoints"},
+	"serviceaccount":          {kind: "ServiceAccount", version: "v1"},
+	"persistentvolumeclaim":   {kind: "PersistentVolumeClaim", version: "v1"},
+	"replicationcontroller":   {kind: "ReplicationController", version: "v1"},
+	"event":                   {kind: "Event", version: "v1"},
+	"limitrange":              {kind: "LimitRange", version: "v1"},
+	"resourcequota":           {kind: "ResourceQuota", version: "v1"},
+	"node":                    {kind: "Node", version: "v1", clusterScoped: true},
+	"namespace":               {kind: "Namespace", version: "v1", clusterScoped: true},
+	"persistentvolume":        {kind: "PersistentVolume", version: "v1", clusterScoped: true},
+	"deployment":              {kind: "Deployment", group: "apps", version: "v1"},
+	"replicaset":              {kind: "ReplicaSet", group: "apps", version: "v1"},
+	"statefulset":             {kind: "StatefulSet", group: "apps", version: "v1"},
+	"daemonset":               {kind: "DaemonSet", group: "apps", version: "v1"},
+	"controllerrevision":      {kind: "ControllerRevision", group: "apps", version: "v1"},
+	"job":                     {kind: "Job", group: "batch", version: "v1"},
+	"cronjob":                 {kind: "CronJob", group: "batch", version: "v1"},
+	"ingress":                 {kind: "Ingress", group: "networking.k8s.io", version: "v1", resource: "ingresses"},
+	"networkpolicy":           {kind: "NetworkPolicy", group: "networking.k8s.io", version: "v1", resource: "networkpolicies"},
+	"ingressclass":            {kind: "IngressClass", group: "networking.k8s.io", version: "v1", resource: "ingressclasses", clusterScoped: true},
+	"horizontalpodautoscaler": {kind: "HorizontalPodAutoscaler", group: "autoscaling", version: "v2", resource: "horizontalpodautoscalers"},
+	"poddisruptionbudget":     {kind: "PodDisruptionBudget", group: "policy", version: "v1"},
+	"storageclass":            {kind: "StorageClass", group: "storage.k8s.io", version: "v1", resource: "storageclasses", clusterScoped: true},
+	"role":                    {kind: "Role", group: "rbac.authorization.k8s.io", version: "v1"},
+	"rolebinding":             {kind: "RoleBinding", group: "rbac.authorization.k8s.io", version: "v1"},
+	"clusterrole":             {kind: "ClusterRole", group: "rbac.authorization.k8s.io", version: "v1", clusterScoped: true},
+	"clusterrolebinding":      {kind: "ClusterRoleBinding", group: "rbac.authorization.k8s.io", version: "v1", clusterScoped: true},
+}
+
+// k8sKindShortNames maps the kubectl short spellings onto their canonical
+// singular key in builtinK8sKinds.
+var k8sKindShortNames = map[string]string{
+	"po":     "pod",
+	"cm":     "configmap",
+	"svc":    "service",
+	"ep":     "endpoints",
+	"sa":     "serviceaccount",
+	"pvc":    "persistentvolumeclaim",
+	"pv":     "persistentvolume",
+	"rc":     "replicationcontroller",
+	"ev":     "event",
+	"no":     "node",
+	"ns":     "namespace",
+	"deploy": "deployment",
+	"rs":     "replicaset",
+	"sts":    "statefulset",
+	"ds":     "daemonset",
+	"cj":     "cronjob",
+	"ing":    "ingress",
+	"netpol": "networkpolicy",
+	"hpa":    "horizontalpodautoscaler",
+	"pdb":    "poddisruptionbudget",
+	"sc":     "storageclass",
+	"limits": "limitrange",
+	"quota":  "resourcequota",
+}
+
+// singularK8sKindKey normalises a user-typed kind to the singular lower-case
+// key used by builtinK8sKinds. It understands the short names, the plural
+// forms the listing commands print, and CamelCase kinds as written in a
+// manifest.
+func singularK8sKindKey(rawKind string) string {
+	lowered := strings.ToLower(strings.TrimSpace(rawKind))
+	if canonical, isShortName := k8sKindShortNames[lowered]; isShortName {
+		return canonical
+	}
+	if _, isKnown := builtinK8sKinds[lowered]; isKnown {
+		return lowered
+	}
+	// "endpoints" is its own plural, so the plural trims below must not
+	// touch a key that already resolved.
+	for _, candidate := range []string{
+		strings.TrimSuffix(lowered, "es"),
+		strings.TrimSuffix(lowered, "s"),
+	} {
+		if candidate == lowered {
+			continue
+		}
+		if _, isKnown := builtinK8sKinds[candidate]; isKnown {
+			return candidate
+		}
+	}
+	if strings.HasSuffix(lowered, "ies") {
+		candidate := strings.TrimSuffix(lowered, "ies") + "y"
+		if _, isKnown := builtinK8sKinds[candidate]; isKnown {
+			return candidate
+		}
+	}
+	return lowered
+}
+
+// resolveK8sKind maps a user-typed kind onto its group/version/scope.
+// groupOverride and versionOverride come from --group / --api-version and
+// win over the table, which is what makes custom resources reachable. An
+// unknown kind with no --group is a usage error naming the known kinds
+// rather than an empty result the caller has to interpret.
+func resolveK8sKind(rawKind string, groupOverride string, versionOverride string) (k8sKind, error) {
+	if strings.TrimSpace(rawKind) == "" {
+		return k8sKind{}, withExitCode(exitUsage, fmt.Errorf("a resource kind is required"))
+	}
+	resolved, isKnown := builtinK8sKinds[singularK8sKindKey(rawKind)]
+	if !isKnown {
+		if groupOverride == "" && versionOverride == "" {
+			return k8sKind{}, withExitCode(exitUsage, fmt.Errorf(
+				"unknown resource kind %q: pass --group and --api-version for a kind outside %s",
+				rawKind, strings.Join(knownK8sKindNames(), ", ")))
+		}
+		resolved = k8sKind{kind: rawKind, version: "v1"}
+	}
+	if groupOverride != "" {
+		resolved.group = groupOverride
+		resolved.resource = ""
+	}
+	if versionOverride != "" {
+		resolved.version = versionOverride
+	}
+	return resolved, nil
+}
+
+// knownK8sKindNames lists the table's canonical kinds for the usage error.
+func knownK8sKindNames() []string {
+	names := make([]string, 0, len(builtinK8sKinds))
+	for _, entry := range builtinK8sKinds {
+		names = append(names, entry.kind)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/cmd/cluster_k8s_kinds.go
+++ b/cmd/cluster_k8s_kinds.go
@@ -129,9 +129,9 @@ func resolveK8sKind(rawKind string, groupOverride string, versionOverride string
 	}
 	resolved, isKnown := builtinK8sKinds[singularK8sKindKey(rawKind)]
 	if !isKnown {
-		if groupOverride == "" && versionOverride == "" {
+		if groupOverride == "" || versionOverride == "" {
 			return k8sKind{}, withExitCode(exitUsage, fmt.Errorf(
-				"unknown resource kind %q: pass --group and --api-version for a kind outside %s "+
+				"unknown resource kind %q: pass both --group and --api-version for a kind outside %s "+
 					"(spell it as the CamelCase singular, e.g. Certificate, not certificates)",
 				rawKind, strings.Join(knownK8sKindNames(), ", ")))
 		}
@@ -145,7 +145,14 @@ func resolveK8sKind(rawKind string, groupOverride string, versionOverride string
 	}
 	if groupOverride != "" {
 		resolved.group = groupOverride
-		resolved.resource = ""
+		// The explicit plural belongs to the kind, not to the group, so a
+		// matched builtin keeps it. Discarding it would hand the platform's
+		// heuristic kinds it cannot pluralise from the name alone
+		// (Endpoints, Ingress, NetworkPolicy, StorageClass) and 404 against
+		// an object that exists.
+		if !isKnown {
+			resolved.resource = ""
+		}
 	}
 	if versionOverride != "" {
 		resolved.version = versionOverride

--- a/cmd/cluster_k8s_kinds.go
+++ b/cmd/cluster_k8s_kinds.go
@@ -131,10 +131,17 @@ func resolveK8sKind(rawKind string, groupOverride string, versionOverride string
 	if !isKnown {
 		if groupOverride == "" && versionOverride == "" {
 			return k8sKind{}, withExitCode(exitUsage, fmt.Errorf(
-				"unknown resource kind %q: pass --group and --api-version for a kind outside %s",
+				"unknown resource kind %q: pass --group and --api-version for a kind outside %s "+
+					"(spell it as the CamelCase singular, e.g. Certificate, not certificates)",
 				rawKind, strings.Join(knownK8sKindNames(), ", ")))
 		}
-		resolved = k8sKind{kind: rawKind, version: "v1"}
+		// The platform derives the API plural from the kind, so a plural
+		// spelling here becomes a double plural ("certificates" ->
+		// "certificateses") and the read comes back empty - reported as a
+		// confident "not found" for an object that exists. Singularise so
+		// the derivation lands on the real plural whichever spelling the
+		// caller used.
+		resolved = k8sKind{kind: singularKindSpelling(rawKind), version: "v1"}
 	}
 	if groupOverride != "" {
 		resolved.group = groupOverride
@@ -144,6 +151,25 @@ func resolveK8sKind(rawKind string, groupOverride string, versionOverride string
 		resolved.version = versionOverride
 	}
 	return resolved, nil
+}
+
+// singularKindSpelling trims a plural suffix while preserving the caller's
+// capitalisation, which for a custom resource is the only thing that carries
+// the CamelCase the API server expects.
+func singularKindSpelling(rawKind string) string {
+	trimmed := strings.TrimSpace(rawKind)
+	lowered := strings.ToLower(trimmed)
+	switch {
+	case strings.HasSuffix(lowered, "ies") && len(trimmed) > 3:
+		return trimmed[:len(trimmed)-3] + "y"
+	case strings.HasSuffix(lowered, "sses"), strings.HasSuffix(lowered, "xes"),
+		strings.HasSuffix(lowered, "ches"), strings.HasSuffix(lowered, "shes"):
+		return trimmed[:len(trimmed)-2]
+	case strings.HasSuffix(lowered, "s") && !strings.HasSuffix(lowered, "ss"):
+		return trimmed[:len(trimmed)-1]
+	default:
+		return trimmed
+	}
 }
 
 // knownK8sKindNames lists the table's canonical kinds for the usage error.

--- a/cmd/cluster_logs.go
+++ b/cmd/cluster_logs.go
@@ -1,0 +1,303 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+
+	"ankra/internal/client"
+
+	"gopkg.in/yaml.v3"
+)
+
+// maxConcurrentLogFollows bounds how many streams a single `cluster logs`
+// invocation holds open at once. Each target is one long-lived HTTP stream
+// on the platform and one follow on the agent, so an unbounded selector
+// match would open a connection per replica. kubectl draws the same line at
+// five; beyond it the CLI asks the caller to narrow the selector rather
+// than quietly truncating the match.
+const maxConcurrentLogFollows = 5
+
+// logTarget is one pod/container pair to read.
+type logTarget struct {
+	podName       string
+	containerName string
+}
+
+// podLogGroup is the structured form of one target's output.
+type podLogGroup struct {
+	Pod       string   `json:"pod" yaml:"pod"`
+	Container string   `json:"container,omitempty" yaml:"container,omitempty"`
+	Lines     []string `json:"lines" yaml:"lines"`
+}
+
+// resolveLogTargets turns the command's pod argument or label selector into
+// the concrete pod/container pairs to read. allContainers expands each pod
+// to every container it declares, including init and ephemeral containers,
+// which is where a failing init container's log lives.
+func resolveLogTargets(
+	clusterID string,
+	namespace string,
+	podName string,
+	labelSelector string,
+	containerName string,
+	allContainers bool,
+) ([]logTarget, error) {
+	if podName != "" && !allContainers {
+		return []logTarget{{podName: podName, containerName: containerName}}, nil
+	}
+
+	request := client.ResourceRequestItem{Kind: "Pod", Version: "v1", Namespace: namespace}
+	if podName != "" {
+		request.Name = podName
+	}
+	if labelSelector != "" {
+		request.LabelSelector = labelSelector
+	}
+	response, requestError := apiClient.GetResources(clusterID, client.GetResourcesRequest{
+		ResourceRequests: []client.ResourceRequestItem{request},
+	})
+	if requestError != nil {
+		return nil, requestError
+	}
+	if len(response.ResourceResponses) == 0 || len(response.ResourceResponses[0].Items) == 0 {
+		if podName != "" {
+			return nil, withExitCode(exitNotFound, fmt.Errorf(
+				"pod %q not found in namespace %s", podName, namespace))
+		}
+		return nil, withExitCode(exitNotFound, fmt.Errorf(
+			"no pods match selector %q in namespace %s", labelSelector, namespace))
+	}
+
+	targets := []logTarget{}
+	for _, item := range response.ResourceResponses[0].Items {
+		pod, isPod := item.(map[string]interface{})
+		if !isPod {
+			continue
+		}
+		name := getNestedString(pod, "metadata", "name")
+		if name == "" {
+			continue
+		}
+		if !allContainers {
+			targets = append(targets, logTarget{podName: name, containerName: containerName})
+			continue
+		}
+		for _, container := range podContainerNames(pod) {
+			targets = append(targets, logTarget{podName: name, containerName: container})
+		}
+	}
+	sort.SliceStable(targets, func(first int, second int) bool {
+		if targets[first].podName != targets[second].podName {
+			return targets[first].podName < targets[second].podName
+		}
+		return targets[first].containerName < targets[second].containerName
+	})
+	if len(targets) == 0 {
+		return nil, withExitCode(exitNotFound, fmt.Errorf(
+			"no readable containers found for the selected pods in namespace %s", namespace))
+	}
+	return targets, nil
+}
+
+// podContainerNames lists every container of a pod in the order a reader
+// wants them: init containers first (they run first and are the usual
+// cause of a stuck pod), then the app containers, then any ephemeral
+// debug containers.
+func podContainerNames(pod map[string]interface{}) []string {
+	names := []string{}
+	spec, hasSpec := getNestedMap(pod, "spec")
+	if !hasSpec {
+		return names
+	}
+	for _, key := range []string{"initContainers", "containers", "ephemeralContainers"} {
+		containers, isList := spec[key].([]interface{})
+		if !isList {
+			continue
+		}
+		for _, rawContainer := range containers {
+			container, isMap := rawContainer.(map[string]interface{})
+			if !isMap {
+				continue
+			}
+			if name := getNestedString(container, "name"); name != "" {
+				names = append(names, name)
+			}
+		}
+	}
+	return names
+}
+
+// streamLogTargets reads every target. A single target streams straight to
+// the writer; several targets are prefixed so the interleaved output stays
+// attributable, and are read concurrently when following so a quiet replica
+// does not block a noisy one.
+func streamLogTargets(
+	ctx context.Context,
+	clusterID string,
+	targets []logTarget,
+	options client.PodLogOptions,
+	showPrefix bool,
+	writer io.Writer,
+) error {
+	if len(targets) == 1 && !showPrefix {
+		options.PodName = targets[0].podName
+		options.ContainerName = targets[0].containerName
+		return apiClient.StreamPodLogs(ctx, clusterID, options, writer)
+	}
+
+	var outputLock sync.Mutex
+	streamOne := func(target logTarget) error {
+		targetOptions := options
+		targetOptions.PodName = target.podName
+		targetOptions.ContainerName = target.containerName
+		prefixed := &prefixingWriter{
+			prefix: logTargetPrefix(target),
+			target: writer,
+			lock:   &outputLock,
+		}
+		streamError := apiClient.StreamPodLogs(ctx, clusterID, targetOptions, prefixed)
+		if flushError := prefixed.Flush(); flushError != nil && streamError == nil {
+			streamError = flushError
+		}
+		if streamError != nil {
+			return fmt.Errorf("%s: %w", logTargetPrefix(target), streamError)
+		}
+		return nil
+	}
+
+	if !options.Follow {
+		for _, target := range targets {
+			if streamError := streamOne(target); streamError != nil {
+				return streamError
+			}
+		}
+		return nil
+	}
+
+	var waitGroup sync.WaitGroup
+	streamErrors := make([]error, len(targets))
+	for index, target := range targets {
+		waitGroup.Add(1)
+		go func(slot int, streamTarget logTarget) {
+			defer waitGroup.Done()
+			streamErrors[slot] = streamOne(streamTarget)
+		}(index, target)
+	}
+	waitGroup.Wait()
+	for _, streamError := range streamErrors {
+		if streamError != nil {
+			return streamError
+		}
+	}
+	return nil
+}
+
+func logTargetPrefix(target logTarget) string {
+	if target.containerName == "" {
+		return target.podName
+	}
+	return target.podName + "/" + target.containerName
+}
+
+// prefixingWriter stamps every complete line with its target and serialises
+// writes across concurrent streams so two replicas cannot interleave inside
+// a single line.
+type prefixingWriter struct {
+	prefix    string
+	target    io.Writer
+	lock      *sync.Mutex
+	remainder []byte
+}
+
+func (writer *prefixingWriter) Write(payload []byte) (int, error) {
+	writer.lock.Lock()
+	defer writer.lock.Unlock()
+	consumed := len(payload)
+	buffer := append(writer.remainder, payload...)
+	for {
+		newlineIndex := bytes.IndexByte(buffer, '\n')
+		if newlineIndex < 0 {
+			break
+		}
+		line := buffer[:newlineIndex]
+		buffer = buffer[newlineIndex+1:]
+		if _, writeError := fmt.Fprintf(writer.target, "[%s] %s\n", writer.prefix, line); writeError != nil {
+			return consumed, writeError
+		}
+	}
+	writer.remainder = append([]byte(nil), buffer...)
+	return consumed, nil
+}
+
+// Flush emits a trailing partial line, which a stream that ended without a
+// newline would otherwise drop.
+func (writer *prefixingWriter) Flush() error {
+	writer.lock.Lock()
+	defer writer.lock.Unlock()
+	if len(writer.remainder) == 0 {
+		return nil
+	}
+	_, writeError := fmt.Fprintf(writer.target, "[%s] %s\n", writer.prefix, writer.remainder)
+	writer.remainder = nil
+	return writeError
+}
+
+// collectLogTargets reads every target into memory for the -o json|yaml
+// forms. It is only reachable on a bounded read, so the whole output is
+// known to terminate.
+func collectLogTargets(
+	ctx context.Context,
+	clusterID string,
+	targets []logTarget,
+	options client.PodLogOptions,
+) ([]podLogGroup, error) {
+	groups := make([]podLogGroup, 0, len(targets))
+	for _, target := range targets {
+		targetOptions := options
+		targetOptions.PodName = target.podName
+		targetOptions.ContainerName = target.containerName
+		var buffer bytes.Buffer
+		if streamError := apiClient.StreamPodLogs(ctx, clusterID, targetOptions, &buffer); streamError != nil {
+			return nil, fmt.Errorf("%s: %w", logTargetPrefix(target), streamError)
+		}
+		groups = append(groups, podLogGroup{
+			Pod:       target.podName,
+			Container: target.containerName,
+			Lines:     splitLogLines(buffer.String()),
+		})
+	}
+	return groups, nil
+}
+
+func splitLogLines(output string) []string {
+	trimmed := strings.TrimSuffix(output, "\n")
+	if trimmed == "" {
+		return []string{}
+	}
+	return strings.Split(trimmed, "\n")
+}
+
+func renderLogGroups(groups []podLogGroup, outputFormat string) error {
+	switch outputFormat {
+	case "json":
+		encoded, marshalError := json.MarshalIndent(groups, "", "  ")
+		if marshalError != nil {
+			return fmt.Errorf("marshalling to JSON: %w", marshalError)
+		}
+		fmt.Println(string(encoded))
+		return nil
+	default:
+		encoded, marshalError := yaml.Marshal(groups)
+		if marshalError != nil {
+			return fmt.Errorf("marshalling to YAML: %w", marshalError)
+		}
+		fmt.Print(string(encoded))
+		return nil
+	}
+}

--- a/cmd/cluster_logs.go
+++ b/cmd/cluster_logs.go
@@ -24,6 +24,14 @@ import (
 // than quietly truncating the match.
 const maxConcurrentLogFollows = 5
 
+// maxBoundedLogTargets caps a non-following multi-target read. Those run
+// sequentially, and the -o json|yaml path buffers every target's output
+// before it can encode, so an unnarrowed selector in a busy namespace would
+// otherwise be both very slow and unbounded in memory. The limit is high
+// enough for any realistic Deployment and low enough that hitting it means
+// the selector, not the CLI, is the thing to fix.
+const maxBoundedLogTargets = 50
+
 // logTarget is one pod/container pair to read.
 type logTarget struct {
 	podName       string

--- a/cmd/cluster_logs.go
+++ b/cmd/cluster_logs.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -171,29 +172,71 @@ func streamLogTargets(
 		return nil
 	}
 
+	// A bounded multi-target read must not abandon the remaining targets on
+	// the first failure. --all-containers --previous is the case that makes
+	// this load-bearing: a container that never terminated has no previous
+	// log and the apiserver answers 400, so whichever container happens to
+	// sort first would otherwise decide whether the crash-looping one's log
+	// is ever printed.
 	if !options.Follow {
+		failures := []error{}
 		for _, target := range targets {
 			if streamError := streamOne(target); streamError != nil {
-				return streamError
+				failures = append(failures, streamError)
 			}
 		}
-		return nil
+		return reportTargetFailures(failures, len(targets))
 	}
 
+	// A following read only ends when the caller interrupts it, so a target
+	// that dies mid-follow must be reported the moment it happens: waiting
+	// for the others would hold the failure until interrupt, and by then the
+	// cancelled context makes the caller discard it. Report to stderr (stdout
+	// is the log stream) and leave the surviving targets following, which is
+	// what kubectl does with a partially broken selector.
 	var waitGroup sync.WaitGroup
 	streamErrors := make([]error, len(targets))
 	for index, target := range targets {
 		waitGroup.Add(1)
 		go func(slot int, streamTarget logTarget) {
 			defer waitGroup.Done()
-			streamErrors[slot] = streamOne(streamTarget)
+			streamError := streamOne(streamTarget)
+			streamErrors[slot] = streamError
+			if streamError != nil && ctx.Err() == nil {
+				fmt.Fprintln(os.Stderr, streamError.Error())
+			}
 		}(index, target)
 	}
 	waitGroup.Wait()
+
+	failures := []error{}
 	for _, streamError := range streamErrors {
 		if streamError != nil {
-			return streamError
+			failures = append(failures, streamError)
 		}
+	}
+	// The failures already reached stderr as they happened, so only the
+	// all-failed case has anything left to say.
+	if len(failures) == len(targets) && len(failures) > 0 {
+		return failures[0]
+	}
+	return nil
+}
+
+// reportTargetFailures decides what a partially failed multi-target read
+// returns. Every target failing means nothing was read, so the command
+// failed. A partial failure still produced logs, so the failures are named on
+// stderr (stdout is the log stream) and the command exits zero rather than
+// throwing away a successful read.
+func reportTargetFailures(failures []error, targetCount int) error {
+	if len(failures) == 0 {
+		return nil
+	}
+	if len(failures) == targetCount {
+		return failures[0]
+	}
+	for _, failure := range failures {
+		fmt.Fprintln(os.Stderr, failure.Error())
 	}
 	return nil
 }
@@ -218,7 +261,6 @@ type prefixingWriter struct {
 func (writer *prefixingWriter) Write(payload []byte) (int, error) {
 	writer.lock.Lock()
 	defer writer.lock.Unlock()
-	consumed := len(payload)
 	buffer := append(writer.remainder, payload...)
 	for {
 		newlineIndex := bytes.IndexByte(buffer, '\n')
@@ -228,11 +270,20 @@ func (writer *prefixingWriter) Write(payload []byte) (int, error) {
 		line := buffer[:newlineIndex]
 		buffer = buffer[newlineIndex+1:]
 		if _, writeError := fmt.Fprintf(writer.target, "[%s] %s\n", writer.prefix, line); writeError != nil {
+			// Keep only what is still unwritten, so a later Flush cannot
+			// re-emit a line this call already delivered. buffer opened with
+			// the previous remainder, so clamp to io.Writer's contract:
+			// 0 <= n <= len(payload).
+			writer.remainder = append([]byte(nil), buffer...)
+			consumed := len(payload) - len(buffer)
+			if consumed < 0 {
+				consumed = 0
+			}
 			return consumed, writeError
 		}
 	}
 	writer.remainder = append([]byte(nil), buffer...)
-	return consumed, nil
+	return len(payload), nil
 }
 
 // Flush emits a trailing partial line, which a stream that ended without a

--- a/cmd/cluster_top.go
+++ b/cmd/cluster_top.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	"ankra/internal/client"
@@ -486,8 +487,11 @@ func parseKubernetesQuantity(raw string) (float64, bool) {
 }
 
 func parseQuantityNumber(digits string, multiplier float64) (float64, bool) {
-	var parsed float64
-	if _, scanError := fmt.Sscanf(strings.TrimSpace(digits), "%g", &parsed); scanError != nil {
+	// ParseFloat rather than Sscanf: Sscanf("%g") stops at the first
+	// character it cannot use and reports success, so "12abc" would read as
+	// 12 and a malformed quantity would render as a plausible measurement.
+	parsed, parseError := strconv.ParseFloat(strings.TrimSpace(digits), 64)
+	if parseError != nil {
 		return 0, false
 	}
 	return parsed * multiplier, true

--- a/cmd/cluster_top.go
+++ b/cmd/cluster_top.go
@@ -1,0 +1,509 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// The metrics API is aggregated by metrics-server and is not part of the
+// platform's Kubernetes cache: a measurement is only meaningful live. Its
+// plurals also do not follow the kind (PodMetrics is served as "pods"), so
+// the resource is stated explicitly instead of derived.
+const (
+	metricsAPIGroup   = "metrics.k8s.io"
+	metricsAPIVersion = "v1beta1"
+)
+
+// metricsUnavailableHint is the guidance printed when the cluster answers
+// with no metrics objects, which almost always means metrics-server is not
+// installed rather than that nothing is running.
+const metricsUnavailableHint = "No live metrics returned. metrics-server provides this API; " +
+	"install it (or check that it is healthy) before using 'cluster top'. " +
+	"For historical usage from Prometheus, use 'ankra cluster metrics'."
+
+var clusterTopCmd = &cobra.Command{
+	Use:   "top",
+	Short: "Show live CPU and memory usage from the metrics API",
+	Long: `Show live resource usage measured by metrics-server.
+
+This is the "which container just got OOMKilled" view. It reads the
+aggregated metrics API directly, so it works on clusters where Prometheus
+was never installed. For trends over time use 'ankra cluster metrics',
+which queries Prometheus.`,
+	Annotations: map[string]string{"group": "kubernetes"},
+}
+
+var clusterTopPodsCmd = &cobra.Command{
+	Use:   "pods",
+	Short: "Show live CPU and memory usage per pod",
+	Long: `Show live CPU and memory usage per pod, measured by metrics-server.
+
+Examples:
+  ankra cluster top pods -n default
+  ankra cluster top pods --all-namespaces --sort-by memory
+  ankra cluster top pods -n default --containers
+  ankra cluster top pods --all-namespaces -o json`,
+	Args:        cobra.NoArgs,
+	Annotations: map[string]string{"group": "kubernetes"},
+	RunE:        runTopPods,
+}
+
+var clusterTopNodesCmd = &cobra.Command{
+	Use:   "nodes",
+	Short: "Show live CPU and memory usage per node",
+	Long: `Show live CPU and memory usage per node, measured by metrics-server.
+
+Percentages are computed against each node's allocatable capacity. If the
+node list cannot be read the percentage columns are omitted rather than
+guessed.
+
+Examples:
+  ankra cluster top nodes
+  ankra cluster top nodes --sort-by cpu
+  ankra cluster top nodes -o json`,
+	Args:        cobra.NoArgs,
+	Annotations: map[string]string{"group": "kubernetes"},
+	RunE:        runTopNodes,
+}
+
+func runTopPods(cmd *cobra.Command, _ []string) error {
+	outputFormat, _ := cmd.Flags().GetString("output")
+	if err := validateK8sOutputFormat(outputFormat); err != nil {
+		return err
+	}
+	sortBy, _ := cmd.Flags().GetString("sort-by")
+	if err := validateTopSortBy(sortBy); err != nil {
+		return err
+	}
+	namespace, _ := cmd.Flags().GetString("namespace")
+	allNamespaces, _ := cmd.Flags().GetBool("all-namespaces")
+	showContainers, _ := cmd.Flags().GetBool("containers")
+	if allNamespaces {
+		namespace = ""
+	}
+
+	cluster, clusterError := resolveActiveCluster(cmd)
+	if clusterError != nil {
+		return clusterError
+	}
+	items, fetchError := fetchLiveMetrics(cluster.ID, "PodMetrics", "pods", namespace)
+	if fetchError != nil {
+		return fetchError
+	}
+	if handled, structuredError := renderStructuredMetrics(items, outputFormat); handled {
+		return structuredError
+	}
+	if len(items) == 0 {
+		fmt.Println(metricsUnavailableHint)
+		return nil
+	}
+
+	if showContainers {
+		renderContainerUsageTable(items, sortBy)
+		return nil
+	}
+	renderPodUsageTable(items, sortBy)
+	return nil
+}
+
+func runTopNodes(cmd *cobra.Command, _ []string) error {
+	outputFormat, _ := cmd.Flags().GetString("output")
+	if err := validateK8sOutputFormat(outputFormat); err != nil {
+		return err
+	}
+	sortBy, _ := cmd.Flags().GetString("sort-by")
+	if err := validateTopSortBy(sortBy); err != nil {
+		return err
+	}
+
+	cluster, clusterError := resolveActiveCluster(cmd)
+	if clusterError != nil {
+		return clusterError
+	}
+	items, fetchError := fetchLiveMetrics(cluster.ID, "NodeMetrics", "nodes", "")
+	if fetchError != nil {
+		return fetchError
+	}
+	if handled, structuredError := renderStructuredMetrics(items, outputFormat); handled {
+		return structuredError
+	}
+	if len(items) == 0 {
+		fmt.Println(metricsUnavailableHint)
+		return nil
+	}
+	renderNodeUsageTable(items, nodeAllocatable(cluster.ID), sortBy)
+	return nil
+}
+
+func validateTopSortBy(sortBy string) error {
+	switch sortBy {
+	case "", "name", "cpu", "memory":
+		return nil
+	default:
+		return withExitCode(exitUsage, fmt.Errorf(
+			"unsupported --sort-by %q: use name, cpu or memory", sortBy))
+	}
+}
+
+// renderStructuredMetrics writes the -o json|yaml form. handled reports
+// that the command is finished.
+func renderStructuredMetrics(items []map[string]interface{}, outputFormat string) (bool, error) {
+	switch outputFormat {
+	case "json":
+		encoded, marshalError := json.MarshalIndent(items, "", "  ")
+		if marshalError != nil {
+			return true, fmt.Errorf("marshalling to JSON: %w", marshalError)
+		}
+		fmt.Println(string(encoded))
+		return true, nil
+	case "yaml":
+		encoded, marshalError := yaml.Marshal(items)
+		if marshalError != nil {
+			return true, fmt.Errorf("marshalling to YAML: %w", marshalError)
+		}
+		fmt.Print(string(encoded))
+		return true, nil
+	}
+	return false, nil
+}
+
+// fetchLiveMetrics reads the aggregated metrics API. skip_cache keeps the
+// platform from answering out of its Kubernetes cache, which is keyed by
+// plural and would hand back plain Pods or Nodes for these requests; a
+// cached answer that arrives anyway (the platform degrades to stale cache
+// when a cluster is offline) is refused rather than rendered as a live
+// measurement.
+func fetchLiveMetrics(clusterID string, kind string, resource string, namespace string) ([]map[string]interface{}, error) {
+	request := client.ResourceRequestItem{
+		Kind:     kind,
+		Group:    metricsAPIGroup,
+		Version:  metricsAPIVersion,
+		Resource: resource,
+	}
+	if namespace != "" {
+		request.Namespace = namespace
+	}
+	response, requestError := apiClient.GetResources(clusterID, client.GetResourcesRequest{
+		ResourceRequests: []client.ResourceRequestItem{request},
+		SkipCache:        true,
+	})
+	if requestError != nil {
+		return nil, requestError
+	}
+	if len(response.ResourceResponses) == 0 {
+		return nil, nil
+	}
+	responseItem := response.ResourceResponses[0]
+	if responseItem.CacheMetadata != nil {
+		return nil, fmt.Errorf(
+			"live metrics unavailable: the platform answered from its cached inventory (%s). "+
+				"Check that the cluster is online and its agent is connected",
+			responseItem.CacheMetadata.SyncStatus)
+	}
+	measurements := make([]map[string]interface{}, 0, len(responseItem.Items))
+	for _, item := range responseItem.Items {
+		measurement, isMap := item.(map[string]interface{})
+		if !isMap {
+			continue
+		}
+		// A cached Pod and a PodMetrics both carry metadata.name; only the
+		// measurement carries usage, so that is the discriminator.
+		if !hasUsageMeasurement(measurement) {
+			continue
+		}
+		measurements = append(measurements, measurement)
+	}
+	return measurements, nil
+}
+
+func hasUsageMeasurement(measurement map[string]interface{}) bool {
+	if _, hasUsage := getNestedMap(measurement, "usage"); hasUsage {
+		return true
+	}
+	containers, isList := measurement["containers"].([]interface{})
+	return isList && len(containers) > 0
+}
+
+// podUsage totals a PodMetrics across its containers.
+func podUsage(measurement map[string]interface{}) (int64, int64) {
+	var cpuNanocores int64
+	var memoryBytes int64
+	containers, isList := measurement["containers"].([]interface{})
+	if !isList {
+		return 0, 0
+	}
+	for _, rawContainer := range containers {
+		container, isMap := rawContainer.(map[string]interface{})
+		if !isMap {
+			continue
+		}
+		containerCPU, containerMemory := usageQuantities(container)
+		cpuNanocores += containerCPU
+		memoryBytes += containerMemory
+	}
+	return cpuNanocores, memoryBytes
+}
+
+// usageQuantities reads the usage block of a metrics object, returning CPU
+// in nanocores and memory in bytes.
+func usageQuantities(object map[string]interface{}) (int64, int64) {
+	usage, hasUsage := getNestedMap(object, "usage")
+	if !hasUsage {
+		return 0, 0
+	}
+	cpuNanocores, _ := parseKubernetesQuantity(fmt.Sprintf("%v", usage["cpu"]))
+	memoryBytes, _ := parseKubernetesQuantity(fmt.Sprintf("%v", usage["memory"]))
+	// CPU quantities are cores; nanocores keeps the millicore rendering
+	// exact for the "123456789n" values metrics-server emits.
+	return int64(cpuNanocores * 1e9), int64(memoryBytes)
+}
+
+type usageRow struct {
+	name         string
+	namespace    string
+	container    string
+	cpuNanocores int64
+	memoryBytes  int64
+	cpuCapacity  int64
+	memCapacity  int64
+	hasCapacity  bool
+}
+
+func sortUsageRows(rows []usageRow, sortBy string) {
+	switch sortBy {
+	case "cpu":
+		sort.SliceStable(rows, func(first int, second int) bool {
+			return rows[first].cpuNanocores > rows[second].cpuNanocores
+		})
+	case "memory":
+		sort.SliceStable(rows, func(first int, second int) bool {
+			return rows[first].memoryBytes > rows[second].memoryBytes
+		})
+	default:
+		sort.SliceStable(rows, func(first int, second int) bool {
+			if rows[first].namespace != rows[second].namespace {
+				return rows[first].namespace < rows[second].namespace
+			}
+			if rows[first].name != rows[second].name {
+				return rows[first].name < rows[second].name
+			}
+			return rows[first].container < rows[second].container
+		})
+	}
+}
+
+func renderPodUsageTable(items []map[string]interface{}, sortBy string) {
+	rows := make([]usageRow, 0, len(items))
+	for _, measurement := range items {
+		cpuNanocores, memoryBytes := podUsage(measurement)
+		rows = append(rows, usageRow{
+			name:         getNestedString(measurement, "metadata", "name"),
+			namespace:    getNestedString(measurement, "metadata", "namespace"),
+			cpuNanocores: cpuNanocores,
+			memoryBytes:  memoryBytes,
+		})
+	}
+	sortUsageRows(rows, sortBy)
+
+	usageTable := table.NewWriter()
+	usageTable.SetOutputMirror(os.Stdout)
+	usageTable.SetStyle(table.StyleRounded)
+	usageTable.AppendHeader(table.Row{"Name", "Namespace", "CPU", "Memory"})
+	for _, row := range rows {
+		usageTable.AppendRow(table.Row{
+			row.name, row.namespace,
+			formatMillicores(row.cpuNanocores),
+			formatMebibytes(row.memoryBytes),
+		})
+	}
+	usageTable.Render()
+}
+
+func renderContainerUsageTable(items []map[string]interface{}, sortBy string) {
+	rows := []usageRow{}
+	for _, measurement := range items {
+		containers, isList := measurement["containers"].([]interface{})
+		if !isList {
+			continue
+		}
+		for _, rawContainer := range containers {
+			container, isMap := rawContainer.(map[string]interface{})
+			if !isMap {
+				continue
+			}
+			cpuNanocores, memoryBytes := usageQuantities(container)
+			rows = append(rows, usageRow{
+				name:         getNestedString(measurement, "metadata", "name"),
+				namespace:    getNestedString(measurement, "metadata", "namespace"),
+				container:    getNestedString(container, "name"),
+				cpuNanocores: cpuNanocores,
+				memoryBytes:  memoryBytes,
+			})
+		}
+	}
+	sortUsageRows(rows, sortBy)
+
+	usageTable := table.NewWriter()
+	usageTable.SetOutputMirror(os.Stdout)
+	usageTable.SetStyle(table.StyleRounded)
+	usageTable.AppendHeader(table.Row{"Pod", "Namespace", "Container", "CPU", "Memory"})
+	for _, row := range rows {
+		usageTable.AppendRow(table.Row{
+			row.name, row.namespace, row.container,
+			formatMillicores(row.cpuNanocores),
+			formatMebibytes(row.memoryBytes),
+		})
+	}
+	usageTable.Render()
+}
+
+func renderNodeUsageTable(items []map[string]interface{}, capacity map[string]nodeCapacity, sortBy string) {
+	rows := make([]usageRow, 0, len(items))
+	for _, measurement := range items {
+		cpuNanocores, memoryBytes := usageQuantities(measurement)
+		name := getNestedString(measurement, "metadata", "name")
+		row := usageRow{name: name, cpuNanocores: cpuNanocores, memoryBytes: memoryBytes}
+		if allocatable, isKnown := capacity[name]; isKnown {
+			row.cpuCapacity = allocatable.cpuNanocores
+			row.memCapacity = allocatable.memoryBytes
+			row.hasCapacity = true
+		}
+		rows = append(rows, row)
+	}
+	sortUsageRows(rows, sortBy)
+
+	usageTable := table.NewWriter()
+	usageTable.SetOutputMirror(os.Stdout)
+	usageTable.SetStyle(table.StyleRounded)
+	usageTable.AppendHeader(table.Row{"Name", "CPU", "CPU %", "Memory", "Memory %"})
+	for _, row := range rows {
+		usageTable.AppendRow(table.Row{
+			row.name,
+			formatMillicores(row.cpuNanocores),
+			formatUsagePercent(row.cpuNanocores, row.cpuCapacity, row.hasCapacity),
+			formatMebibytes(row.memoryBytes),
+			formatUsagePercent(row.memoryBytes, row.memCapacity, row.hasCapacity),
+		})
+	}
+	usageTable.Render()
+}
+
+type nodeCapacity struct {
+	cpuNanocores int64
+	memoryBytes  int64
+}
+
+// nodeAllocatable reads each node's allocatable capacity so the node view
+// can show percentages. A failure here is not fatal: the percentage columns
+// render as "-" rather than the command failing over a decoration.
+func nodeAllocatable(clusterID string) map[string]nodeCapacity {
+	capacities := map[string]nodeCapacity{}
+	response, requestError := apiClient.GetResources(clusterID, client.GetResourcesRequest{
+		ResourceRequests: []client.ResourceRequestItem{{Kind: "Node", Version: "v1"}},
+	})
+	if requestError != nil || len(response.ResourceResponses) == 0 {
+		return capacities
+	}
+	for _, item := range response.ResourceResponses[0].Items {
+		node, isMap := item.(map[string]interface{})
+		if !isMap {
+			continue
+		}
+		allocatable, hasAllocatable := getNestedMap(node, "status")
+		if !hasAllocatable {
+			continue
+		}
+		quantities, isMap := allocatable["allocatable"].(map[string]interface{})
+		if !isMap {
+			continue
+		}
+		cpuCores, cpuOK := parseKubernetesQuantity(fmt.Sprintf("%v", quantities["cpu"]))
+		memoryBytes, memoryOK := parseKubernetesQuantity(fmt.Sprintf("%v", quantities["memory"]))
+		if !cpuOK || !memoryOK {
+			continue
+		}
+		capacities[getNestedString(node, "metadata", "name")] = nodeCapacity{
+			cpuNanocores: int64(cpuCores * 1e9),
+			memoryBytes:  int64(memoryBytes),
+		}
+	}
+	return capacities
+}
+
+func formatMillicores(cpuNanocores int64) string {
+	return fmt.Sprintf("%dm", cpuNanocores/1_000_000)
+}
+
+func formatMebibytes(memoryBytes int64) string {
+	return fmt.Sprintf("%dMi", memoryBytes/(1024*1024))
+}
+
+func formatUsagePercent(used int64, capacity int64, hasCapacity bool) string {
+	if !hasCapacity || capacity <= 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%d%%", used*100/capacity)
+}
+
+// parseKubernetesQuantity converts the resource.Quantity spellings the
+// metrics and node APIs emit into a plain number - cores for CPU, bytes for
+// memory. It covers the decimal SI and binary suffixes plus the "n"/"u"/"m"
+// sub-unit suffixes metrics-server uses; anything else reports false rather
+// than silently reading as zero.
+func parseKubernetesQuantity(raw string) (float64, bool) {
+	value := strings.TrimSpace(raw)
+	if value == "" || value == "<nil>" {
+		return 0, false
+	}
+	binarySuffixes := map[string]float64{
+		"Ki": 1 << 10, "Mi": 1 << 20, "Gi": 1 << 30,
+		"Ti": 1 << 40, "Pi": 1 << 50, "Ei": 1 << 60,
+	}
+	for suffix, multiplier := range binarySuffixes {
+		if strings.HasSuffix(value, suffix) {
+			return parseQuantityNumber(strings.TrimSuffix(value, suffix), multiplier)
+		}
+	}
+	decimalSuffixes := map[string]float64{
+		"n": 1e-9, "u": 1e-6, "m": 1e-3,
+		"k": 1e3, "M": 1e6, "G": 1e9,
+		"T": 1e12, "P": 1e15, "E": 1e18,
+	}
+	lastCharacter := value[len(value)-1:]
+	if multiplier, isSuffix := decimalSuffixes[lastCharacter]; isSuffix {
+		return parseQuantityNumber(value[:len(value)-1], multiplier)
+	}
+	return parseQuantityNumber(value, 1)
+}
+
+func parseQuantityNumber(digits string, multiplier float64) (float64, bool) {
+	var parsed float64
+	if _, scanError := fmt.Sscanf(strings.TrimSpace(digits), "%g", &parsed); scanError != nil {
+		return 0, false
+	}
+	return parsed * multiplier, true
+}
+
+func init() {
+	clusterTopPodsCmd.Flags().StringP("namespace", "n", "", "Kubernetes namespace")
+	clusterTopPodsCmd.Flags().BoolP("all-namespaces", "A", false, "Show pods across all namespaces")
+	clusterTopPodsCmd.Flags().Bool("containers", false, "Break usage down per container")
+	clusterTopPodsCmd.Flags().String("sort-by", "name", "Sort by: name, cpu or memory")
+	clusterTopPodsCmd.Flags().StringP("output", "o", "table", "Output format: table, json, yaml")
+
+	clusterTopNodesCmd.Flags().String("sort-by", "name", "Sort by: name, cpu or memory")
+	clusterTopNodesCmd.Flags().StringP("output", "o", "table", "Output format: table, json, yaml")
+
+	clusterTopCmd.AddCommand(clusterTopPodsCmd)
+	clusterTopCmd.AddCommand(clusterTopNodesCmd)
+	clusterCmd.AddCommand(clusterTopCmd)
+}

--- a/cmd/cluster_top.go
+++ b/cmd/cluster_top.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"sort"
 	"strconv"
@@ -47,6 +48,9 @@ var clusterTopPodsCmd = &cobra.Command{
 	Use:   "pods",
 	Short: "Show live CPU and memory usage per pod",
 	Long: `Show live CPU and memory usage per pod, measured by metrics-server.
+
+Without -n or --all-namespaces this reads every namespace, unlike kubectl
+top, which defaults to the current one.
 
 Examples:
   ankra cluster top pods -n default
@@ -201,10 +205,22 @@ func fetchLiveMetrics(clusterID string, kind string, resource string, namespace 
 		return nil, requestError
 	}
 	if len(response.ResourceResponses) == 0 {
-		return nil, nil
+		return []map[string]interface{}{}, nil
 	}
 	responseItem := response.ResourceResponses[0]
+	// Fix 5: an errored response carries no items, which would otherwise be
+	// diagnosed as "metrics-server is not installed" and exit zero. The
+	// platform reports the agent's message here.
+	if responseItem.Status != "" && responseItem.Status != "success" {
+		return nil, fmt.Errorf(
+			"the cluster could not answer the metrics read (status %q): check that metrics-server is healthy and that the agent can reach the aggregated API",
+			responseItem.Status)
+	}
 	if responseItem.CacheMetadata != nil {
+		if responseItem.CacheMetadata.SyncStatus == "sandbox" {
+			return nil, fmt.Errorf(
+				"live metrics are not available on a sandbox cluster: import a real cluster to read the metrics API")
+		}
 		return nil, fmt.Errorf(
 			"live metrics unavailable: the platform answered from its cached inventory (%s). "+
 				"Check that the cluster is online and its agent is connected",
@@ -226,46 +242,74 @@ func fetchLiveMetrics(clusterID string, kind string, resource string, namespace 
 	return measurements, nil
 }
 
+// hasUsageMeasurement distinguishes a metrics object from a plain Pod or
+// Node, which the platform's cache would return for the same request. A
+// NodeMetrics carries usage directly; a PodMetrics carries it per container,
+// and a containers list whose entries have no usage block is not a
+// measurement however much it looks like one.
 func hasUsageMeasurement(measurement map[string]interface{}) bool {
 	if _, hasUsage := getNestedMap(measurement, "usage"); hasUsage {
 		return true
 	}
 	containers, isList := measurement["containers"].([]interface{})
-	return isList && len(containers) > 0
-}
-
-// podUsage totals a PodMetrics across its containers.
-func podUsage(measurement map[string]interface{}) (int64, int64) {
-	var cpuNanocores int64
-	var memoryBytes int64
-	containers, isList := measurement["containers"].([]interface{})
-	if !isList {
-		return 0, 0
+	if !isList || len(containers) == 0 {
+		return false
 	}
 	for _, rawContainer := range containers {
 		container, isMap := rawContainer.(map[string]interface{})
 		if !isMap {
-			continue
+			return false
 		}
-		containerCPU, containerMemory := usageQuantities(container)
+		if _, hasUsage := getNestedMap(container, "usage"); !hasUsage {
+			return false
+		}
+	}
+	return true
+}
+
+// podUsage totals a PodMetrics across its containers. isMeasured is false if
+// any container's usage failed to parse: a partial total would under-report
+// the pod while looking like a real measurement.
+func podUsage(measurement map[string]interface{}) (int64, int64, bool) {
+	containers, isList := measurement["containers"].([]interface{})
+	if !isList || len(containers) == 0 {
+		return 0, 0, false
+	}
+	var cpuNanocores int64
+	var memoryBytes int64
+	for _, rawContainer := range containers {
+		container, isMap := rawContainer.(map[string]interface{})
+		if !isMap {
+			return 0, 0, false
+		}
+		containerCPU, containerMemory, isContainerMeasured := usageQuantities(container)
+		if !isContainerMeasured {
+			return 0, 0, false
+		}
 		cpuNanocores += containerCPU
 		memoryBytes += containerMemory
 	}
-	return cpuNanocores, memoryBytes
+	return cpuNanocores, memoryBytes, true
 }
 
 // usageQuantities reads the usage block of a metrics object, returning CPU
-// in nanocores and memory in bytes.
-func usageQuantities(object map[string]interface{}) (int64, int64) {
+// in nanocores and memory in bytes. isMeasured is false when either quantity
+// is missing or unparseable, so the caller renders "-" rather than a
+// confident zero that is indistinguishable from an idle container.
+func usageQuantities(object map[string]interface{}) (int64, int64, bool) {
 	usage, hasUsage := getNestedMap(object, "usage")
 	if !hasUsage {
-		return 0, 0
+		return 0, 0, false
 	}
-	cpuNanocores, _ := parseKubernetesQuantity(fmt.Sprintf("%v", usage["cpu"]))
-	memoryBytes, _ := parseKubernetesQuantity(fmt.Sprintf("%v", usage["memory"]))
+	cpuCores, isCPUParsed := parseKubernetesQuantity(fmt.Sprintf("%v", usage["cpu"]))
+	memoryBytes, isMemoryParsed := parseKubernetesQuantity(fmt.Sprintf("%v", usage["memory"]))
+	if !isCPUParsed || !isMemoryParsed {
+		return 0, 0, false
+	}
 	// CPU quantities are cores; nanocores keeps the millicore rendering
-	// exact for the "123456789n" values metrics-server emits.
-	return int64(cpuNanocores * 1e9), int64(memoryBytes)
+	// exact for the "123456789n" values metrics-server emits. Round rather
+	// than truncate so "100u" is 100000n, not 99999n.
+	return int64(math.Round(cpuCores * 1e9)), int64(math.Round(memoryBytes)), true
 }
 
 type usageRow struct {
@@ -274,9 +318,19 @@ type usageRow struct {
 	container    string
 	cpuNanocores int64
 	memoryBytes  int64
+	isMeasured   bool
 	cpuCapacity  int64
 	memCapacity  int64
 	hasCapacity  bool
+}
+
+// formatUsage renders a measurement, or "-" when the cluster did not give one
+// that parses. A zero would read as an idle container.
+func formatUsage(value int64, isMeasured bool, render func(int64) string) string {
+	if !isMeasured {
+		return "-"
+	}
+	return render(value)
 }
 
 func sortUsageRows(rows []usageRow, sortBy string) {
@@ -305,12 +359,13 @@ func sortUsageRows(rows []usageRow, sortBy string) {
 func renderPodUsageTable(items []map[string]interface{}, sortBy string) {
 	rows := make([]usageRow, 0, len(items))
 	for _, measurement := range items {
-		cpuNanocores, memoryBytes := podUsage(measurement)
+		cpuNanocores, memoryBytes, isMeasured := podUsage(measurement)
 		rows = append(rows, usageRow{
 			name:         getNestedString(measurement, "metadata", "name"),
 			namespace:    getNestedString(measurement, "metadata", "namespace"),
 			cpuNanocores: cpuNanocores,
 			memoryBytes:  memoryBytes,
+			isMeasured:   isMeasured,
 		})
 	}
 	sortUsageRows(rows, sortBy)
@@ -322,8 +377,8 @@ func renderPodUsageTable(items []map[string]interface{}, sortBy string) {
 	for _, row := range rows {
 		usageTable.AppendRow(table.Row{
 			row.name, row.namespace,
-			formatMillicores(row.cpuNanocores),
-			formatMebibytes(row.memoryBytes),
+			formatUsage(row.cpuNanocores, row.isMeasured, formatMillicores),
+			formatUsage(row.memoryBytes, row.isMeasured, formatMebibytes),
 		})
 	}
 	usageTable.Render()
@@ -341,13 +396,14 @@ func renderContainerUsageTable(items []map[string]interface{}, sortBy string) {
 			if !isMap {
 				continue
 			}
-			cpuNanocores, memoryBytes := usageQuantities(container)
+			cpuNanocores, memoryBytes, isMeasured := usageQuantities(container)
 			rows = append(rows, usageRow{
 				name:         getNestedString(measurement, "metadata", "name"),
 				namespace:    getNestedString(measurement, "metadata", "namespace"),
 				container:    getNestedString(container, "name"),
 				cpuNanocores: cpuNanocores,
 				memoryBytes:  memoryBytes,
+				isMeasured:   isMeasured,
 			})
 		}
 	}
@@ -360,8 +416,8 @@ func renderContainerUsageTable(items []map[string]interface{}, sortBy string) {
 	for _, row := range rows {
 		usageTable.AppendRow(table.Row{
 			row.name, row.namespace, row.container,
-			formatMillicores(row.cpuNanocores),
-			formatMebibytes(row.memoryBytes),
+			formatUsage(row.cpuNanocores, row.isMeasured, formatMillicores),
+			formatUsage(row.memoryBytes, row.isMeasured, formatMebibytes),
 		})
 	}
 	usageTable.Render()
@@ -370,9 +426,12 @@ func renderContainerUsageTable(items []map[string]interface{}, sortBy string) {
 func renderNodeUsageTable(items []map[string]interface{}, capacity map[string]nodeCapacity, sortBy string) {
 	rows := make([]usageRow, 0, len(items))
 	for _, measurement := range items {
-		cpuNanocores, memoryBytes := usageQuantities(measurement)
+		cpuNanocores, memoryBytes, isMeasured := usageQuantities(measurement)
 		name := getNestedString(measurement, "metadata", "name")
-		row := usageRow{name: name, cpuNanocores: cpuNanocores, memoryBytes: memoryBytes}
+		row := usageRow{
+			name: name, cpuNanocores: cpuNanocores,
+			memoryBytes: memoryBytes, isMeasured: isMeasured,
+		}
 		if allocatable, isKnown := capacity[name]; isKnown {
 			row.cpuCapacity = allocatable.cpuNanocores
 			row.memCapacity = allocatable.memoryBytes
@@ -389,10 +448,10 @@ func renderNodeUsageTable(items []map[string]interface{}, capacity map[string]no
 	for _, row := range rows {
 		usageTable.AppendRow(table.Row{
 			row.name,
-			formatMillicores(row.cpuNanocores),
-			formatUsagePercent(row.cpuNanocores, row.cpuCapacity, row.hasCapacity),
-			formatMebibytes(row.memoryBytes),
-			formatUsagePercent(row.memoryBytes, row.memCapacity, row.hasCapacity),
+			formatUsage(row.cpuNanocores, row.isMeasured, formatMillicores),
+			formatUsagePercent(row.cpuNanocores, row.cpuCapacity, row.hasCapacity && row.isMeasured),
+			formatUsage(row.memoryBytes, row.isMeasured, formatMebibytes),
+			formatUsagePercent(row.memoryBytes, row.memCapacity, row.hasCapacity && row.isMeasured),
 		})
 	}
 	usageTable.Render()
@@ -433,8 +492,8 @@ func nodeAllocatable(clusterID string) map[string]nodeCapacity {
 			continue
 		}
 		capacities[getNestedString(node, "metadata", "name")] = nodeCapacity{
-			cpuNanocores: int64(cpuCores * 1e9),
-			memoryBytes:  int64(memoryBytes),
+			cpuNanocores: int64(math.Round(cpuCores * 1e9)),
+			memoryBytes:  int64(math.Round(memoryBytes)),
 		}
 	}
 	return capacities
@@ -491,7 +550,7 @@ func parseQuantityNumber(digits string, multiplier float64) (float64, bool) {
 	// character it cannot use and reports success, so "12abc" would read as
 	// 12 and a malformed quantity would render as a plausible measurement.
 	parsed, parseError := strconv.ParseFloat(strings.TrimSpace(digits), 64)
-	if parseError != nil {
+	if parseError != nil || math.IsInf(parsed, 0) || math.IsNaN(parsed) {
 		return 0, false
 	}
 	return parsed * multiplier, true

--- a/cmd/cluster_top.go
+++ b/cmd/cluster_top.go
@@ -216,6 +216,11 @@ func fetchLiveMetrics(clusterID string, kind string, resource string, namespace 
 			"the cluster could not answer the metrics read (status %q): check that metrics-server is healthy and that the agent can reach the aggregated API",
 			responseItem.Status)
 	}
+	// Deliberately the pointer, not CacheMetadata.ServedFromCache: the
+	// platform attaches cache metadata on three paths, and the sandbox one
+	// sets ServedFromCache false while still returning synthesised objects.
+	// Gating on the flag would let a sandbox cluster's fabricated pods render
+	// as live measurements.
 	if responseItem.CacheMetadata != nil {
 		if responseItem.CacheMetadata.SyncStatus == "sandbox" {
 			return nil, fmt.Errorf(
@@ -465,12 +470,22 @@ type nodeCapacity struct {
 // nodeAllocatable reads each node's allocatable capacity so the node view
 // can show percentages. A failure here is not fatal: the percentage columns
 // render as "-" rather than the command failing over a decoration.
+//
+// Nodes are one of the kinds the platform keeps in its resource cache, so
+// this read has to ask for a live answer explicitly - otherwise a percentage
+// would pair a live measurement with a cached capacity, which is the kind of
+// half-fresh number that reads as authoritative and is not. A cached answer
+// arriving anyway drops the capacities, and the column renders "-".
 func nodeAllocatable(clusterID string) map[string]nodeCapacity {
 	capacities := map[string]nodeCapacity{}
 	response, requestError := apiClient.GetResources(clusterID, client.GetResourcesRequest{
 		ResourceRequests: []client.ResourceRequestItem{{Kind: "Node", Version: "v1"}},
+		SkipCache:        true,
 	})
 	if requestError != nil || len(response.ResourceResponses) == 0 {
+		return capacities
+	}
+	if response.ResourceResponses[0].CacheMetadata != nil {
 		return capacities
 	}
 	for _, item := range response.ResourceResponses[0].Items {

--- a/internal/client/kubernetes.go
+++ b/internal/client/kubernetes.go
@@ -91,10 +91,15 @@ type FieldSelector struct {
 }
 
 type ResourceRequestItem struct {
-	Kind           string          `json:"kind"`
-	Namespace      string          `json:"namespace,omitempty"`
-	Name           string          `json:"name,omitempty"`
-	Group          string          `json:"group,omitempty"`
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Group     string `json:"group,omitempty"`
+	// Resource is the API plural. The backend derives one from Kind when
+	// this is empty, and that derivation is wrong for the aggregated
+	// metrics API (PodMetrics is served as "pods", not "podmetricses"), so
+	// callers outside the ordinary kinds send it explicitly.
+	Resource       string          `json:"resource,omitempty"`
 	Version        string          `json:"version"`
 	LabelSelector  string          `json:"label_selector,omitempty"`
 	FieldSelectors []FieldSelector `json:"field_selectors,omitempty"`
@@ -105,15 +110,29 @@ type GetResourcesRequest struct {
 	SkipCache        bool                  `json:"skip_cache"`
 }
 
+// ResourceCacheMetadata is present only when the platform answered from its
+// Kubernetes cache instead of the live cluster. Reads that are only correct
+// live - the aggregated metrics API above all - must refuse a cached answer
+// rather than render yesterday's objects as today's measurements.
+type ResourceCacheMetadata struct {
+	ServedFromCache  bool    `json:"served_from_cache"`
+	StalenessSeconds int     `json:"staleness_seconds"`
+	SyncStatus       string  `json:"sync_status"`
+	Warning          *string `json:"warning"`
+	IsDeleted        bool    `json:"is_deleted"`
+	DeletedAt        *string `json:"deleted_at"`
+}
+
 type ResourceResponseItem struct {
-	Status     string        `json:"status"`
-	Group      *string       `json:"group"`
-	Items      []interface{} `json:"items"`
-	Kind       string        `json:"kind"`
-	Name       *string       `json:"name"`
-	Namespace  *string       `json:"namespace"`
-	Version    string        `json:"version"`
-	TotalCount *int          `json:"total_count"`
+	Status        string                 `json:"status"`
+	Group         *string                `json:"group"`
+	Items         []interface{}          `json:"items"`
+	Kind          string                 `json:"kind"`
+	Name          *string                `json:"name"`
+	Namespace     *string                `json:"namespace"`
+	Version       string                 `json:"version"`
+	TotalCount    *int                   `json:"total_count"`
+	CacheMetadata *ResourceCacheMetadata `json:"cache_metadata"`
 }
 
 type GetResourcesResponse struct {
@@ -173,6 +192,15 @@ type PodLogOptions struct {
 	// first batch, or the server's keepalive comment, which it only sends
 	// once it has nothing buffered.
 	Follow bool
+	// Previous reads the log of the container instance that terminated
+	// (kubectl logs --previous) - the only readable output of a container
+	// stuck in CrashLoopBackOff. The terminated log is closed, so the
+	// platform bounds the read regardless of Follow. A platform or agent
+	// that predates the parameter ignores it and serves the current
+	// container instead, which is why the CLI states the requirement in
+	// its help rather than silently presenting the wrong log as the right
+	// one.
+	Previous bool
 }
 
 // podLogsDrainIdle is how long a non-follow read waits for another line
@@ -197,6 +225,14 @@ func (c *Client) StreamPodLogs(ctx context.Context, clusterID string, opts PodLo
 		// The route defaults to follow=true; only the bounded read has to
 		// say so, which keeps the following request byte-identical to what
 		// every released CLI has always sent.
+		params.Set("follow", "false")
+	}
+	if opts.Previous {
+		params.Set("previous", "true")
+		// The route bounds a previous read whatever follow says, so the
+		// client has to take the drain path or it would sit waiting on a
+		// stream the server already closed.
+		opts.Follow = false
 		params.Set("follow", "false")
 	}
 


### PR DESCRIPTION
Bead: ankra-ymkj8.1 · Linear PLA-769 · Ankra ticket #1077 (Smartoptics)

## Why

Smartoptics' report, in one line: *"the CLI can now see almost everything in a cluster but it cannot ACT inside a running container, and it cannot read the one log that matters when a pod is crash-looping. Every real debugging session therefore ends in `cluster access grant` + kubectl through the kube gateway."*

That trade is bad in both directions — it hands out broader standing access than the task needs, and it moves the work outside the record Ankra keeps of everything else. This PR ships items 1, 3, 4, 5 and 7 of their priority list. All five are read-only and all five run on the existing organisation-scoped `/kubernetes` surface: **no grant, no new route, no widened privilege**.

## What is new

### `cluster logs --previous` (`-p`)

Reads the log of the container instance that terminated. For a pod in `CrashLoopBackOff` that is the only output with the failure in it.

Because that log is closed, `--previous` is always a bounded read — it prints and exits rather than parking on a stream that can never produce another line. Needs the platform and agent sides (ankraio/cluster#1621, ankraio/agent#77); an older agent serves the current container's log, which is why the flag help says so rather than the CLI presenting the wrong log as the right one.

### `cluster logs -l <selector>` and `--all-containers`

A three-replica Deployment used to mean listing pods to learn the hashed names, then three separate invocations. Now one selector reads them all, and `--all-containers` expands each pod to every container it declares — **init and ephemeral containers included**, which is where a stuck pod's real error usually is.

With more than one target each line is prefixed `[pod]` or `[pod/container]`, written through a mutex so two replicas cannot interleave inside a single line. A *following* read is capped at 5 concurrent streams (kubectl's `--max-log-requests` default): each target is one long-lived HTTP stream on the platform and one follow on the agent, so an unbounded selector match would otherwise open a connection per replica. Over the cap it is a usage error telling you to narrow the selector or pass `--follow=false`, not a silent truncation.

### `cluster describe <kind> <name>`

Conditions, a pod's per-container state with the detail that explains it (`CrashLoopBackOff` + exit code, `ImagePullBackOff` + registry error, restart counts, last state), and the events whose `involvedObject` is that resource — one call instead of three.

This is **not** a `kubectl describe` clone and does not claim to be: a faithful clone is a per-kind renderer for every kind in the API. It is the generic subset that answers "why is this not ready?", which is what the ticket asked for. `-o json|yaml` emits `{object, events}` so nothing is lost to the rendering.

Kubectl's spellings resolve (`pod` / `pods` / `po` / `Pod`), and anything outside the built-in table is reachable with `--group` / `--api-version` — an unknown kind with neither is a usage error listing the known kinds rather than an empty result you have to interpret.

### `cluster events --for <kind>/<name>`

Mounted at both `cluster events` and `cluster get events`, from one implementation. `--for` scopes by `involvedObject.kind` / `.name` / `.namespace` using **server-side field selectors**, not a substring filter — so a pod whose name is a prefix of another pod's name is not conflated with it. `--type Normal|Warning` narrows further. The old `--name` and `-l` flags on `get events` still work.

### `cluster top pods|nodes`

Live CPU and memory from the aggregated metrics API, so it answers "which container just got OOMKilled" on clusters that never installed Prometheus. `top pods` takes `--containers` and `--sort-by cpu|memory`; `top nodes` shows usage against each node's allocatable capacity.

**The trap this had to avoid.** Ankra's resource cache is keyed by API *plural*, and `PodMetrics` is served as `pods` — so a naive metrics read comes back from the cache as a list of plain `Pod` objects with the request's `kind: PodMetrics` echoed on the envelope. Rendering those as measurements would be silently, confidently wrong. So the read sets `skip_cache`, and the two remaining ways a cached answer can arrive are both refused rather than rendered: a non-nil `cache_metadata` (the platform degrades to stale cache when a cluster is offline) errors naming the cache state, and any item without a `usage`/`containers` block is dropped. Empty results print the metrics-server hint instead of an empty table.

## Cross-cutting

Every new command takes `-o json|yaml` and honours `--cluster`. On `logs`, a structured read must terminate before it can be encoded, so `-o json|yaml` implies a bounded read and an *explicit* `--follow=true` alongside it is a usage error rather than a document that never closes.

Exit codes follow the scripting contract: `exitUsage` for invocation mistakes (validated before any API call), `exitNotFound` for a missing object or a selector matching nothing.

## Tests

34 new tests in `cmd/cluster_debug_verbs_test.go`, covering happy path, failure, empty and rejected-invocation for each verb. The mock records the *requests*, not only the rendering, so the tests pin the things that are invisible in output: that `describe` and `events --for` really send `involvedObject.*` field selectors, that `top` sends `skip_cache` with the explicit `pods`/`nodes` plural, and that `--previous` reaches the platform with `Follow` off.

## Gates

- `make test` (`go test -race -count=1 ./...`) — green
- `make lint` (`golangci-lint run`) — 0 issues
- `make build` — green
- `CHANGELOG.md` `## Unreleased` updated

Note: `tools/gendocs` runs on release tags, so the regenerated reference is not in this PR — it is in the ankra-docs PR alongside the changelog entry.

## Not in this PR

`exec`, `port-forward` and `debug` (ephemeral containers) — items 2, 6 and 8. They execute inside a customer's cluster and need their own authorisation, audit and tracked-operation design; filed separately with design notes rather than half-built here.

## Related

- ankraio/cluster#1621, ankraio/agent#77 — the `previous` parameter
- ankraio/ankra-docs — regenerated reference + changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fvsy6nA4hfm2nMDDCvzHxo
