### PR TITLE
feat(stack-profiles): author choices on drafts and preview what apply would deploy (ankra-uhi08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Added
 
+- **Profile choices can now be authored from the terminal, and `apply` can
+  show what it would deploy.** `stack-profiles drafts annotate` gains
+  `--default`, `--type`, `--enum` and `--required`, and `--add` declares an
+  input the draft does not have - such as a **Model size** choice that no
+  manifest references. The new `stack-profiles drafts options set <draft>
+  --parameter model_size --value 32b --set model_id=Qwen/Qwen3-32B --set
+  max_model_len=28672` adds or updates one choice and the inputs it answers
+  (`--unset` drops one; `options remove` drops the choice), with the rules
+  publish enforces - no secret targets, no choice driving another choice -
+  refused on the spot. `drafts get` lists each input's choices. And
+  `stack-profiles apply --dry-run` prints every input with the value it
+  would deploy with and where that value comes from (`--set`, `choice
+  model_size=32b`, `default`), names the required inputs still unset, never
+  echoes a secret, and creates nothing - no cluster needed.
 - **`ankra stack-profiles get` shows what each choice of an input sets.** A
   profile can now offer an input whose choices answer other inputs — a
   **Model size** of `8b` or `32b` that also moves the model id, the context

--- a/cmd/stack_profile_drafts.go
+++ b/cmd/stack_profile_drafts.go
@@ -126,6 +126,9 @@ var stackProfileDraftsGetCmd = &cobra.Command{
 				description = text.Faint.Sprint("(no description yet)")
 			}
 			fmt.Printf("  %s  [%s]\n    %s\n", text.Bold.Sprint(name), parameterType, description)
+			if choices := describeDraftParameterChoices(parameter); choices != "" {
+				fmt.Printf("    choices: %s\n", choices)
+			}
 		}
 		return nil
 	},
@@ -143,42 +146,78 @@ annotations live.`,
 		parameterName, _ := cmd.Flags().GetString("parameter")
 		description, _ := cmd.Flags().GetString("description")
 		title, _ := cmd.Flags().GetString("title")
-		if description == "" && title == "" {
-			return withExitCode(exitUsage, errors.New("provide --description and/or --title"))
+		defaultValue, _ := cmd.Flags().GetString("default")
+		parameterType, _ := cmd.Flags().GetString("type")
+		enumList, _ := cmd.Flags().GetString("enum")
+		required, _ := cmd.Flags().GetBool("required")
+		add, _ := cmd.Flags().GetBool("add")
+		changed := cmd.Flags().Changed
+		if description == "" && title == "" && !changed("default") && !changed("type") && !changed("enum") && !changed("required") && !add {
+			return withExitCode(exitUsage, errors.New("provide at least one of --title, --description, --default, --type, --enum, --required or --add"))
+		}
+		if changed("type") {
+			if typeError := validateParameterType(parameterType); typeError != nil {
+				return typeError
+			}
 		}
 
 		draft, err := apiClient.GetStackProfileDraft(args[0])
 		if err != nil {
 			return fmt.Errorf("reading stack profile draft: %w", err)
 		}
-		found := false
-		for _, parameter := range draft.Parameters {
-			if name, _ := parameter["name"].(string); name == parameterName {
-				if description != "" {
-					parameter["description"] = description
-				}
-				if title != "" {
-					parameter["title"] = title
-				}
-				found = true
-				break
+		parameter := draftParameterByName(draft.Parameters, parameterName)
+		declared := false
+		if parameter == nil {
+			if !add {
+				return fmt.Errorf("parameter %q not found on the draft; it has: %v. Pass --add to declare an input no manifest references, such as a choice that sets other inputs",
+					parameterName, draftParameterNames(draft.Parameters))
+			}
+			// A declared input starts as the platform's detection would have
+			// shaped it; the flags below then apply on top, exactly like an
+			// annotation on a detected input.
+			parameter = map[string]any{
+				"name": parameterName, "title": parameterName, "type": "string",
+				"required": false, "enum_values": []any{}, "group": "variables",
+			}
+			draft.Parameters = append(draft.Parameters, parameter)
+			declared = true
+		}
+		if existingType, _ := parameter["type"].(string); existingType == "secret" &&
+			(changed("type") || changed("default") || changed("enum") || changed("required")) {
+			return withExitCode(exitUsage, fmt.Errorf("%q is a secret input: its type, default, enum and required flag are fixed; only --title and --description apply", parameterName))
+		}
+		if description != "" {
+			parameter["description"] = description
+		}
+		if title != "" {
+			parameter["title"] = title
+		}
+		if changed("default") {
+			if defaultValue == "" {
+				delete(parameter, "default")
+			} else {
+				parameter["default"] = defaultValue
 			}
 		}
-		if !found {
-			names := make([]string, 0, len(draft.Parameters))
-			for _, parameter := range draft.Parameters {
-				if name, _ := parameter["name"].(string); name != "" {
-					names = append(names, name)
-				}
+		if changed("type") {
+			parameter["type"] = parameterType
+		}
+		if changed("enum") {
+			values := splitEnumList(enumList)
+			enumValues := make([]any, 0, len(values))
+			for _, value := range values {
+				enumValues = append(enumValues, value)
 			}
-			return fmt.Errorf("parameter %q not found on the draft; it has: %v", parameterName, names)
+			parameter["enum_values"] = enumValues
+			if len(values) > 0 && !changed("type") {
+				parameter["type"] = "enum"
+			}
+		}
+		if changed("required") {
+			parameter["required"] = required
 		}
 
-		updated, err := apiClient.UpdateStackProfileDraft(draft.ID, client.UpdateStackProfileDraftRequest{
-			Spec:       draft.Spec,
-			Parameters: draft.Parameters,
-			Version:    draft.Version,
-		})
+		updated, err := writeDraftParameters(draft)
 		if err != nil {
 			return fmt.Errorf("annotating stack profile draft: %w", err)
 		}
@@ -187,7 +226,12 @@ annotations live.`,
 		} else if handled {
 			return nil
 		}
-		fmt.Printf("Annotated %s on draft '%s'.\n", parameterName, updated.Name)
+		if declared {
+			fmt.Printf("Declared input %s on draft '%s'.\n", parameterName, updated.Name)
+			fmt.Printf("Give it choices that set other inputs with:\n  ankra stack-profiles drafts options set %s --parameter %s --value <value> --set <input>=<value>\n", updated.ID, parameterName)
+		} else {
+			fmt.Printf("Annotated %s on draft '%s'.\n", parameterName, updated.Name)
+		}
 		fmt.Println("Publish to make it live:")
 		fmt.Printf("  ankra stack-profiles drafts publish %s --changelog \"...\"\n", updated.ID)
 		return nil
