### PR TITLE
feat(stack-profiles): show what each choice of an input sets in get (ankra-ajomg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Added
 
+- **`ankra stack-profiles get` shows what each choice of an input sets.** A
+  profile can now offer an input whose choices answer other inputs — a
+  **Model size** of `8b` or `32b` that also moves the model id, the context
+  length and the model-store size. Below the parameters table, `get` prints
+  a `Choices for <input> (--set <input>=<value>)` block per such input,
+  listing every choice, its label and reasoning, and the `sets name=value`
+  lines it applies, so you can read what `--set model_size=32b` will do
+  before you `apply`. The platform resolves the choice server-side, so
+  `apply --set model_size=32b` with no other bindings deploys the whole
+  set; a `--set` of your own on one of those inputs still wins.
 - **`--sort <column>` and `--order asc|desc` on the main list commands**
   (`cluster list`, `cluster addons list`, `org list`, `credentials list`,
   `tokens list`) let you order the output by any rendered column — e.g.

--- a/cmd/stack_profiles.go
+++ b/cmd/stack_profiles.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -313,8 +314,40 @@ var stackProfilesGetCmd = &cobra.Command{
 			parametersTable.AppendRow(table.Row{parameter.Name, parameter.Type, required, defaultValue, description})
 		}
 		parametersTable.Render()
+		printParameterChoices(parameters)
 		return nil
 	},
+}
+
+// printParameterChoices lists, for every parameter that offers choices, what
+// each choice sets on the other parameters - so a reader of `get` can tell
+// that `--set model_size=32b` also moves the model id and the context
+// length before they bind anything.
+func printParameterChoices(parameters []client.StackProfileParameter) {
+	for _, parameter := range parameters {
+		if len(parameter.Options) == 0 {
+			continue
+		}
+		fmt.Printf("\nChoices for %s (--set %s=<value>):\n", parameter.Name, parameter.Name)
+		for _, option := range parameter.Options {
+			label := option.Value
+			if option.Title != nil && *option.Title != "" && *option.Title != option.Value {
+				label = fmt.Sprintf("%s  %s", option.Value, *option.Title)
+			}
+			fmt.Printf("  %s\n", label)
+			if option.Description != nil && *option.Description != "" {
+				fmt.Printf("    %s\n", *option.Description)
+			}
+			targets := make([]string, 0, len(option.Sets))
+			for target := range option.Sets {
+				targets = append(targets, target)
+			}
+			sort.Strings(targets)
+			for _, target := range targets {
+				fmt.Printf("    sets %s=%s\n", target, option.Sets[target])
+			}
+		}
+	}
 }
 
 var stackProfilesApplyCmd = &cobra.Command{

--- a/cmd/stack_profiles_get_test.go
+++ b/cmd/stack_profiles_get_test.go
@@ -70,3 +70,46 @@ func TestStackProfilesGetJSONOutput(t *testing.T) {
 		t.Errorf("expected json with profile field, got: %s", output)
 	}
 }
