### PR TITLE
feat(dns): org domain get|set, org dns zones, and cluster domain as a read (ankra-ymkj8.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Added
 
+- **`ankra org domain get|set` reads and writes the organisation's own Ankra
+  root domain.** Every Ankra-generated hostname — the organisation's delegated
+  DNS zone, its clusters' domains, and the preview hostnames built from them —
+  nests under a root domain that defaults to `ankra.cc`. Registering your own
+  was portal-only; it is now scriptable against the same backend setting the
+  portal writes (AI > Settings > Workspaces, "Custom Ankra domain").
+  `set --default` returns the organisation to the platform default. When the
+  switch is refused because zones or records still live under the old root,
+  the error lists exactly which cluster domains and which DNS records are
+  blocking it, and the command that removes each.
+- **`ankra org dns zones` lists every cluster domain in the organisation.**
+  The inventory a root-domain switch has to clear: cluster, zone fqdn, and
+  state. Previously the only way to discover a cluster's domain was
+  `ankra cluster domain <cluster>`, which created one where none existed.
 - **`--sort <column>` and `--order asc|desc` on the main list commands**
   (`cluster list`, `cluster addons list`, `org list`, `credentials list`,
   `tokens list`) let you order the output by any rendered column — e.g.
@@ -57,6 +71,15 @@
 
 ### Fixed
 
+- **`ankra cluster domain <cluster>` no longer creates a DNS zone when you
+  are only looking.** The command's help called it an idempotent lookup, but
+  it was backed by a POST: checking a cluster's domain enabled one on a
+  cluster that did not have it — and every zone under the old root blocks an
+  organisation root-domain switch, so the read-looking command added blockers
+  to the very migration an operator was trying to run. The plain command is
+  now a read (a cluster without a zone reports state `none`), and creating a
+  zone is the explicit `--enable`. Scripts that relied on the bare command to
+  enable a domain must add `--enable`.
 - **`ankra cluster apply` no longer drops a manifest's or addon's `group`
   label.** The platform's IaC export writes an organizational `group` on
   manifests and addons, but `apply` never read the key and the request it

--- a/cmd/cluster_domain.go
+++ b/cmd/cluster_domain.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -10,39 +11,54 @@ import (
 
 var clusterDomainCmd = &cobra.Command{
 	Use:   "domain <cluster>",
-	Short: "Show the cluster's generated public domain, enabling it if needed",
-	Long: `Show the cluster's generated public domain, queueing the zone if the
-cluster does not have one yet. The domain nests under the organisation's
-Ankra-managed root (ankra.cc by default; an organisation may register its
-own custom domain in the AI environment settings).
+	Short: "Show the cluster's generated public domain",
+	Long: `Show the cluster's generated public domain. The domain nests under the
+organisation's Ankra-managed root - ankra.cc by default, or the organisation's
+own domain when one is registered (portal: AI > Settings > Workspaces, field
+"Custom Ankra domain"; CLI: 'ankra org domain').
 
-The call is idempotent: a cluster that already has a zone reports its
-existing domain unchanged, so this doubles as a lookup. A fresh zone reads
-"pending" until it is published to the authoritative nameservers and then
-turns "active"; external-dns is wired to it on the next cloud-provider pass,
-after which any ingress hostname under the domain resolves with TLS.
+The plain command is a read: it never creates a zone. A cluster that has no
+domain reports state "none", and 'ankra org dns zones' lists every cluster in
+the organisation that does have one.
 
---remove hands the zone back for teardown instead: the removal step before
-an organisation switches its Ankra root domain (the switch is refused while
-cluster zones still live under the old root). A later call without --remove
-re-enables it under the organisation's current root.`,
+--enable queues the zone for a cluster that has none. It is idempotent: a
+cluster that already has a zone reports its existing domain unchanged. A fresh
+zone reads "pending" until it is published to the authoritative nameservers
+and then turns "active"; external-dns is wired to it on the next
+cloud-provider pass, after which any ingress hostname under the domain
+resolves with TLS.
+
+--remove hands the zone back for teardown: the removal step before an
+organisation switches its Ankra root domain (the switch is refused while
+cluster zones still live under the old root). A later --enable re-creates it
+under the organisation's current root.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if clusterDomainEnable && clusterDomainRemove {
+			return withExitCode(exitUsage, errors.New("--enable and --remove are mutually exclusive"))
+		}
+
 		clusterID, err := resolveClusterID(args[0])
 		if err != nil {
 			return err
 		}
 
 		var result *client.ClusterDNSZoneResponse
-		if clusterDomainRemove {
+		switch {
+		case clusterDomainRemove:
 			result, err = apiClient.DisableClusterDNSZone(clusterID)
 			if err != nil {
 				return fmt.Errorf("removing cluster dns zone: %w", err)
 			}
-		} else {
+		case clusterDomainEnable:
 			result, err = apiClient.EnableClusterDNSZone(clusterID)
 			if err != nil {
 				return fmt.Errorf("enabling cluster dns zone: %w", err)
+			}
+		default:
+			result, err = apiClient.GetClusterDNSZone(clusterID)
+			if err != nil {
+				return fmt.Errorf("reading cluster dns zone: %w", err)
 			}
 		}
 
@@ -52,23 +68,42 @@ re-enables it under the organisation's current root.`,
 			return nil
 		}
 
-		fmt.Printf("Domain: %s\n", result.FQDN)
-		fmt.Printf("State:  %s\n", result.State)
+		if result.State == clusterDomainStateNone {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Domain: (none)\nState:  none\n")
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+				"\nThis cluster has no public domain. Run 'ankra cluster domain %s --enable' to create one.\n",
+				args[0])
+			return nil
+		}
+
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Domain: %s\n", result.FQDN)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "State:  %s\n", result.State)
 		switch {
 		case clusterDomainRemove:
-			fmt.Println("\nThe zone is being torn down; hostnames under it stop resolving once the teardown completes.")
-		case result.State != "active":
-			fmt.Println("\nThe zone publishes shortly; once active, any hostname under the domain is yours the moment an ingress claims it.")
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
+				"\nThe zone is being torn down; hostnames under it stop resolving once the teardown completes.")
+		case clusterDomainEnable && result.State != "active":
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
+				"\nThe zone publishes shortly; once active, any hostname under the domain is yours the moment an ingress claims it.")
 		}
 		return nil
 	},
 }
 
-var clusterDomainRemove bool
+// clusterDomainStateNone is the state the read surface reports for a cluster
+// that holds no DNS zone at all.
+const clusterDomainStateNone = "none"
+
+var (
+	clusterDomainEnable bool
+	clusterDomainRemove bool
+)
 
 func init() {
 	clusterCmd.AddCommand(clusterDomainCmd)
 	registerStructuredOutputFlags(clusterDomainCmd)
+	clusterDomainCmd.Flags().BoolVar(&clusterDomainEnable, "enable", false,
+		"Create the cluster's generated public domain if it does not have one (idempotent)")
 	clusterDomainCmd.Flags().BoolVar(&clusterDomainRemove, "remove", false,
-		"Remove the cluster's generated public domain (tear the zone down) instead of enabling it")
+		"Remove the cluster's generated public domain (tear the zone down)")
 }

--- a/cmd/cluster_domain.go
+++ b/cmd/cluster_domain.go
@@ -68,7 +68,12 @@ under the organisation's current root.`,
 			return nil
 		}
 
