### PR TITLE
feat(upcloud): add --cni to ankra cluster upcloud create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,10 @@
   neither `resize` (the CLI has no bastion instance-type call for these three)
   nor `diagnose` on Scaleway, whose managed Public Gateway is probed by the
   health loop but has no SSH job lane.
+- **`ankra cluster upcloud create --cni`** selects the container network
+  interface for k3s clusters (`flannel`, `calico`, or `cilium`; the platform
+  default applies when omitted), closing a gap where the CNI was only
+  choosable from the portal wizard and the API.
 
 ### Fixed
 

--- a/cmd/upcloud_cluster.go
+++ b/cmd/upcloud_cluster.go
@@ -32,6 +32,7 @@ var upcloudCreateCmd = &cobra.Command{
 		workerCount, _ := cmd.Flags().GetInt("worker-count")
 		workerPlan, _ := cmd.Flags().GetString("worker-plan")
 		distribution, _ := cmd.Flags().GetString("distribution")
+		cni, _ := cmd.Flags().GetString("cni")
 		kubeVersion, _ := cmd.Flags().GetString("kubernetes-version")
 		etcdTopology, _ := cmd.Flags().GetString("etcd-topology")
 		etcdNodeCount, _ := cmd.Flags().GetInt("etcd-node-count")
@@ -57,6 +58,7 @@ var upcloudCreateCmd = &cobra.Command{
 			WorkerCount:           workerCount,
 			WorkerPlan:            workerPlan,
 			Distribution:          distribution,
+			CNI:                   cni,
 			EtcdTopology:          etcdTopology,
 			EtcdNodeCount:         etcdNodeCount,
 			EtcdPlan:              etcdPlan,
@@ -536,6 +538,7 @@ func init() {
 	upcloudCreateCmd.Flags().Int("etcd-node-count", 3, "Number of dedicated etcd nodes when --etcd-topology=external (3 or 5)")
 	upcloudCreateCmd.Flags().String("etcd-plan", "2xCPU-4GB", "Plan for dedicated etcd nodes when --etcd-topology=external")
 	upcloudCreateCmd.Flags().Bool("external-cloud-provider", true, "Install the UpCloud CCM and CSI (cloud-provider=external) for LoadBalancers and persistent volumes (default on; pass --external-cloud-provider=false to skip, which also disables --include-networking)")
+	upcloudCreateCmd.Flags().String("cni", "", "CNI plugin: flannel, calico, or cilium (optional; the platform default is used when omitted)")
 	upcloudCreateCmd.Flags().Bool("include-networking", true, "Install Traefik + cert-manager for ingress (default on; pass --include-networking=false to skip). Requires --external-cloud-provider (the ingress LoadBalancer is provisioned by the cloud controller manager)")
 	registerIncludeDNSFlag(upcloudCreateCmd)
 	upcloudCreateCmd.Flags().String("gitops-credential-name", "", "GitOps GitHub credential name; when set with --gitops-repository, the generated upcloud-cloud-provider stack is committed to Git (optional)")

--- a/cmd/upcloud_cluster_test.go
+++ b/cmd/upcloud_cluster_test.go
@@ -132,3 +132,34 @@ func TestUpcloudCreate_NetworkIPRangeFlagPinsTheRange(t *testing.T) {
 		t.Errorf("NetworkIPRange = %q, want 10.90.0.0/24", mock.gotRequest.NetworkIPRange)
 	}
 }
+
+func TestUpcloudCreate_CNIFlagReachesRequest(t *testing.T) {
+	mock := &upcloudCreateMock{}
+	resetConfirmFlag(t, upcloudCreateCmd)
+	_ = captureStdout(t, func() {
+		if _, err := runWithInput(t, mock, "", "cluster", "upcloud", "create",
+			"--name", "gpu-chat", "--credential-id", "cred-1",
+			"--ssh-key-credential-id", "ssh-1", "--zone", "fi-hel2",
+			"--cni", "cilium"); err != nil {
+			t.Fatalf("execute failed: %v", err)
+		}
+	})
+	if mock.gotRequest.CNI != "cilium" {
+		t.Errorf("CNI = %q, want cilium", mock.gotRequest.CNI)
+	}
+}
+
+func TestUpcloudCreate_CNIDefaultsToPlatformChoice(t *testing.T) {
+	mock := &upcloudCreateMock{}
+	resetConfirmFlag(t, upcloudCreateCmd)
+	_ = captureStdout(t, func() {
+		if _, err := runWithInput(t, mock, "", "cluster", "upcloud", "create",
+			"--name", "gpu-chat", "--credential-id", "cred-1",
+			"--ssh-key-credential-id", "ssh-1", "--zone", "fi-hel2"); err != nil {
+			t.Fatalf("execute failed: %v", err)
+		}
+	})
+	if mock.gotRequest.CNI != "" {
+		t.Errorf("CNI = %q, want empty so the platform applies its default", mock.gotRequest.CNI)
+	}
+}

--- a/internal/client/upcloud_clusters.go
+++ b/internal/client/upcloud_clusters.go
@@ -22,6 +22,7 @@ type CreateUpcloudClusterRequest struct {
 	WorkerCount           int     `json:"worker_count"`
 	WorkerPlan            string  `json:"worker_plan"`
 	Distribution          string  `json:"distribution"`
+	CNI                   string  `json:"cni,omitempty"`
 	KubernetesVersion     *string `json:"kubernetes_version,omitempty"`
 	EtcdTopology          string  `json:"etcd_topology,omitempty"`
 	EtcdNodeCount         int     `json:"etcd_node_count,omitempty"`

--- a/internal/client/upcloud_clusters_test.go
+++ b/internal/client/upcloud_clusters_test.go
@@ -527,3 +527,52 @@ func TestCreateUpcloudCluster_SendsExplicitNetworkIPRange(t *testing.T) {
 		t.Errorf("network_ip_range = %v, want 10.90.0.0/24", receivedBody["network_ip_range"])
 	}
 }
+
+func TestCreateUpcloudCluster_SendsCNI(t *testing.T) {
+	expectedResponse := CreateUpcloudClusterResponse{ClusterID: "upcloud-cluster-456", Name: "gpu-chat"}
+	var receivedBody map[string]any
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&receivedBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		jsonResponse(t, w, http.StatusCreated, expectedResponse)
+	})
+	req := CreateUpcloudClusterRequest{
+		Name: "gpu-chat", CredentialID: "cred-1", SSHKeyCredentialID: "ssh-1",
+		Zone: "fi-hel2", BastionPlan: "1xCPU-2GB",
+		ControlPlaneCount: 1, ControlPlanePlan: "2xCPU-4GB",
+		WorkerCount: 1, WorkerPlan: "GPU-8xCPU-64GB-1xL4", Distribution: "k3s",
+		CNI: "cilium",
+	}
+	if _, err := testClient.CreateUpcloudCluster(req); err != nil {
+		t.Fatalf("CreateUpcloudCluster: %v", err)
+	}
+	if got, ok := receivedBody["cni"].(string); !ok || got != "cilium" {
+		t.Errorf("cni = %v, want cilium", receivedBody["cni"])
+	}
+}
+
+// An unset CNI must stay off the wire so the platform applies its own
+// default instead of validating an empty string against its allowed values.
+func TestCreateUpcloudCluster_OmitsUnsetCNI(t *testing.T) {
+	expectedResponse := CreateUpcloudClusterResponse{ClusterID: "upcloud-cluster-456", Name: "gpu-chat"}
+	var receivedBody map[string]any
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&receivedBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		jsonResponse(t, w, http.StatusCreated, expectedResponse)
+	})
+	req := CreateUpcloudClusterRequest{
+		Name: "gpu-chat", CredentialID: "cred-1", SSHKeyCredentialID: "ssh-1",
+		Zone: "fi-hel2", BastionPlan: "1xCPU-2GB",
+		ControlPlaneCount: 1, ControlPlanePlan: "2xCPU-4GB",
+		WorkerCount: 1, WorkerPlan: "2xCPU-4GB", Distribution: "k3s",
+	}
+	if _, err := testClient.CreateUpcloudCluster(req); err != nil {
+		t.Fatalf("CreateUpcloudCluster: %v", err)
+	}
+	if value, present := receivedBody["cni"]; present {
+		t.Errorf("cni must be omitted when unset, got %v", value)
+	}
+}


