### PR TITLE
fix(domain): report the held removal, split the blockers you cannot clear, and say what a root switch touches (ankra-ymkj8.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 ## Unreleased
 
+### Added
+
+- **`ankra cluster playground destroy <cluster_id>` tears the organisation's
+  playground down.** The platform has served the DELETE since playgrounds
+  shipped; only the CLI could not reach it, so `create` and `status` had no
+  matching way out. It is idempotent — an environment already deprovisioning
+  or removed answers its current phase rather than an error. It also has a
+  second job: a live playground publishes a wildcard DNS record in the
+  organisation's zone, that record is reconciled rather than written once,
+  and it is therefore the one blocker of `ankra org domain set` that deleting
+  cannot clear. Destroying the environment is what clears it.
+
+### Changed
+
+- **`ankra cluster domain <cluster> --remove` now holds.** Removing a
+  cluster's domain and watching it reappear about fifty seconds later, active
+  and under the same label, was the reason the documented root-domain switch
+  could not be completed: every removal was reverted before the next one
+  could be made. The removal is now recorded as a deliberate act, so nothing
+  re-creates the zone — not the external-dns Ankra runs on the cluster, and
+  not the discovery that mints zones for clusters that have none. A read
+  reports `Opted out: yes` for as long as the hold stands, which is what
+  distinguishes a domain that is gone from one that is between passes.
+  `--enable` withdraws the hold and re-creates the zone under the
+  organisation's current root, under exactly the name it had before.
+- **A refused `ankra org domain set` now separates the blockers you can clear
+  from the ones you cannot, and names what to remove instead.** DNS records
+  the platform publishes and re-asserts are listed apart from your own, with
+  the writer named, because telling an admin to `ankra org dns delete` a
+  record the playground provisioner writes back on its next pass is advice
+  that cannot work. Live playground environments are listed outright, with
+  the command that destroys them. The cluster-domain section now also says
+  what those clusters' external-dns will do about the removal, and that a
+  root switch never re-labels a zone — labels come from the cluster id, so
+  `--txt-owner-id` and any GitOps path built from one survive the switch
+  unchanged.
+- **`ankra org domain --help` and `ankra org domain set --help` state what
+  Ankra does to the domain you register.** Ankra creates one subzone,
+  `<org_short_id>.<domain>`, and works only inside it: records already
+  published at the apex or under any other name are never read, written or
+  deleted, by the switch or by anything Ankra runs afterwards. A domain that
+  already serves production hostnames is safe to register on that count, and
+  it is now written down rather than something to infer.
+
 ## v0.13.0-rc0 — 2026-08-22
 
 ### Added

--- a/cmd/cluster_domain.go
+++ b/cmd/cluster_domain.go
@@ -30,8 +30,16 @@ resolves with TLS.
 
 --remove hands the zone back for teardown: the removal step before an
 organisation switches its Ankra root domain (the switch is refused while
-cluster zones still live under the old root). A later --enable re-creates it
-under the organisation's current root.`,
+cluster zones still live under the old root). The removal is then HELD -
+nothing re-creates the zone, including the external-dns Ankra runs on the
+cluster and the discovery that mints zones for clusters that lack one - until
+you ask for it back. A read reports "opted out" for as long as the hold
+stands.
+
+--enable withdraws the hold and re-creates the zone under the organisation's
+current root. The cluster's label is derived from its id, so the zone comes
+back under exactly the name it had before, and the external-dns Ankra manages
+for it keeps the same --txt-owner-id.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if clusterDomainEnable && clusterDomainRemove {
@@ -75,6 +83,18 @@ under the organisation's current root.`,
 		// the CLI answer a removal with an "run --enable" hint.
 		if result.State == clusterDomainStateNone && !clusterDomainEnable && !clusterDomainRemove {
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Domain: (none)\nState:  none\n")
+			if result.OptedOut {
+				// A removal that reports "none" is the exact moment PLA-771
+				// was watched from. Saying only "run --enable to create one"
+				// here reads as "nothing happened", which is what sent the
+				// reporter back to watch for the zone returning.
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Opted out: yes\n")
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+					"\nThis cluster's domain was removed and the removal is held: nothing will "+
+						"re-create it.\nRun 'ankra cluster domain %s --enable' when you want it back.\n",
+					args[0])
+				return nil
+			}
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
 				"\nThis cluster has no public domain. Run 'ankra cluster domain %s --enable' to create one.\n",
 				args[0])
@@ -83,10 +103,15 @@ under the organisation's current root.`,
 
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Domain: %s\n", result.FQDN)
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "State:  %s\n", result.State)
+		if result.OptedOut {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Opted out: yes\n")
+		}
 		switch {
 		case clusterDomainRemove:
 			_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
-				"\nThe zone is being torn down; hostnames under it stop resolving once the teardown completes.")
+				"\nThe zone is being torn down; hostnames under it stop resolving once the teardown completes."+
+					"\nThe removal is held once it finishes - nothing re-creates the zone until "+
+					"'ankra cluster domain <cluster> --enable'.")
 		case clusterDomainEnable && result.State != "active":
 			_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
 				"\nThe zone publishes shortly; once active, any hostname under the domain is yours the moment an ingress claims it.")

