### PR TITLE
release: promote the changelog to v0.13.0 (ankra-jo5qx)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Ankra CLI Changelog
 
-## Unreleased
+## v0.13.0 — 2026-08-22
+
+Makes the platform's IaC export round-trip. `cluster apply` now carries an
+exported ImportCluster back without dropping addon values, stack variables,
+group labels, or base64-encoded manifests — the clone-edit-apply loop deploys
+what the file says, or fails naming what it could not read, instead of
+silently installing chart defaults. Stack profiles gain the portal's whole
+lifecycle rather than just the read half, and the main list commands learn
+`--sort`/`--order` so `cluster list --sort created --order desc` puts the
+newest clusters first.
 
 ### Added
 


### PR DESCRIPTION
## What & why

Promotes `## Unreleased` to `## v0.13.0 — 2026-08-22` so the tag can be cut. Fifteen commits sit on master since v0.12.0 — among them the four `cluster apply` fixes that make the platform's IaC export round-trip, the stack-profiles lifecycle commands, `--sort`/`--order` on the main list commands, `--include-dns` on every provider create, and the bastion groups for Scaleway/Proxmox/Morpheus — and none are in a tagged release. `release.yml` extracts release notes by matching the `## v<version>` heading, so this promotion is what makes the release carry the written notes instead of auto-generated ones.

Follows the same structure as the v0.12.0 promotion (#106): heading retitled with the date, a short thematic intro paragraph under it, no empty Unreleased section left behind.

The section was audited commit-by-commit against master: every user-visible change since v0.12.0 has an entry; the only commits without one are CI/chore (#113, #120, #121), which get none by convention. No breaking changes → minor bump, straight release without RCs (v0.12.0 precedent).

After merge: tag the squash commit `v0.13.0` and push the tag; `release.yml` builds the six-target matrix and creates the GitHub release. Note: the two darwin matrix builds still run on GitHub-hosted `macos-latest`, so if the org Actions billing issue (ankra-m5m9d) is still live they will not start — the release will be held/reported rather than shipped incomplete.

Bead: ankra-jo5qx

## Test plan

- Changelog-only change; YAML/markdown untouched by code gates. Pre-commit hook (go test + golangci-lint) passed on commit.
- Verified `release.yml`'s note-extraction matches the `## v0.13.0` heading format used by every prior release section.

## Docs checklist

- [x] No user-facing command/flag changes — no docs needed
- [ ] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); ensure `Short`/`Long`/`Example` on new commands are written for docs readers
- [ ] Broader behaviour changes — docs updated in [ankra-docs](https://github.com/ankraio/ankra-docs) (link the PR): <!-- PR link -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