-		if result.State == clusterDomainStateNone {
+		// Only the bare lookup can meaningfully report "none": --enable
+		// always returns a queued zone and --remove answers 404 when there
+		// was nothing to remove. Guarding the branch keeps it that way, so a
+		// backend that ever reported "none" from either verb could not make
+		// the CLI answer a removal with an "run --enable" hint.
+		if result.State == clusterDomainStateNone && !clusterDomainEnable && !clusterDomainRemove {
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Domain: (none)\nState:  none\n")
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
 				"\nThis cluster has no public domain. Run 'ankra cluster domain %s --enable' to create one.\n",

--- a/cmd/cluster_domain_test.go
+++ b/cmd/cluster_domain_test.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/pflag"
+)
+
+const domainTestClusterID = "3f0a2f7e-0000-4000-8000-0000000000aa"
+
+// clusterDomainMock records which DNS-zone verb the command reached for, so
+// the tests can prove the plain lookup never mutates.
+type clusterDomainMock struct {
+	baseMock
+
+	readCalls    []string
+	enableCalls  []string
+	disableCalls []string
+	zone         client.ClusterDNSZoneResponse
+}
+
+func (m *clusterDomainMock) GetClusterDNSZone(clusterID string) (*client.ClusterDNSZoneResponse, error) {
+	m.readCalls = append(m.readCalls, clusterID)
+	zone := m.zone
+	return &zone, nil
+}
+
+func (m *clusterDomainMock) EnableClusterDNSZone(clusterID string) (*client.ClusterDNSZoneResponse, error) {
+	m.enableCalls = append(m.enableCalls, clusterID)
+	return &client.ClusterDNSZoneResponse{Success: true, FQDN: "abc.org1234.ankra.cc", State: "pending"}, nil
+}
+
+func (m *clusterDomainMock) DisableClusterDNSZone(clusterID string) (*client.ClusterDNSZoneResponse, error) {
+	m.disableCalls = append(m.disableCalls, clusterID)
+	return &client.ClusterDNSZoneResponse{Success: true, FQDN: "abc.org1234.ankra.cc", State: "deleting"}, nil
+}
+
+func resetClusterDomainFlags(t *testing.T) {
+	t.Helper()
+	clusterDomainCmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		_ = flag.Value.Set(flag.DefValue)
+		flag.Changed = false
+	})
+	clusterDomainEnable = false
+	clusterDomainRemove = false
+}
+
+func runClusterDomain(t *testing.T, mock *clusterDomainMock, arguments ...string) (string, error) {
+	t.Helper()
+	setMockClient(t, mock)
+	resetClusterDomainFlags(t)
+	output := new(bytes.Buffer)
+	rootCmd.SetOut(output)
+	rootCmd.SetErr(output)
+	rootCmd.SetArgs(append([]string{"cluster", "domain"}, arguments...))
+	executeError := rootCmd.Execute()
+	return output.String(), executeError
+}
+
+func TestRunClusterDomain_PlainLookupNeverEnablesTheZone(t *testing.T) {
+	mock := &clusterDomainMock{zone: client.ClusterDNSZoneResponse{
+		Success: true, FQDN: "abc.org1234.ankra.cc", State: "active"}}
+
+	output, executeError := runClusterDomain(t, mock, domainTestClusterID)
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	if len(mock.enableCalls) != 0 || len(mock.disableCalls) != 0 {
+		t.Fatalf("the plain lookup mutated: enable=%v disable=%v", mock.enableCalls, mock.disableCalls)
+	}
+	if len(mock.readCalls) != 1 || mock.readCalls[0] != domainTestClusterID {
+		t.Fatalf("read calls = %v", mock.readCalls)
+	}
+	if !strings.Contains(output, "abc.org1234.ankra.cc") || !strings.Contains(output, "active") {
+		t.Errorf("output = %s", output)
+	}
+}
+
+func TestRunClusterDomain_ReportsNoneAndPointsAtEnable(t *testing.T) {
+	mock := &clusterDomainMock{zone: client.ClusterDNSZoneResponse{Success: true, State: "none"}}
+
+	output, executeError := runClusterDomain(t, mock, domainTestClusterID)
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	if len(mock.enableCalls) != 0 {
+		t.Fatalf("a cluster without a zone must not be enabled by a lookup: %v", mock.enableCalls)
+	}
+	if !strings.Contains(output, "none") || !strings.Contains(output, "--enable") {
+		t.Errorf("output = %s, want the none state and the --enable hint", output)
+	}
+}
+
+func TestRunClusterDomain_EnableCreatesTheZone(t *testing.T) {
+	mock := &clusterDomainMock{}
+
+	output, executeError := runClusterDomain(t, mock, domainTestClusterID, "--enable")
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	if len(mock.enableCalls) != 1 || len(mock.readCalls) != 0 {
+		t.Fatalf("enable=%v read=%v", mock.enableCalls, mock.readCalls)
+	}
+	if !strings.Contains(output, "pending") {
+		t.Errorf("output = %s", output)
+	}
+}
+
+func TestRunClusterDomain_RemoveTearsTheZoneDown(t *testing.T) {
+	mock := &clusterDomainMock{}
+
+	output, executeError := runClusterDomain(t, mock, domainTestClusterID, "--remove")
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	if len(mock.disableCalls) != 1 || len(mock.readCalls) != 0 {
+		t.Fatalf("disable=%v read=%v", mock.disableCalls, mock.readCalls)
+	}
+	if !strings.Contains(output, "deleting") {
+		t.Errorf("output = %s", output)
+	}
+}
+
+func TestRunClusterDomain_RefusesEnableWithRemove(t *testing.T) {
+	mock := &clusterDomainMock{}
+
+	output, executeError := runClusterDomain(t, mock, domainTestClusterID, "--enable", "--remove")
+	if executeError == nil {
+		t.Fatalf("expected a usage error, output: %s", output)
+	}
+	var coded *codedError
+	if !errors.As(executeError, &coded) || coded.code != exitUsage {
+		t.Fatalf("error = %v, want exitUsage", executeError)
+	}
+	if len(mock.readCalls)+len(mock.enableCalls)+len(mock.disableCalls) != 0 {
+		t.Fatalf("the refusal must not reach the API")
+	}
+}
+
+func TestRunClusterDomain_StructuredOutputStaysParseable(t *testing.T) {
+	mock := &clusterDomainMock{zone: client.ClusterDNSZoneResponse{Success: true, State: "none"}}
+
+	output, executeError := runClusterDomain(t, mock, domainTestClusterID, "-o", "json")
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	if !strings.Contains(output, `"state": "none"`) {
+		t.Errorf("json output = %s", output)
+	}
+	if strings.Contains(output, "--enable") {
+		t.Errorf("the human hint leaked into stdout: %s", output)
+	}
+}