--- a/cmd/cluster_domain_test.go
+++ b/cmd/cluster_domain_test.go
@@ -163,8 +163,11 @@ func TestRunClusterDomain_StructuredOutputStaysParseable(t *testing.T) {
 }
 
 func TestRunClusterDomain_RemoveDoesNotEmitTheEnableHint(t *testing.T) {
-	// A backend that answered a removal with state "none" must not send the
-	// operator back to --enable.
+	// A backend that answered a removal with state "none" must not answer it
+	// with the empty-cluster hint - "this cluster has no public domain,
+	// create one" reads as though the removal did nothing. Naming --enable as
+	// the way back is a different statement and belongs there: the removal is
+	// held, and that is how the hold is withdrawn.
 	mock := &clusterDomainMock{}
 	mock.disableState = clusterDomainStateNone
 
@@ -172,7 +175,29 @@ func TestRunClusterDomain_RemoveDoesNotEmitTheEnableHint(t *testing.T) {
 	if executeError != nil {
 		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
 	}
-	if strings.Contains(output, "--enable") {
-		t.Errorf("the removal path emitted the enable hint:\n%s", output)
+	if strings.Contains(output, "has no public domain") {
+		t.Errorf("the removal path emitted the empty-cluster hint:\n%s", output)
+	}
+	if !strings.Contains(output, "held") {
+		t.Errorf("the removal path must say the removal is held:\n%s", output)
+	}
+}
+
+func TestRunClusterDomain_ReportsAHeldRemoval(t *testing.T) {
+	// The window PLA-771 was watched from: the teardown has finished, the
+	// zone row is gone, and the operator is looking for the difference
+	// between "removed and staying removed" and "removed a moment ago".
+	mock := &clusterDomainMock{zone: client.ClusterDNSZoneResponse{
+		Success: true, State: clusterDomainStateNone, OptedOut: true}}
+
+	output, executeError := runClusterDomain(t, mock, domainTestClusterID)
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	if !strings.Contains(output, "Opted out: yes") {
+		t.Errorf("a held removal must report the hold:\n%s", output)
+	}
+	if strings.Contains(output, "has no public domain") {
+		t.Errorf("a held removal is not an empty cluster:\n%s", output)
 	}
 }

--- a/cmd/cluster_playground.go
+++ b/cmd/cluster_playground.go
@@ -66,8 +66,11 @@ var clusterPlaygroundDestroyCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("destroying the playground: %w", err)
 		}
-		fmt.Printf("Cluster ID: %s\n", result.ClusterID)
-		fmt.Printf("Phase:      %s\n", result.Phase)
+		// cmd.OutOrStdout() rather than fmt.Printf: the destroy verb is the
+		// one this group's output is asserted on, and a bare Printf writes
+		// past the writer a test sets.
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Cluster ID: %s\n", result.ClusterID)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Phase:      %s\n", result.Phase)
 		return nil
 	},
 }

--- a/cmd/cluster_playground.go
+++ b/cmd/cluster_playground.go
@@ -8,7 +8,7 @@ import (
 
 var clusterPlaygroundCmd = &cobra.Command{
 	Use:   "playground",
-	Short: "Create and inspect your organisation's playground",
+	Short: "Create, inspect and destroy your organisation's playground",
 	Long: "The playground is a real, writable Kubernetes environment Ankra provisions for you - " +
 		"a virtual cluster on Ankra's own infrastructure, with the agent already installed. " +
 		"Every organisation may hold one; it expires after a period of inactivity.",
@@ -51,8 +51,30 @@ var clusterPlaygroundStatusCmd = &cobra.Command{
 	},
 }
 
+var clusterPlaygroundDestroyCmd = &cobra.Command{
+	Use:   "destroy <cluster_id>",
+	Short: "Destroy your organisation's playground",
+	Long: "Tear the organisation's playground down. Teardown runs in the background: poll " +
+		"`ankra cluster playground status <cluster_id>` until the phase reaches removed.\n\n" +
+		"This is also how a refused `ankra org domain set` is cleared. A playground publishes a " +
+		"wildcard DNS record in the organisation's zone, and that record is reconciled rather " +
+		"than written once - deleting it with `ankra org dns delete` only lasts until the " +
+		"provisioner's next pass. Destroying the environment is what removes it for good.",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		result, err := apiClient.DestroyPlayground(args[0])
+		if err != nil {
+			return fmt.Errorf("destroying the playground: %w", err)
+		}
+		fmt.Printf("Cluster ID: %s\n", result.ClusterID)
+		fmt.Printf("Phase:      %s\n", result.Phase)
+		return nil
+	},
+}
+
 func init() {
 	clusterPlaygroundCmd.AddCommand(clusterPlaygroundCreateCmd)
 	clusterPlaygroundCmd.AddCommand(clusterPlaygroundStatusCmd)
+	clusterPlaygroundCmd.AddCommand(clusterPlaygroundDestroyCmd)
 	clusterCmd.AddCommand(clusterPlaygroundCmd)
 }

--- a/cmd/cluster_playground_test.go
+++ b/cmd/cluster_playground_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"errors"
 	"strings"
 	"testing"
