### PR TITLE
fix(stack-profiles): a declared choice input survives the draft save (ankra-4lmte)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,12 +63,15 @@
   were current.
 - **Profile choices can now be authored from the terminal, and `apply` can
   show what it would deploy.** `stack-profiles drafts annotate` gains
-  `--default`, `--type`, `--enum` and `--required`, and `--add` declares an
-  input the draft does not have - such as a **Model size** choice that no
-  manifest references. The new `stack-profiles drafts options set <draft>
+  `--default`, `--type`, `--enum` and `--required`, and `--add --enum a,b`
+  declares an input the draft does not have - such as a **Model size** choice
+  that no manifest references - born with its enum values as choices, which
+  is what keeps the platform from dropping it on the next save. The new
+  `stack-profiles drafts options set <draft>
   --parameter model_size --value 32b --set model_id=Qwen/Qwen3-32B --set
   max_model_len=28672` adds or updates one choice and the inputs it answers
-  (`--unset` drops one; `options remove` drops the choice), with the rules
+  (declaring the input if the draft does not have it yet; `--unset` drops an
+  assignment; `options remove` drops the choice), with the rules
   publish enforces - no secret targets, no choice driving another choice -
   refused on the spot. `drafts get` lists each input's choices. And
   `stack-profiles apply --dry-run` prints every input with the value it

--- a/cmd/stack_profile_drafts.go
+++ b/cmd/stack_profile_drafts.go
@@ -169,8 +169,15 @@ annotations live.`,
 		declared := false
 		if parameter == nil {
 			if !add {
-				return fmt.Errorf("parameter %q not found on the draft; it has: %v. Pass --add to declare an input no manifest references, such as a choice that sets other inputs",
+				return fmt.Errorf("parameter %q not found on the draft; it has: %v. Pass --add --enum <choices> to declare an input no manifest references, such as a choice that sets other inputs",
 					parameterName, draftParameterNames(draft.Parameters))
+			}
+			// The platform re-detects a draft's inputs on every save and keeps
+			// an input no manifest references only while it offers choices, so
+			// a declared input must be born with its choices or the save drops
+			// it silently.
+			if len(splitEnumList(enumList)) == 0 {
+				return withExitCode(exitUsage, fmt.Errorf("--add needs --enum <choice,choice,...>: an input no manifest references is kept by the platform only while it offers choices"))
 			}
 			// A declared input starts as the platform's detection would have
 			// shaped it; the flags below then apply on top, exactly like an
@@ -211,6 +218,25 @@ annotations live.`,
 			parameter["enum_values"] = enumValues
 			if len(values) > 0 && !changed("type") {
 				parameter["type"] = "enum"
+			}
+			// On an input that offers choices, the enum values ARE the choices:
+			// keep the choices whose value is still listed (with their sets),
+			// add a bare choice for each new value. A declared input is born
+			// this way, which is what keeps it on the draft across saves.
+			if existing := draftParameterOptions(parameter); declared || len(existing) > 0 {
+				byValue := map[string]map[string]any{}
+				for _, option := range existing {
+					byValue[fmt.Sprint(option["value"])] = option
+				}
+				reconciled := make([]map[string]any, 0, len(values))
+				for _, value := range values {
+					if option, present := byValue[value]; present {
+						reconciled = append(reconciled, option)
+						continue
+					}
+					reconciled = append(reconciled, map[string]any{"value": value})
+				}
+				storeDraftParameterOptions(parameter, reconciled)
 			}
 		}
 		if changed("required") {

--- a/cmd/stack_profile_options.go
+++ b/cmd/stack_profile_options.go
@@ -199,9 +199,17 @@ var stackProfileDraftsOptionsSetCmd = &cobra.Command{
 			return fmt.Errorf("reading stack profile draft: %w", err)
 		}
 		parameter := draftParameterByName(draft.Parameters, parameterName)
+		declared := false
 		if parameter == nil {
-			return fmt.Errorf("parameter %q not found on the draft; it has: %v. Declare a choice input that no manifest references with 'ankra stack-profiles drafts annotate %s --parameter %s --add --type enum'",
-				parameterName, draftParameterNames(draft.Parameters), draft.ID, parameterName)
+			// An input no manifest references is kept by the platform only
+			// while it offers choices, so the first choice is what declares
+			// it; there is nothing to declare separately first.
+			parameter = map[string]any{
+				"name": parameterName, "title": parameterName, "type": "enum",
+				"required": false, "enum_values": []any{}, "group": "variables",
+			}
+			draft.Parameters = append(draft.Parameters, parameter)
+			declared = true
 		}
 		if parameterType, _ := parameter["type"].(string); parameterType == "secret" {
 			return withExitCode(exitUsage, fmt.Errorf("%q is a secret input and cannot offer choices", parameterName))
@@ -255,6 +263,9 @@ var stackProfileDraftsOptionsSetCmd = &cobra.Command{
 		verb := "Updated"
 		if created {
 			verb = "Added"
+		}
+		if declared {
+			fmt.Printf("Declared input %s on draft '%s'.\n", parameterName, updated.Name)
 		}
 		fmt.Printf("%s choice '%s' on %s (%d %s).\n", verb, value, parameterName, len(options), pluralise(len(options), "choice", "choices"))
 		for _, target := range sortedAssignmentTargets(sets) {

--- a/cmd/stack_profile_options_test.go
+++ b/cmd/stack_profile_options_test.go
@@ -112,8 +112,56 @@ func TestDraftsAnnotateDeclaresAChoiceInput(t *testing.T) {
 	if len(mock.updateRequest.Parameters) != 4 {
 		t.Errorf("expected the three detected inputs plus the declared one, got %d", len(mock.updateRequest.Parameters))
 	}
+	// The platform keeps an unreferenced input only while it offers choices,
+	// so a declared input is born with its enum values as choices.
+	options := draftParameterOptions(parameter)
+	if len(options) != 2 || options[0]["value"] != "8b" || options[1]["value"] != "32b" {
+		t.Errorf("expected the enum values seeded as choices, got %v", parameter["options"])
+	}
 	if !strings.Contains(stdout, "Declared input model_size") || !strings.Contains(stdout, "drafts options set draft-1 --parameter model_size") {
 		t.Errorf("expected the declare guidance, got: %s", stdout)
+	}
+}
+
+func TestDraftsAnnotateAddNeedsEnumSoTheInputSurvivesTheSave(t *testing.T) {
+	resetStackProfileDraftAuthoringFlags(t)
+	mock := &stackProfileDraftMock{draft: gpuChatDraft()}
+	setMockClient(t, mock)
+
+	_, err := executeCommand("stack-profiles", "drafts", "annotate", "draft-1", "--parameter", "model_size", "--add", "--title", "Model size")
+
+	if err == nil || !strings.Contains(err.Error(), "--add needs --enum") {
+		t.Fatalf("expected the --enum requirement, got %v", err)
+	}
+	if mock.updateRequest != nil {
+		t.Error("an input that would be dropped on save must not be written")
+	}
+}
+
+func TestDraftsAnnotateEnumReconcilesExistingChoices(t *testing.T) {
+	resetStackProfileDraftAuthoringFlags(t)
+	draft := gpuChatDraft()
+	draft.Parameters = append(draft.Parameters, map[string]any{
+		"name": "model_size", "type": "enum", "enum_values": []any{"8b", "32b"},
+		"options": []any{
+			map[string]any{"value": "8b", "sets": map[string]any{"model_id": "Qwen/Qwen3-8B"}},
+			map[string]any{"value": "32b", "sets": map[string]any{"model_id": "Qwen/Qwen3-32B"}},
+		},
+	})
+	mock := &stackProfileDraftMock{draft: draft}
+	setMockClient(t, mock)
+
+	_, _ = executeCommand("stack-profiles", "drafts", "annotate", "draft-1", "--parameter", "model_size", "--enum", "8b,70b")
+
+	options := draftParameterOptions(parameterFromRequest(t, mock.updateRequest, "model_size"))
+	if len(options) != 2 || options[0]["value"] != "8b" || options[1]["value"] != "70b" {
+		t.Fatalf("options = %v", options)
+	}
+	if draftOptionSets(options[0])["model_id"] != "Qwen/Qwen3-8B" {
+		t.Errorf("a kept choice must keep its sets, got %v", options[0])
+	}
+	if len(draftOptionSets(options[1])) != 0 {
+		t.Errorf("a new choice starts bare, got %v", options[1])
 	}
 }
 
@@ -273,7 +321,7 @@ func TestDraftsOptionsSetRefusesBadTargets(t *testing.T) {
 	}
 }
 
-func TestDraftsOptionsSetRefusesASecretSelectorAndUnknownInput(t *testing.T) {
+func TestDraftsOptionsSetRefusesASecretSelector(t *testing.T) {
 	resetStackProfileDraftAuthoringFlags(t)
 	mock := &stackProfileDraftMock{draft: gpuChatDraft()}
 	setMockClient(t, mock)
@@ -282,11 +330,33 @@ func TestDraftsOptionsSetRefusesASecretSelectorAndUnknownInput(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "secret input and cannot offer choices") {
 		t.Fatalf("expected the secret refusal, got %v", err)
 	}
+	if mock.updateRequest != nil {
+		t.Error("a refused selector must not write the draft")
+	}
+}
 
+// The platform keeps an unreferenced input only while it offers choices, so
+// the first choice is what declares it - no separate declare step.
+func TestDraftsOptionsSetDeclaresAMissingInputWithItsFirstChoice(t *testing.T) {
 	resetStackProfileDraftAuthoringFlags(t)
-	_, err = executeCommand("stack-profiles", "drafts", "options", "set", "draft-1", "--parameter", "model_size", "--value", "8b")
-	if err == nil || !strings.Contains(err.Error(), "--add --type enum") {
-		t.Fatalf("expected the declare hint, got %v", err)
+	mock := &stackProfileDraftMock{draft: gpuChatDraft()}
+	setMockClient(t, mock)
+
+	stdout := captureStdout(t, func() {
+		_, _ = executeCommand("stack-profiles", "drafts", "options", "set", "draft-1",
+			"--parameter", "model_size", "--value", "8b", "--set", "model_id=Qwen/Qwen3-8B")
+	})
+
+	parameter := parameterFromRequest(t, mock.updateRequest, "model_size")
+	if parameter["type"] != "enum" || parameter["title"] != "model_size" {
+		t.Errorf("declared parameter = %v", parameter)
+	}
+	options := draftParameterOptions(parameter)
+	if len(options) != 1 || draftOptionSets(options[0])["model_id"] != "Qwen/Qwen3-8B" {
+		t.Errorf("options = %v", parameter["options"])
+	}
+	if !strings.Contains(stdout, "Declared input model_size on draft 'gpu-chat'.") || !strings.Contains(stdout, "Added choice '8b' on model_size (1 choice).") {
+		t.Errorf("unexpected output: %s", stdout)
 	}
 }
 


### PR DESCRIPTION
## What

Found while testing #126 against production: `drafts annotate <draft> --parameter model_size --add …` reported success, but reading the draft back showed no `model_size`. The platform re-detects a draft's inputs on every save and keeps an input no manifest references **only while it offers choices** (cluster#1623's `preserveOptionSetParameters`); the portal's "Add a choice" seeds one empty option, the CLI seeded none — so the server dropped it silently.

- `drafts annotate --add` now requires `--enum a,b,…` and the declared input is born with those values as its choices (the enum values *are* the choices). On an input that already offers choices, `--enum` reconciles: listed values keep their `sets`, new values start bare.
- `drafts options set` declares a missing input with its first choice instead of erroring — the first choice is what makes the input persist, so there is nothing to declare separately.
- Output and the error hint say why.

## Verified live (production, org Ankra AB, gpu-chat draft `bad1ba16`, unpublished)

```
drafts annotate … --parameter model_size --add --enum 8b,32b --title "Model size" --default 8b
→ read back: model_size present, type enum, enum_values [8b,32b], options [{8b},{32b}]
drafts options set … --value 32b --set model_repository=Qwen/Qwen3-32B --set model_max_length=28672 --set gpu_memory_utilization=0.95 --set model_store_size=120Gi
drafts options set … --value 8b  --set model_repository=Qwen/Qwen3-8B-FP8 --set model_max_length=32768 …
drafts get      → choices: 8b (sets …), 32b (sets …)
drafts validate → {"valid": true, "issues": []}
```

Before the fix the same `annotate --add` produced a draft at version 2 with no `model_size`.

## Tests

`TestDraftsAnnotateDeclaresAChoiceInput` now asserts the seeded choices; new `TestDraftsAnnotateAddNeedsEnumSoTheInputSurvivesTheSave`, `TestDraftsAnnotateEnumReconcilesExistingChoices`, `TestDraftsOptionsSetDeclaresAMissingInputWithItsFirstChoice`. `go test -race ./...`, `gofmt`, `golangci-lint` (0 issues) pass.

Bead: ankra-4lmte