--- a/cmd/cluster_domain_test.go
+++ b/cmd/cluster_domain_test.go
@@ -22,6 +22,7 @@ type clusterDomainMock struct {
 	enableCalls  []string
 	disableCalls []string
 	zone         client.ClusterDNSZoneResponse
+	disableState string
 }
 
 func (m *clusterDomainMock) GetClusterDNSZone(clusterID string) (*client.ClusterDNSZoneResponse, error) {
@@ -37,7 +38,11 @@ func (m *clusterDomainMock) EnableClusterDNSZone(clusterID string) (*client.Clus
 
 func (m *clusterDomainMock) DisableClusterDNSZone(clusterID string) (*client.ClusterDNSZoneResponse, error) {
 	m.disableCalls = append(m.disableCalls, clusterID)
-	return &client.ClusterDNSZoneResponse{Success: true, FQDN: "abc.org1234.ankra.cc", State: "deleting"}, nil
+	state := m.disableState
+	if state == "" {
+		state = "deleting"
+	}
+	return &client.ClusterDNSZoneResponse{Success: true, FQDN: "abc.org1234.ankra.cc", State: state}, nil
 }
 
 func resetClusterDomainFlags(t *testing.T) {
@@ -154,5 +159,20 @@ func TestRunClusterDomain_StructuredOutputStaysParseable(t *testing.T) {
 	}
 	if strings.Contains(output, "--enable") {
 		t.Errorf("the human hint leaked into stdout: %s", output)
+	}
+}
+
+func TestRunClusterDomain_RemoveDoesNotEmitTheEnableHint(t *testing.T) {
+	// A backend that answered a removal with state "none" must not send the
+	// operator back to --enable.
+	mock := &clusterDomainMock{}
+	mock.disableState = clusterDomainStateNone
+
+	output, executeError := runClusterDomain(t, mock, domainTestClusterID, "--remove")
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	if strings.Contains(output, "--enable") {
+		t.Errorf("the removal path emitted the enable hint:\n%s", output)
 	}
 }

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -527,6 +527,18 @@ func (m baseMock) DeleteOrganisationDnsRecord(ctx context.Context, recordID stri
 	return errors.New("not implemented")
 }
 
+func (m baseMock) ListOrganisationClusterDnsZones(ctx context.Context) (*client.DnsClusterZonesListResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetOrganisationDomain(ctx context.Context) (*client.OrganisationDomain, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) SetOrganisationDomain(ctx context.Context, rootDomain string) (*client.OrganisationDomain, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) CreateSupportTicket(ctx context.Context, req client.CreateSupportTicketRequest) (*client.SupportTicket, error) {
 	return nil, errors.New("not implemented")
 }
@@ -1812,6 +1824,10 @@ func (m baseMock) ImportManagedCluster(provider client.ManagedK8sProvider, reque
 }
 
 func (m baseMock) EnableClusterDNSZone(clusterID string) (*client.ClusterDNSZoneResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetClusterDNSZone(clusterID string) (*client.ClusterDNSZoneResponse, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/cmd/org_dns.go
+++ b/cmd/org_dns.go
@@ -25,6 +25,7 @@ a new or edited record starts in state pending and turns active once it is
 published to the authoritative nameservers.
 
   ankra org dns zone
+  ankra org dns zones
   ankra org dns list
   ankra org dns add chat CNAME lb-1234.example-lb.com --ttl 300
   ankra org dns update chat target.example.com
@@ -89,6 +90,71 @@ var orgDnsListCmd = &cobra.Command{
 		}
 		return renderDnsRecords(cmd.OutOrStdout(), list.Items, out)
 	},
+}
+
+var orgDnsZonesCmd = &cobra.Command{
+	Use:   "zones",
+	Short: "List the cluster domains in the organisation",
+	Long: `List every cluster-level DNS zone in the organisation: the cluster, the
+zone fqdn, and its reconciliation state.
+
+This is the inventory a root-domain switch has to clear. Switching the
+organisation's Ankra root domain ('ankra org domain set') is refused while any
+cluster zone still lives under the old root, and a zone is removed with
+'ankra cluster domain <cluster> --remove'.
+
+Listing is a read: it never creates a zone.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out, err := structuredFormatFromFlags(cmd)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+		defer cancel()
+
+		list, err := apiClient.ListOrganisationClusterDnsZones(ctx)
+		if err != nil {
+			return fmt.Errorf("list cluster DNS zones: %w", err)
+		}
+		return renderDnsClusterZones(cmd.OutOrStdout(), list.Items, out)
+	},
+}
+
+func renderDnsClusterZones(out io.Writer, zones []client.DnsClusterZone, format outputFormat) error {
+	switch format {
+	case outputJSON:
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(client.DnsClusterZonesListResult{Items: zones})
+	case outputYAML:
+		enc := yaml.NewEncoder(out)
+		enc.SetIndent(2)
+		defer func() { _ = enc.Close() }()
+		return enc.Encode(client.DnsClusterZonesListResult{Items: zones})
+	}
+	if len(zones) == 0 {
+		_, _ = fmt.Fprintln(out, "No cluster domains. Nothing blocks an organisation root-domain switch.")
+		return nil
+	}
+	t := table.NewWriter()
+	t.SetOutputMirror(out)
+	t.SetStyle(table.StyleRounded)
+	t.AppendHeader(table.Row{"CLUSTER", "DOMAIN", "STATE", "ERROR"})
+	for _, zone := range zones {
+		clusterName := zone.ClusterName
+		if clusterName == "" {
+			clusterName = zone.ClusterID
+		}
+		lastError := ""
+		if zone.LastError != nil {
+			lastError = truncateForDisplay(*zone.LastError, 40)
+		}
+		t.AppendRow(table.Row{clusterName, zone.FQDN, zone.State, lastError})
+	}
+	t.Render()
+	return nil
 }
 
 var orgDnsAddCmd = &cobra.Command{
@@ -276,7 +342,7 @@ func renderDnsRecords(out io.Writer, records []client.DnsRecord, format outputFo
 }
 
 func init() {
-	registerStructuredOutputFlags(orgDnsZoneCmd, orgDnsListCmd)
+	registerStructuredOutputFlags(orgDnsZoneCmd, orgDnsZonesCmd, orgDnsListCmd)
 	orgDnsAddCmd.Flags().Int("ttl", 0, "TTL in seconds (30..86400); omitted means Auto")
 	orgDnsUpdateCmd.Flags().Int("ttl", 0, "TTL in seconds (30..86400); omitted keeps the record's current ttl")
 	orgDnsUpdateCmd.Flags().String("type", "", "Record type (CNAME, A, TXT) to disambiguate a name reference")
@@ -284,6 +350,7 @@ func init() {
 	orgDnsDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
 	orgDnsCmd.AddCommand(orgDnsZoneCmd)
+	orgDnsCmd.AddCommand(orgDnsZonesCmd)
 	orgDnsCmd.AddCommand(orgDnsListCmd)
 	orgDnsCmd.AddCommand(orgDnsAddCmd)
 	orgDnsCmd.AddCommand(orgDnsUpdateCmd)

--- a/cmd/org_domain.go
+++ b/cmd/org_domain.go
@@ -96,6 +96,17 @@ still live under the old root; the refusal lists them.`,
 		if err != nil {
 			var blocked *client.OrganisationDomainBlockedError
 			if errors.As(err, &blocked) {
+				// A refused switch is the one failure whose payload a script
+				// wants: with -o json|yaml the blocker inventory goes to
+				// stdout in the requested format and the error stays short,
+				// so structured output is still parseable. The exit code is
+				// non-zero either way.
+				if out == outputJSON || out == outputYAML {
+					if renderError := renderOrganisationDomainBlocked(cmd, blocked, out); renderError != nil {
+						return renderError
+					}
+					return withExitCode(exitError, errors.New("the organisation domain was not changed"))
+				}
 				return withExitCode(exitError, errors.New(organisationDomainBlockedMessage(blocked)))
 			}
 			return fmt.Errorf("set organisation domain: %w", err)
@@ -105,6 +116,48 @@ still live under the old root; the refusal lists them.`,
 }
 
 var orgDomainUseDefault bool
+
+// organisationDomainBlockedDocument is the machine-readable rendering of a
+// refused switch: the same members the backend sent, so a script reading
+// -o json|yaml sees the blocker inventory rather than an unparseable error
+// string.
+type organisationDomainBlockedDocument struct {
+	Detail                        string                                         `json:"detail" yaml:"detail"`
+	BlockingClusterZones          []client.OrganisationDomainBlockingClusterZone `json:"blocking_cluster_zones" yaml:"blocking_cluster_zones"`
+	BlockingClusterZonesTruncated bool                                           `json:"blocking_cluster_zones_truncated,omitempty" yaml:"blocking_cluster_zones_truncated,omitempty"`
+	BlockingDnsRecords            []client.OrganisationDomainBlockingDnsRecord   `json:"blocking_dns_records" yaml:"blocking_dns_records"`
+	BlockingDnsRecordsTruncated   bool                                           `json:"blocking_dns_records_truncated,omitempty" yaml:"blocking_dns_records_truncated,omitempty"`
+}
+
+// renderOrganisationDomainBlocked writes the refusal inventory to stdout in
+// the requested structured format.
+func renderOrganisationDomainBlocked(cmd *cobra.Command, blocked *client.OrganisationDomainBlockedError, format outputFormat) error {
+	document := organisationDomainBlockedDocument{
+		Detail:                        blocked.Detail,
+		BlockingClusterZones:          blocked.ClusterZones,
+		BlockingClusterZonesTruncated: blocked.ClusterZonesTruncated,
+		BlockingDnsRecords:            blocked.DnsRecords,
+		BlockingDnsRecordsTruncated:   blocked.DnsRecordsTruncated,
+	}
+	if document.BlockingClusterZones == nil {
+		document.BlockingClusterZones = []client.OrganisationDomainBlockingClusterZone{}
+	}
+	if document.BlockingDnsRecords == nil {
+		document.BlockingDnsRecords = []client.OrganisationDomainBlockingDnsRecord{}
+	}
+	switch format {
+	case outputJSON:
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(document)
+	case outputYAML:
+		encoder := yaml.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent(2)
+		defer func() { _ = encoder.Close() }()
+		return encoder.Encode(document)
+	}
+	return nil
+}
 
 // organisationDomainBlockedMessage turns the backend's structured refusal
 // into an actionable error: the refusal text, every blocking cluster zone and
@@ -120,12 +173,18 @@ func organisationDomainBlockedMessage(blocked *client.OrganisationDomainBlockedE
 			}
 			message += fmt.Sprintf("\n  %s  %s  (%s)", clusterName, zone.FQDN, zone.State)
 		}
+		if blocked.ClusterZonesTruncated {
+			message += "\n  ... and more; run 'ankra org dns zones' for the full list."
+		}
 		message += "\n  Remove each with: ankra cluster domain <cluster> --remove"
 	}
 	if len(blocked.DnsRecords) > 0 {
 		message += "\n\nDNS records still under the current root:"
 		for _, record := range blocked.DnsRecords {
 			message += fmt.Sprintf("\n  %s  %s  (%s)", record.RecordType, record.Name, record.State)
+		}
+		if blocked.DnsRecordsTruncated {
+			message += "\n  ... and more; run 'ankra org dns list' for the full list."
 		}
 		message += "\n  Remove each with: ankra org dns delete <record>"
 	}

--- a/cmd/org_domain.go
+++ b/cmd/org_domain.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+var orgDomainCmd = &cobra.Command{
+	Use:   "domain",
+	Short: "Show or register the organisation's Ankra root domain",
+	Long: `Show or register the root domain every Ankra-generated hostname in the
+organisation nests under - the organisation's delegated DNS zone, its clusters'
+domains, and the preview hostnames built from them.
+
+Unset, the platform default (ankra.cc) applies. Registering your own domain
+requires it to be delegated to the Ankra nameservers first; the write is
+refused otherwise, naming the nameservers to point at.
+
+  ankra org domain get
+  ankra org domain set example.com
+  ankra org domain set --default
+
+This is the same setting the portal writes at AI > Settings > Workspaces
+("Custom Ankra domain"). Changing it is refused while cluster DNS zones or DNS
+records still live under the old root; the refusal lists exactly what to
+remove. Use 'ankra org dns zones' and 'ankra org dns list' to inventory them,
+'ankra cluster domain <cluster> --remove' and 'ankra org dns delete <record>'
+to clear them. Ankra re-creates the organisation zone under the new domain
+automatically once the switch is accepted.
+
+Reading requires organisation membership; changing it requires organisation
+admin.`,
+}
+
+var orgDomainGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Show the organisation's Ankra root domain",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out, err := structuredFormatFromFlags(cmd)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+		defer cancel()
+
+		domain, err := apiClient.GetOrganisationDomain(ctx)
+		if err != nil {
+			return fmt.Errorf("get organisation domain: %w", err)
+		}
+		return renderOrganisationDomain(cmd, domain, out)
+	},
+}
+
+var orgDomainSetCmd = &cobra.Command{
+	Use:   "set [domain]",
+	Short: "Register the organisation's own Ankra root domain",
+	Long: `Register the organisation's own root domain, or clear it back to the
+platform default with --default.
+
+The domain must be a bare domain you own (example.com, not sub.example.com or
+a domain under the platform default), already delegated to the Ankra
+nameservers. The switch is refused while cluster DNS zones or DNS records
+still live under the old root; the refusal lists them.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out, err := structuredFormatFromFlags(cmd)
+		if err != nil {
+			return err
+		}
+		if orgDomainUseDefault && len(args) > 0 {
+			return withExitCode(exitUsage, errors.New("pass a domain or --default, not both"))
+		}
+		if !orgDomainUseDefault && len(args) == 0 {
+			return withExitCode(exitUsage,
+				errors.New("pass the domain to register, or --default to follow the platform default"))
+		}
+		rootDomain := ""
+		if len(args) > 0 {
+			rootDomain = args[0]
+		}
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 120*time.Second)
+		defer cancel()
+
+		domain, err := apiClient.SetOrganisationDomain(ctx, rootDomain)
+		if err != nil {
+			var blocked *client.OrganisationDomainBlockedError
+			if errors.As(err, &blocked) {
+				return withExitCode(exitError, errors.New(organisationDomainBlockedMessage(blocked)))
+			}
+			return fmt.Errorf("set organisation domain: %w", err)
+		}
+		return renderOrganisationDomain(cmd, domain, out)
+	},
+}
+
+var orgDomainUseDefault bool
+
+// organisationDomainBlockedMessage turns the backend's structured refusal
+// into an actionable error: the refusal text, every blocking cluster zone and
+// DNS record, and the command that clears each kind.
+func organisationDomainBlockedMessage(blocked *client.OrganisationDomainBlockedError) string {
+	message := blocked.Detail
+	if len(blocked.ClusterZones) > 0 {
+		message += "\n\nCluster domains still under the current root:"
+		for _, zone := range blocked.ClusterZones {
+			clusterName := zone.ClusterName
+			if clusterName == "" {
+				clusterName = zone.ClusterID
+			}
+			message += fmt.Sprintf("\n  %s  %s  (%s)", clusterName, zone.FQDN, zone.State)
+		}
+		message += "\n  Remove each with: ankra cluster domain <cluster> --remove"
+	}
+	if len(blocked.DnsRecords) > 0 {
+		message += "\n\nDNS records still under the current root:"
+		for _, record := range blocked.DnsRecords {
+			message += fmt.Sprintf("\n  %s  %s  (%s)", record.RecordType, record.Name, record.State)
+		}
+		message += "\n  Remove each with: ankra org dns delete <record>"
+	}
+	return message
+}
+
+func renderOrganisationDomain(cmd *cobra.Command, domain *client.OrganisationDomain, format outputFormat) error {
+	switch format {
+	case outputJSON:
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(domain)
+	case outputYAML:
+		encoder := yaml.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent(2)
+		defer func() { _ = encoder.Close() }()
+		return encoder.Encode(domain)
+	}
+	if domain.DNSRootDomain == "" {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+			"Domain:  %s (platform default)\nDefault: %s\n",
+			domain.DNSRootDomainDefault, domain.DNSRootDomainDefault)
+		return nil
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Domain:  %s\nDefault: %s\n",
+		domain.DNSRootDomain, domain.DNSRootDomainDefault)
+	return nil
+}
+
+func init() {
+	registerStructuredOutputFlags(orgDomainGetCmd, orgDomainSetCmd)
+	orgDomainSetCmd.Flags().BoolVar(&orgDomainUseDefault, "default", false,
+		"Clear the custom domain and follow the platform default")
+	orgDomainCmd.AddCommand(orgDomainGetCmd)
+	orgDomainCmd.AddCommand(orgDomainSetCmd)
+	orgCmd.AddCommand(orgDomainCmd)
+}

--- a/cmd/org_domain_test.go
+++ b/cmd/org_domain_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -227,5 +228,81 @@ func TestRunOrgDnsZones_StructuredOutputStaysParseable(t *testing.T) {
 	}
 	if !strings.Contains(output.String(), `"cluster_name": "playground"`) {
 		t.Errorf("json output = %s", output.String())
+	}
+}
+
+func TestRunOrgDomainSet_BlockedSwitchHonoursStructuredOutput(t *testing.T) {
+	mock := &orgDomainMock{
+		domain: client.OrganisationDomain{DNSRootDomainDefault: "ankra.cc"},
+		setError: &client.OrganisationDomainBlockedError{
+			Detail: "Changing dns_root_domain requires removing the organisation's cluster DNS zones and DNS records first. Ankra then re-creates your zone under the new domain automatically.",
+			ClusterZones: []client.OrganisationDomainBlockingClusterZone{
+				{ClusterID: "c-1", ClusterName: "playground", FQDN: "abc.org1234.ankra.cc", State: "active"},
+			},
+			DnsRecords: []client.OrganisationDomainBlockingDnsRecord{
+				{ID: "r-1", Name: "chat.org1234.ankra.cc", RecordType: "A", State: "active"},
+			},
+			DnsRecordsTruncated: true,
+		},
+	}
+	setMockClient(t, mock)
+	resetOrgDomainFlags(t)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(stderr)
+	rootCmd.SetArgs([]string{"org", "domain", "set", "smartoptics.dev", "-o", "json"})
+	executeError := rootCmd.Execute()
+	if executeError == nil {
+		t.Fatalf("a blocked switch must still fail, stdout: %s", stdout.String())
+	}
+
+	var document struct {
+		Detail               string `json:"detail"`
+		BlockingClusterZones []struct {
+			ClusterName string `json:"cluster_name"`
+		} `json:"blocking_cluster_zones"`
+		BlockingDnsRecords []struct {
+			Name string `json:"name"`
+		} `json:"blocking_dns_records"`
+		DnsRecordsTruncated bool `json:"blocking_dns_records_truncated"`
+	}
+	if unmarshalError := json.Unmarshal(stdout.Bytes(), &document); unmarshalError != nil {
+		t.Fatalf("stdout must stay parseable json: %v\nstdout: %s", unmarshalError, stdout.String())
+	}
+	if len(document.BlockingClusterZones) != 1 || document.BlockingClusterZones[0].ClusterName != "playground" {
+		t.Errorf("cluster zones = %+v", document.BlockingClusterZones)
+	}
+	if len(document.BlockingDnsRecords) != 1 || document.BlockingDnsRecords[0].Name != "chat.org1234.ankra.cc" {
+		t.Errorf("dns records = %+v", document.BlockingDnsRecords)
+	}
+	if !document.DnsRecordsTruncated {
+		t.Errorf("the truncation flag must survive into the structured output: %s", stdout.String())
+	}
+}
+
+func TestRunOrgDomainSet_HumanRefusalNamesTheTruncation(t *testing.T) {
+	mock := &orgDomainMock{
+		domain: client.OrganisationDomain{DNSRootDomainDefault: "ankra.cc"},
+		setError: &client.OrganisationDomainBlockedError{
+			Detail: "blocked",
+			DnsRecords: []client.OrganisationDomainBlockingDnsRecord{
+				{ID: "r-1", Name: "chat.org1234.ankra.cc", RecordType: "A", State: "active"},
+			},
+			DnsRecordsTruncated: true,
+		},
+	}
+	setMockClient(t, mock)
+	resetOrgDomainFlags(t)
+	output := new(bytes.Buffer)
+	rootCmd.SetOut(output)
+	rootCmd.SetErr(output)
+	rootCmd.SetArgs([]string{"org", "domain", "set", "smartoptics.dev"})
+	executeError := rootCmd.Execute()
+	if executeError == nil {
+		t.Fatal("expected a refusal")
+	}
+	if !strings.Contains(executeError.Error(), "run 'ankra org dns list' for the full list") {
+		t.Errorf("a truncated list must say so:\n%s", executeError.Error())
 	}
 }