@@ -299,6 +343,11 @@ func init() {
 	stackProfileDraftsAnnotateCmd.Flags().String("parameter", "", "Parameter name to annotate")
 	stackProfileDraftsAnnotateCmd.Flags().String("description", "", "Guidance shown under the field in the launch form")
 	stackProfileDraftsAnnotateCmd.Flags().String("title", "", "Display title for the field (optional)")
+	stackProfileDraftsAnnotateCmd.Flags().String("default", "", "Default value (pass an empty string to clear it)")
+	stackProfileDraftsAnnotateCmd.Flags().String("type", "", "Input type: string, number, boolean or enum")
+	stackProfileDraftsAnnotateCmd.Flags().String("enum", "", "Allowed values, comma separated (implies --type enum)")
+	stackProfileDraftsAnnotateCmd.Flags().Bool("required", false, "Whether the input must be set when the profile is used (--required=false to relax)")
+	stackProfileDraftsAnnotateCmd.Flags().Bool("add", false, "Declare the input if the draft does not have it, e.g. a choice that sets other inputs and is referenced by no manifest")
 	_ = stackProfileDraftsAnnotateCmd.MarkFlagRequired("parameter")
 
 	stackProfileDraftsPublishCmd.Flags().String("channel", "stable", "Release channel for the version")

--- a/cmd/stack_profile_options.go
+++ b/cmd/stack_profile_options.go
@@ -1,0 +1,450 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// Draft parameters travel as generic maps (client.StackProfileDraft) so an
+// edit never drops a field this client does not model. The helpers below
+// read and write only the members the option commands touch.
+
+var parameterTypeChoices = []string{"string", "number", "boolean", "enum"}
+
+func draftParameterByName(parameters []map[string]any, name string) map[string]any {
+	for _, parameter := range parameters {
+		if parameterName, _ := parameter["name"].(string); parameterName == name {
+			return parameter
+		}
+	}
+	return nil
+}
+
+func draftParameterNames(parameters []map[string]any) []string {
+	names := make([]string, 0, len(parameters))
+	for _, parameter := range parameters {
+		if name, _ := parameter["name"].(string); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func draftParameterOptions(parameter map[string]any) []map[string]any {
+	raw, _ := parameter["options"].([]any)
+	options := make([]map[string]any, 0, len(raw))
+	for _, item := range raw {
+		if option, ok := item.(map[string]any); ok {
+			options = append(options, option)
+		}
+	}
+	return options
+}
+
+// storeDraftParameterOptions writes the options back and keeps the enum
+// mirror the platform maintains (an input with options is an enum over its
+// option values), so a reader that predates options still sees the choices.
+func storeDraftParameterOptions(parameter map[string]any, options []map[string]any) {
+	if len(options) == 0 {
+		delete(parameter, "options")
+		return
+	}
+	stored := make([]any, 0, len(options))
+	enumValues := make([]any, 0, len(options))
+	for _, option := range options {
+		stored = append(stored, option)
+		enumValues = append(enumValues, fmt.Sprint(option["value"]))
+	}
+	parameter["options"] = stored
+	parameter["type"] = "enum"
+	parameter["enum_values"] = enumValues
+}
+
+func draftOptionSets(option map[string]any) map[string]string {
+	raw, _ := option["sets"].(map[string]any)
+	sets := map[string]string{}
+	for target, value := range raw {
+		sets[target] = fmt.Sprint(value)
+	}
+	return sets
+}
+
+func storeDraftOptionSets(option map[string]any, sets map[string]string) {
+	if len(sets) == 0 {
+		delete(option, "sets")
+		return
+	}
+	stored := map[string]any{}
+	for target, value := range sets {
+		stored[target] = value
+	}
+	option["sets"] = stored
+}
+
+func sortedAssignmentTargets(sets map[string]string) []string {
+	targets := make([]string, 0, len(sets))
+	for target := range sets {
+		targets = append(targets, target)
+	}
+	sort.Strings(targets)
+	return targets
+}
+
+// describeAssignmentProblem mirrors the rules publish enforces on an
+// option's targets, so the author hears about a bad target now rather than
+// at publish. The server stays authoritative.
+func describeAssignmentProblem(parameters []map[string]any, selectorName string, target string) string {
+	if target == selectorName {
+		return fmt.Sprintf("an option of %q cannot set %q itself", selectorName, target)
+	}
+	targetParameter := draftParameterByName(parameters, target)
+	if targetParameter == nil {
+		return fmt.Sprintf("%q is not an input on this draft; it has: %v", target, draftParameterNames(parameters))
+	}
+	if targetType, _ := targetParameter["type"].(string); targetType == "secret" {
+		return fmt.Sprintf("%q is a secret input; secret values are never stored in a profile", target)
+	}
+	if len(draftParameterOptions(targetParameter)) > 0 {
+		return fmt.Sprintf("%q offers options of its own; options cannot drive other options", target)
+	}
+	return ""
+}
+
+// describeDraftParameterChoices renders an input's options on one line for
+// `drafts get`, e.g. "8b (sets model_id=Qwen/Qwen3-8B), 32b (sets ...)".
+func describeDraftParameterChoices(parameter map[string]any) string {
+	options := draftParameterOptions(parameter)
+	if len(options) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(options))
+	for _, option := range options {
+		sets := draftOptionSets(option)
+		assignments := make([]string, 0, len(sets))
+		for _, target := range sortedAssignmentTargets(sets) {
+			assignments = append(assignments, target+"="+sets[target])
+		}
+		part := fmt.Sprint(option["value"])
+		if len(assignments) > 0 {
+			part += " (sets " + strings.Join(assignments, ", ") + ")"
+		}
+		parts = append(parts, part)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func splitEnumList(raw string) []string {
+	values := []string{}
+	for _, value := range strings.Split(raw, ",") {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			values = append(values, trimmed)
+		}
+	}
+	return values
+}
+
+func writeDraftParameters(draft *client.StackProfileDraft) (*client.StackProfileDraft, error) {
+	updated, err := apiClient.UpdateStackProfileDraft(draft.ID, client.UpdateStackProfileDraftRequest{
+		Spec:       draft.Spec,
+		Parameters: draft.Parameters,
+		Version:    draft.Version,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("updating stack profile draft: %w", err)
+	}
+	return updated, nil
+}
+
+var stackProfileDraftsOptionsCmd = &cobra.Command{
+	Use:   "options",
+	Short: "Give an input choices that set other inputs",
+	Long: `Give a draft's input choices, where each choice also answers other inputs.
+
+One "Model size" input with a choice of 8b or 32b can then move the model id,
+the context length and the volume size together, so whoever applies the
+profile picks one thing instead of keeping four consistent. At apply time the
+platform resolves a choice in a fixed order: a value passed with --set, then
+what the selected choice sets, then the input's own default.
+
+A choice can set any non-secret input that does not offer choices of its own.
+Declare a choice input that no manifest references with
+'drafts annotate <draft-id> --parameter <name> --add --type enum'.`,
+}
+
+var stackProfileDraftsOptionsSetCmd = &cobra.Command{
+	Use:   "set <draft-id>",
+	Short: "Add or update one choice on an input",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		parameterName, _ := cmd.Flags().GetString("parameter")
+		value, _ := cmd.Flags().GetString("value")
+		title, _ := cmd.Flags().GetString("title")
+		description, _ := cmd.Flags().GetString("description")
+		assignments, _ := cmd.Flags().GetStringArray("set")
+		removals, _ := cmd.Flags().GetStringArray("unset")
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return withExitCode(exitUsage, errors.New("--value is required: the value the input takes when this choice is picked"))
+		}
+
+		draft, err := apiClient.GetStackProfileDraft(args[0])
+		if err != nil {
+			return fmt.Errorf("reading stack profile draft: %w", err)
+		}
+		parameter := draftParameterByName(draft.Parameters, parameterName)
+		if parameter == nil {
+			return fmt.Errorf("parameter %q not found on the draft; it has: %v. Declare a choice input that no manifest references with 'ankra stack-profiles drafts annotate %s --parameter %s --add --type enum'",
+				parameterName, draftParameterNames(draft.Parameters), draft.ID, parameterName)
+		}
+		if parameterType, _ := parameter["type"].(string); parameterType == "secret" {
+			return withExitCode(exitUsage, fmt.Errorf("%q is a secret input and cannot offer choices", parameterName))
+		}
+
+		options := draftParameterOptions(parameter)
+		var option map[string]any
+		for _, candidate := range options {
+			if fmt.Sprint(candidate["value"]) == value {
+				option = candidate
+				break
+			}
+		}
+		created := option == nil
+		if created {
+			option = map[string]any{"value": value}
+			options = append(options, option)
+		}
+		if title != "" {
+			option["title"] = title
+		}
+		if description != "" {
+			option["description"] = description
+		}
+		sets := draftOptionSets(option)
+		for _, entry := range assignments {
+			target, assigned, splitError := splitParameterAssignment(entry, "--set")
+			if splitError != nil {
+				return withExitCode(exitUsage, splitError)
+			}
+			if problem := describeAssignmentProblem(draft.Parameters, parameterName, target); problem != "" {
+				return withExitCode(exitUsage, errors.New(problem))
+			}
+			sets[target] = assigned
+		}
+		for _, target := range removals {
+			delete(sets, strings.TrimSpace(target))
+		}
+		storeDraftOptionSets(option, sets)
+		storeDraftParameterOptions(parameter, options)
+
+		updated, err := writeDraftParameters(draft)
+		if err != nil {
+			return err
+		}
+		if handled, err := renderStructured(cmd, updated); err != nil {
+			return err
+		} else if handled {
+			return nil
+		}
+		verb := "Updated"
+		if created {
+			verb = "Added"
+		}
+		fmt.Printf("%s choice '%s' on %s (%d %s).\n", verb, value, parameterName, len(options), pluralise(len(options), "choice", "choices"))
+		for _, target := range sortedAssignmentTargets(sets) {
+			fmt.Printf("  sets %s=%s\n", target, sets[target])
+		}
+		if len(sets) == 0 {
+			fmt.Println("  sets nothing yet: add --set <input>=<value> to have this choice answer other inputs")
+		}
+		fmt.Println("Publish to make it live:")
+		fmt.Printf("  ankra stack-profiles drafts publish %s --changelog \"...\"\n", updated.ID)
+		return nil
+	},
+}
+
+var stackProfileDraftsOptionsRemoveCmd = &cobra.Command{
+	Use:   "remove <draft-id>",
+	Short: "Remove one choice from an input",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		parameterName, _ := cmd.Flags().GetString("parameter")
+		value, _ := cmd.Flags().GetString("value")
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return withExitCode(exitUsage, errors.New("--value is required"))
+		}
+
+		draft, err := apiClient.GetStackProfileDraft(args[0])
+		if err != nil {
+			return fmt.Errorf("reading stack profile draft: %w", err)
+		}
+		parameter := draftParameterByName(draft.Parameters, parameterName)
+		if parameter == nil {
+			return fmt.Errorf("parameter %q not found on the draft; it has: %v", parameterName, draftParameterNames(draft.Parameters))
+		}
+		options := draftParameterOptions(parameter)
+		remaining := make([]map[string]any, 0, len(options))
+		for _, option := range options {
+			if fmt.Sprint(option["value"]) != value {
+				remaining = append(remaining, option)
+			}
+		}
+		if len(remaining) == len(options) {
+			values := make([]string, 0, len(options))
+			for _, option := range options {
+				values = append(values, fmt.Sprint(option["value"]))
+			}
+			return fmt.Errorf("%q has no choice %q; it has: %v", parameterName, value, values)
+		}
+		storeDraftParameterOptions(parameter, remaining)
+
+		updated, err := writeDraftParameters(draft)
+		if err != nil {
+			return err
+		}
+		if handled, err := renderStructured(cmd, updated); err != nil {
+			return err
+		} else if handled {
+			return nil
+		}
+		fmt.Printf("Removed choice '%s' from %s (%d %s left).\n", value, parameterName, len(remaining), pluralise(len(remaining), "choice", "choices"))
+		return nil
+	},
+}
+
+func pluralise(count int, singular string, plural string) string {
+	if count == 1 {
+		return singular
+	}
+	return plural
+}
+
+// bindingPreview is one row of `apply --dry-run`: the value an input will
+// deploy with and where it came from.
+type bindingPreview struct {
+	Name     string `json:"name"`
+	Value    string `json:"value"`
+	Source   string `json:"source"`
+	Required bool   `json:"required"`
+}
+
+// previewResolvedBindings applies the platform's resolution order - a value
+// you set, then what the selected choice sets, then the input's default - to
+// the bindings without creating anything, so the whole set can be read before
+// apply. Later choice inputs win on overlap, as on the server. Secret values
+// are never echoed.
+func previewResolvedBindings(parameters []client.StackProfileParameter, bindings []client.ParameterBinding) []bindingPreview {
+	explicit := map[string]string{}
+	order := []string{}
+	for _, binding := range bindings {
+		if strings.TrimSpace(binding.Value) == "" {
+			continue
+		}
+		if _, seen := explicit[binding.Name]; !seen {
+			order = append(order, binding.Name)
+		}
+		explicit[binding.Name] = binding.Value
+	}
+	byName := map[string]client.StackProfileParameter{}
+	for _, parameter := range parameters {
+		byName[parameter.Name] = parameter
+	}
+
+	type derivedValue struct{ value, source string }
+	derived := map[string]derivedValue{}
+	for _, selector := range parameters {
+		if len(selector.Options) == 0 || selector.Type == "secret" {
+			continue
+		}
+		selection := strings.TrimSpace(explicit[selector.Name])
+		if selection == "" && selector.Default != nil {
+			selection = strings.TrimSpace(*selector.Default)
+		}
+		if selection == "" {
+			continue
+		}
+		for _, option := range selector.Options {
+			if option.Value != selection {
+				continue
+			}
+			for _, target := range sortedAssignmentTargets(option.Sets) {
+				targetParameter, declared := byName[target]
+				if !declared || targetParameter.Type == "secret" || len(targetParameter.Options) > 0 {
+					continue
+				}
+				derived[target] = derivedValue{option.Sets[target], fmt.Sprintf("choice %s=%s", selector.Name, option.Value)}
+			}
+		}
+	}
+
+	rows := make([]bindingPreview, 0, len(parameters)+len(order))
+	for _, parameter := range parameters {
+		row := bindingPreview{Name: parameter.Name, Required: parameter.Required}
+		switch {
+		case explicit[parameter.Name] != "":
+			row.Value, row.Source = explicit[parameter.Name], "--set"
+		case derived[parameter.Name].source != "":
+			row.Value, row.Source = derived[parameter.Name].value, derived[parameter.Name].source
+		case parameter.Default != nil && strings.TrimSpace(*parameter.Default) != "":
+			row.Value, row.Source = *parameter.Default, "default"
+		default:
+			row.Source = "unset"
+		}
+		if parameter.Type == "secret" && row.Value != "" {
+			row.Value = "********"
+		}
+		rows = append(rows, row)
+	}
+	for _, name := range order {
+		if _, declared := byName[name]; declared {
+			continue
+		}
+		rows = append(rows, bindingPreview{Name: name, Value: explicit[name], Source: "--set (not an input of this version)"})
+	}
+	return rows
+}
+
+func unsetRequiredInputs(rows []bindingPreview) []string {
+	missing := []string{}
+	for _, row := range rows {
+		if row.Required && row.Source == "unset" {
+			missing = append(missing, row.Name)
+		}
+	}
+	return missing
+}
+
+func init() {
+	stackProfileDraftsOptionsSetCmd.Flags().String("parameter", "", "Input the choice belongs to")
+	stackProfileDraftsOptionsSetCmd.Flags().String("value", "", "Value the input takes when this choice is picked")
+	stackProfileDraftsOptionsSetCmd.Flags().String("title", "", "Label shown for the choice (optional)")
+	stackProfileDraftsOptionsSetCmd.Flags().String("description", "", "Why someone would pick this choice (optional)")
+	stackProfileDraftsOptionsSetCmd.Flags().StringArray("set", nil, "Input this choice answers: name=value (repeatable)")
+	stackProfileDraftsOptionsSetCmd.Flags().StringArray("unset", nil, "Stop this choice answering an input: name (repeatable)")
+	_ = stackProfileDraftsOptionsSetCmd.MarkFlagRequired("parameter")
+	_ = stackProfileDraftsOptionsSetCmd.MarkFlagRequired("value")
+
+	stackProfileDraftsOptionsRemoveCmd.Flags().String("parameter", "", "Input the choice belongs to")
+	stackProfileDraftsOptionsRemoveCmd.Flags().String("value", "", "Value of the choice to remove")
+	_ = stackProfileDraftsOptionsRemoveCmd.MarkFlagRequired("parameter")
+	_ = stackProfileDraftsOptionsRemoveCmd.MarkFlagRequired("value")
+
+	stackProfileDraftsOptionsCmd.AddCommand(stackProfileDraftsOptionsSetCmd, stackProfileDraftsOptionsRemoveCmd)
+	stackProfileDraftsCmd.AddCommand(stackProfileDraftsOptionsCmd)
+	registerStructuredOutputFlags(stackProfileDraftsOptionsSetCmd, stackProfileDraftsOptionsRemoveCmd)
+}
+
+// validateParameterType is shared by annotate's --type.
+func validateParameterType(parameterType string) error {
+	if slices.Contains(parameterTypeChoices, parameterType) {
+		return nil
+	}
+	return withExitCode(exitUsage, fmt.Errorf("--type must be one of %s", strings.Join(parameterTypeChoices, ", ")))
+}

