### PR TITLE
feat(alerts): route kind lists, negation, and a routing preview (ankra-ymkj8.4)

### DIFF
--- a/cmd/alerts_routes.go
+++ b/cmd/alerts_routes.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"ankra/internal/client"
 
@@ -50,10 +51,11 @@ var alertsRoutesListCmd = &cobra.Command{
 		writer.SetStyle(table.StyleRounded)
 		writer.AppendHeader(table.Row{"ID", "Priority", "Kind", "Severity", "Cluster", "Destination", "Mode", "Enabled"})
 		for _, route := range list.Items {
+			routeRow := route
 			writer.AppendRow(table.Row{
 				route.ID,
 				route.Priority,
-				valueOrAny(route.Kind),
+				renderRouteKindFilter(&routeRow),
 				valueOrAny(route.Severity),
 				valueOrAny(route.ClusterID),
 				route.DestinationID,
@@ -84,9 +86,12 @@ notification kinds; severities are critical, warning, and info.
 		if validationError := validateRouteFilterFlags(cmd); validationError != nil {
 			return validationError
 		}
+		kinds, kindsNegated := routeKindFilterFlags(cmd)
 		request := client.CreateNotificationRouteRequest{
 			DestinationID: mustFlagString(cmd, "destination-id"),
 			Kind:          changedStringFlag(cmd, "kind"),
+			Kinds:         kinds,
+			KindsNegated:  kindsNegated,
 			Severity:      changedStringFlag(cmd, "severity"),
 			ClusterID:     changedStringFlag(cmd, "cluster-id"),
 			SourceID:      changedStringFlag(cmd, "source-id"),
@@ -122,9 +127,12 @@ rest keep their current values.
 		if validationError := validateRouteFilterFlags(cmd); validationError != nil {
 			return validationError
 		}
+		kinds, kindsNegated := routeKindFilterFlags(cmd)
 		request := client.UpdateNotificationRouteRequest{
 			DestinationID: changedStringFlag(cmd, "destination-id"),
 			Kind:          changedStringFlag(cmd, "kind"),
+			Kinds:         kinds,
+			KindsNegated:  kindsNegated,
 			Severity:      changedStringFlag(cmd, "severity"),
 			ClusterID:     changedStringFlag(cmd, "cluster-id"),
 			SourceID:      changedStringFlag(cmd, "source-id"),
@@ -133,7 +141,7 @@ rest keep their current values.
 			Mode:          changedStringFlag(cmd, "mode"),
 			Enabled:       enabledFromFlags(cmd),
 		}
-		if request == (client.UpdateNotificationRouteRequest{}) {
+		if isEmptyRouteUpdate(request) {
 			return withExitCode(exitUsage, errors.New("nothing to update: pass at least one flag"))
 		}
 		route, updateError := apiClient.UpdateNotificationRoute(args[0], request)
@@ -188,10 +196,135 @@ queued, not once the receiver has accepted it.`,
 	},
 }
 
+var alertsRoutesPreviewCmd = &cobra.Command{
+	Use:   "preview",
+	Short: "Show which destinations a notification would reach",
+	Long: `Resolve a hypothetical notification against the organisation's routing
+rules and, with --alert-id, that alert's own destinations, and print the
+destinations it would reach with the reason each one matched.
+
+Nothing is delivered and nothing is changed - this is a dry run.
+
+Pass --alert-id whenever you preview an alert firing. A destination reached
+by both the alert's own list and a routing rule is delivered to once, and
+without the alert id the preview cannot tell you which rule that affects.
+
+  ankra alerts routes preview --kind alert_trigger_fired --severity critical
+  ankra alerts routes preview --kind alert_trigger_fired --severity critical --alert-id <alert-id>
+  ankra alerts routes preview --kind gitops_sync_failed --severity warning --cluster-id <cluster-id> -o json`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if validationError := validatePreviewFlags(cmd); validationError != nil {
+			return validationError
+		}
+		preview, previewError := apiClient.PreviewNotificationRoutes(client.PreviewNotificationRoutesRequest{
+			Kind:      mustFlagString(cmd, "kind"),
+			Severity:  mustFlagString(cmd, "severity"),
+			ClusterID: changedStringFlag(cmd, "cluster-id"),
+			SourceID:  changedStringFlag(cmd, "source-id"),
+			AlertID:   changedStringFlag(cmd, "alert-id"),
+		})
+		if previewError != nil {
+			return fmt.Errorf("previewing notification routes: %w", previewError)
+		}
+		if rendered, renderError := renderStructured(cmd, preview); rendered || renderError != nil {
+			return renderError
+		}
+		printNotificationRoutePreview(cmd.OutOrStdout(), preview)
+		return nil
+	},
+}
+
+// validatePreviewFlags rejects the enum values the backend would refuse, so
+// a typo exits with the usage code instead of a 422 body.
+func validatePreviewFlags(cmd *cobra.Command) error {
+	if kind := mustFlagString(cmd, "kind"); kind == "" {
+		return withExitCode(exitUsage, errors.New("--kind is required"))
+	}
+	severity := mustFlagString(cmd, "severity")
+	if severity != "critical" && severity != "warning" && severity != "info" {
+		return withExitCode(exitUsage,
+			fmt.Errorf("unsupported --severity %q (use critical, warning, or info)", severity))
+	}
+	return nil
+}
+
+func printNotificationRoutePreview(out io.Writer, preview *client.NotificationRoutePreview) {
+	if !preview.Routable {
+		_, _ = fmt.Fprintf(out, "%s\n\n", preview.RoutableReason)
+	}
+	if len(preview.Deliveries) == 0 {
+		_, _ = fmt.Fprintln(out, "This notification would not be delivered to any destination.")
+	} else {
+		_, _ = fmt.Fprintln(out, "This notification would be delivered to:")
+		renderPreviewDeliveries(out, preview.Deliveries)
+	}
+	if preview.HomeDestinationUsed {
+		_, _ = fmt.Fprintln(out, "\nNo routing rule matched, so this fell back to the organisation home channel.")
+	}
+	if len(preview.Suppressed) > 0 {
+		_, _ = fmt.Fprintln(out, "\nNot delivered:")
+		renderPreviewDeliveries(out, preview.Suppressed)
+	}
+	if len(preview.RouteEvaluations) > 0 {
+		_, _ = fmt.Fprintln(out, "\nRule evaluation:")
+		writer := table.NewWriter()
+		writer.SetOutputMirror(out)
+		writer.SetStyle(table.StyleRounded)
+		writer.AppendHeader(table.Row{"Rule", "Priority", "Mode", "Matched", "Outcome", "Reason"})
+		for _, evaluation := range preview.RouteEvaluations {
+			writer.AppendRow(table.Row{
+				evaluation.RouteID,
+				evaluation.Priority,
+				evaluation.Mode,
+				evaluation.Matched,
+				evaluation.Outcome,
+				evaluation.Reason,
+			})
+		}
+		writer.Render()
+	}
+}
+
+func renderPreviewDeliveries(out io.Writer, deliveries []client.NotificationRoutePreviewDelivery) {
+	writer := table.NewWriter()
+	writer.SetOutputMirror(out)
+	writer.SetStyle(table.StyleRounded)
+	writer.AppendHeader(table.Row{"Destination", "Via", "Rule", "Reason"})
+	for _, delivery := range deliveries {
+		writer.AppendRow(table.Row{
+			previewDestinationLabel(delivery),
+			delivery.Via,
+			valueOrAny(delivery.RouteID),
+			delivery.Reason,
+		})
+	}
+	writer.Render()
+}
+
+// previewDestinationLabel prefers the destination name; a route whose
+// destination has been removed has no name to show.
+func previewDestinationLabel(delivery client.NotificationRoutePreviewDelivery) string {
+	if delivery.DestinationName != "" {
+		return delivery.DestinationName
+	}
+	return delivery.DestinationID
+}
+
 // validateRouteFilterFlags rejects enum values the backend would refuse
 // with a validation error, so a typo exits with the usage code and a plain
 // message instead of a 422 body.
 func validateRouteFilterFlags(cmd *cobra.Command) error {
+	setKindFlags := []string{}
+	for _, name := range []string{"kind", "kinds", "exclude-kinds"} {
+		if cmd.Flags().Changed(name) {
+			setKindFlags = append(setKindFlags, "--"+name)
+		}
+	}
+	if len(setKindFlags) > 1 {
+		return withExitCode(exitUsage, fmt.Errorf("%s are mutually exclusive: a route has one kind filter",
+			strings.Join(setKindFlags, " and ")))
+	}
 	if mode := mustFlagString(cmd, "mode"); cmd.Flags().Changed("mode") && mode != "include" && mode != "exclude" {
 		return withExitCode(exitUsage, fmt.Errorf("unsupported --mode %q (use include or exclude)", mode))
 	}
@@ -200,6 +333,59 @@ func validateRouteFilterFlags(cmd *cobra.Command) error {
 		return withExitCode(exitUsage, fmt.Errorf("unsupported --severity %q (use critical, warning, or info)", severity))
 	}
 	return nil
+}
+
+// routeKindFilterFlags resolves --kinds / --exclude-kinds into the wire pair.
+// A nil list leaves both members out of the body, so the backend keeps the
+// route's current kind filter on update and applies no filter on create.
+func routeKindFilterFlags(cmd *cobra.Command) ([]string, *bool) {
+	if cmd.Flags().Changed("exclude-kinds") {
+		negated := true
+		return splitCommaList(mustFlagString(cmd, "exclude-kinds")), &negated
+	}
+	if cmd.Flags().Changed("kinds") {
+		negated := false
+		return splitCommaList(mustFlagString(cmd, "kinds")), &negated
+	}
+	return nil, nil
+}
+
+// splitCommaList parses a comma-separated flag value, dropping the empty
+// entries a trailing or doubled comma leaves behind.
+func splitCommaList(value string) []string {
+	entries := []string{}
+	for _, entry := range strings.Split(value, ",") {
+		trimmed := strings.TrimSpace(entry)
+		if trimmed != "" {
+			entries = append(entries, trimmed)
+		}
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	return entries
+}
+
+// isEmptyRouteUpdate reports whether an update carries no change at all.
+// The struct cannot be compared with == because it holds a slice.
+func isEmptyRouteUpdate(request client.UpdateNotificationRouteRequest) bool {
+	return request.DestinationID == nil && request.Kind == nil && request.Kinds == nil &&
+		request.KindsNegated == nil && request.Severity == nil && request.ClusterID == nil &&
+		request.SourceID == nil && request.Priority == nil && request.StopOnMatch == nil &&
+		request.Mode == nil && request.Enabled == nil
+}
+
+// renderRouteKindFilter renders a route's kind filter for humans: the list,
+// the negated list, or "any" when the route carries no kind filter.
+func renderRouteKindFilter(route *client.NotificationRoute) string {
+	if len(route.Kinds) > 0 {
+		joined := strings.Join(route.Kinds, ", ")
+		if route.KindsNegated {
+			return "all except " + joined
+		}
+		return joined
+	}
+	return valueOrAny(route.Kind)
 }
 
 // valueOrAny renders a nullable route filter: an unset filter matches any
@@ -215,7 +401,7 @@ func printNotificationRoute(out io.Writer, route *client.NotificationRoute) {
 	_, _ = fmt.Fprintf(out, "ID:            %s\n", route.ID)
 	_, _ = fmt.Fprintf(out, "Destination:   %s\n", route.DestinationID)
 	_, _ = fmt.Fprintf(out, "Priority:      %d\n", route.Priority)
-	_, _ = fmt.Fprintf(out, "Kind:          %s\n", valueOrAny(route.Kind))
+	_, _ = fmt.Fprintf(out, "Kind:          %s\n", renderRouteKindFilter(route))
 	_, _ = fmt.Fprintf(out, "Severity:      %s\n", valueOrAny(route.Severity))
 	_, _ = fmt.Fprintf(out, "Cluster:       %s\n", valueOrAny(route.ClusterID))
 	_, _ = fmt.Fprintf(out, "Source:        %s\n", valueOrAny(route.SourceID))
@@ -230,6 +416,8 @@ func printNotificationRoute(out io.Writer, route *client.NotificationRoute) {
 // and update leaves unmentioned members alone.
 func registerRouteFilterFlags(cmd *cobra.Command) {
 	cmd.Flags().String("kind", "", "Only notifications of this kind (for example execution_failed)")
+	cmd.Flags().String("kinds", "", "Only notifications of these kinds (comma-separated)")
+	cmd.Flags().String("exclude-kinds", "", "Every kind EXCEPT these (comma-separated)")
 	cmd.Flags().String("severity", "", "Only notifications of this severity: critical, warning, or info")
 	cmd.Flags().String("cluster-id", "", "Only notifications about this cluster (id)")
 	cmd.Flags().String("source-id", "", "Only notifications from this source id")
@@ -252,11 +440,19 @@ func init() {
 
 	alertsRoutesDeleteCmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
 
+	alertsRoutesPreviewCmd.Flags().String("kind", "", "Notification kind to resolve (for example alert_trigger_fired)")
+	alertsRoutesPreviewCmd.Flags().String("severity", "critical", "Notification severity: critical, warning, or info")
+	alertsRoutesPreviewCmd.Flags().String("cluster-id", "", "Resolve as a notification about this cluster")
+	alertsRoutesPreviewCmd.Flags().String("source-id", "", "Resolve as a notification from this source id")
+	alertsRoutesPreviewCmd.Flags().String("alert-id", "", "Resolve as a firing of this alert, including its own destinations")
+	_ = alertsRoutesPreviewCmd.MarkFlagRequired("kind")
+
 	registerStructuredOutputFlags(
 		alertsRoutesListCmd,
 		alertsRoutesCreateCmd,
 		alertsRoutesUpdateCmd,
 		alertsRoutesTestCmd,
+		alertsRoutesPreviewCmd,
 	)
 
 	alertsRoutesCmd.AddCommand(alertsRoutesListCmd)
@@ -264,5 +460,6 @@ func init() {
 	alertsRoutesCmd.AddCommand(alertsRoutesUpdateCmd)
 	alertsRoutesCmd.AddCommand(alertsRoutesDeleteCmd)
 	alertsRoutesCmd.AddCommand(alertsRoutesTestCmd)
+	alertsRoutesCmd.AddCommand(alertsRoutesPreviewCmd)
 	alertsCmd.AddCommand(alertsRoutesCmd)
 }

--- a/cmd/alerts_routes.go
+++ b/cmd/alerts_routes.go
@@ -51,11 +51,10 @@ var alertsRoutesListCmd = &cobra.Command{
 		writer.SetStyle(table.StyleRounded)
 		writer.AppendHeader(table.Row{"ID", "Priority", "Kind", "Severity", "Cluster", "Destination", "Mode", "Enabled"})
 		for _, route := range list.Items {
-			routeRow := route
 			writer.AppendRow(table.Row{
 				route.ID,
 				route.Priority,
-				renderRouteKindFilter(&routeRow),
+				renderRouteKindFilter(route),
 				valueOrAny(route.Severity),
 				valueOrAny(route.ClusterID),
 				route.DestinationID,
@@ -325,6 +324,16 @@ func validateRouteFilterFlags(cmd *cobra.Command) error {
 		return withExitCode(exitUsage, fmt.Errorf("%s are mutually exclusive: a route has one kind filter",
 			strings.Join(setKindFlags, " and ")))
 	}
+	// An empty value parses to no kinds, but the flag being present still
+	// carries the negation for that branch - so `--exclude-kinds ""` would
+	// send kinds_negated with no kinds and silently invert what an existing
+	// route matches. Neither flag is a way to clear a filter.
+	for _, name := range []string{"kinds", "exclude-kinds"} {
+		if cmd.Flags().Changed(name) && len(splitCommaList(mustFlagString(cmd, name))) == 0 {
+			return withExitCode(exitUsage,
+				fmt.Errorf("--%s needs at least one kind (it cannot be used to clear a route's kind filter)", name))
+		}
+	}
 	if mode := mustFlagString(cmd, "mode"); cmd.Flags().Changed("mode") && mode != "include" && mode != "exclude" {
 		return withExitCode(exitUsage, fmt.Errorf("unsupported --mode %q (use include or exclude)", mode))
 	}
@@ -377,7 +386,7 @@ func isEmptyRouteUpdate(request client.UpdateNotificationRouteRequest) bool {
 
 // renderRouteKindFilter renders a route's kind filter for humans: the list,
 // the negated list, or "any" when the route carries no kind filter.
-func renderRouteKindFilter(route *client.NotificationRoute) string {
+func renderRouteKindFilter(route client.NotificationRoute) string {
 	if len(route.Kinds) > 0 {
 		joined := strings.Join(route.Kinds, ", ")
 		if route.KindsNegated {
@@ -401,7 +410,7 @@ func printNotificationRoute(out io.Writer, route *client.NotificationRoute) {
 	_, _ = fmt.Fprintf(out, "ID:            %s\n", route.ID)
 	_, _ = fmt.Fprintf(out, "Destination:   %s\n", route.DestinationID)
 	_, _ = fmt.Fprintf(out, "Priority:      %d\n", route.Priority)
-	_, _ = fmt.Fprintf(out, "Kind:          %s\n", renderRouteKindFilter(route))
+	_, _ = fmt.Fprintf(out, "Kind:          %s\n", renderRouteKindFilter(*route))
 	_, _ = fmt.Fprintf(out, "Severity:      %s\n", valueOrAny(route.Severity))
 	_, _ = fmt.Fprintf(out, "Cluster:       %s\n", valueOrAny(route.ClusterID))
 	_, _ = fmt.Fprintf(out, "Source:        %s\n", valueOrAny(route.SourceID))

--- a/cmd/alerts_routes_test.go
+++ b/cmd/alerts_routes_test.go
@@ -611,3 +611,41 @@ func TestAlertsRoutesPreviewRendersJSON(t *testing.T) {
 		t.Fatalf("the json body lost the delivery: %s", stdout)
 	}
 }
+
+func TestAlertsRoutesRejectsAnEmptyKindList(t *testing.T) {
+	// A subtest per flag: the cobra flag tree is process-global and
+	// runAlertsCommand only resets it on the enclosing test's cleanup, so two
+	// invocations in one function would see each other's Changed markers.
+	for _, flag := range []string{"--kinds", "--exclude-kinds"} {
+		t.Run(flag, func(subtest *testing.T) {
+			mock := &notificationRoutesMock{routes: sampleNotificationRoutes()}
+			_, _, runError := runAlertsCommand(subtest, mock, "", "alerts", "routes", "update",
+				"7c1e0d5a-0000-4000-8000-000000000001", flag, "")
+			if runError == nil {
+				subtest.Fatalf("%s with an empty value must be rejected", flag)
+			}
+			if !strings.Contains(runError.Error(), "needs at least one kind") {
+				subtest.Fatalf("%s: the error must say why: %v", flag, runError)
+			}
+			// The real hazard: the flag's branch still carries the negation,
+			// so without this guard an empty value would send kinds_negated
+			// with no kinds and silently invert an existing route.
+			if mock.updateRequest != nil {
+				subtest.Fatalf("%s: a rejected command must not reach the API: %+v", flag, mock.updateRequest)
+			}
+		})
+	}
+}
+
+func TestAlertsRoutesAcceptsAKindListWithStrayCommas(t *testing.T) {
+	mock := &notificationRoutesMock{}
+	_, _, runError := runAlertsCommand(t, mock, "", "alerts", "routes", "create",
+		"--destination-id", "3d0f6a2e-0000-4000-8000-000000000001",
+		"--kinds", "execution_failed,,agent_offline,")
+	if runError != nil {
+		t.Fatalf("stray commas must not fail the command: %v", runError)
+	}
+	if len(mock.createRequest.Kinds) != 2 {
+		t.Fatalf("stray commas must be dropped, not sent: %+v", mock.createRequest.Kinds)
+	}
+}

--- a/cmd/alerts_routes_test.go
+++ b/cmd/alerts_routes_test.go
@@ -11,12 +11,15 @@ import (
 
 type notificationRoutesMock struct {
 	baseMock
-	routes        []client.NotificationRoute
-	createRequest *client.CreateNotificationRouteRequest
-	updatedID     string
-	updateRequest *client.UpdateNotificationRouteRequest
-	deleteCalls   []string
-	testCalls     []string
+	routes         []client.NotificationRoute
+	createRequest  *client.CreateNotificationRouteRequest
+	updatedID      string
+	updateRequest  *client.UpdateNotificationRouteRequest
+	deleteCalls    []string
+	testCalls      []string
+	previewRequest *client.PreviewNotificationRoutesRequest
+	preview        *client.NotificationRoutePreview
+	previewError   error
 }
 
 func (m *notificationRoutesMock) ListNotificationRoutes() (*client.NotificationRouteList, error) {
@@ -37,6 +40,8 @@ func (m *notificationRoutesMock) CreateNotificationRoute(request client.CreateNo
 		ID:             "7c1e0d5a-0000-4000-8000-000000000010",
 		OrganisationID: "0f0f0f0f-0000-4000-8000-000000000001",
 		Kind:           request.Kind,
+		Kinds:          request.Kinds,
+		KindsNegated:   request.KindsNegated != nil && *request.KindsNegated,
 		Severity:       request.Severity,
 		ClusterID:      request.ClusterID,
 		SourceID:       request.SourceID,
@@ -76,6 +81,14 @@ func (m *notificationRoutesMock) DeleteNotificationRoute(routeID string) error {
 func (m *notificationRoutesMock) TestNotificationRoute(routeID string) (*client.NotificationRouteTestResult, error) {
 	m.testCalls = append(m.testCalls, routeID)
 	return &client.NotificationRouteTestResult{DeliveryID: "9e9e9e9e-0000-4000-8000-000000000042"}, nil
+}
+
+func (m *notificationRoutesMock) PreviewNotificationRoutes(request client.PreviewNotificationRoutesRequest) (*client.NotificationRoutePreview, error) {
+	m.previewRequest = &request
+	if m.previewError != nil {
+		return nil, m.previewError
+	}
+	return m.preview, nil
 }
 
 func sampleNotificationRoutes() []client.NotificationRoute {
@@ -429,5 +442,172 @@ func TestAlertsRoutesTestPrintsDeliveryID(t *testing.T) {
 	}
 	if decoded["delivery_id"] != "9e9e9e9e-0000-4000-8000-000000000042" {
 		t.Errorf("unexpected JSON document: %s", stdout)
+	}
+}
+
+func TestAlertsRoutesCreateSendsAKindList(t *testing.T) {
+	mock := &notificationRoutesMock{}
+	stdout, _, runError := runAlertsCommand(t, mock, "", "alerts", "routes", "create",
+		"--destination-id", "3d0f6a2e-0000-4000-8000-000000000001",
+		"--kinds", "execution_failed,resource_reconcile_failed")
+	if runError != nil {
+		t.Fatalf("alerts routes create failed: %v", runError)
+	}
+	if mock.createRequest == nil {
+		t.Fatal("no create request was sent")
+	}
+	if len(mock.createRequest.Kinds) != 2 ||
+		mock.createRequest.Kinds[0] != "execution_failed" ||
+		mock.createRequest.Kinds[1] != "resource_reconcile_failed" {
+		t.Fatalf("the kind list was not sent: %+v", mock.createRequest.Kinds)
+	}
+	if mock.createRequest.KindsNegated == nil || *mock.createRequest.KindsNegated {
+		t.Fatalf("a positive list must not be negated: %+v", mock.createRequest.KindsNegated)
+	}
+	if !strings.Contains(stdout, "execution_failed, resource_reconcile_failed") {
+		t.Errorf("the kind list must be rendered, got:\n%s", stdout)
+	}
+}
+
+func TestAlertsRoutesCreateSendsAnExcludedKindList(t *testing.T) {
+	mock := &notificationRoutesMock{}
+	stdout, _, runError := runAlertsCommand(t, mock, "", "alerts", "routes", "create",
+		"--destination-id", "3d0f6a2e-0000-4000-8000-000000000001",
+		"--exclude-kinds", "alert_trigger_fired")
+	if runError != nil {
+		t.Fatalf("alerts routes create failed: %v", runError)
+	}
+	if mock.createRequest.KindsNegated == nil || !*mock.createRequest.KindsNegated {
+		t.Fatal("--exclude-kinds must negate the list")
+	}
+	if !strings.Contains(stdout, "all except alert_trigger_fired") {
+		t.Errorf("a negated list must read as an exception, got:\n%s", stdout)
+	}
+}
+
+func TestAlertsRoutesCreateRejectsCompetingKindFlags(t *testing.T) {
+	mock := &notificationRoutesMock{}
+	_, _, runError := runAlertsCommand(t, mock, "", "alerts", "routes", "create",
+		"--destination-id", "3d0f6a2e-0000-4000-8000-000000000001",
+		"--kind", "execution_failed", "--exclude-kinds", "alert_trigger_fired")
+	if runError == nil {
+		t.Fatal("two kind filters on one route must be rejected")
+	}
+	if !strings.Contains(runError.Error(), "mutually exclusive") {
+		t.Fatalf("the error must say why: %v", runError)
+	}
+	if mock.createRequest != nil {
+		t.Fatal("a rejected command must not reach the API")
+	}
+}
+
+func samplePreview() *client.NotificationRoutePreview {
+	routeID := "7c1e0d5a-0000-4000-8000-000000000001"
+	return &client.NotificationRoutePreview{
+		Kind:     "alert_trigger_fired",
+		Severity: "critical",
+		Routable: true,
+		Deliveries: []client.NotificationRoutePreviewDelivery{{
+			DestinationID:   "3d0f6a2e-0000-4000-8000-000000000001",
+			DestinationName: "infra-channel",
+			Via:             "alert_destination",
+			Reason:          "Attached to this alert's own Notifications -> Destinations list.",
+		}},
+		Suppressed: []client.NotificationRoutePreviewDelivery{{
+			DestinationID:   "3d0f6a2e-0000-4000-8000-000000000001",
+			DestinationName: "infra-channel",
+			Via:             "route",
+			RouteID:         &routeID,
+			Reason:          "Already delivered by the alert's own destination list.",
+		}},
+		RouteEvaluations: []client.NotificationRoutePreviewEvaluation{{
+			RouteID: routeID, DestinationID: "3d0f6a2e-0000-4000-8000-000000000001",
+			Priority: 100, Mode: "include", Matched: true, Outcome: "included",
+			Reason: "Include rule matched and adds its destination.",
+		}},
+	}
+}
+
+func TestAlertsRoutesPreviewRendersDeliveriesAndSuppressions(t *testing.T) {
+	mock := &notificationRoutesMock{preview: samplePreview()}
+	stdout, _, runError := runAlertsCommand(t, mock, "", "alerts", "routes", "preview",
+		"--kind", "alert_trigger_fired", "--severity", "critical",
+		"--alert-id", "cb91430a-e432-4df1-b654-68a566b5910a")
+	if runError != nil {
+		t.Fatalf("alerts routes preview failed: %v", runError)
+	}
+	if mock.previewRequest == nil {
+		t.Fatal("no preview request was sent")
+	}
+	if mock.previewRequest.AlertID == nil ||
+		*mock.previewRequest.AlertID != "cb91430a-e432-4df1-b654-68a566b5910a" {
+		t.Fatalf("the alert id must reach the API: %+v", mock.previewRequest)
+	}
+	for _, fragment := range []string{
+		"This notification would be delivered to:",
+		"infra-channel",
+		"alert_destination",
+		"Not delivered:",
+		"Already delivered by the alert's own destination list.",
+		"Rule evaluation:",
+	} {
+		if !strings.Contains(stdout, fragment) {
+			t.Errorf("expected the preview to contain %q, got:\n%s", fragment, stdout)
+		}
+	}
+}
+
+func TestAlertsRoutesPreviewRendersNothingDelivered(t *testing.T) {
+	mock := &notificationRoutesMock{preview: &client.NotificationRoutePreview{
+		Kind: "execution_failed", Severity: "info", Routable: true,
+	}}
+	stdout, _, runError := runAlertsCommand(t, mock, "", "alerts", "routes", "preview",
+		"--kind", "execution_failed", "--severity", "info")
+	if runError != nil {
+		t.Fatalf("alerts routes preview failed: %v", runError)
+	}
+	if !strings.Contains(stdout, "would not be delivered to any destination") {
+		t.Errorf("an empty preview must say so, got:\n%s", stdout)
+	}
+}
+
+func TestAlertsRoutesPreviewRejectsAnUnknownSeverity(t *testing.T) {
+	mock := &notificationRoutesMock{preview: samplePreview()}
+	_, _, runError := runAlertsCommand(t, mock, "", "alerts", "routes", "preview",
+		"--kind", "execution_failed", "--severity", "urgent")
+	if runError == nil {
+		t.Fatal("an unknown severity must be rejected before the request")
+	}
+	if mock.previewRequest != nil {
+		t.Fatal("a rejected command must not reach the API")
+	}
+}
+
+func TestAlertsRoutesPreviewSurfacesApiFailure(t *testing.T) {
+	mock := &notificationRoutesMock{previewError: client.NewUnexpectedResponseError(404, "Alert not found")}
+	_, _, runError := runAlertsCommand(t, mock, "", "alerts", "routes", "preview",
+		"--kind", "alert_trigger_fired", "--severity", "critical",
+		"--alert-id", "cb91430a-e432-4df1-b654-68a566b5910a")
+	if runError == nil {
+		t.Fatal("an API failure must surface")
+	}
+	if !strings.Contains(runError.Error(), "Alert not found") {
+		t.Fatalf("the backend detail must survive: %v", runError)
+	}
+}
+
+func TestAlertsRoutesPreviewRendersJSON(t *testing.T) {
+	mock := &notificationRoutesMock{preview: samplePreview()}
+	stdout, _, runError := runAlertsCommand(t, mock, "", "alerts", "routes", "preview",
+		"--kind", "alert_trigger_fired", "--severity", "critical", "-o", "json")
+	if runError != nil {
+		t.Fatalf("alerts routes preview -o json failed: %v", runError)
+	}
+	var decoded client.NotificationRoutePreview
+	if unmarshalError := json.Unmarshal([]byte(stdout), &decoded); unmarshalError != nil {
+		t.Fatalf("preview json did not decode: %v\n%s", unmarshalError, stdout)
+	}
+	if len(decoded.Deliveries) != 1 || decoded.Deliveries[0].DestinationName != "infra-channel" {
+		t.Fatalf("the json body lost the delivery: %s", stdout)
 	}
 }

--- a/cmd/alerts_test.go
+++ b/cmd/alerts_test.go
@@ -31,6 +31,7 @@ func alertsCommandTree() []*cobra.Command {
 		alertsRoutesUpdateCmd,
 		alertsRoutesDeleteCmd,
 		alertsRoutesTestCmd,
+		alertsRoutesPreviewCmd,
 	}
 }
 

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1871,6 +1871,10 @@ func (m baseMock) TestNotificationRoute(routeID string) (*client.NotificationRou
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) PreviewNotificationRoutes(request client.PreviewNotificationRoutesRequest) (*client.NotificationRoutePreview, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) DisableClusterDNSZone(clusterID string) (*client.ClusterDNSZoneResponse, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -520,5 +520,6 @@ type APIClient interface {
 	UpdateNotificationRoute(routeID string, request client.UpdateNotificationRouteRequest) (*client.NotificationRoute, error)
 	DeleteNotificationRoute(routeID string) error
 	TestNotificationRoute(routeID string) (*client.NotificationRouteTestResult, error)
+	PreviewNotificationRoutes(request client.PreviewNotificationRoutesRequest) (*client.NotificationRoutePreview, error)
 	DisableClusterDNSZone(clusterID string) (*client.ClusterDNSZoneResponse, error)
 }

--- a/internal/client/alerts.go
+++ b/internal/client/alerts.go
@@ -147,19 +147,21 @@ type TeamsChannelList struct {
 // "include") or withheld from (mode "exclude") the destination. Routes are
 // evaluated in ascending priority; StopOnMatch ends the walk at this rule.
 type NotificationRoute struct {
-	ID             string  `json:"id" yaml:"id"`
-	OrganisationID string  `json:"organisation_id" yaml:"organisation_id"`
-	Kind           *string `json:"kind" yaml:"kind"`
-	Severity       *string `json:"severity" yaml:"severity"`
-	ClusterID      *string `json:"cluster_id" yaml:"cluster_id"`
-	SourceID       *string `json:"source_id" yaml:"source_id"`
-	DestinationID  string  `json:"destination_id" yaml:"destination_id"`
-	Priority       int     `json:"priority" yaml:"priority"`
-	StopOnMatch    bool    `json:"stop_on_match" yaml:"stop_on_match"`
-	Mode           string  `json:"mode" yaml:"mode"`
-	Enabled        bool    `json:"enabled" yaml:"enabled"`
-	CreatedAt      string  `json:"created_at" yaml:"created_at"`
-	UpdatedAt      string  `json:"updated_at" yaml:"updated_at"`
+	ID             string   `json:"id" yaml:"id"`
+	OrganisationID string   `json:"organisation_id" yaml:"organisation_id"`
+	Kind           *string  `json:"kind" yaml:"kind"`
+	Kinds          []string `json:"kinds" yaml:"kinds"`
+	KindsNegated   bool     `json:"kinds_negated" yaml:"kinds_negated"`
+	Severity       *string  `json:"severity" yaml:"severity"`
+	ClusterID      *string  `json:"cluster_id" yaml:"cluster_id"`
+	SourceID       *string  `json:"source_id" yaml:"source_id"`
+	DestinationID  string   `json:"destination_id" yaml:"destination_id"`
+	Priority       int      `json:"priority" yaml:"priority"`
+	StopOnMatch    bool     `json:"stop_on_match" yaml:"stop_on_match"`
+	Mode           string   `json:"mode" yaml:"mode"`
+	Enabled        bool     `json:"enabled" yaml:"enabled"`
+	CreatedAt      string   `json:"created_at" yaml:"created_at"`
+	UpdatedAt      string   `json:"updated_at" yaml:"updated_at"`
 }
 
 // NotificationRouteList is the GET /api/v1/org/notifications/routes body.
@@ -171,30 +173,84 @@ type NotificationRouteList struct {
 // required; the backend defaults priority to 100, stop_on_match to false,
 // mode to "include", and enabled to true for omitted members.
 type CreateNotificationRouteRequest struct {
-	DestinationID string  `json:"destination_id"`
-	Kind          *string `json:"kind,omitempty"`
-	Severity      *string `json:"severity,omitempty"`
-	ClusterID     *string `json:"cluster_id,omitempty"`
-	SourceID      *string `json:"source_id,omitempty"`
-	Priority      *int    `json:"priority,omitempty"`
-	StopOnMatch   *bool   `json:"stop_on_match,omitempty"`
-	Mode          *string `json:"mode,omitempty"`
-	Enabled       *bool   `json:"enabled,omitempty"`
+	DestinationID string   `json:"destination_id"`
+	Kind          *string  `json:"kind,omitempty"`
+	Kinds         []string `json:"kinds,omitempty"`
+	KindsNegated  *bool    `json:"kinds_negated,omitempty"`
+	Severity      *string  `json:"severity,omitempty"`
+	ClusterID     *string  `json:"cluster_id,omitempty"`
+	SourceID      *string  `json:"source_id,omitempty"`
+	Priority      *int     `json:"priority,omitempty"`
+	StopOnMatch   *bool    `json:"stop_on_match,omitempty"`
+	Mode          *string  `json:"mode,omitempty"`
+	Enabled       *bool    `json:"enabled,omitempty"`
 }
 
 // UpdateNotificationRouteRequest is the PATCH body. The backend applies
 // only the members present in the JSON document, so a nil member is left
 // out of the wire body entirely rather than sent as null.
 type UpdateNotificationRouteRequest struct {
-	DestinationID *string `json:"destination_id,omitempty"`
-	Kind          *string `json:"kind,omitempty"`
-	Severity      *string `json:"severity,omitempty"`
-	ClusterID     *string `json:"cluster_id,omitempty"`
-	SourceID      *string `json:"source_id,omitempty"`
-	Priority      *int    `json:"priority,omitempty"`
-	StopOnMatch   *bool   `json:"stop_on_match,omitempty"`
-	Mode          *string `json:"mode,omitempty"`
-	Enabled       *bool   `json:"enabled,omitempty"`
+	DestinationID *string  `json:"destination_id,omitempty"`
+	Kind          *string  `json:"kind,omitempty"`
+	Kinds         []string `json:"kinds,omitempty"`
+	KindsNegated  *bool    `json:"kinds_negated,omitempty"`
+	Severity      *string  `json:"severity,omitempty"`
+	ClusterID     *string  `json:"cluster_id,omitempty"`
+	SourceID      *string  `json:"source_id,omitempty"`
+	Priority      *int     `json:"priority,omitempty"`
+	StopOnMatch   *bool    `json:"stop_on_match,omitempty"`
+	Mode          *string  `json:"mode,omitempty"`
+	Enabled       *bool    `json:"enabled,omitempty"`
+}
+
+// PreviewNotificationRoutesRequest is the POST .../routes/preview body: the
+// hypothetical notification to resolve. AlertID names the alert whose own
+// destinations compete with the routing rules, and is what lets the preview
+// report the de-duplication instead of over-promising deliveries.
+type PreviewNotificationRoutesRequest struct {
+	Kind      string  `json:"kind"`
+	Severity  string  `json:"severity"`
+	ClusterID *string `json:"cluster_id,omitempty"`
+	SourceID  *string `json:"source_id,omitempty"`
+	AlertID   *string `json:"alert_id,omitempty"`
+}
+
+// NotificationRoutePreviewDelivery is one destination the notification
+// would, or would not, reach.
+type NotificationRoutePreviewDelivery struct {
+	DestinationID   string  `json:"destination_id" yaml:"destination_id"`
+	DestinationName string  `json:"destination_name" yaml:"destination_name"`
+	Via             string  `json:"via" yaml:"via"`
+	RouteID         *string `json:"route_id" yaml:"route_id"`
+	Reason          string  `json:"reason" yaml:"reason"`
+}
+
+// NotificationRoutePreviewEvaluation is one routing rule's fate in the walk.
+type NotificationRoutePreviewEvaluation struct {
+	RouteID       string `json:"route_id" yaml:"route_id"`
+	DestinationID string `json:"destination_id" yaml:"destination_id"`
+	Priority      int    `json:"priority" yaml:"priority"`
+	Mode          string `json:"mode" yaml:"mode"`
+	StopOnMatch   bool   `json:"stop_on_match" yaml:"stop_on_match"`
+	Matched       bool   `json:"matched" yaml:"matched"`
+	Outcome       string `json:"outcome" yaml:"outcome"`
+	Reason        string `json:"reason" yaml:"reason"`
+}
+
+// NotificationRoutePreview is the dry-run answer to "this notification would
+// be delivered to: ...".
+type NotificationRoutePreview struct {
+	Kind                string                               `json:"kind" yaml:"kind"`
+	Severity            string                               `json:"severity" yaml:"severity"`
+	ClusterID           *string                              `json:"cluster_id" yaml:"cluster_id"`
+	SourceID            *string                              `json:"source_id" yaml:"source_id"`
+	AlertID             *string                              `json:"alert_id" yaml:"alert_id"`
+	Routable            bool                                 `json:"routable" yaml:"routable"`
+	RoutableReason      string                               `json:"routable_reason" yaml:"routable_reason"`
+	Deliveries          []NotificationRoutePreviewDelivery   `json:"deliveries" yaml:"deliveries"`
+	Suppressed          []NotificationRoutePreviewDelivery   `json:"suppressed" yaml:"suppressed"`
+	RouteEvaluations    []NotificationRoutePreviewEvaluation `json:"route_evaluations" yaml:"route_evaluations"`
+	HomeDestinationUsed bool                                 `json:"home_destination_used" yaml:"home_destination_used"`
 }
 
 // NotificationRouteTestResult is the 202 body of POST .../routes/{id}/test:
@@ -351,6 +407,17 @@ func (c *Client) UpdateNotificationRoute(routeID string, request UpdateNotificat
 // with no body.
 func (c *Client) DeleteNotificationRoute(routeID string) error {
 	return c.sendJSON(http.MethodDelete, c.notificationRouteURL(routeID), nil, nil)
+}
+
+// PreviewNotificationRoutes resolves a hypothetical notification against the
+// organisation's routing rules and alert destinations. It is a dry run: the
+// backend delivers nothing and writes nothing.
+func (c *Client) PreviewNotificationRoutes(request PreviewNotificationRoutesRequest) (*NotificationRoutePreview, error) {
+	var preview NotificationRoutePreview
+	if previewError := c.sendJSON(http.MethodPost, c.BaseURL+notificationRoutesBasePath+"/preview", request, &preview); previewError != nil {
+		return nil, previewError
+	}
+	return &preview, nil
 }
 
 // TestNotificationRoute queues a sample delivery through the route's


### PR DESCRIPTION
## What

The CLI half of PLA-760 / Ankra ticket #1071 (Smartoptics). Backend: ankraio/cluster#1624.

**Kind is a list.** `ankra alerts routes create|update` gain `--kinds` and `--exclude-kinds`:

```bash
ankra alerts routes create --destination-id <id> --kinds execution_failed,resource_reconcile_failed
ankra alerts routes create --destination-id <id> --exclude-kinds alert_trigger_fired
```

"Operation failed and Reconciliation failing, nothing else" is one rule; "everything except Alert firing, because alerts already have their own destinations" is one rule instead of ten. `--kind` still works and is equivalent to `--kinds` with one entry; passing more than one of the three exits with the usage code and a message naming both flags, rather than a 422 body.

**`ankra alerts routes preview`** answers the question the whole ticket was really about:

```bash
ankra alerts routes preview --kind alert_trigger_fired --severity critical --alert-id <alert-id>
```

It prints the destinations the notification would reach, the ones it would not (with the reason — "already delivered by the alert's own destination list"), and the per-rule evaluation including rules a stop-on-match never reached. `-o json` / `-o yaml` for scripting. Nothing is delivered and nothing is written.

`--alert-id` is the flag that matters: without it the preview cannot know which destinations the alert itself covers, so the help text says so and the docs repeat it.

**Rendering.** Route listings and `printNotificationRoute` show the kind filter as the list it is, or `all except <kinds>` when negated, instead of the single value or `any`.

## Notes

- `--kinds` / `--exclude-kinds` are comma-separated `String` flags, not cobra `StringSlice`. `StringSlice` appends rather than replaces when its value is `Set` a second time, and `resetTreeFlags` in the test harness resets by calling `Set(DefValue)` — which accumulated `[]` entries across tests. A plain string plus an explicit split is deterministic under that harness.
- `reference/cli/alerts.mdx` in ankra-docs is regenerated from this tree in the docs PR.

## Gates

`go build ./...`, `go vet ./...`, `go test ./...` — all green. New tests cover both kind flags, their mutual exclusion, the preview's rendering (delivered / not delivered / empty), its JSON output, the pre-flight severity rejection, and an API failure surfacing the backend detail.

Bead: ankra-ymkj8.4