--- a/cmd/org_domain_test.go
+++ b/cmd/org_domain_test.go
@@ -1,0 +1,231 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/pflag"
+)
+
+// orgDomainMock captures the root-domain reads and writes plus the cluster
+// zone inventory the migration lane needs.
+type orgDomainMock struct {
+	baseMock
+
+	domain     client.OrganisationDomain
+	setCalls   []string
+	setError   error
+	zones      []client.DnsClusterZone
+	zonesError error
+}
+
+func (m *orgDomainMock) GetOrganisationDomain(ctx context.Context) (*client.OrganisationDomain, error) {
+	domain := m.domain
+	return &domain, nil
+}
+
+func (m *orgDomainMock) SetOrganisationDomain(ctx context.Context, rootDomain string) (*client.OrganisationDomain, error) {
+	m.setCalls = append(m.setCalls, rootDomain)
+	if m.setError != nil {
+		return nil, m.setError
+	}
+	m.domain.DNSRootDomain = rootDomain
+	domain := m.domain
+	return &domain, nil
+}
+
+func (m *orgDomainMock) ListOrganisationClusterDnsZones(ctx context.Context) (*client.DnsClusterZonesListResult, error) {
+	if m.zonesError != nil {
+		return nil, m.zonesError
+	}
+	return &client.DnsClusterZonesListResult{Items: m.zones}, nil
+}
+
+func resetOrgDomainFlags(t *testing.T) {
+	t.Helper()
+	for _, flagged := range []interface{ Flags() *pflag.FlagSet }{
+		orgDomainGetCmd, orgDomainSetCmd, orgDnsZonesCmd,
+	} {
+		flagged.Flags().VisitAll(func(flag *pflag.Flag) {
+			_ = flag.Value.Set(flag.DefValue)
+			flag.Changed = false
+		})
+	}
+	orgDomainUseDefault = false
+}
+
+func TestRunOrgDomainGet_ShowsTheRegisteredDomain(t *testing.T) {
+	mock := &orgDomainMock{domain: client.OrganisationDomain{
+		DNSRootDomain: "smartoptics.dev", DNSRootDomainDefault: "ankra.cc"}}
+	setMockClient(t, mock)
+	resetOrgDomainFlags(t)
+	output := new(bytes.Buffer)
+	rootCmd.SetOut(output)
+	rootCmd.SetErr(output)
+	rootCmd.SetArgs([]string{"org", "domain", "get"})
+	if executeError := rootCmd.Execute(); executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output.String())
+	}
+	if !strings.Contains(output.String(), "smartoptics.dev") {
+		t.Errorf("output = %s", output.String())
+	}
+}
+
+func TestRunOrgDomainGet_NamesThePlatformDefaultWhenUnset(t *testing.T) {
+	mock := &orgDomainMock{domain: client.OrganisationDomain{DNSRootDomainDefault: "ankra.cc"}}
+	setMockClient(t, mock)
+	resetOrgDomainFlags(t)
+	output := new(bytes.Buffer)
+	rootCmd.SetOut(output)
+	rootCmd.SetErr(output)
+	rootCmd.SetArgs([]string{"org", "domain", "get"})
+	if executeError := rootCmd.Execute(); executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output.String())
+	}
+	if !strings.Contains(output.String(), "ankra.cc (platform default)") {
+		t.Errorf("output = %s", output.String())
+	}
+}
+
+func TestRunOrgDomainSet_SendsTheDomain(t *testing.T) {
+	mock := &orgDomainMock{domain: client.OrganisationDomain{DNSRootDomainDefault: "ankra.cc"}}
+	setMockClient(t, mock)
+	resetOrgDomainFlags(t)
+	output := new(bytes.Buffer)
+	rootCmd.SetOut(output)
+	rootCmd.SetErr(output)
+	rootCmd.SetArgs([]string{"org", "domain", "set", "smartoptics.dev"})
+	if executeError := rootCmd.Execute(); executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output.String())
+	}
+	if len(mock.setCalls) != 1 || mock.setCalls[0] != "smartoptics.dev" {
+		t.Fatalf("set calls = %v", mock.setCalls)
+	}
+}
+
+func TestRunOrgDomainSet_DefaultClearsTheCustomDomain(t *testing.T) {
+	mock := &orgDomainMock{domain: client.OrganisationDomain{
+		DNSRootDomain: "smartoptics.dev", DNSRootDomainDefault: "ankra.cc"}}
+	setMockClient(t, mock)
+	resetOrgDomainFlags(t)
+	output := new(bytes.Buffer)
+	rootCmd.SetOut(output)
+	rootCmd.SetErr(output)
+	rootCmd.SetArgs([]string{"org", "domain", "set", "--default"})
+	if executeError := rootCmd.Execute(); executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output.String())
+	}
+	if len(mock.setCalls) != 1 || mock.setCalls[0] != "" {
+		t.Fatalf("set calls = %v, want one empty value", mock.setCalls)
+	}
+}
+
+func TestRunOrgDomainSet_RefusesWithNoDomainAndNoDefault(t *testing.T) {
+	mock := &orgDomainMock{}
+	setMockClient(t, mock)
+	resetOrgDomainFlags(t)
+	output := new(bytes.Buffer)
+	rootCmd.SetOut(output)
+	rootCmd.SetErr(output)
+	rootCmd.SetArgs([]string{"org", "domain", "set"})
+	executeError := rootCmd.Execute()
+	var coded *codedError
+	if !errors.As(executeError, &coded) || coded.code != exitUsage {
+		t.Fatalf("error = %v, want exitUsage", executeError)
+	}
+	if len(mock.setCalls) != 0 {
+		t.Fatalf("the refusal must not reach the API: %v", mock.setCalls)
+	}
+}
+
+func TestRunOrgDomainSet_ListsTheBlockingZonesAndRecords(t *testing.T) {
+	mock := &orgDomainMock{
+		domain: client.OrganisationDomain{DNSRootDomainDefault: "ankra.cc"},
+		setError: &client.OrganisationDomainBlockedError{
+			Detail: "Changing dns_root_domain requires removing the organisation's cluster DNS zones and DNS records first. Ankra then re-creates your zone under the new domain automatically.",
+			ClusterZones: []client.OrganisationDomainBlockingClusterZone{
+				{ClusterID: "c-1", ClusterName: "playground", FQDN: "abc.org1234.ankra.cc", State: "active"},
+			},
+			DnsRecords: []client.OrganisationDomainBlockingDnsRecord{
+				{ID: "r-1", Name: "chat.org1234.ankra.cc", RecordType: "A", State: "active"},
+			},
+		},
+	}
+	setMockClient(t, mock)
+	resetOrgDomainFlags(t)
+	output := new(bytes.Buffer)
+	rootCmd.SetOut(output)
+	rootCmd.SetErr(output)
+	rootCmd.SetArgs([]string{"org", "domain", "set", "smartoptics.dev"})
+	executeError := rootCmd.Execute()
+	if executeError == nil {
+		t.Fatalf("expected a refusal, output: %s", output.String())
+	}
+	message := executeError.Error()
+	for _, expected := range []string{
+		"playground", "abc.org1234.ankra.cc", "chat.org1234.ankra.cc",
+		"ankra cluster domain <cluster> --remove", "ankra org dns delete <record>",
+	} {
+		if !strings.Contains(message, expected) {
+			t.Errorf("refusal message missing %q:\n%s", expected, message)
+		}
+	}
+}
+
+func TestRunOrgDnsZones_ListsTheClusterDomains(t *testing.T) {
+	mock := &orgDomainMock{zones: []client.DnsClusterZone{
+		{ClusterID: "c-1", ClusterName: "playground", FQDN: "abc.org1234.ankra.cc", State: "active"},
+	}}
+	setMockClient(t, mock)
+	resetOrgDomainFlags(t)
+	output := new(bytes.Buffer)
+	rootCmd.SetOut(output)
+	rootCmd.SetErr(output)
+	rootCmd.SetArgs([]string{"org", "dns", "zones"})
+	if executeError := rootCmd.Execute(); executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output.String())
+	}
+	if !strings.Contains(output.String(), "playground") ||
+		!strings.Contains(output.String(), "abc.org1234.ankra.cc") {
+		t.Errorf("output = %s", output.String())
+	}
+}
+
+func TestRunOrgDnsZones_ReportsAnEmptyInventory(t *testing.T) {
+	mock := &orgDomainMock{zones: []client.DnsClusterZone{}}
+	setMockClient(t, mock)
+	resetOrgDomainFlags(t)
+	output := new(bytes.Buffer)
+	rootCmd.SetOut(output)
+	rootCmd.SetErr(output)
+	rootCmd.SetArgs([]string{"org", "dns", "zones"})
+	if executeError := rootCmd.Execute(); executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output.String())
+	}
+	if !strings.Contains(output.String(), "No cluster domains") {
+		t.Errorf("output = %s", output.String())
+	}
+}
+
+func TestRunOrgDnsZones_StructuredOutputStaysParseable(t *testing.T) {
+	mock := &orgDomainMock{zones: []client.DnsClusterZone{
+		{ClusterID: "c-1", ClusterName: "playground", FQDN: "abc.org1234.ankra.cc", State: "pending"},
+	}}
+	setMockClient(t, mock)
+	resetOrgDomainFlags(t)
+	output := new(bytes.Buffer)
+	rootCmd.SetOut(output)
+	rootCmd.SetErr(output)
+	rootCmd.SetArgs([]string{"org", "dns", "zones", "-o", "json"})
+	if executeError := rootCmd.Execute(); executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output.String())
+	}
+	if !strings.Contains(output.String(), `"cluster_name": "playground"`) {
+		t.Errorf("json output = %s", output.String())
+	}
+}

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -78,6 +78,9 @@ type APIClient interface {
 	CreateOrganisationDnsRecord(ctx context.Context, name, recordType, content string, ttl *int) (*client.DnsRecord, error)
 	UpdateOrganisationDnsRecord(ctx context.Context, recordID, content string, ttl *int) (*client.DnsRecord, error)
 	DeleteOrganisationDnsRecord(ctx context.Context, recordID string) error
+	ListOrganisationClusterDnsZones(ctx context.Context) (*client.DnsClusterZonesListResult, error)
+	GetOrganisationDomain(ctx context.Context) (*client.OrganisationDomain, error)
+	SetOrganisationDomain(ctx context.Context, rootDomain string) (*client.OrganisationDomain, error)
 
 	CreateSupportTicket(ctx context.Context, req client.CreateSupportTicketRequest) (*client.SupportTicket, error)
 	ReviewSupportTicket(ctx context.Context, req client.ReviewSupportTicketRequest) (*client.SupportTicketReview, error)
@@ -505,6 +508,7 @@ type APIClient interface {
 	DiscoverManagedClusters(provider client.ManagedK8sProvider, credentialID string) (*client.DiscoverManagedClustersResponse, error)
 	ImportManagedCluster(provider client.ManagedK8sProvider, request client.ImportManagedClusterRequest) (*client.ImportManagedClusterResponse, error)
 	EnableClusterDNSZone(clusterID string) (*client.ClusterDNSZoneResponse, error)
+	GetClusterDNSZone(clusterID string) (*client.ClusterDNSZoneResponse, error)
 
 	ListAlertDestinations(options client.ListAlertDestinationsOptions) (*client.AlertDestinationList, error)
 	GetAlertDestination(destinationID string) (*client.AlertDestination, error)

--- a/internal/client/cluster_dns_zone.go
+++ b/internal/client/cluster_dns_zone.go
@@ -14,6 +14,20 @@ type ClusterDNSZoneResponse struct {
 	State   string `json:"state"`
 }
 
+// GetClusterDNSZone reads the cluster's generated public DNS zone without
+// creating one: the non-mutating lookup twin of EnableClusterDNSZone. A
+// cluster that has no zone reports state "none" with an empty fqdn, so
+// checking a cluster's domain never enables it - and never adds a blocker to
+// a pending organisation root-domain switch.
+func (c *Client) GetClusterDNSZone(clusterID string) (*ClusterDNSZoneResponse, error) {
+	requestURL := fmt.Sprintf("%s/api/v1/clusters/%s/dns-zone", c.BaseURL, url.PathEscape(clusterID))
+	var response ClusterDNSZoneResponse
+	if err := c.getJSON(requestURL, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
 // EnableClusterDNSZone queues the cluster's generated Ankra DNS zone (under
 // the organisation's selected root domain) and returns its fqdn and state.
 // The call is idempotent: a cluster that already has a zone reports the

--- a/internal/client/cluster_dns_zone_test.go
+++ b/internal/client/cluster_dns_zone_test.go
@@ -51,3 +51,40 @@ func TestDisableClusterDNSZone_DeletesAndDecodesZone(t *testing.T) {
 		t.Errorf("state = %s, want deleting", result.State)
 	}
 }
+
+func TestGetClusterDNSZone_ReadsWithoutMutating(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/clusters/cluster-1/dns-zone" {
+			t.Errorf("path = %s, want /api/v1/clusters/cluster-1/dns-zone", r.URL.Path)
+		}
+		jsonResponse(t, w, http.StatusOK, ClusterDNSZoneResponse{
+			Success: true, FQDN: "abc123.org456.ankra.cc", State: "active"})
+	}
+	testClient := newTestClient(t, handler)
+
+	result, err := testClient.GetClusterDNSZone("cluster-1")
+	if err != nil {
+		t.Fatalf("GetClusterDNSZone: %v", err)
+	}
+	if result.FQDN != "abc123.org456.ankra.cc" || result.State != "active" {
+		t.Errorf("result = %+v", result)
+	}
+}
+
+func TestGetClusterDNSZone_ReportsNoneForAClusterWithoutAZone(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(t, w, http.StatusOK, ClusterDNSZoneResponse{Success: true, FQDN: "", State: "none"})
+	}
+	testClient := newTestClient(t, handler)
+
+	result, err := testClient.GetClusterDNSZone("cluster-1")
+	if err != nil {
+		t.Fatalf("GetClusterDNSZone: %v", err)
+	}
+	if result.FQDN != "" || result.State != "none" {
+		t.Errorf("result = %+v, want the none state", result)
+	}
+}

