### PR TITLE
release: revert the premature v0.13.0 changelog promotion (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,6 @@
 # Ankra CLI Changelog
 
-## v0.13.0 — 2026-08-22
-
-Makes the platform's IaC export round-trip. `cluster apply` now carries an
-exported ImportCluster back without dropping addon values, stack variables,
-group labels, or base64-encoded manifests — the clone-edit-apply loop deploys
-what the file says, or fails naming what it could not read, instead of
-silently installing chart defaults. Stack profiles gain the portal's whole
-lifecycle rather than just the read half, and the main list commands learn
-`--sort`/`--order` so `cluster list --sort created --order desc` puts the
-newest clusters first.
+## Unreleased
 
 ## v0.13.0-rc0 — 2026-08-22
 


### PR DESCRIPTION
## What & why

Reverts #131 (`f7a2f8f`). #131 and #130 raced: #130 promoted `## Unreleased` to `## v0.13.0-rc0` for the Smartoptics support-sweep RC and merged 77 seconds before #131, which had been cut from a pre-rc0 base and promoted the same content to a straight `## v0.13.0`. The textual merge was clean, so master ended up with an entry-less `## v0.13.0` section stacked above the real `## v0.13.0-rc0` one — wrong for every path forward: tagging v0.13.0 against it would ship release notes with no entries, and the stable cut after rc0 soak needs to write that section itself with the entries folded in (the v0.11.0-line convention: stable section carries the full list, rc sections retained beneath).

The v0.13.0-rc0 lane is untouched — its tag points below #131's commit, so its notes extracted cleanly and the release built normally.

After this revert, master's changelog is: empty `## Unreleased` (room for the next cycle), then `## v0.13.0-rc0 — 2026-08-22`, then history. Stable v0.13.0 will be promoted properly once the RC has soaked (tracked in ankra-jo5qx — mentioned as context; this PR does not deliver that bead).

## Test plan

Changelog-only revert; pre-commit hook (go test + golangci-lint) passed on commit. Verified the reverted file's top-of-file state matches the post-rc0-promote convention.

## Docs checklist

- [x] No user-facing command/flag changes — no docs needed
- [ ] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); ensure `Short`/`Long`/`Example` on new commands are written for docs readers
- [ ] Broader behaviour changes — docs updated in [ankra-docs](https://github.com/ankraio/ankra-docs) (link the PR): <!-- PR link -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