--- a/cmd/stack_profile_options_test.go
+++ b/cmd/stack_profile_options_test.go
@@ -1,0 +1,475 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+
+	"ankra/internal/client"
+)
+
+// stackProfileDraftMock serves one draft and records the parameter list
+// written back, so a test can assert exactly what an authoring command
+// changed and that it left every other field alone.
+type stackProfileDraftMock struct {
+	baseMock
+	draft         *client.StackProfileDraft
+	updateRequest *client.UpdateStackProfileDraftRequest
+}
+
+func (mock *stackProfileDraftMock) GetStackProfileDraft(draftID string) (*client.StackProfileDraft, error) {
+	return mock.draft, nil
+}
+
+func (mock *stackProfileDraftMock) UpdateStackProfileDraft(draftID string, request client.UpdateStackProfileDraftRequest) (*client.StackProfileDraft, error) {
+	mock.updateRequest = &request
+	updated := *mock.draft
+	updated.Parameters = request.Parameters
+	updated.Version = request.Version + 1
+	return &updated, nil
+}
+
+func gpuChatDraft() *client.StackProfileDraft {
+	return &client.StackProfileDraft{
+		ID:      "draft-1",
+		Name:    "gpu-chat",
+		Spec:    json.RawMessage(`{"stacks":[]}`),
+		Version: 3,
+		Parameters: []map[string]any{
+			{"name": "model_id", "type": "string", "required": true, "enum_values": []any{}, "group": "variables"},
+			{"name": "max_model_len", "type": "number", "required": false, "default": "16384", "enum_values": []any{}},
+			{"name": "api_key", "type": "secret", "required": true, "group": "secrets"},
+		},
+	}
+}
+
+func resetStackProfileDraftAuthoringFlags(t *testing.T) {
+	t.Helper()
+	for _, command := range []struct {
+		flags *pflag.FlagSet
+		reset map[string]string
+	}{
+		{stackProfileDraftsAnnotateCmd.Flags(), map[string]string{
+			"parameter": "", "description": "", "title": "", "default": "", "type": "", "enum": "",
+			"required": "false", "add": "false", "output": ""}},
+		{stackProfileDraftsOptionsSetCmd.Flags(), map[string]string{
+			"parameter": "", "value": "", "title": "", "description": "", "output": ""}},
+		{stackProfileDraftsOptionsRemoveCmd.Flags(), map[string]string{"parameter": "", "value": "", "output": ""}},
+	} {
+		for name, value := range command.reset {
+			_ = command.flags.Set(name, value)
+			if flag := command.flags.Lookup(name); flag != nil {
+				flag.Changed = false
+			}
+		}
+		for _, name := range []string{"set", "unset"} {
+			if flag := command.flags.Lookup(name); flag != nil {
+				if sliceValue, ok := flag.Value.(pflag.SliceValue); ok {
+					_ = sliceValue.Replace([]string{})
+				}
+				flag.Changed = false
+			}
+		}
+	}
+}
+
+func parameterFromRequest(t *testing.T, request *client.UpdateStackProfileDraftRequest, name string) map[string]any {
+	t.Helper()
+	if request == nil {
+		t.Fatal("expected the draft to be written back")
+	}
+	parameter := draftParameterByName(request.Parameters, name)
+	if parameter == nil {
+		t.Fatalf("parameter %q missing from the written draft; have %v", name, draftParameterNames(request.Parameters))
+	}
+	return parameter
+}
+
+func TestDraftsAnnotateDeclaresAChoiceInput(t *testing.T) {
+	resetStackProfileDraftAuthoringFlags(t)
+	mock := &stackProfileDraftMock{draft: gpuChatDraft()}
+	setMockClient(t, mock)
+
+	stdout := captureStdout(t, func() {
+		_, _ = executeCommand("stack-profiles", "drafts", "annotate", "draft-1",
+			"--parameter", "model_size", "--add", "--type", "enum", "--enum", "8b, 32b",
+			"--default", "8b", "--title", "Model size", "--required")
+	})
+
+	parameter := parameterFromRequest(t, mock.updateRequest, "model_size")
+	if parameter["type"] != "enum" || parameter["default"] != "8b" || parameter["title"] != "Model size" {
+		t.Errorf("declared parameter = %v", parameter)
+	}
+	if required, _ := parameter["required"].(bool); !required {
+		t.Errorf("expected required=true, got %v", parameter["required"])
+	}
+	enumValues, _ := parameter["enum_values"].([]any)
+	if len(enumValues) != 2 || enumValues[0] != "8b" || enumValues[1] != "32b" {
+		t.Errorf("enum_values = %v", parameter["enum_values"])
+	}
+	if len(mock.updateRequest.Parameters) != 4 {
+		t.Errorf("expected the three detected inputs plus the declared one, got %d", len(mock.updateRequest.Parameters))
+	}
+	if !strings.Contains(stdout, "Declared input model_size") || !strings.Contains(stdout, "drafts options set draft-1 --parameter model_size") {
+		t.Errorf("expected the declare guidance, got: %s", stdout)
+	}
+}
+
+func TestDraftsAnnotateRefusesUnknownInputWithoutAdd(t *testing.T) {
+	resetStackProfileDraftAuthoringFlags(t)
+	mock := &stackProfileDraftMock{draft: gpuChatDraft()}
+	setMockClient(t, mock)
+
+	_, err := executeCommand("stack-profiles", "drafts", "annotate", "draft-1", "--parameter", "model_size", "--title", "Model size")
+
+	if err == nil || !strings.Contains(err.Error(), "Pass --add") {
+		t.Fatalf("expected the --add hint, got %v", err)
+	}
+	if mock.updateRequest != nil {
+		t.Error("nothing must be written when the input is unknown")
+	}
+}
+
+func TestDraftsAnnotateRejectsABadTypeAndSecretReshaping(t *testing.T) {
+	resetStackProfileDraftAuthoringFlags(t)
+	mock := &stackProfileDraftMock{draft: gpuChatDraft()}
+	setMockClient(t, mock)
+
+	_, err := executeCommand("stack-profiles", "drafts", "annotate", "draft-1", "--parameter", "model_id", "--type", "list")
+	if err == nil || !strings.Contains(err.Error(), "--type must be one of") {
+		t.Fatalf("expected a type usage error, got %v", err)
+	}
+
+	resetStackProfileDraftAuthoringFlags(t)
+	_, err = executeCommand("stack-profiles", "drafts", "annotate", "draft-1", "--parameter", "api_key", "--default", "hunter2")
+	if err == nil || !strings.Contains(err.Error(), "secret input") {
+		t.Fatalf("expected the secret refusal, got %v", err)
+	}
+	if mock.updateRequest != nil {
+		t.Error("nothing must be written on a refused annotation")
+	}
+}
+
+func TestDraftsAnnotateKeepsExistingOptionsWhenRetitling(t *testing.T) {
+	resetStackProfileDraftAuthoringFlags(t)
+	draft := gpuChatDraft()
+	draft.Parameters = append(draft.Parameters, map[string]any{
+		"name": "model_size", "type": "enum", "enum_values": []any{"8b"},
+		"options": []any{map[string]any{"value": "8b", "sets": map[string]any{"model_id": "Qwen/Qwen3-8B"}}},
+	})
+	mock := &stackProfileDraftMock{draft: draft}
+	setMockClient(t, mock)
+
+	_, _ = executeCommand("stack-profiles", "drafts", "annotate", "draft-1", "--parameter", "model_size", "--title", "Model size")
+
+	parameter := parameterFromRequest(t, mock.updateRequest, "model_size")
+	if len(draftParameterOptions(parameter)) != 1 {
+		t.Errorf("options must survive a title edit, got %v", parameter["options"])
+	}
+}
+
+func TestDraftsOptionsSetAddsAChoiceThatAnswersOtherInputs(t *testing.T) {
+	resetStackProfileDraftAuthoringFlags(t)
+	draft := gpuChatDraft()
+	draft.Parameters = append(draft.Parameters, map[string]any{"name": "model_size", "type": "string", "enum_values": []any{}})
+	mock := &stackProfileDraftMock{draft: draft}
+	setMockClient(t, mock)
+
+	stdout := captureStdout(t, func() {
+		_, _ = executeCommand("stack-profiles", "drafts", "options", "set", "draft-1",
+			"--parameter", "model_size", "--value", "32b", "--title", "Qwen3 32B",
+			"--set", "model_id=Qwen/Qwen3-32B", "--set", "max_model_len=28672")
+	})
+
+	parameter := parameterFromRequest(t, mock.updateRequest, "model_size")
+	options := draftParameterOptions(parameter)
+	if len(options) != 1 || options[0]["value"] != "32b" || options[0]["title"] != "Qwen3 32B" {
+		t.Fatalf("options = %v", parameter["options"])
+	}
+	sets := draftOptionSets(options[0])
+	if sets["model_id"] != "Qwen/Qwen3-32B" || sets["max_model_len"] != "28672" {
+		t.Errorf("sets = %v", sets)
+	}
+	if parameter["type"] != "enum" {
+		t.Errorf("an input with options must become an enum, got %v", parameter["type"])
+	}
+	if enumValues, _ := parameter["enum_values"].([]any); len(enumValues) != 1 || enumValues[0] != "32b" {
+		t.Errorf("enum_values must mirror the option values, got %v", parameter["enum_values"])
+	}
+	if !strings.Contains(stdout, "Added choice '32b' on model_size (1 choice).") ||
+		!strings.Contains(stdout, "sets max_model_len=28672\n  sets model_id=Qwen/Qwen3-32B") {
+		t.Errorf("unexpected output: %s", stdout)
+	}
+}
+
+func TestDraftsOptionsSetUpdatesAnExistingChoiceInPlace(t *testing.T) {
+	resetStackProfileDraftAuthoringFlags(t)
+	draft := gpuChatDraft()
+	draft.Parameters = append(draft.Parameters, map[string]any{
+		"name": "model_size", "type": "enum", "enum_values": []any{"8b", "32b"},
+		"options": []any{
+			map[string]any{"value": "8b", "sets": map[string]any{"model_id": "Qwen/Qwen3-8B", "max_model_len": "16384"}},
+			map[string]any{"value": "32b", "sets": map[string]any{"model_id": "Qwen/Qwen3-32B"}},
+		},
+	})
+	mock := &stackProfileDraftMock{draft: draft}
+	setMockClient(t, mock)
+
+	stdout := captureStdout(t, func() {
+		_, _ = executeCommand("stack-profiles", "drafts", "options", "set", "draft-1",
+			"--parameter", "model_size", "--value", "8b", "--set", "model_id=Qwen/Qwen3-8B-AWQ", "--unset", "max_model_len")
+	})
+
+	options := draftParameterOptions(parameterFromRequest(t, mock.updateRequest, "model_size"))
+	if len(options) != 2 {
+		t.Fatalf("expected both choices to remain, got %d", len(options))
+	}
+	sets := draftOptionSets(options[0])
+	if sets["model_id"] != "Qwen/Qwen3-8B-AWQ" {
+		t.Errorf("model_id = %q", sets["model_id"])
+	}
+	if _, present := sets["max_model_len"]; present {
+		t.Errorf("--unset must drop the assignment, got %v", sets)
+	}
+	if !strings.Contains(stdout, "Updated choice '8b' on model_size (2 choices).") {
+		t.Errorf("unexpected output: %s", stdout)
+	}
+}
+
+func TestDraftsOptionsSetRefusesBadTargets(t *testing.T) {
+	cases := []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{"secret", "api_key=x", "secret input"},
+		{"self", "model_size=8b", "itself"},
+		{"unknown", "gone=1", "not an input on this draft"},
+		{"chained", "tier=ha", "options of its own"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			resetStackProfileDraftAuthoringFlags(t)
+			draft := gpuChatDraft()
+			draft.Parameters = append(draft.Parameters,
+				map[string]any{"name": "model_size", "type": "string", "enum_values": []any{}},
+				map[string]any{"name": "tier", "type": "enum", "options": []any{map[string]any{"value": "ha"}}},
+			)
+			mock := &stackProfileDraftMock{draft: draft}
+			setMockClient(t, mock)
+
+			_, err := executeCommand("stack-profiles", "drafts", "options", "set", "draft-1",
+				"--parameter", "model_size", "--value", "8b", "--set", testCase.target)
+
+			if err == nil || !strings.Contains(err.Error(), testCase.want) {
+				t.Fatalf("expected %q in the error, got %v", testCase.want, err)
+			}
+			if mock.updateRequest != nil {
+				t.Error("a refused assignment must not write the draft")
+			}
+		})
+	}
+}
+
+func TestDraftsOptionsSetRefusesASecretSelectorAndUnknownInput(t *testing.T) {
+	resetStackProfileDraftAuthoringFlags(t)
+	mock := &stackProfileDraftMock{draft: gpuChatDraft()}
+	setMockClient(t, mock)
+
+	_, err := executeCommand("stack-profiles", "drafts", "options", "set", "draft-1", "--parameter", "api_key", "--value", "x")
+	if err == nil || !strings.Contains(err.Error(), "secret input and cannot offer choices") {
+		t.Fatalf("expected the secret refusal, got %v", err)
+	}
+
+	resetStackProfileDraftAuthoringFlags(t)
+	_, err = executeCommand("stack-profiles", "drafts", "options", "set", "draft-1", "--parameter", "model_size", "--value", "8b")
+	if err == nil || !strings.Contains(err.Error(), "--add --type enum") {
+		t.Fatalf("expected the declare hint, got %v", err)
+	}
+}
+
+func TestDraftsOptionsRemoveDropsAChoice(t *testing.T) {
+	resetStackProfileDraftAuthoringFlags(t)
+	draft := gpuChatDraft()
+	draft.Parameters = append(draft.Parameters, map[string]any{
+		"name": "model_size", "type": "enum", "enum_values": []any{"8b", "32b"},
+		"options": []any{map[string]any{"value": "8b"}, map[string]any{"value": "32b"}},
+	})
+	mock := &stackProfileDraftMock{draft: draft}
+	setMockClient(t, mock)
+
+	stdout := captureStdout(t, func() {
+		_, _ = executeCommand("stack-profiles", "drafts", "options", "remove", "draft-1", "--parameter", "model_size", "--value", "8b")
+	})
+
+	parameter := parameterFromRequest(t, mock.updateRequest, "model_size")
+	options := draftParameterOptions(parameter)
+	if len(options) != 1 || options[0]["value"] != "32b" {
+		t.Errorf("options = %v", parameter["options"])
+	}
+	if enumValues, _ := parameter["enum_values"].([]any); len(enumValues) != 1 || enumValues[0] != "32b" {
+		t.Errorf("enum_values must follow the remaining choices, got %v", parameter["enum_values"])
+	}
+	if !strings.Contains(stdout, "Removed choice '8b' from model_size (1 choice left).") {
+		t.Errorf("unexpected output: %s", stdout)
+	}
+
+	resetStackProfileDraftAuthoringFlags(t)
+	mock.updateRequest = nil
+	_, err := executeCommand("stack-profiles", "drafts", "options", "remove", "draft-1", "--parameter", "model_size", "--value", "70b")
+	if err == nil || !strings.Contains(err.Error(), "has no choice") {
+		t.Fatalf("expected the missing-choice error, got %v", err)
+	}
+}
+
+func TestDraftsGetListsChoices(t *testing.T) {
+	draft := gpuChatDraft()
+	draft.Parameters = append(draft.Parameters, map[string]any{
+		"name": "model_size", "type": "enum", "description": "Pick the model.",
+		"options": []any{
+			map[string]any{"value": "8b", "sets": map[string]any{"model_id": "Qwen/Qwen3-8B"}},
+			map[string]any{"value": "32b", "sets": map[string]any{"model_id": "Qwen/Qwen3-32B", "max_model_len": "28672"}},
+		},
+	})
+	setMockClient(t, &stackProfileDraftMock{draft: draft})
+
+	stdout := captureStdout(t, func() {
+		_, _ = executeCommand("stack-profiles", "drafts", "get", "draft-1")
+	})
+
+	if !strings.Contains(stdout, "choices: 8b (sets model_id=Qwen/Qwen3-8B), 32b (sets max_model_len=28672, model_id=Qwen/Qwen3-32B)") {
+		t.Errorf("expected the choices line, got: %s", stdout)
+	}
+	if strings.Count(stdout, "choices:") != 1 {
+		t.Errorf("inputs without options must not get a choices line: %s", stdout)
+	}
+}
+
+func stringPointer(value string) *string { return &value }
+
+func gpuChatParameters() []client.StackProfileParameter {
+	return []client.StackProfileParameter{
+		{Name: "model_size", Type: "enum", Default: stringPointer("8b"), EnumValues: []string{"8b", "32b"},
+			Options: []client.StackProfileParameterOption{
+				{Value: "8b", Sets: map[string]string{"model_id": "Qwen/Qwen3-8B", "max_model_len": "16384"}},
+				{Value: "32b", Sets: map[string]string{"model_id": "Qwen/Qwen3-32B", "max_model_len": "28672"}},
+			}},
+		{Name: "model_id", Type: "string", Required: true},
+		{Name: "max_model_len", Type: "number", Required: true},
+		{Name: "gpu_memory_utilization", Type: "number", Default: stringPointer("0.90")},
+		{Name: "chat_host", Type: "string", Required: true},
+		{Name: "api_key", Type: "secret", Required: true},
+	}
+}
+
+func TestPreviewResolvedBindingsFollowsThePlatformOrder(t *testing.T) {
+	rows := previewResolvedBindings(gpuChatParameters(), []client.ParameterBinding{
+		{Name: "model_size", Value: "32b"},
+		{Name: "max_model_len", Value: "8192"},
+		{Name: "api_key", Value: "hunter2"},
+		{Name: "typo", Value: "x"},
+	})
+	byName := map[string]bindingPreview{}
+	for _, row := range rows {
+		byName[row.Name] = row
+	}
+	if byName["model_id"].Value != "Qwen/Qwen3-32B" || byName["model_id"].Source != "choice model_size=32b" {
+		t.Errorf("model_id = %+v", byName["model_id"])
+	}
+	if byName["max_model_len"].Value != "8192" || byName["max_model_len"].Source != "--set" {
+		t.Errorf("a --set must win over the choice, got %+v", byName["max_model_len"])
+	}
+	if byName["gpu_memory_utilization"].Value != "0.90" || byName["gpu_memory_utilization"].Source != "default" {
+		t.Errorf("gpu_memory_utilization = %+v", byName["gpu_memory_utilization"])
+	}
+	if byName["chat_host"].Source != "unset" || !byName["chat_host"].Required {
+		t.Errorf("chat_host = %+v", byName["chat_host"])
+	}
+	if byName["api_key"].Value != "********" {
+		t.Errorf("a secret value must never be echoed, got %+v", byName["api_key"])
+	}
+	if byName["typo"].Source != "--set (not an input of this version)" {
+		t.Errorf("an unknown --set must be called out, got %+v", byName["typo"])
+	}
+	if missing := unsetRequiredInputs(rows); len(missing) != 1 || missing[0] != "chat_host" {
+		t.Errorf("unset required = %v", missing)
+	}
+}
+
+func TestPreviewResolvedBindingsUsesTheSelectorDefaultAndLaterSelectorWins(t *testing.T) {
+	parameters := []client.StackProfileParameter{
+		{Name: "size", Type: "enum", Default: stringPointer("small"), Options: []client.StackProfileParameterOption{
+			{Value: "small", Sets: map[string]string{"replicas": "1", "storage": "20Gi"}}}},
+		{Name: "tier", Type: "enum", Default: stringPointer("ha"), Options: []client.StackProfileParameterOption{
+			{Value: "ha", Sets: map[string]string{"replicas": "3"}}}},
+		{Name: "replicas", Type: "number"},
+		{Name: "storage", Type: "string"},
+	}
+	rows := previewResolvedBindings(parameters, nil)
+	byName := map[string]bindingPreview{}
+	for _, row := range rows {
+		byName[row.Name] = row
+	}
+	if byName["replicas"].Value != "3" || byName["replicas"].Source != "choice tier=ha" {
+		t.Errorf("replicas = %+v", byName["replicas"])
+	}
+	if byName["storage"].Value != "20Gi" || byName["storage"].Source != "choice size=small" {
+		t.Errorf("storage = %+v", byName["storage"])
+	}
+}
+
+func TestStackProfilesApplyDryRunPreviewsWithoutCreating(t *testing.T) {
+	resetStackProfileApplyFlags(t)
+	mock := &stackProfileMock{detail: &client.StackProfileDetail{
+		Profile: client.StackProfileSummary{ID: "profile-1", Name: "gpu-chat", CurrentVersion: 11, LatestVersion: 11},
+		CurrentVersionDetail: &client.StackProfileVersionDetail{
+			Version: 11, Channel: "stable", Parameters: gpuChatParameters(),
+		},
+	}}
+	setMockClient(t, mock)
+
+	stdout := captureStdout(t, func() {
+		_, _ = executeCommand("stack-profiles", "apply", "profile-1", "--dry-run",
+			"--set", "model_size=32b", "--set", "chat_host=chat.example.com", "--set", "api_key=hunter2")
+	})
+
+	if mock.instantiateRequest != nil {
+		t.Fatal("--dry-run must not instantiate anything")
+	}
+	for _, expected := range []string{
+		"Dry run: inputs 'gpu-chat' v11 would deploy with (nothing created):",
+		"Qwen/Qwen3-32B",
+		"choice model_size=32b",
+		"Every required input is set.",
+	} {
+		if !strings.Contains(stdout, expected) {
+			t.Errorf("expected %q in output, got: %s", expected, stdout)
+		}
+	}
+	if strings.Contains(stdout, "hunter2") {
+		t.Errorf("secret value leaked into the preview: %s", stdout)
+	}
+
+	resetStackProfileApplyFlags(t)
+	output, err := executeCommand("stack-profiles", "apply", "profile-1", "--dry-run", "--set", "model_size=8b", "--output", "json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var structured struct {
+		Version  int              `json:"version"`
+		Bindings []bindingPreview `json:"bindings"`
+	}
+	if unmarshalError := json.Unmarshal([]byte(output), &structured); unmarshalError != nil {
+		t.Fatalf("expected JSON, got %v: %s", unmarshalError, output)
+	}
+	if structured.Version != 11 || len(structured.Bindings) != len(gpuChatParameters()) {
+		t.Errorf("structured = %+v", structured)
+	}
+	for _, row := range structured.Bindings {
+		if row.Name == "model_id" && (row.Value != "Qwen/Qwen3-8B" || row.Source != "choice model_size=8b") {
+			t.Errorf("model_id row = %+v", row)
+		}
+	}
+}