--- a/internal/client/dnsrecords.go
+++ b/internal/client/dnsrecords.go
@@ -66,6 +66,37 @@ func (c *Client) GetOrganisationDnsZone(ctx context.Context) (*DnsZone, error) {
 	return &out, nil
 }
 
+// DnsClusterZone mirrors one cluster-level delegated zone in the
+// organisation: the cluster it belongs to, the zone fqdn, and its
+// reconciliation state. ClusterName is empty when the cluster row is already
+// gone and only the zone teardown is outstanding.
+type DnsClusterZone struct {
+	ClusterID   string  `json:"cluster_id"`
+	ClusterName string  `json:"cluster_name"`
+	FQDN        string  `json:"fqdn"`
+	State       string  `json:"state"`
+	LastError   *string `json:"last_error,omitempty"`
+}
+
+type DnsClusterZonesListResult struct {
+	Items []DnsClusterZone `json:"items"`
+}
+
+// ListOrganisationClusterDnsZones returns every cluster-level DNS zone in the
+// organisation - the inventory an admin has to clear before switching the
+// organisation's Ankra root domain. It is a read: it never creates a zone.
+func (c *Client) ListOrganisationClusterDnsZones(ctx context.Context) (*DnsClusterZonesListResult, error) {
+	body, err := c.doDnsRequest(ctx, http.MethodGet, c.BaseURL+"/api/v1/org/dns/cluster-zones", nil)
+	if err != nil {
+		return nil, err
+	}
+	var out DnsClusterZonesListResult
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &out, nil
+}
+
 func (c *Client) ListOrganisationDnsRecords(ctx context.Context) (*DnsRecordsListResult, error) {
 	body, err := c.doDnsRequest(ctx, http.MethodGet, c.BaseURL+"/api/v1/org/dns/records", nil)
 	if err != nil {

--- a/internal/client/org_domain.go
+++ b/internal/client/org_domain.go
@@ -47,18 +47,25 @@ type OrganisationDomainBlockingDnsRecord struct {
 // OrganisationDomainBlockedError is the backend's refusal of a root-domain
 // switch, with the exact rows that have to be cleared first. Callers use
 // errors.As to render the list instead of the message alone.
+//
+// The Truncated flags mean the backend capped that list and more blockers
+// exist, so clearing everything listed will not be enough on its own.
 type OrganisationDomainBlockedError struct {
-	Detail       string
-	ClusterZones []OrganisationDomainBlockingClusterZone
-	DnsRecords   []OrganisationDomainBlockingDnsRecord
+	Detail                string
+	ClusterZones          []OrganisationDomainBlockingClusterZone
+	ClusterZonesTruncated bool
+	DnsRecords            []OrganisationDomainBlockingDnsRecord
+	DnsRecordsTruncated   bool
 }
 
 func (e *OrganisationDomainBlockedError) Error() string { return e.Detail }
 
 type organisationDomainRefusal struct {
-	Detail               string                                  `json:"detail"`
-	BlockingClusterZones []OrganisationDomainBlockingClusterZone `json:"blocking_cluster_zones"`
-	BlockingDnsRecords   []OrganisationDomainBlockingDnsRecord   `json:"blocking_dns_records"`
+	Detail                        string                                  `json:"detail"`
+	BlockingClusterZones          []OrganisationDomainBlockingClusterZone `json:"blocking_cluster_zones"`
+	BlockingClusterZonesTruncated bool                                    `json:"blocking_cluster_zones_truncated"`
+	BlockingDnsRecords            []OrganisationDomainBlockingDnsRecord   `json:"blocking_dns_records"`
+	BlockingDnsRecordsTruncated   bool                                    `json:"blocking_dns_records_truncated"`
 }
 
 type organisationDomainSettings struct {
@@ -148,9 +155,11 @@ func (c *Client) doOrganisationDomainRequest(ctx context.Context, method string,
 		if unmarshalError := json.Unmarshal(responseBody, &refusal); unmarshalError == nil && refusal.Detail != "" {
 			if len(refusal.BlockingClusterZones) > 0 || len(refusal.BlockingDnsRecords) > 0 {
 				return nil, &OrganisationDomainBlockedError{
-					Detail:       refusal.Detail,
-					ClusterZones: refusal.BlockingClusterZones,
-					DnsRecords:   refusal.BlockingDnsRecords,
+					Detail:                refusal.Detail,
+					ClusterZones:          refusal.BlockingClusterZones,
+					ClusterZonesTruncated: refusal.BlockingClusterZonesTruncated,
+					DnsRecords:            refusal.BlockingDnsRecords,
+					DnsRecordsTruncated:   refusal.BlockingDnsRecordsTruncated,
 				}
 			}
 			return nil, errors.New(refusal.Detail)

--- a/internal/client/org_domain.go
+++ b/internal/client/org_domain.go
@@ -1,0 +1,164 @@
+package client
+
+// The organisation's Ankra root domain, read and written through the same
+// backend surface the portal's AI → Settings → Workspaces screen uses
+// (GET/PUT /api/v1/org/ai-environment, the bearer twins of the browser
+// routes). There is no second source of truth: the CLI sends only the
+// dns_root_domain member, and the backend's present-vs-absent update
+// contract leaves every other AI environment setting untouched.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// OrganisationDomain reports the organisation's Ankra root domain: the
+// custom domain it registered (empty when it follows the platform default)
+// and the platform default itself, so a caller can show what an unset choice
+// resolves to.
+type OrganisationDomain struct {
+	DNSRootDomain        string `json:"dns_root_domain"`
+	DNSRootDomainDefault string `json:"dns_root_domain_default"`
+}
+
+// OrganisationDomainBlockingClusterZone is one cluster DNS zone that refuses
+// a root-domain switch until it is removed.
+type OrganisationDomainBlockingClusterZone struct {
+	ClusterID   string `json:"cluster_id"`
+	ClusterName string `json:"cluster_name"`
+	FQDN        string `json:"fqdn"`
+	State       string `json:"state"`
+}
+
+// OrganisationDomainBlockingDnsRecord is one DNS record that refuses a
+// root-domain switch until it is removed.
+type OrganisationDomainBlockingDnsRecord struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	RecordType string `json:"record_type"`
+	State      string `json:"state"`
+}
+
+// OrganisationDomainBlockedError is the backend's refusal of a root-domain
+// switch, with the exact rows that have to be cleared first. Callers use
+// errors.As to render the list instead of the message alone.
+type OrganisationDomainBlockedError struct {
+	Detail       string
+	ClusterZones []OrganisationDomainBlockingClusterZone
+	DnsRecords   []OrganisationDomainBlockingDnsRecord
+}
+
+func (e *OrganisationDomainBlockedError) Error() string { return e.Detail }
+
+type organisationDomainRefusal struct {
+	Detail               string                                  `json:"detail"`
+	BlockingClusterZones []OrganisationDomainBlockingClusterZone `json:"blocking_cluster_zones"`
+	BlockingDnsRecords   []OrganisationDomainBlockingDnsRecord   `json:"blocking_dns_records"`
+}
+
+type organisationDomainSettings struct {
+	DNSRootDomain        *string `json:"dns_root_domain"`
+	DNSRootDomainDefault string  `json:"dns_root_domain_default"`
+}
+
+// GetOrganisationDomain reads the organisation's Ankra root domain.
+func (c *Client) GetOrganisationDomain(ctx context.Context) (*OrganisationDomain, error) {
+	body, err := c.doOrganisationDomainRequest(ctx, http.MethodGet, nil)
+	if err != nil {
+		return nil, err
+	}
+	return decodeOrganisationDomain(body)
+}
+
+// SetOrganisationDomain registers the organisation's own root domain, or
+// clears it back to the platform default when rootDomain is empty. The
+// backend refuses the switch while cluster DNS zones or DNS records still
+// live under the old root; that refusal comes back as an
+// OrganisationDomainBlockedError carrying the blocking rows.
+func (c *Client) SetOrganisationDomain(ctx context.Context, rootDomain string) (*OrganisationDomain, error) {
+	payload := map[string]any{"dns_root_domain": nil}
+	if rootDomain != "" {
+		payload["dns_root_domain"] = rootDomain
+	}
+	encoded, marshalError := json.Marshal(payload)
+	if marshalError != nil {
+		return nil, fmt.Errorf("encode request: %w", marshalError)
+	}
+	body, err := c.doOrganisationDomainRequest(ctx, http.MethodPut, encoded)
+	if err != nil {
+		return nil, err
+	}
+	return decodeOrganisationDomain(body)
+}
+
+func decodeOrganisationDomain(body []byte) (*OrganisationDomain, error) {
+	var settings organisationDomainSettings
+	if unmarshalError := json.Unmarshal(body, &settings); unmarshalError != nil {
+		return nil, fmt.Errorf("parse response: %w", unmarshalError)
+	}
+	domain := OrganisationDomain{DNSRootDomainDefault: settings.DNSRootDomainDefault}
+	if settings.DNSRootDomain != nil {
+		domain.DNSRootDomain = *settings.DNSRootDomain
+	}
+	return &domain, nil
+}
+
+// doOrganisationDomainRequest sends an authenticated JSON request to the AI
+// environment settings routes. A 400 carrying the switch guard's blocker
+// inventory becomes an OrganisationDomainBlockedError; other 400/403 bodies
+// surface their detail verbatim - those texts are user-actionable.
+func (c *Client) doOrganisationDomainRequest(ctx context.Context, method string, body []byte) ([]byte, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	request, requestError := http.NewRequestWithContext(ctx, method,
+		c.BaseURL+"/api/v1/org/ai-environment", bodyReader)
+	if requestError != nil {
+		return nil, fmt.Errorf("create request: %w", requestError)
+	}
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	request.Header.Set("Authorization", "Bearer "+c.Token)
+
+	response, sendError := c.HTTP.Do(request)
+	if sendError != nil {
+		return nil, fmt.Errorf("request failed: %w", sendError)
+	}
+	defer closeBody(response)
+
+	responseBody, readError := readResponseBody(response)
+	if readError != nil {
+		return nil, fmt.Errorf("read response: %w", readError)
+	}
+
+	switch response.StatusCode {
+	case http.StatusOK:
+		return responseBody, nil
+	case http.StatusUnauthorized:
+		return nil, ErrUnauthorized
+	case http.StatusBadRequest, http.StatusForbidden:
+		var refusal organisationDomainRefusal
+		if unmarshalError := json.Unmarshal(responseBody, &refusal); unmarshalError == nil && refusal.Detail != "" {
+			if len(refusal.BlockingClusterZones) > 0 || len(refusal.BlockingDnsRecords) > 0 {
+				return nil, &OrganisationDomainBlockedError{
+					Detail:       refusal.Detail,
+					ClusterZones: refusal.BlockingClusterZones,
+					DnsRecords:   refusal.BlockingDnsRecords,
+				}
+			}
+			return nil, errors.New(refusal.Detail)
+		}
+		return nil, newUnexpectedResponseError("organisation domain request failed",
+			response.StatusCode, truncateForError(responseBody, 500))
+	default:
+		return nil, newUnexpectedResponseError("organisation domain request failed",
+			response.StatusCode, truncateForError(responseBody, 500))
+	}
+}

--- a/internal/client/org_domain_test.go
+++ b/internal/client/org_domain_test.go
@@ -1,0 +1,183 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestGetOrganisationDomain_ReadsTheAiEnvironmentTwin(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/org/ai-environment" {
+			t.Errorf("path = %s, want /api/v1/org/ai-environment", r.URL.Path)
+		}
+		jsonResponse(t, w, http.StatusOK, map[string]any{
+			"dns_root_domain": "smartoptics.dev", "dns_root_domain_default": "ankra.cc"})
+	}
+	testClient := newTestClient(t, handler)
+
+	domain, err := testClient.GetOrganisationDomain(context.Background())
+	if err != nil {
+		t.Fatalf("GetOrganisationDomain: %v", err)
+	}
+	if domain.DNSRootDomain != "smartoptics.dev" || domain.DNSRootDomainDefault != "ankra.cc" {
+		t.Errorf("domain = %+v", domain)
+	}
+}
+
+func TestGetOrganisationDomain_ReportsAnUnsetCustomDomainAsEmpty(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(t, w, http.StatusOK, map[string]any{
+			"dns_root_domain": nil, "dns_root_domain_default": "ankra.cc"})
+	}
+	testClient := newTestClient(t, handler)
+
+	domain, err := testClient.GetOrganisationDomain(context.Background())
+	if err != nil {
+		t.Fatalf("GetOrganisationDomain: %v", err)
+	}
+	if domain.DNSRootDomain != "" || domain.DNSRootDomainDefault != "ankra.cc" {
+		t.Errorf("domain = %+v", domain)
+	}
+}
+
+func TestSetOrganisationDomain_SendsOnlyTheRootDomainMember(t *testing.T) {
+	var receivedBody map[string]any
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("method = %s, want PUT", r.Method)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		if unmarshalError := json.Unmarshal(raw, &receivedBody); unmarshalError != nil {
+			t.Fatalf("request body is not json: %v", unmarshalError)
+		}
+		jsonResponse(t, w, http.StatusOK, map[string]any{
+			"dns_root_domain": "smartoptics.dev", "dns_root_domain_default": "ankra.cc"})
+	}
+	testClient := newTestClient(t, handler)
+
+	if _, err := testClient.SetOrganisationDomain(context.Background(), "smartoptics.dev"); err != nil {
+		t.Fatalf("SetOrganisationDomain: %v", err)
+	}
+	if len(receivedBody) != 1 || receivedBody["dns_root_domain"] != "smartoptics.dev" {
+		t.Errorf("body = %v, want only dns_root_domain", receivedBody)
+	}
+}
+
+func TestSetOrganisationDomain_ClearsWithAnExplicitNull(t *testing.T) {
+	var receivedRaw string
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		receivedRaw = string(raw)
+		jsonResponse(t, w, http.StatusOK, map[string]any{
+			"dns_root_domain": nil, "dns_root_domain_default": "ankra.cc"})
+	}
+	testClient := newTestClient(t, handler)
+
+	if _, err := testClient.SetOrganisationDomain(context.Background(), ""); err != nil {
+		t.Fatalf("SetOrganisationDomain: %v", err)
+	}
+	if !strings.Contains(receivedRaw, `"dns_root_domain":null`) {
+		t.Errorf("body = %s, want an explicit null so the backend clears the field", receivedRaw)
+	}
+}
+
+func TestSetOrganisationDomain_SurfacesTheBlockingRows(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(t, w, http.StatusBadRequest, map[string]any{
+			"detail": "Changing dns_root_domain requires removing the organisation's cluster DNS zones and DNS records first. Ankra then re-creates your zone under the new domain automatically.",
+			"blocking_cluster_zones": []map[string]any{{
+				"cluster_id": "c-1", "cluster_name": "playground",
+				"fqdn": "abc.org1234.ankra.cc", "state": "active"}},
+			"blocking_dns_records": []map[string]any{{
+				"id": "r-1", "name": "chat.org1234.ankra.cc",
+				"record_type": "A", "state": "active"}},
+		})
+	}
+	testClient := newTestClient(t, handler)
+
+	_, err := testClient.SetOrganisationDomain(context.Background(), "smartoptics.dev")
+	var blocked *OrganisationDomainBlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("error = %v, want an OrganisationDomainBlockedError", err)
+	}
+	if len(blocked.ClusterZones) != 1 || blocked.ClusterZones[0].ClusterName != "playground" {
+		t.Errorf("cluster zones = %+v", blocked.ClusterZones)
+	}
+	if len(blocked.DnsRecords) != 1 || blocked.DnsRecords[0].Name != "chat.org1234.ankra.cc" {
+		t.Errorf("dns records = %+v", blocked.DnsRecords)
+	}
+}
+
+func TestSetOrganisationDomain_SurfacesAPlainValidationDetail(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(t, w, http.StatusBadRequest, map[string]any{
+			"detail": "dns_root_domain must be a bare domain like example.com."})
+	}
+	testClient := newTestClient(t, handler)
+
+	_, err := testClient.SetOrganisationDomain(context.Background(), "not a domain!")
+	if err == nil || err.Error() != "dns_root_domain must be a bare domain like example.com." {
+		t.Fatalf("error = %v, want the backend detail verbatim", err)
+	}
+	var blocked *OrganisationDomainBlockedError
+	if errors.As(err, &blocked) {
+		t.Fatalf("a plain validation refusal must not decode as a blocked switch: %v", err)
+	}
+}
+
+func TestGetOrganisationDomain_ReportsUnauthorized(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}
+	testClient := newTestClient(t, handler)
+
+	if _, err := testClient.GetOrganisationDomain(context.Background()); !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("error = %v, want ErrUnauthorized", err)
+	}
+}
+
+func TestListOrganisationClusterDnsZones_ReadsTheInventory(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/org/dns/cluster-zones" {
+			t.Errorf("path = %s, want /api/v1/org/dns/cluster-zones", r.URL.Path)
+		}
+		jsonResponse(t, w, http.StatusOK, DnsClusterZonesListResult{Items: []DnsClusterZone{
+			{ClusterID: "c-1", ClusterName: "playground", FQDN: "abc.org1234.ankra.cc", State: "active"},
+		}})
+	}
+	testClient := newTestClient(t, handler)
+
+	list, err := testClient.ListOrganisationClusterDnsZones(context.Background())
+	if err != nil {
+		t.Fatalf("ListOrganisationClusterDnsZones: %v", err)
+	}
+	if len(list.Items) != 1 || list.Items[0].ClusterName != "playground" {
+		t.Errorf("items = %+v", list.Items)
+	}
+}
+
+func TestListOrganisationClusterDnsZones_ReportsAnEmptyInventory(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(t, w, http.StatusOK, DnsClusterZonesListResult{Items: []DnsClusterZone{}})
+	}
+	testClient := newTestClient(t, handler)
+
+	list, err := testClient.ListOrganisationClusterDnsZones(context.Background())
+	if err != nil {
+		t.Fatalf("ListOrganisationClusterDnsZones: %v", err)
+	}
+	if len(list.Items) != 0 {
+		t.Errorf("items = %+v, want empty", list.Items)
+	}
+}