+
+func TestStackProfilesGetListsWhatEachChoiceSets(t *testing.T) {
+	resetStackProfileGetFlags(t)
+	large := "Qwen3 32B on one L40S"
+	reasoning := "Needs a 120Gi model store."
+	mock := &stackProfileMock{detail: &client.StackProfileDetail{
+		Profile: client.StackProfileSummary{ID: "profile-1", Name: "gpu-chat", CurrentVersion: 1, LatestVersion: 1},
+		CurrentVersionDetail: &client.StackProfileVersionDetail{
+			Version: 1,
+			Channel: "stable",
+			Parameters: []client.StackProfileParameter{
+				{
+					Name: "model_size", Type: "enum", EnumValues: []string{"8b", "32b"},
+					Options: []client.StackProfileParameterOption{
+						{Value: "8b", Sets: map[string]string{"model_id": "Qwen/Qwen3-8B"}},
+						{Value: "32b", Title: &large, Description: &reasoning, Sets: map[string]string{
+							"model_store_size": "120Gi", "model_id": "Qwen/Qwen3-32B"}},
+					},
+				},
+				{Name: "model_id", Type: "string"},
+				{Name: "model_store_size", Type: "string"},
+			},
+		},
+	}}
+	setMockClient(t, mock)
+
+	stdout := captureStdout(t, func() {
+		_, _ = executeCommand("stack-profiles", "get", "profile-1")
+	})
+
+	for _, expected := range []string{
+		"Choices for model_size (--set model_size=<value>):",
+		"  8b\n    sets model_id=Qwen/Qwen3-8B",
+		"  32b  Qwen3 32B on one L40S\n    Needs a 120Gi model store.\n    sets model_id=Qwen/Qwen3-32B\n    sets model_store_size=120Gi",
+	} {
+		if !strings.Contains(stdout, expected) {
+			t.Errorf("expected %q in output, got: %s", expected, stdout)
+		}
+	}
+	if strings.Contains(stdout, "Choices for model_id") {
+		t.Errorf("an input without options must not get a choices block, got: %s", stdout)
+	}
+}

--- a/internal/client/stack_profiles.go
+++ b/internal/client/stack_profiles.go
@@ -35,14 +35,25 @@ type StackProfileIacExport struct {
 }
 
 type StackProfileParameter struct {
-	Name        string   `json:"name"`
-	Title       *string  `json:"title"`
-	Description *string  `json:"description"`
-	Type        string   `json:"type"`
-	Required    bool     `json:"required"`
-	Default     *string  `json:"default"`
-	EnumValues  []string `json:"enum_values"`
-	Group       *string  `json:"group"`
+	Name        string                        `json:"name"`
+	Title       *string                       `json:"title"`
+	Description *string                       `json:"description"`
+	Type        string                        `json:"type"`
+	Required    bool                          `json:"required"`
+	Default     *string                       `json:"default"`
+	EnumValues  []string                      `json:"enum_values"`
+	Group       *string                       `json:"group"`
+	Options     []StackProfileParameterOption `json:"options,omitempty"`
+}
+
+// StackProfileParameterOption is one choice of a parameter that also answers
+// other parameters: binding the parameter to Value lays Sets (parameter name
+// to value) underneath the caller's own --set bindings at instantiation.
+type StackProfileParameterOption struct {
+	Value       string            `json:"value"`
+	Title       *string           `json:"title,omitempty"`
+	Description *string           `json:"description,omitempty"`
+	Sets        map[string]string `json:"sets,omitempty"`
 }
 
 type StackProfileVersionSummary struct {


### PR DESCRIPTION
## What

`ankra stack-profiles get` now shows what each choice of an input sets.

A profile can offer an input whose choices answer other inputs (ankraio/cluster#1623): binding `model_size=32b` also moves the model id, the context length and the model-store size. Below the parameters table, `get` prints one block per such input:

```
Choices for model_size (--set model_size=<value>):
  8b
    sets model_id=Qwen/Qwen3-8B
  32b  Qwen3 32B on one L40S
    Needs a 120Gi model store.
    sets model_id=Qwen/Qwen3-32B
    sets model_store_size=120Gi
```

so the effect of `apply --set model_size=32b` can be read before anything is bound. The platform resolves the choice server-side, so `apply` needs no change: `--set model_size=32b` with no other bindings deploys the whole set, and a `--set` of your own on one of those inputs still wins over the option.

Inputs without options print exactly as before; `options` is `omitempty` on the client model, so `-o json|yaml` output for existing profiles is unchanged.

## Tests

`TestStackProfilesGetListsWhatEachChoiceSets` covers the block layout (label, reasoning, sorted `sets` lines) and that an input without options gets no block. `go test -race -count=1 ./...` passes.

## Changelog

Entry added under `## Unreleased` → `### Added`.

Bead: ankra-ajomg
