### PR TITLE
release: cut v0.13.0-rc0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.13.0-rc0 — 2026-08-22
+
 ### Added
 
 - **`ankra cluster logs --previous` reads the log a crash-looping container


### PR DESCRIPTION
Cuts **v0.13.0-rc0** — the first RC of the v0.13.0 minor line, carrying the Smartoptics support-sweep CLI work (bead `ankra-ymkj8`) plus the stack-profile lifecycle and create-flag additions merged this cycle.

CHANGELOG.md only — no source changes. Promotes the `## Unreleased` block to `## v0.13.0-rc0 — 2026-08-22`.

Highlights in this RC:
- `cluster logs --previous` / `-l <selector>` / `--all-containers`, `cluster describe`, `cluster events --for`, `cluster top pods|nodes` (PLA-769)
- `org domain get|set`, `org dns zones`, and `cluster domain` made a non-mutating read (PLA-768/#1076, PLA-770/#1078)
- stack-profiles full lifecycle + drafts options/annotate, `apply --dry-run`
- `--include-dns` on every provider create; `bastion` groups for scaleway/proxmox/morpheus; `upcloud create --cni`
- fixes: `cluster apply` group/values/variables/manifest_base64 round-trip, `--follow=false` bounded read, git-hook repo inspection

Any tag containing `-` publishes as a GitHub prerelease, so this reaches only beta-channel users (`ankra config beta enable`). Tag is cut after merge.