### PR DESCRIPTION
> **Scope after rebase: this PR only adds `--cni`.** The original branch also carried the `--network-ip-range` auto-assignment and `--include-dns`; both are already on master (#117 for the network range under bead ankra-st3f2, and `registerIncludeDNSFlag` for `--include-dns` on every provider create), so only the `--cni` half remains. Original description follows for context.

## The bug

`ankra cluster upcloud create` hardcoded `--network-ip-range 10.0.0.0/16` and always sent it. UpCloud rejects overlapping networks, so on any account that already holds a `10.0.x` private network the create is **accepted**, then wedges at the network step with the reconcile loop failing forever:

```
UpCloud API 409: Network address 10.0.0.0/16 overlaps with an existing private network 10.0.0.0/24.
```

Reproduced live today (cluster `379f68e0`, nine resources failing) while the identical create through the API lane — which omits the field — auto-picked a free range and provisioned first try. The CLI was the only surface pinning a literal default.

## The fix

- `--network-ip-range` defaults to empty; an unset range is **omitted** from the request (`omitempty`), so the platform picks a range that is free in the account. Passing a range still pins it, and the help text now says exactly that. *(Already on master via #117.)*
- Parity gaps closed while in the file: `--cni` (k3s: flannel/calico/cilium) and `--include-dns` (delegated ankra.cc subdomain opt-out, default on) — completing the `external-cloud-provider` / `include-networking` / `include-dns` trio the API and wizard already expose. *(`--include-dns` already on master; `--cni` is what this PR adds.)*

## What this PR changes

- `ankra cluster upcloud create --cni flannel|calico|cilium`, sent as `cni` on the create request and omitted when unset so the platform default still applies. Help text follows the platform contract (`cni: Literal["flannel", "calico", "cilium"]`, default applied server-side) rather than claiming kubeadm forces cilium, which the platform only enforces on Scaleway.
- Tests: cmd-level `TestUpcloudCreate_CNIFlagReachesRequest` / `TestUpcloudCreate_CNIDefaultsToPlatformChoice` (flag reaches the request; unset stays empty), client-level `TestCreateUpcloudCluster_SendsCNI` / `TestCreateUpcloudCluster_OmitsUnsetCNI` (`cni` on the wire when set, absent when unset).
- CHANGELOG: one `Unreleased → Added` entry for `--cni`; the network-range and `--include-dns` entries already on master are left untouched.

## Verification

`go build ./... && go vet ./... && go test -race -count=1 ./...` green; `golangci-lint run ./...` 0 issues.

## Related

The portal wizard prefills the same `10.0.0.0/16` literal and would hit the same 409 — filed separately. A server-side create preflight that rejects an overlapping range at request time (instead of accepting and failing in reconcile) is also filed.

Supersedes #88, which conflicted with master after today's merges; rebased via cherry-pick, conflicts resolved in: `CHANGELOG.md`, `cmd/upcloud_cluster.go`, `internal/client/upcloud_clusters_test.go` (plus a duplicate `--include-dns` registration dropped from the auto-merged `cmd/upcloud_cluster.go`, which would have panicked at init alongside master's `registerIncludeDNSFlag`).