@@ -16,6 +17,10 @@ type playgroundMock struct {
 	status          *client.PlaygroundStatus
 	statusError     error
 	statusRequested string
+
+	destroyResult    *client.DestroyPlaygroundResult
+	destroyError     error
+	destroyRequested string
 }
 
 func (m *playgroundMock) CreatePlayground() (*client.CreatePlaygroundResult, error) {
@@ -25,6 +30,11 @@ func (m *playgroundMock) CreatePlayground() (*client.CreatePlaygroundResult, err
 func (m *playgroundMock) GetPlaygroundStatus(clusterID string) (*client.PlaygroundStatus, error) {
 	m.statusRequested = clusterID
 	return m.status, m.statusError
+}
+
+func (m *playgroundMock) DestroyPlayground(clusterID string) (*client.DestroyPlaygroundResult, error) {
+	m.destroyRequested = clusterID
+	return m.destroyResult, m.destroyError
 }
 
 func withPlaygroundMock(t *testing.T, mock *playgroundMock) {
@@ -102,5 +112,45 @@ func TestPlaygroundStatusOmitsAnAbsentMessage(t *testing.T) {
 	})
 	if strings.Contains(output, "Message:") {
 		t.Errorf("expected no Message line, got: %s", output)
+	}
+}
+
+func TestPlaygroundDestroyPrintsTheClusterIDAndPhase(t *testing.T) {
+	mock := &playgroundMock{
+		destroyResult: &client.DestroyPlaygroundResult{ClusterID: "cluster-42", Phase: "deprovisioning"},
+	}
+	withPlaygroundMock(t, mock)
+	output := new(bytes.Buffer)
+	clusterPlaygroundDestroyCmd.SetOut(output)
+	clusterPlaygroundDestroyCmd.SetErr(output)
+	t.Cleanup(func() {
+		clusterPlaygroundDestroyCmd.SetOut(nil)
+		clusterPlaygroundDestroyCmd.SetErr(nil)
+	})
+
+	if runError := clusterPlaygroundDestroyCmd.RunE(
+		clusterPlaygroundDestroyCmd, []string{"cluster-42"}); runError != nil {
+		t.Fatalf("destroy failed: %v", runError)
+	}
+	if mock.destroyRequested != "cluster-42" {
+		t.Errorf("destroy asked for %q, want cluster-42", mock.destroyRequested)
+	}
+	// The phase is what tells the caller teardown was scheduled rather than
+	// finished, so it has to be in the output, not just the cluster id.
+	for _, expected := range []string{"cluster-42", "deprovisioning"} {
+		if !strings.Contains(output.String(), expected) {
+			t.Errorf("expected %q in the output, got: %s", expected, output.String())
+		}
+	}
+}
+
+func TestPlaygroundDestroySurfacesTheServerError(t *testing.T) {
+	withPlaygroundMock(t, &playgroundMock{destroyError: errors.New("Playground not found.")})
+	runError := clusterPlaygroundDestroyCmd.RunE(clusterPlaygroundDestroyCmd, []string{"cluster-42"})
+	if runError == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(runError.Error(), "Playground not found.") {
+		t.Errorf("the server detail must survive: %v", runError)
 	}
 }

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1227,6 +1227,10 @@ func (m baseMock) GetPlaygroundStatus(string) (*client.PlaygroundStatus, error) 
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) DestroyPlayground(string) (*client.DestroyPlaygroundResult, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) ListOvhNodeGroups(clusterID string) (*client.NodeGroupListResult, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/org_domain.go
+++ b/cmd/org_domain.go
@@ -36,6 +36,27 @@ remove. Use 'ankra org dns zones' and 'ankra org dns list' to inventory them,
 to clear them. Ankra re-creates the organisation zone under the new domain
 automatically once the switch is accepted.
 
+WHAT ANKRA TOUCHES IN YOUR DOMAIN
+
+Ankra creates one subzone in the domain you register - <org_short_id>.<domain>
+- and works only inside it. It does not read, write or delete records anywhere
+else in the domain. Records you already publish at the apex or under any other
+name are untouched by registering the domain, by the switch itself, and by
+everything Ankra does afterwards. A domain that already serves your production
+hostnames is safe to register on that count.
+
+The delegation is strict below that too: each cluster gets its own subzone
+under the organisation zone, and the external-dns Ankra installs on a cluster
+holds a token pinned to that cluster's subzone alone.
+
+WHAT A SWITCH DOES NOT CHANGE
+
+Zone labels are derived from the organisation and cluster ids, so they are the
+same under any root. A cluster keeps its label across a switch, and with it
+the --txt-owner-id of the external-dns Ankra manages for it and any GitOps
+path built from it. A switch never re-stamps an owner id and never leaves an
+external-dns pointed at a TXT registry it no longer matches.
+
 Reading requires organisation membership; changing it requires organisation
 admin.`,
 }
@@ -69,8 +90,32 @@ platform default with --default.
 
 The domain must be a bare domain you own (example.com, not sub.example.com or
 a domain under the platform default), already delegated to the Ankra
-nameservers. The switch is refused while cluster DNS zones or DNS records
-still live under the old root; the refusal lists them.`,
+nameservers.
+
+Existing records in that domain are preserved. Ankra creates one subzone,
+<org_short_id>.<domain>, and confines itself to it - nothing at the apex or
+under any other name is read, written or deleted, by this command or by
+anything Ankra runs afterwards.
+
+The switch is refused while cluster DNS zones or DNS records still live under
+the old root; the refusal lists them, and says which of them you clear
+yourself and which are published by something you have to remove first:
+
+  Cluster domains  ankra cluster domain <cluster> --remove
+                   Each such cluster runs Ankra's external-dns against its own
+                   zone. The removal is held once it completes, so external-dns
+                   cannot re-create the zone while you finish the switch.
+                   Restore it afterwards with --enable, which re-mints the zone
+                   under the new root and keeps the cluster's label and
+                   external-dns --txt-owner-id exactly as they were.
+  Your DNS records ankra org dns delete <record>
+  Ankra's records  These are reconciled, so deleting one lasts until the lane
+                   that owns it runs again. The refusal names what publishes
+                   them - today, a playground, cleared with
+                   'ankra cluster playground destroy <cluster_id>'.
+
+Clearing every blocker by hand is the current sequence. See
+'ankra org domain --help' for what a switch does and does not change.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out, err := structuredFormatFromFlags(cmd)
@@ -127,6 +172,7 @@ type organisationDomainBlockedDocument struct {
 	BlockingClusterZonesTruncated bool                                           `json:"blocking_cluster_zones_truncated,omitempty" yaml:"blocking_cluster_zones_truncated,omitempty"`
 	BlockingDnsRecords            []client.OrganisationDomainBlockingDnsRecord   `json:"blocking_dns_records" yaml:"blocking_dns_records"`
 	BlockingDnsRecordsTruncated   bool                                           `json:"blocking_dns_records_truncated,omitempty" yaml:"blocking_dns_records_truncated,omitempty"`
+	BlockingPlaygrounds           []client.OrganisationDomainBlockingPlayground  `json:"blocking_playgrounds" yaml:"blocking_playgrounds"`
 }
 
 // renderOrganisationDomainBlocked writes the refusal inventory to stdout in
@@ -138,12 +184,16 @@ func renderOrganisationDomainBlocked(cmd *cobra.Command, blocked *client.Organis
 		BlockingClusterZonesTruncated: blocked.ClusterZonesTruncated,
 		BlockingDnsRecords:            blocked.DnsRecords,
 		BlockingDnsRecordsTruncated:   blocked.DnsRecordsTruncated,
+		BlockingPlaygrounds:           blocked.Playgrounds,
 	}
 	if document.BlockingClusterZones == nil {
 		document.BlockingClusterZones = []client.OrganisationDomainBlockingClusterZone{}
 	}
 	if document.BlockingDnsRecords == nil {
 		document.BlockingDnsRecords = []client.OrganisationDomainBlockingDnsRecord{}
+	}
+	if document.BlockingPlaygrounds == nil {
+		document.BlockingPlaygrounds = []client.OrganisationDomainBlockingPlayground{}
 	}
 	switch format {
 	case outputJSON:
@@ -162,6 +212,12 @@ func renderOrganisationDomainBlocked(cmd *cobra.Command, blocked *client.Organis
 // organisationDomainBlockedMessage turns the backend's structured refusal
 // into an actionable error: the refusal text, every blocking cluster zone and
 // DNS record, and the command that clears each kind.
+//
+// Records are split by who wrote them. A record an admin created is cleared
+// with 'ankra org dns delete'; a record a platform lane owns is reconciled,
+// so deleting it only lasts until that lane's next pass and the environment
+// behind it has to go instead. Printing one instruction for both kinds is
+// what sent the reporter of PLA-771 round the same loop repeatedly.
 func organisationDomainBlockedMessage(blocked *client.OrganisationDomainBlockedError) string {
 	message := blocked.Detail
 	if len(blocked.ClusterZones) > 0 {
@@ -177,10 +233,16 @@ func organisationDomainBlockedMessage(blocked *client.OrganisationDomainBlockedE
 			message += "\n  ... and more; run 'ankra org dns zones' for the full list."
 		}
 		message += "\n  Remove each with: ankra cluster domain <cluster> --remove"
+		message += "\n  Each of these clusters runs Ankra's external-dns against its own zone."
+		message += "\n  The removal is held once it completes, so external-dns cannot bring the"
+		message += "\n  zone back; 'ankra cluster domain <cluster> --enable' is what restores it."
+		message += "\n  Re-enabling keeps the zone's label, and with it external-dns's"
+		message += "\n  --txt-owner-id and your GitOps paths - a root switch never re-labels."
 	}
-	if len(blocked.DnsRecords) > 0 {
+	adminRecords, platformRecords := partitionBlockingDnsRecords(blocked.DnsRecords)
+	if len(adminRecords) > 0 {
 		message += "\n\nDNS records still under the current root:"
-		for _, record := range blocked.DnsRecords {
+		for _, record := range adminRecords {
 			message += fmt.Sprintf("\n  %s  %s  (%s)", record.RecordType, record.Name, record.State)
 		}
 		if blocked.DnsRecordsTruncated {
@@ -188,7 +250,55 @@ func organisationDomainBlockedMessage(blocked *client.OrganisationDomainBlockedE
 		}
 		message += "\n  Remove each with: ankra org dns delete <record>"
 	}
+	if len(platformRecords) > 0 {
+		message += "\n\nDNS records Ankra owns and re-creates:"
+		for _, record := range platformRecords {
+			message += fmt.Sprintf("\n  %s  %s  (created by %s)", record.RecordType, record.Name, record.CreatedBy)
+		}
+		if len(adminRecords) == 0 && blocked.DnsRecordsTruncated {
+			message += "\n  ... and more; run 'ankra org dns list' for the full list."
+		}
+		message += "\n  Deleting these does not clear them - the lane that owns each one writes"
+		message += "\n  it again on its next pass. Remove what publishes them instead."
+	}
+	if len(blocked.Playgrounds) > 0 {
+		message += "\n\nPlayground environments publishing those records:"
+		for _, playground := range blocked.Playgrounds {
+			clusterName := playground.ClusterName
+			if clusterName == "" {
+				clusterName = playground.ClusterID
+			}
+			message += fmt.Sprintf("\n  %s  %s  (%s)", clusterName, playground.ClusterID, playground.Phase)
+		}
+		message += "\n  Destroy each with: ankra cluster playground destroy <cluster_id>"
+		message += "\n  The switch cannot be attempted while a playground exists."
+	}
 	return message
+}
+
+// partitionBlockingDnsRecords splits the refusal's records into the ones an
+// admin can delete and the ones a platform lane re-asserts. A record with no
+// created_by - an older backend that does not send the member - is treated as
+// the admin's, which keeps the advice for existing records exactly what it
+// was before this split existed.
+func partitionBlockingDnsRecords(records []client.OrganisationDomainBlockingDnsRecord) (
+	adminRecords []client.OrganisationDomainBlockingDnsRecord,
+	platformRecords []client.OrganisationDomainBlockingDnsRecord) {
+	for _, record := range records {
+		if platformOwnedDnsRecordWriters[record.CreatedBy] {
+			platformRecords = append(platformRecords, record)
+			continue
+		}
+		adminRecords = append(adminRecords, record)
+	}
+	return adminRecords, platformRecords
+}
+
+// platformOwnedDnsRecordWriters are the created_by values the platform's own
+// lanes stamp on records they reconcile. Everything else is a record some
+// human asked for, whatever wrote it on their behalf.
+var platformOwnedDnsRecordWriters = map[string]bool{
+	"playground_provisioner": true,
 }
 
 func renderOrganisationDomain(cmd *cobra.Command, domain *client.OrganisationDomain, format outputFormat) error {

--- a/cmd/org_domain_test.go
+++ b/cmd/org_domain_test.go
@@ -306,3 +306,111 @@ func TestRunOrgDomainSet_HumanRefusalNamesTheTruncation(t *testing.T) {
 		t.Errorf("a truncated list must say so:\n%s", executeError.Error())
 	}
 }
+
+func TestRunOrgDomainSet_SeparatesPlatformOwnedRecordsAndNamesThePlayground(t *testing.T) {
+	// PLA-771: an admin was told to delete a record that the playground
+	// provisioner wrote back two minutes later. The refusal has to say which
+	// records deleting actually clears, and name the environment that has to
+	// go for the rest.
+	mock := &orgDomainMock{
+		domain: client.OrganisationDomain{DNSRootDomainDefault: "ankra.cc"},
+		setError: &client.OrganisationDomainBlockedError{
+			Detail: "Changing dns_root_domain requires removing the organisation's cluster DNS zones and DNS records first. Ankra then re-creates your zone under the new domain automatically.",
+			DnsRecords: []client.OrganisationDomainBlockingDnsRecord{
+				{ID: "r-1", Name: "chat.org1234.ankra.cc", RecordType: "A", State: "active", CreatedBy: "mark@example.com"},
+				{ID: "r-2", Name: "*.smdjc5s3hx", RecordType: "A", State: "active", CreatedBy: "playground_provisioner"},
+			},
+			Playgrounds: []client.OrganisationDomainBlockingPlayground{
+				{ClusterID: "pg-1", ClusterName: "playground-smartoptics", Phase: "ready"},
+			},
+		},
+	}
+	setMockClient(t, mock)
+	resetOrgDomainFlags(t)
+	output := new(bytes.Buffer)
+	rootCmd.SetOut(output)
+	rootCmd.SetErr(output)
+	rootCmd.SetArgs([]string{"org", "domain", "set", "smartoptics.dev"})
+	if executeError := rootCmd.Execute(); executeError == nil {
+		t.Fatalf("expected a refusal, output: %s", output.String())
+	} else {
+		message := executeError.Error()
+		for _, expected := range []string{
+			"DNS records still under the current root:",
+			"chat.org1234.ankra.cc",
+			"ankra org dns delete <record>",
+			"DNS records Ankra owns and re-creates:",
+			"*.smdjc5s3hx",
+			"created by playground_provisioner",
+			"Playground environments publishing those records:",
+			"playground-smartoptics",
+			"ankra cluster playground destroy <cluster_id>",
+		} {
+			if !strings.Contains(message, expected) {
+				t.Errorf("refusal message missing %q:\n%s", expected, message)
+			}
+		}
+		// The admin's own record must not be listed under the section that
+		// says deleting is futile, and the platform's must not be listed
+		// under the one that says to delete it.
+		adminSection := message[strings.Index(message, "DNS records still under the current root:"):strings.Index(message, "DNS records Ankra owns and re-creates:")]
+		if strings.Contains(adminSection, "*.smdjc5s3hx") {
+			t.Errorf("a platform-owned record was listed as deletable:\n%s", message)
+		}
+		platformSection := message[strings.Index(message, "DNS records Ankra owns and re-creates:"):]
+		if strings.Contains(platformSection, "chat.org1234.ankra.cc") {
+			t.Errorf("an admin's own record was listed as platform-owned:\n%s", message)
+		}
+	}
+}
+
+func TestRunOrgDomainSet_NamesTheExternalDNSInteractionOnBlockingZones(t *testing.T) {
+	// Ask 1 of PLA-771: the refusal must explain what the clusters it lists
+	// are going to do about it, and that their labels survive the switch.
+	mock := &orgDomainMock{
+		domain: client.OrganisationDomain{DNSRootDomainDefault: "ankra.cc"},
+		setError: &client.OrganisationDomainBlockedError{
+			Detail: "Changing dns_root_domain requires removing the organisation's cluster DNS zones and DNS records first. Ankra then re-creates your zone under the new domain automatically.",
+			ClusterZones: []client.OrganisationDomainBlockingClusterZone{
+				{ClusterID: "c-1", ClusterName: "so-development", FQDN: "axmndle4sl.qh4thi04cs.ankra.cc", State: "active"},
+			},
+		},
+	}
+	setMockClient(t, mock)
+	resetOrgDomainFlags(t)
+	output := new(bytes.Buffer)
+	rootCmd.SetOut(output)
+	rootCmd.SetErr(output)
+	rootCmd.SetArgs([]string{"org", "domain", "set", "smartoptics.dev"})
+	if executeError := rootCmd.Execute(); executeError == nil {
+		t.Fatalf("expected a refusal, output: %s", output.String())
+	} else {
+		message := executeError.Error()
+		for _, expected := range []string{
+			"so-development", "axmndle4sl.qh4thi04cs.ankra.cc",
+			"external-dns", "held", "--txt-owner-id", "never re-labels",
+		} {
+			if !strings.Contains(message, expected) {
+				t.Errorf("refusal message missing %q:\n%s", expected, message)
+			}
+		}
+	}
+}
+
+func TestOrganisationDomainBlockedMessage_TreatsAnUnknownWriterAsTheAdmins(t *testing.T) {
+	// An older backend does not send created_by. Reading the empty string as
+	// "platform-owned" would tell admins their own records cannot be deleted.
+	blocked := &client.OrganisationDomainBlockedError{
+		Detail: "refused",
+		DnsRecords: []client.OrganisationDomainBlockingDnsRecord{
+			{ID: "r-1", Name: "legacy.org1234.ankra.cc", RecordType: "CNAME", State: "active"},
+		},
+	}
+	message := organisationDomainBlockedMessage(blocked)
+	if !strings.Contains(message, "ankra org dns delete <record>") {
+		t.Errorf("a record with no writer must stay deletable:\n%s", message)
+	}
+	if strings.Contains(message, "DNS records Ankra owns and re-creates:") {
+		t.Errorf("a record with no writer must not be called platform-owned:\n%s", message)
+	}
+}

--- a/cmd/org_domain_test.go
+++ b/cmd/org_domain_test.go
@@ -352,13 +352,20 @@ func TestRunOrgDomainSet_SeparatesPlatformOwnedRecordsAndNamesThePlayground(t *t
 		}
 		// The admin's own record must not be listed under the section that
 		// says deleting is futile, and the platform's must not be listed
-		// under the one that says to delete it.
-		adminSection := message[strings.Index(message, "DNS records still under the current root:"):strings.Index(message, "DNS records Ankra owns and re-creates:")]
-		if strings.Contains(adminSection, "*.smdjc5s3hx") {
+		// under the one that says to delete it. Both offsets are checked
+		// before slicing: strings.Index answers -1 for a missing header, and
+		// the loop above only calls t.Errorf, so a regression that drops a
+		// header would reach this line and panic instead of reporting.
+		adminStart := strings.Index(message, "DNS records still under the current root:")
+		platformStart := strings.Index(message, "DNS records Ankra owns and re-creates:")
+		if adminStart < 0 || platformStart < 0 || adminStart > platformStart {
+			t.Fatalf("expected both record sections in order, got adminStart=%d platformStart=%d:\n%s",
+				adminStart, platformStart, message)
+		}
+		if strings.Contains(message[adminStart:platformStart], "*.smdjc5s3hx") {
 			t.Errorf("a platform-owned record was listed as deletable:\n%s", message)
 		}
-		platformSection := message[strings.Index(message, "DNS records Ankra owns and re-creates:"):]
-		if strings.Contains(platformSection, "chat.org1234.ankra.cc") {
+		if strings.Contains(message[platformStart:], "chat.org1234.ankra.cc") {
 			t.Errorf("an admin's own record was listed as platform-owned:\n%s", message)
 		}
 	}

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -329,6 +329,7 @@ type APIClient interface {
 	ListKubeadmVersions() (*client.ListVersionsResult, error)
 	CreatePlayground() (*client.CreatePlaygroundResult, error)
 	GetPlaygroundStatus(clusterID string) (*client.PlaygroundStatus, error)
+	DestroyPlayground(clusterID string) (*client.DestroyPlaygroundResult, error)
 	ListOvhNodeGroups(clusterID string) (*client.NodeGroupListResult, error)
 	AddOvhNodeGroup(ctx context.Context, clusterID string, req client.AddNodeGroupRequest, wait bool) (*client.AddNodeGroupResult, bool, error)
 	ScaleOvhNodeGroup(ctx context.Context, clusterID, groupName string, count int, wait bool) (*client.ScaleNodeGroupResult, bool, error)

--- a/internal/client/cluster_dns_zone.go
+++ b/internal/client/cluster_dns_zone.go
@@ -8,10 +8,16 @@ import (
 // ClusterDNSZoneResponse reports the cluster's generated public DNS zone
 // after the opt-in: the fqdn every ingress hostname can live under, and the
 // zone's reconciliation state (pending until published, then active).
+//
+// OptedOut separates the two ways state "none" happens: the cluster never
+// had a zone, or one was removed and the removal is being held so nothing
+// re-creates it. Older backends omit the member and it reads false, which is
+// the right answer for every cluster they know about.
 type ClusterDNSZoneResponse struct {
-	Success bool   `json:"success"`
-	FQDN    string `json:"fqdn"`
-	State   string `json:"state"`
+	Success  bool   `json:"success"`
+	FQDN     string `json:"fqdn"`
+	State    string `json:"state"`
+	OptedOut bool   `json:"opted_out"`
 }
 
 // GetClusterDNSZone reads the cluster's generated public DNS zone without

--- a/internal/client/org_domain.go
+++ b/internal/client/org_domain.go
@@ -36,12 +36,25 @@ type OrganisationDomainBlockingClusterZone struct {
 }
 
 // OrganisationDomainBlockingDnsRecord is one DNS record that refuses a
-// root-domain switch until it is removed.
+// root-domain switch until it is removed. CreatedBy names the writer: a
+// record a platform lane owns comes back the moment it is deleted, so
+// telling the two kinds apart is what stops the advice being wrong.
 type OrganisationDomainBlockingDnsRecord struct {
 	ID         string `json:"id"`
 	Name       string `json:"name"`
 	RecordType string `json:"record_type"`
 	State      string `json:"state"`
+	CreatedBy  string `json:"created_by"`
+}
+
+// OrganisationDomainBlockingPlayground is one live playground environment.
+// Its wildcard record is reconciled rather than written once, so while the
+// environment exists that record cannot be cleared - the playground is the
+// blocker, and the record is only how it shows up.
+type OrganisationDomainBlockingPlayground struct {
+	ClusterID   string `json:"cluster_id"`
+	ClusterName string `json:"cluster_name"`
+	Phase       string `json:"phase"`
 }
 
 // OrganisationDomainBlockedError is the backend's refusal of a root-domain
@@ -56,6 +69,7 @@ type OrganisationDomainBlockedError struct {
 	ClusterZonesTruncated bool
 	DnsRecords            []OrganisationDomainBlockingDnsRecord
 	DnsRecordsTruncated   bool
+	Playgrounds           []OrganisationDomainBlockingPlayground
 }
 
 func (e *OrganisationDomainBlockedError) Error() string { return e.Detail }
@@ -66,6 +80,7 @@ type organisationDomainRefusal struct {
 	BlockingClusterZonesTruncated bool                                    `json:"blocking_cluster_zones_truncated"`
 	BlockingDnsRecords            []OrganisationDomainBlockingDnsRecord   `json:"blocking_dns_records"`
 	BlockingDnsRecordsTruncated   bool                                    `json:"blocking_dns_records_truncated"`
+	BlockingPlaygrounds           []OrganisationDomainBlockingPlayground  `json:"blocking_playgrounds"`
 }
 
 type organisationDomainSettings struct {
@@ -160,6 +175,7 @@ func (c *Client) doOrganisationDomainRequest(ctx context.Context, method string,
 					ClusterZonesTruncated: refusal.BlockingClusterZonesTruncated,
 					DnsRecords:            refusal.BlockingDnsRecords,
 					DnsRecordsTruncated:   refusal.BlockingDnsRecordsTruncated,
+					Playgrounds:           refusal.BlockingPlaygrounds,
 				}
 			}
 			return nil, errors.New(refusal.Detail)

--- a/internal/client/playground.go
+++ b/internal/client/playground.go
@@ -45,3 +45,30 @@ func (c *Client) GetPlaygroundStatus(clusterID string) (*PlaygroundStatus, error
 	}
 	return &status, nil
 }
+
+// DestroyPlaygroundResult is the DELETE body: the phase the environment
+// holds after the call, which is `deprovisioning` once teardown is
+// scheduled, or the terminal phase it had already reached.
+type DestroyPlaygroundResult struct {
+	ClusterID string `json:"cluster_id"`
+	Phase     string `json:"phase"`
+}
+
+// DestroyPlayground tears the organisation's playground down. Idempotent -
+// an environment already deprovisioning or removed answers its current
+// phase rather than an error, so a retry after a dropped response is not a
+// failure.
+//
+// This is also the way out of a refused `ankra org domain set`: a live
+// playground's wildcard DNS record is reconciled, so it is re-created every
+// time an admin deletes it, and destroying the environment is what actually
+// clears that blocker.
+func (c *Client) DestroyPlayground(clusterID string) (*DestroyPlaygroundResult, error) {
+	url := fmt.Sprintf("%s/api/v1/org/clusters/playground/%s",
+		c.BaseURL, neturl.PathEscape(clusterID))
+	var result DestroyPlaygroundResult
+	if err := c.deleteCSRFJSON(url, &result, "destroy playground"); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}


### PR DESCRIPTION
Bead: ankra-ymkj8.16
Linear: PLA-771 (Ankra ticket #1079, Smartoptics)
Backend: ankraio/cluster#1687

The CLI half of making the root-domain switch converge. Follow-up to
ankra-cli#122/#123/#124 (ankra-ymkj8.2).

## `ankra cluster domain <cluster> --remove` reports the hold

The customer removed a cluster's domain, watched it read `none`, and watched it
read `active` again fifty seconds later under the same label. Backend-side the
removal now holds (cluster#1687); CLI-side the read has to *say so*, because
state `none` alone is exactly the ambiguity they were stuck in — a domain that
is gone and one that is between reconciler passes look identical.

```
Domain: (none)
State:  none
Opted out: yes

This cluster's domain was removed and the removal is held: nothing will re-create it.
Run 'ankra cluster domain so-development --enable' when you want it back.
```

## A refused `ankra org domain set` separates blockers you can clear from ones you cannot

```
Cluster domains still under the current root:
  so-development  axmndle4sl.qh4thi04cs.ankra.cc  (active)
  Remove each with: ankra cluster domain <cluster> --remove
  Each of these clusters runs Ankra's external-dns against its own zone.
  The removal is held once it completes, so external-dns cannot bring the
  zone back; 'ankra cluster domain <cluster> --enable' is what restores it.
  Re-enabling keeps the zone's label, and with it external-dns's
  --txt-owner-id and your GitOps paths - a root switch never re-labels.

DNS records still under the current root:
  CNAME  chat.qh4thi04cs.ankra.cc  (active)
  Remove each with: ankra org dns delete <record>

DNS records Ankra owns and re-creates:
  A  *.smdjc5s3hx  (created by playground_provisioner)
  Deleting these does not clear them - the lane that owns each one writes
  it again on its next pass. Remove what publishes them instead.

Playground environments publishing those records:
  playground  5f2a1c3e-...  (ready)
  Destroy each with: ankra cluster playground destroy <cluster_id>
  The switch cannot be attempted while a playground exists.
```

The middle two sections used to be one, which is how the reporter ended up
deleting `*.smdjc5s3hx` and watching `playground_provisioner` write it back two
minutes later. Records arriving without `created_by` — an older backend — are
treated as the admin's, so nothing that was deletable before starts reading as
un-deletable.

The cluster-zone paragraph answers ask 1: what those clusters' external-dns will
do about the removal, and that labels come from the cluster id so a switch never
re-labels.

## `--help` answers the question that decides whether the switch is safe

Their words: *"whether adopting it as the Ankra root leaves them alone is the
single fact that decides whether this is safe, and it is not written down
anywhere."* It is now, in both `ankra org domain --help` and `set --help`:

> Ankra creates one subzone in the domain you register — `<org_short_id>.<domain>`
> — and works only inside it. It does not read, write or delete records anywhere
> else in the domain. Records you already publish at the apex or under any other
> name are untouched by registering the domain, by the switch itself, and by
> everything Ankra does afterwards.

Plus a **WHAT A SWITCH DOES NOT CHANGE** section on label and `--txt-owner-id`
stability. Both are read off `EnsureOrganisationZone` and `ClusterDNSZoneLabel`.

## `ankra cluster playground destroy <cluster_id>`

The refusal now points at a playground as the thing to remove, and there was no
CLI verb to remove it — `DELETE /api/v1/org/clusters/playground/{id}` has existed
since playgrounds shipped, but `create` and `status` were the only commands
wired to it. Idempotent, like the endpoint.

## Tests

- `TestRunClusterDomain_ReportsAHeldRemoval`
- `TestRunOrgDomainSet_SeparatesPlatformOwnedRecordsAndNamesThePlayground` —
  including that neither kind of record leaks into the other's section
- `TestRunOrgDomainSet_NamesTheExternalDNSInteractionOnBlockingZones`
- `TestOrganisationDomainBlockedMessage_TreatsAnUnknownWriterAsTheAdmins` — the
  older-backend case

`TestRunClusterDomain_RemoveDoesNotEmitTheEnableHint` asserted on the substring
`--enable`; it now asserts on the empty-cluster hint it was written to guard
("this cluster has no public domain, create one"), and additionally that the
removal path states the hold. Naming `--enable` as the way to withdraw a hold is
a different statement, and the removal path should make it.

`go build ./...` and `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DgQPJJkGkGjRYAFJ56iJ4