### PR DESCRIPTION
Bead: ankra-ymkj8.2
Linear: PLA-768 (Ankra #1076) — Smartoptics, reported against v0.12.0

Needs cluster#1625 (the GET dns-zone route and the `/api/v1/org/ai-environment`
twins) deployed before `cluster domain` and `org domain` work against
production.

## Issue 2 — `cluster domain` was a mutating POST described as a lookup

The help said "The call is idempotent, so it doubles as a lookup." It *is*
idempotent, but on a cluster with no zone it created one — and every cluster
zone under the old root blocks an organisation root-domain switch. So the
read-looking command added blockers to the exact migration the next paragraph
of the same help text described.

```
ankra cluster domain <cluster>            # read — reports the domain, or state "none"
ankra cluster domain <cluster> --enable   # create it (idempotent)
ankra cluster domain <cluster> --remove   # hand it back for teardown
```

The plain command now calls the new `GET /api/v1/clusters/{id}/dns-zone`. A
cluster with no zone prints `State: none` and, on **stderr**, the `--enable`
command to create one — stdout stays parseable for `-o json|yaml`. `--enable`
with `--remove` is a usage error (exit 2) and never reaches the API.

**Breaking for scripts** that relied on the bare command to enable a domain:
they must add `--enable`. Called out in the CHANGELOG's Fixed section. Not a
`DEPRECATIONS.md` entry — no command is deprecated or forwarded, the default
verb changed.