--- a/cmd/stack_profiles.go
+++ b/cmd/stack_profiles.go
@@ -376,16 +376,21 @@ which parameters a profile expects.`,
 			return versionError
 		}
 		deploy, _ := cmd.Flags().GetBool("deploy")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		setValues, _ := cmd.Flags().GetStringArray("set")
 		setFiles, _ := cmd.Flags().GetStringArray("set-file")
 		setEnvs, _ := cmd.Flags().GetStringArray("set-env")
 
-		clusterID, clusterLabel, err := resolveApplyTargetCluster(clusterFlag)
+		parameters, err := buildParameterBindings(setValues, setFiles, setEnvs)
 		if err != nil {
 			return err
 		}
 
-		parameters, err := buildParameterBindings(setValues, setFiles, setEnvs)
+		if dryRun {
+			return previewApply(cmd, profileID, versionFlag, parameters)
+		}
+
+		clusterID, clusterLabel, err := resolveApplyTargetCluster(clusterFlag)
 		if err != nil {
 			return err
 		}
@@ -446,6 +451,58 @@ which parameters a profile expects.`,
 		}
 		return nil
 	},
+}
+
+// previewApply is `apply --dry-run`: it reads the profile version's inputs,
+// resolves the bindings the way the platform will (a --set value, then what
+// the selected choice sets, then the input's default) and prints the
+// result. Nothing is created, so no cluster is needed.
+func previewApply(cmd *cobra.Command, profileID string, versionFlag int, bindings []client.ParameterBinding) error {
+	detail, err := apiClient.GetStackProfile(profileID)
+	if err != nil {
+		return fmt.Errorf("reading stack profile: %w", err)
+	}
+	parameters, shownVersion, err := selectProfileParameters(detail, versionFlag, profileID)
+	if err != nil {
+		return err
+	}
+	rows := previewResolvedBindings(parameters, bindings)
+
+	format, err := structuredFormatFromFlags(cmd)
+	if err != nil {
+		return err
+	}
+	if format != outputDefault {
+		return encodeStructured(cmd.OutOrStdout(), format, map[string]any{
+			"profile_id": profileID,
+			"version":    shownVersion,
+			"bindings":   rows,
+		})
+	}
+
+	fmt.Printf("Dry run: inputs '%s' v%d would deploy with (nothing created):\n", detail.Profile.Name, shownVersion)
+	previewTable := table.NewWriter()
+	previewTable.SetOutputMirror(os.Stdout)
+	previewTable.SetStyle(table.StyleRounded)
+	previewTable.AppendHeader(table.Row{"Input", "Value", "Source"})
+	for _, row := range rows {
+		name := row.Name
+		if row.Required {
+			name += " *"
+		}
+		value := row.Value
+		if value == "" {
+			value = "-"
+		}
+		previewTable.AppendRow(table.Row{name, value, row.Source})
+	}
+	previewTable.Render()
+	if missing := unsetRequiredInputs(rows); len(missing) > 0 {
+		fmt.Printf("\n%d required %s still unset: %s\n", len(missing), pluralise(len(missing), "input", "inputs"), strings.Join(missing, ", "))
+		return nil
+	}
+	fmt.Println("\nEvery required input is set. Re-run without --dry-run to create the draft.")
+	return nil
 }
 
 func resolveApplyTargetCluster(clusterFlag string) (string, string, error) {
@@ -561,6 +618,7 @@ func init() {
 	stackProfilesApplyCmd.Flags().StringArray("set-file", nil, "Bind a parameter from a file: name=path (repeatable; secret-safe)")
 	stackProfilesApplyCmd.Flags().StringArray("set-env", nil, "Bind a parameter from an environment variable: name=ENV_VAR (repeatable; secret-safe)")
 	stackProfilesApplyCmd.Flags().Bool("deploy", false, "Deploy the stack immediately instead of leaving a draft for review")
+	stackProfilesApplyCmd.Flags().Bool("dry-run", false, "Show the value every input would deploy with (your --set, the selected choice, or the default) without creating anything")
 	registerStructuredOutputFlags(stackProfilesApplyCmd)
 
 	stackProfilesCmd.AddCommand(stackProfilesListCmd)

--- a/cmd/stack_profiles_apply_test.go
+++ b/cmd/stack_profiles_apply_test.go
@@ -45,6 +45,7 @@ func resetStackProfileApplyFlags(t *testing.T) {
 		"stack-name": "",
 		"version":    "0",
 		"deploy":     "false",
+		"dry-run":    "false",
 		"output":     "",
 	} {
 		_ = flags.Set(name, value)


### PR DESCRIPTION
## What

Closes the portal/CLI parity gap left by option sets (ankraio/cluster#1623, ankra-cli#125): the CLI could read and deploy a profile's choices but not author them, and could not show the resolved set before applying.

### Author choices on a draft

```bash
# declare the choice input (no manifest references it, so detection cannot see it)
ankra stack-profiles drafts annotate <draft> --parameter model_size --add --type enum --title "Model size" --default 8b

# give it choices that answer other inputs
ankra stack-profiles drafts options set <draft> --parameter model_size --value 8b  --title "Qwen3 8B on one L4" \
  --set model_id=Qwen/Qwen3-8B  --set max_model_len=16384 --set model_store_size=60Gi
ankra stack-profiles drafts options set <draft> --parameter model_size --value 32b --title "Qwen3 32B on one L40S" \
  --set model_id=Qwen/Qwen3-32B --set max_model_len=28672 --set model_store_size=120Gi

ankra stack-profiles drafts get <draft>        # lists each input's choices
ankra stack-profiles drafts publish <draft> --changelog "Model size choice"
```

- `drafts annotate` gains `--default`, `--type string|number|boolean|enum`, `--enum a,b,c` (implies enum), `--required` / `--required=false`, and `--add`. A declared input starts shaped as detection would shape it; secrets keep their type/default/enum/required.
- `drafts options set` upserts one choice by value (`--title`, `--description`, repeatable `--set name=value`, `--unset name`); `drafts options remove` drops one. Both keep the platform's enum mirror (`type: enum`, `enum_values` = option values) and refuse on the spot what publish would refuse: a secret target, the choice setting itself, an unknown input, a target that offers choices of its own, a secret selector.
- Everything goes through the existing `UpdateStackProfileDraft` lane, so the server's `ValidateParameterOptions` / `NormaliseParameterOptions` apply unchanged and the portal's Inputs tab shows the result.

### Preview before applying

```
$ ankra stack-profiles apply gpu-chat --dry-run --set model_size=32b --set chat_host=chat.example.com
Dry run: inputs 'gpu-chat' v11 would deploy with (nothing created):
╭──────────────────────────┬──────────────────────┬──────────────────────╮
│ Input                    │ Value                │ Source               │
├──────────────────────────┼──────────────────────┼──────────────────────┤
│ model_size               │ 32b                  │ --set                │
│ model_id *               │ Qwen/Qwen3-32B       │ choice model_size=32b│
│ max_model_len *          │ 28672                │ choice model_size=32b│
│ gpu_memory_utilization   │ 0.90                 │ default              │
│ chat_host *              │ chat.example.com     │ --set                │
│ api_key *                │ -                    │ unset                │
╰──────────────────────────┴──────────────────────┴──────────────────────╯

1 required input still unset: api_key
```

`--dry-run` resolves exactly as the platform does (`--set` > selected choice's sets > default, later choice inputs win on overlap), flags a `--set` that names no input of that version, never echoes a secret, needs no cluster, and creates nothing. `-o json|yaml` returns `{profile_id, version, bindings[]}`.

## Tests

14 new tests in `cmd/stack_profile_options_test.go`: declare-with-`--add`, unknown-input hint, bad type and secret reshaping refused, options survive a retitle, choice add/update/`--unset`/remove, every refused target, `drafts get` choices line, the resolver (order, later-selector-wins, secret masking, unknown `--set`), and `apply --dry-run` text + JSON with no instantiate call.

`go test -race -count=1 ./...`, `gofmt`, `golangci-lint run` (0 issues) all pass.

## Changelog

Entry under `## Unreleased` → `### Added`.

Bead: ankra-uhi08