## Issue 3 — nothing enumerated the cluster zones

```
ankra org dns zones
```

lists every cluster domain in the organisation (cluster, fqdn, state, error)
over the existing `GET /api/v1/org/dns/cluster-zones`. This is the inventory a
root-domain switch has to clear; before it, the only way to discover a
cluster's domain was the command that created one. Supports `-o json|yaml`
and prints "No cluster domains. Nothing blocks an organisation root-domain
switch." when empty.

## Issue 1 — no CLI surface for the organisation root domain

```
ankra org domain get
ankra org domain set example.com
ankra org domain set --default
```

`dns_root_domain` was portal-only. It is not on `/api/v1/org/ai-settings` (the
AI *provider* surface the reporter checked, correctly finding nothing) — it
lives on the AI *environment* settings, now reachable at
`GET/PUT /api/v1/org/ai-environment`. The CLI writes only the
`dns_root_domain` member, so the backend's present-vs-absent update contract
leaves every other AI environment setting untouched; there is no second source
of truth.

A refused switch decodes into an `OrganisationDomainBlockedError` carrying the
backend's structured `blocking_cluster_zones` / `blocking_dns_records`, and the
command prints them with the command that clears each kind:

```
Changing dns_root_domain requires removing the organisation's cluster DNS zones
and DNS records first. Ankra then re-creates your zone under the new domain
automatically.

Cluster domains still under the current root:
  playground  abc.org1234.ankra.cc  (active)
  Remove each with: ankra cluster domain <cluster> --remove

DNS records still under the current root:
  A  chat.org1234.ankra.cc  (active)
  Remove each with: ankra org dns delete <record>
```

## Help text

`cluster domain --help` now names the exact portal location ("AI > Settings >
Workspaces, field \"Custom Ankra domain\"") and the CLI equivalent, and
describes each verb's real behaviour. ankra-cli#100 had only reworded the
sentence the ticket quotes; it added no surface.

## Tests

Happy path, failure, empty, and unauthorized across both layers:

- `internal/client`: GET decodes a zone and the `none` state; org-domain get
  with and without a custom domain; set sends only `dns_root_domain`; clearing
  sends an explicit `null`; a blocked switch decodes the blockers; a plain 400
  detail does *not* decode as blocked; 401 maps to `ErrUnauthorized`;
  cluster-zone listing populated and empty.
- `cmd`: the plain lookup never calls enable/disable, the `none` path points at
  `--enable` without enabling, `--enable` and `--remove` route correctly,
  `--enable --remove` exits 2 without touching the API, JSON output stays clean;
  `org domain get|set` including `--default`, the usage refusal, and the
  rendered blocker list; `org dns zones` populated, empty, and as JSON.

## Gates

`go build ./...`, `go test -race -count=1 ./...`, and `golangci-lint run`
(0 issues) all green.

## Docs

The generated `reference/cli` pages are **not** hand-updated here.
`.github/workflows/docs-sync.yml` regenerates them from the released command
tree on the next stable `v*.*.*` tag, with the correct version banner; running
`gendocs` now would stamp the wrong version and publish other lanes' unreleased
commands. The narrative docs and the changelog ship in the ankra-docs PR.
