### PR TITLE
fix(application): accept the application name everywhere <application-id> is taken (ankra-83336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,20 @@
   already serves production hostnames is safe to register on that count, and
   it is now written down rather than something to infer.
 
+### Fixed
+
+- **Every per-application command now accepts the application's name where it
+  takes `<application-id>`.** `application list` prints names, so a name is
+  what a user passes to `application branches`, `application demo list`,
+  `application demo config get` and the rest — and each of those answered a
+  bare `500 Internal Server Error`, because the name travelled to the
+  backend's uuid-typed lookup unchecked. A name is now resolved through the
+  same server-side search the `list` command uses, exactly the way
+  stack-profiles, credentials and clusters already resolve theirs: a uuid
+  passes straight through, an unknown name says to check
+  `ankra application list`, and a name two applications share lists the
+  candidate ids instead of picking one. (PLA-786)
+
 ## v0.13.0-rc0 — 2026-08-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,9 @@
   applications than one page holds, and a lookup that cannot run says so
   rather than sending the name on to be rejected. An empty argument — an
   unset variable in a script — is now refused as the usage error it is,
-  instead of searching with no filter at all. (PLA-786)
+  instead of searching with no filter at all. A name that matches no
+  application exits 3 (not found), the same code an id that does not exist
+  already produced, and an ambiguous name exits 2. (PLA-786)
 
 ## v0.13.0-rc0 — 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,10 @@
   unset variable in a script — is now refused as the usage error it is,
   instead of searching with no filter at all. A name that matches no
   application exits 3 (not found), the same code an id that does not exist
-  already produced, and an ambiguous name exits 2. (PLA-786)
+  already produced, and an ambiguous name exits 2. A lookup that cannot be
+  completed — the listing failed, was unreadable, or was too large to read
+  to the end — reports that instead of answering from what it managed to
+  read. (PLA-786)
 
 ## v0.13.0-rc0 — 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,9 @@
   candidate ids instead of picking one. The lookup walks every page of the
   listing, so a name still resolves in an organisation with more
   applications than one page holds, and a lookup that cannot run says so
-  rather than sending the name on to be rejected. (PLA-786)
+  rather than sending the name on to be rejected. An empty argument — an
+  unset variable in a script — is now refused as the usage error it is,
+  instead of searching with no filter at all. (PLA-786)
 
 ## v0.13.0-rc0 — 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,10 @@
   stack-profiles, credentials and clusters already resolve theirs: a uuid
   passes straight through, an unknown name says to check
   `ankra application list`, and a name two applications share lists the
-  candidate ids instead of picking one. (PLA-786)
+  candidate ids instead of picking one. The lookup walks every page of the
+  listing, so a name still resolves in an organisation with more
+  applications than one page holds, and a lookup that cannot run says so
+  rather than sending the name on to be rejected. (PLA-786)
 
 ## v0.13.0-rc0 — 2026-08-22
 

--- a/cmd/application_aiconfig.go
+++ b/cmd/application_aiconfig.go
@@ -42,8 +42,12 @@ func newApplicationAIConfigGetCommand() *cobra.Command {
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
 				return formatError
 			}
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
 			payload, getError := apiClient.GetApplicationAIConfig(command.Context(),
-				strings.TrimSpace(arguments[0]))
+				applicationID)
 			if getError != nil {
 				return getError
 			}
@@ -87,8 +91,12 @@ edit it, and pass the file back with --file (or '-' to read stdin).`,
 				return withExitCode(exitUsage,
 					fmt.Errorf("%s does not contain valid JSON", filePath))
 			}
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
 			payload, updateError := apiClient.UpdateApplicationAIConfig(command.Context(),
-				strings.TrimSpace(arguments[0]), json.RawMessage(content))
+				applicationID, json.RawMessage(content))
 			if updateError != nil {
 				return updateError
 			}
@@ -109,12 +117,15 @@ func newApplicationAIConfigClearCommand() *cobra.Command {
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
 				return formatError
 			}
-			applicationID := strings.TrimSpace(arguments[0])
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
 			yes, _ := command.Flags().GetBool("yes")
 			if confirmError := confirmPrompt(
 				command.InOrStdin(), command.OutOrStdout(),
 				fmt.Sprintf("Reset the AI configuration of application %q to the organisation defaults? [y/N]: ",
-					applicationID),
+					strings.TrimSpace(arguments[0])),
 				yes,
 			); confirmError != nil {
 				return confirmError

--- a/cmd/application_aiconfig_test.go
+++ b/cmd/application_aiconfig_test.go
@@ -44,7 +44,7 @@ func (mock *applicationAIConfigMock) GetApplicationPublishedAddon(requestContext
 
 func TestApplicationAIConfigSetRequiresValidJSONFile(t *testing.T) {
 	mock := &applicationAIConfigMock{}
-	if _, executeError := runApplicationCommand(t, mock, "ai-config", "set", "app-1"); executeError == nil {
+	if _, executeError := runApplicationCommand(t, mock, "ai-config", "set", testApplicationID); executeError == nil {
 		t.Fatal("expected an error without --file")
 	}
 	badJSONPath := filepath.Join(t.TempDir(), "lanes.json")
@@ -52,7 +52,7 @@ func TestApplicationAIConfigSetRequiresValidJSONFile(t *testing.T) {
 		t.Fatal(writeError)
 	}
 	if _, executeError := runApplicationCommand(t, mock,
-		"ai-config", "set", "app-1", "--file", badJSONPath); executeError == nil {
+		"ai-config", "set", testApplicationID, "--file", badJSONPath); executeError == nil {
 		t.Fatal("expected invalid JSON to be refused")
 	}
 	if mock.sentConfiguration != nil {
@@ -68,7 +68,7 @@ func TestApplicationAIConfigSetSendsConfiguration(t *testing.T) {
 		t.Fatal(writeError)
 	}
 	if _, executeError := runApplicationCommand(t, mock,
-		"ai-config", "set", "app-1", "--file", configurationPath); executeError != nil {
+		"ai-config", "set", testApplicationID, "--file", configurationPath); executeError != nil {
 		t.Fatalf("ai-config set failed: %v", executeError)
 	}
 	if string(mock.sentConfiguration) != configuration {
@@ -79,14 +79,14 @@ func TestApplicationAIConfigSetSendsConfiguration(t *testing.T) {
 func TestApplicationAIConfigClearConfirmation(t *testing.T) {
 	mock := &applicationAIConfigMock{}
 	if _, executeError := runApplicationCommandWithInput(t, mock, "n\n",
-		"ai-config", "clear", "app-1"); executeError == nil {
+		"ai-config", "clear", testApplicationID); executeError == nil {
 		t.Fatal("expected the declined confirmation to error")
 	}
 	if mock.resetCalls != 0 {
 		t.Fatalf("expected no reset call on decline, got %d", mock.resetCalls)
 	}
 	if _, executeError := runApplicationCommand(t, mock,
-		"ai-config", "clear", "app-1", "--yes"); executeError != nil {
+		"ai-config", "clear", testApplicationID, "--yes"); executeError != nil {
 		t.Fatalf("ai-config clear --yes failed: %v", executeError)
 	}
 	if mock.resetCalls != 1 {
@@ -96,7 +96,7 @@ func TestApplicationAIConfigClearConfirmation(t *testing.T) {
 
 func TestApplicationPublishAddonMapsFlags(t *testing.T) {
 	mock := &applicationAIConfigMock{}
-	if _, executeError := runApplicationCommand(t, mock, "publish-addon", "app-1",
+	if _, executeError := runApplicationCommand(t, mock, "publish-addon", testApplicationID,
 		"--version", "1.2.0", "--display-name", "Website",
 		"--category", "web", "--changelog", "TLS defaults"); executeError != nil {
 		t.Fatalf("publish-addon failed: %v", executeError)
@@ -113,7 +113,7 @@ func TestApplicationPublishAddonMapsFlags(t *testing.T) {
 
 func TestApplicationPublishedAddonReads(t *testing.T) {
 	mock := &applicationAIConfigMock{}
-	output, executeError := runApplicationCommand(t, mock, "published-addon", "app-1")
+	output, executeError := runApplicationCommand(t, mock, "published-addon", testApplicationID)
 	if executeError != nil {
 		t.Fatalf("published-addon failed: %v", executeError)
 	}

--- a/cmd/application_auto_deploy.go
+++ b/cmd/application_auto_deploy.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -48,8 +47,12 @@ auto-deploy that is off from one that is on but has had nothing to pick up.`,
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
 				return formatError
 			}
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
 			payload, getError := apiClient.GetApplicationAutoDeploy(command.Context(),
-				strings.TrimSpace(arguments[0]))
+				applicationID)
 			if getError != nil {
 				return getError
 			}
@@ -81,8 +84,12 @@ safe default to infer from a bare 'set'.`,
 					errors.New("--enabled is required: pass --enabled to turn auto-deploy on, or --enabled=false to turn it off"))
 			}
 			enabled, _ := command.Flags().GetBool("enabled")
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
 			payload, setError := apiClient.SetApplicationAutoDeploy(command.Context(),
-				strings.TrimSpace(arguments[0]), enabled)
+				applicationID, enabled)
 			if setError != nil {
 				return setError
 			}

--- a/cmd/application_catalog.go
+++ b/cmd/application_catalog.go
@@ -33,8 +33,12 @@ a version; other clusters install the add-on from the catalogue.`,
 			description, _ := command.Flags().GetString("description")
 			category, _ := command.Flags().GetString("category")
 			changelog, _ := command.Flags().GetString("changelog")
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
 			payload, publishError := apiClient.PublishApplicationAddon(command.Context(),
-				strings.TrimSpace(arguments[0]), client.PublishApplicationAddonRequest{
+				applicationID, client.PublishApplicationAddonRequest{
 					Version:     strings.TrimSpace(version),
 					DisplayName: strings.TrimSpace(displayName),
 					Description: description,

--- a/cmd/application_demo.go
+++ b/cmd/application_demo.go
@@ -48,8 +48,12 @@ Kubernetes events behind a stalled step.`,
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
 				return formatError
 			}
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
 			payload, detailError := apiClient.GetApplicationDemoDetail(command.Context(),
-				strings.TrimSpace(arguments[0]), strings.TrimSpace(arguments[1]))
+				applicationID, strings.TrimSpace(arguments[1]))
 			if detailError != nil {
 				return detailError
 			}
@@ -78,7 +82,10 @@ belonging to that component; --pod addresses one by name (from
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
 				return formatError
 			}
-			applicationID := strings.TrimSpace(arguments[0])
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
 			workspaceID := strings.TrimSpace(arguments[1])
 			tailLines, _ := command.Flags().GetInt("tail")
 			componentName, _ := command.Flags().GetString("component")
@@ -182,7 +189,11 @@ func newApplicationDemoConfigGetCommand() *cobra.Command {
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
 				return formatError
 			}
-			payload, getError := apiClient.GetApplicationDemoConfig(command.Context(), strings.TrimSpace(arguments[0]))
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			payload, getError := apiClient.GetApplicationDemoConfig(command.Context(), applicationID)
 			if getError != nil {
 				return getError
 			}
@@ -218,7 +229,10 @@ entries override by name, everything else is carried forward.`,
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
 				return formatError
 			}
-			applicationID := strings.TrimSpace(arguments[0])
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
 			currentPayload, getError := apiClient.GetApplicationDemoConfig(command.Context(), applicationID)
 			if getError != nil {
 				return getError
@@ -303,8 +317,12 @@ func newApplicationDemoFixCommand() *cobra.Command {
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
 				return formatError
 			}
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
 			payload, fixError := apiClient.FixApplicationDemo(command.Context(),
-				strings.TrimSpace(arguments[0]), strings.TrimSpace(arguments[1]))
+				applicationID, strings.TrimSpace(arguments[1]))
 			if fixError != nil {
 				return fixError
 			}
@@ -327,7 +345,11 @@ including the TTL policy and the staging cluster's status.`,
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
 				return formatError
 			}
-			payload, listError := apiClient.GetApplicationDemos(command.Context(), strings.TrimSpace(arguments[0]))
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			payload, listError := apiClient.GetApplicationDemos(command.Context(), applicationID)
 			if listError != nil {
 				return listError
 			}
@@ -352,7 +374,11 @@ func newApplicationDemoBuildCommand() *cobra.Command {
 			if branch == "" {
 				return withExitCode(exitUsage, errors.New("--branch is required"))
 			}
-			payload, buildError := apiClient.CheckApplicationDemoBuild(command.Context(), strings.TrimSpace(arguments[0]), branch)
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			payload, buildError := apiClient.CheckApplicationDemoBuild(command.Context(), applicationID, branch)
 			if buildError != nil {
 				return buildError
 			}
@@ -393,8 +419,12 @@ so follow the agent run it names.`,
 				return withExitCode(exitUsage,
 					errors.New("--branch is required: the branch whose build is missing"))
 			}
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
 			payload, fixError := apiClient.FixApplicationBuild(command.Context(),
-				strings.TrimSpace(arguments[0]), branch)
+				applicationID, branch)
 			if fixError != nil {
 				return fixError
 			}
@@ -462,7 +492,11 @@ tune one component of a full launch, list them all.`,
 				entryComponent, _ := command.Flags().GetString("entry-component")
 				demoRequest.EntryComponent = &entryComponent
 			}
-			payload, deployError := apiClient.DeployApplicationDemo(command.Context(), strings.TrimSpace(arguments[0]), demoRequest)
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			payload, deployError := apiClient.DeployApplicationDemo(command.Context(), applicationID, demoRequest)
 			if deployError != nil {
 				return deployError
 			}
@@ -598,7 +632,11 @@ func newApplicationDemoStopCommand() *cobra.Command {
 			if workspaceID == "" {
 				return withExitCode(exitUsage, errors.New("workspace id cannot be empty"))
 			}
-			payload, stopError := apiClient.StopApplicationDemo(command.Context(), strings.TrimSpace(arguments[0]), workspaceID)
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			payload, stopError := apiClient.StopApplicationDemo(command.Context(), applicationID, workspaceID)
 			if stopError != nil {
 				return stopError
 			}

--- a/cmd/application_demo_test.go
+++ b/cmd/application_demo_test.go
@@ -80,7 +80,7 @@ const demoDetailFixture = `{
 func TestApplicationDemoDeployMapsComponentFlags(t *testing.T) {
 	mockClient := &applicationDemoMock{deployPayload: json.RawMessage(`{"workspace_id":"ws-1"}`)}
 	_, executeError := runApplicationCommand(t, mockClient,
-		"demo", "deploy", "app-1",
+		"demo", "deploy", testApplicationID,
 		"--branch", "main",
 		"--component", "crm-frontend",
 		"--component", "crm-api",
@@ -121,7 +121,7 @@ func TestApplicationDemoDeployMapsComponentFlags(t *testing.T) {
 func TestApplicationDemoDeployWithoutComponentFlagsSendsNoSelection(t *testing.T) {
 	mockClient := &applicationDemoMock{deployPayload: json.RawMessage(`{"workspace_id":"ws-1"}`)}
 	if _, executeError := runApplicationCommand(t, mockClient,
-		"demo", "deploy", "app-1", "--branch", "main"); executeError != nil {
+		"demo", "deploy", testApplicationID, "--branch", "main"); executeError != nil {
 		t.Fatalf("demo deploy error = %v", executeError)
 	}
 	if mockClient.demoRequest.Components != nil {
@@ -147,7 +147,7 @@ func TestApplicationDemoDeployRejectsBadComponentFlags(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			mockClient := &applicationDemoMock{}
 			_, executeError := runApplicationCommand(t, mockClient,
-				append([]string{"demo", "deploy", "app-1", "--branch", "main"}, arguments...)...)
+				append([]string{"demo", "deploy", testApplicationID, "--branch", "main"}, arguments...)...)
 			if exitCodeFor(executeError) != exitUsage {
 				t.Errorf("exit code = %d, want %d: %v", exitCodeFor(executeError), exitUsage, executeError)
 			}
@@ -164,7 +164,7 @@ func TestApplicationDemoLogsResolvesComponentToReadyPod(t *testing.T) {
 		logsPayload:   json.RawMessage(`{"lines":["listening on 8090"]}`),
 	}
 	if _, executeError := runApplicationCommand(t, mockClient,
-		"demo", "logs", "app-1", "ws-1", "--component", "crm-api", "--tail", "500"); executeError != nil {
+		"demo", "logs", testApplicationID, "ws-1", "--component", "crm-api", "--tail", "500"); executeError != nil {
 		t.Fatalf("demo logs error = %v", executeError)
 	}
 	if mockClient.logsPod != "crm-api-new" {
@@ -178,7 +178,7 @@ func TestApplicationDemoLogsResolvesComponentToReadyPod(t *testing.T) {
 func TestApplicationDemoLogsWithoutComponentSkipsDetailLookup(t *testing.T) {
 	mockClient := &applicationDemoMock{logsPayload: json.RawMessage(`{"lines":[]}`)}
 	if _, executeError := runApplicationCommand(t, mockClient,
-		"demo", "logs", "app-1", "ws-1"); executeError != nil {
+		"demo", "logs", testApplicationID, "ws-1"); executeError != nil {
 		t.Fatalf("demo logs error = %v", executeError)
 	}
 	if mockClient.detailCalls != 0 {
@@ -192,7 +192,7 @@ func TestApplicationDemoLogsWithoutComponentSkipsDetailLookup(t *testing.T) {
 func TestApplicationDemoLogsRejectsUnknownComponent(t *testing.T) {
 	mockClient := &applicationDemoMock{detailPayload: json.RawMessage(demoDetailFixture)}
 	output, executeError := runApplicationCommand(t, mockClient,
-		"demo", "logs", "app-1", "ws-1", "--component", "billing")
+		"demo", "logs", testApplicationID, "ws-1", "--component", "billing")
 	if exitCodeFor(executeError) != exitNotFound {
 		t.Fatalf("exit code = %d, want %d: %v", exitCodeFor(executeError), exitNotFound, executeError)
 	}
@@ -207,7 +207,7 @@ func TestApplicationDemoLogsRejectsUnknownComponent(t *testing.T) {
 func TestApplicationDemoLogsRejectsComponentWithPod(t *testing.T) {
 	mockClient := &applicationDemoMock{detailPayload: json.RawMessage(demoDetailFixture)}
 	_, executeError := runApplicationCommand(t, mockClient,
-		"demo", "logs", "app-1", "ws-1", "--component", "crm-api", "--pod", "crm-api-new")
+		"demo", "logs", testApplicationID, "ws-1", "--component", "crm-api", "--pod", "crm-api-new")
 	if exitCodeFor(executeError) != exitUsage {
 		t.Errorf("exit code = %d, want %d: %v", exitCodeFor(executeError), exitUsage, executeError)
 	}
@@ -230,7 +230,7 @@ func TestApplicationDemoListRendersComponents(t *testing.T) {
 	    ]
 	  }]
 	}`)}
-	output, executeError := runApplicationCommand(t, mockClient, "demo", "list", "app-1")
+	output, executeError := runApplicationCommand(t, mockClient, "demo", "list", testApplicationID)
 	if executeError != nil {
 		t.Fatalf("demo list error = %v", executeError)
 	}
@@ -243,7 +243,7 @@ func TestApplicationDemoListRendersComponents(t *testing.T) {
 
 func TestApplicationDemoListEmpty(t *testing.T) {
 	mockClient := &applicationDemoMock{listPayload: json.RawMessage(`{"demos":[]}`)}
-	output, executeError := runApplicationCommand(t, mockClient, "demo", "list", "app-1")
+	output, executeError := runApplicationCommand(t, mockClient, "demo", "list", testApplicationID)
 	if executeError != nil {
 		t.Fatalf("demo list error = %v", executeError)
 	}
@@ -256,7 +256,7 @@ func TestApplicationDemoListFallsBackWhenPayloadCarriesNoDemosKey(t *testing.T) 
 	// "No active demo workspaces." is a claim about the application, so a
 	// payload that never carried the list must print raw instead.
 	mockClient := &applicationDemoMock{listPayload: json.RawMessage(`{"detail":"staging cluster missing"}`)}
-	output, executeError := runApplicationCommand(t, mockClient, "demo", "list", "app-1")
+	output, executeError := runApplicationCommand(t, mockClient, "demo", "list", testApplicationID)
 	if executeError != nil {
 		t.Fatalf("demo list error = %v", executeError)
 	}
@@ -270,7 +270,7 @@ func TestApplicationDemoListFallsBackWhenPayloadCarriesNoDemosKey(t *testing.T) 
 
 func TestApplicationDemoListStructuredOutputStaysRaw(t *testing.T) {
 	mockClient := &applicationDemoMock{listPayload: json.RawMessage(`{"demos":[],"default_container_port":3000}`)}
-	output, executeError := runApplicationCommand(t, mockClient, "demo", "list", "app-1", "-o", "json")
+	output, executeError := runApplicationCommand(t, mockClient, "demo", "list", testApplicationID, "-o", "json")
 	if executeError != nil {
 		t.Fatalf("demo list error = %v", executeError)
 	}
@@ -281,7 +281,7 @@ func TestApplicationDemoListStructuredOutputStaysRaw(t *testing.T) {
 
 func TestApplicationDemoDetailRendersComponentsAndSteps(t *testing.T) {
 	mockClient := &applicationDemoMock{detailPayload: json.RawMessage(demoDetailFixture)}
-	output, executeError := runApplicationCommand(t, mockClient, "demo", "detail", "app-1", "ws-1")
+	output, executeError := runApplicationCommand(t, mockClient, "demo", "detail", testApplicationID, "ws-1")
 	if executeError != nil {
 		t.Fatalf("demo detail error = %v", executeError)
 	}
@@ -300,7 +300,7 @@ func TestApplicationDemoDetailFallsBackToRawJSON(t *testing.T) {
 	// A payload this rendering cannot decode must still print: a wire shape
 	// the CLI has not caught up with is not a reason to fail a read.
 	mockClient := &applicationDemoMock{detailPayload: json.RawMessage(`{"demo":"not-an-object"}`)}
-	output, executeError := runApplicationCommand(t, mockClient, "demo", "detail", "app-1", "ws-1")
+	output, executeError := runApplicationCommand(t, mockClient, "demo", "detail", testApplicationID, "ws-1")
 	if executeError != nil {
 		t.Fatalf("demo detail error = %v", executeError)
 	}
@@ -315,7 +315,7 @@ func TestApplicationDemoDetailRendersLegacySingleComponent(t *testing.T) {
 	           "image_tag":"sha-abc","container_port":3000,"expires_at":"2099-01-01T00:00:00Z"},
 	  "inspection": {"cluster_reachable": true, "steps": [], "resources": []}
 	}`)}
-	output, executeError := runApplicationCommand(t, mockClient, "demo", "detail", "app-1", "ws-9")
+	output, executeError := runApplicationCommand(t, mockClient, "demo", "detail", testApplicationID, "ws-9")
 	if executeError != nil {
 		t.Fatalf("demo detail error = %v", executeError)
 	}

--- a/cmd/application_env_secrets.go
+++ b/cmd/application_env_secrets.go
@@ -60,8 +60,12 @@ one has a stored value. The values themselves are never returned.`,
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
 				return formatError
 			}
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
 			payload, listError := apiClient.ListApplicationEnvSecrets(command.Context(),
-				strings.TrimSpace(arguments[0]))
+				applicationID)
 			if listError != nil {
 				return listError
 			}
@@ -93,7 +97,10 @@ seal the stored values into the application's deployments and roll them.`,
 			if formatError != nil {
 				return formatError
 			}
-			applicationID := strings.TrimSpace(arguments[0])
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
 			secretKey := strings.TrimSpace(arguments[1])
 			if keyError := validateEnvSecretKey(secretKey); keyError != nil {
 				return keyError
@@ -231,7 +238,10 @@ sealed into them until the next apply.`,
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
 				return formatError
 			}
-			applicationID := strings.TrimSpace(arguments[0])
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
 			secretKey := strings.TrimSpace(arguments[1])
 			if keyError := validateEnvSecretKey(secretKey); keyError != nil {
 				return keyError
@@ -278,8 +288,12 @@ cannot be sealed - and the reason is reported as the error message.`,
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
 				return formatError
 			}
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
 			payload, applyError := apiClient.ApplyApplicationEnvSecrets(command.Context(),
-				strings.TrimSpace(arguments[0]))
+				applicationID)
 			if applyError != nil {
 				return applyError
 			}

--- a/cmd/application_env_secrets.go
+++ b/cmd/application_env_secrets.go
@@ -97,13 +97,16 @@ seal the stored values into the application's deployments and roll them.`,
 			if formatError != nil {
 				return formatError
 			}
-			applicationID, resolveError := resolveApplicationArgument(command, arguments)
-			if resolveError != nil {
-				return resolveError
-			}
+			// The key is checked before the application is resolved: it costs
+			// nothing, and a name now means a listing round-trip that a purely
+			// local mistake should not have to pay for.
 			secretKey := strings.TrimSpace(arguments[1])
 			if keyError := validateEnvSecretKey(secretKey); keyError != nil {
 				return keyError
+			}
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
 			}
 			value, valueError := resolveEnvSecretValue(command, secretKey)
 			if valueError != nil {
@@ -238,13 +241,16 @@ sealed into them until the next apply.`,
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
 				return formatError
 			}
-			applicationID, resolveError := resolveApplicationArgument(command, arguments)
-			if resolveError != nil {
-				return resolveError
-			}
+			// The key is checked before the application is resolved: it costs
+			// nothing, and a name now means a listing round-trip that a purely
+			// local mistake should not have to pay for.
 			secretKey := strings.TrimSpace(arguments[1])
 			if keyError := validateEnvSecretKey(secretKey); keyError != nil {
 				return keyError
+			}
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
 			}
 			yes, _ := command.Flags().GetBool("yes")
 			if confirmError := confirmPrompt(

--- a/cmd/application_lane_parity_test.go
+++ b/cmd/application_lane_parity_test.go
@@ -154,7 +154,7 @@ func TestApplicationLaneParityCommandsRegistered(t *testing.T) {
 func TestApplicationEnvSecretSetReadsTheValueFromStdin(t *testing.T) {
 	mockClient := &applicationLaneMock{payload: json.RawMessage(`{"key":"API_TOKEN","has_value":true}`)}
 	output, executeError := runApplicationCommandWithInput(t, mockClient, "sk-live-abc\n",
-		"env-secrets", "set", "app-1", "API_TOKEN")
+		"env-secrets", "set", testApplicationID, "API_TOKEN")
 	if executeError != nil {
 		t.Fatalf("env-secrets set error = %v", executeError)
 	}
@@ -181,7 +181,7 @@ func TestApplicationEnvSecretSetReadsTheValueFromStdin(t *testing.T) {
 func TestApplicationEnvSecretSetNeverEchoesTheValue(t *testing.T) {
 	mockClient := &applicationLaneMock{payload: json.RawMessage(`{"key":"API_TOKEN","has_value":true}`)}
 	output, executeError := runApplicationCommand(t, mockClient,
-		"env-secrets", "set", "app-1", "API_TOKEN", "--value", "sk-live-secret")
+		"env-secrets", "set", testApplicationID, "API_TOKEN", "--value", "sk-live-secret")
 	if executeError != nil {
 		t.Fatalf("env-secrets set error = %v", executeError)
 	}
@@ -227,7 +227,7 @@ func TestApplicationEnvSecretSetPreservesSignificantWhitespace(t *testing.T) {
 	} {
 		t.Run(testCase.name, func(subTest *testing.T) {
 			mockClient := &applicationLaneMock{payload: json.RawMessage(`{"key":"K"}`)}
-			arguments := append([]string{"env-secrets", "set", "app-1", "K"}, testCase.arguments...)
+			arguments := append([]string{"env-secrets", "set", testApplicationID, "K"}, testCase.arguments...)
 			_, executeError := runApplicationCommandWithInput(subTest, mockClient, testCase.piped, arguments...)
 			if executeError != nil {
 				subTest.Fatalf("env-secrets set error = %v", executeError)
@@ -241,7 +241,7 @@ func TestApplicationEnvSecretSetPreservesSignificantWhitespace(t *testing.T) {
 
 func TestApplicationEnvSecretSetRequiresAValue(t *testing.T) {
 	mockClient := &applicationLaneMock{}
-	_, executeError := runApplicationCommandWithInput(t, mockClient, "", "env-secrets", "set", "app-1", "K")
+	_, executeError := runApplicationCommandWithInput(t, mockClient, "", "env-secrets", "set", testApplicationID, "K")
 	if executeError == nil {
 		t.Fatal("expected an empty value to fail")
 	}
@@ -256,7 +256,7 @@ func TestApplicationEnvSecretSetRequiresAValue(t *testing.T) {
 func TestApplicationEnvSecretDeleteRefusesWhenDeclined(t *testing.T) {
 	mockClient := &applicationLaneMock{}
 	_, executeError := runApplicationCommandWithInput(t, mockClient, "n\n",
-		"env-secrets", "delete", "app-1", "API_TOKEN")
+		"env-secrets", "delete", testApplicationID, "API_TOKEN")
 	if executeError == nil {
 		t.Fatal("a declined confirmation must fail")
 	}
@@ -270,7 +270,7 @@ func TestApplicationEnvSecretDeleteRefusesWhenDeclined(t *testing.T) {
 
 func TestApplicationEnvSecretApplySendsTheApply(t *testing.T) {
 	mockClient := &applicationLaneMock{payload: json.RawMessage(`{"applied_count":2,"failed_count":0}`)}
-	output, executeError := runApplicationCommand(t, mockClient, "env-secrets", "apply", "app-1")
+	output, executeError := runApplicationCommand(t, mockClient, "env-secrets", "apply", testApplicationID)
 	if executeError != nil {
 		t.Fatalf("env-secrets apply error = %v", executeError)
 	}
@@ -286,7 +286,7 @@ func TestApplicationEnvSecretApplySendsTheApply(t *testing.T) {
 // a bare `set` is a usage error rather than defaulting to either.
 func TestApplicationAutoDeploySetRequiresTheFlag(t *testing.T) {
 	mockClient := &applicationLaneMock{}
-	_, executeError := runApplicationCommand(t, mockClient, "auto-deploy", "set", "app-1")
+	_, executeError := runApplicationCommand(t, mockClient, "auto-deploy", "set", testApplicationID)
 	if executeError == nil {
 		t.Fatal("expected a bare set to fail")
 	}
@@ -307,7 +307,7 @@ func TestApplicationAutoDeploySetCarriesBothStates(t *testing.T) {
 		{"--enabled=false", false},
 	} {
 		mockClient := &applicationLaneMock{payload: json.RawMessage(`{"enabled":true}`)}
-		_, executeError := runApplicationCommand(t, mockClient, "auto-deploy", "set", "app-1", testCase.argument)
+		_, executeError := runApplicationCommand(t, mockClient, "auto-deploy", "set", testApplicationID, testCase.argument)
 		if executeError != nil {
 			t.Fatalf("auto-deploy set %s error = %v", testCase.argument, executeError)
 		}
@@ -484,7 +484,7 @@ func TestManifestAddonWithdrawalsBothConfirm(t *testing.T) {
 // build, and a defaulted branch would repair the wrong one silently.
 func TestApplicationDemoFixBuildRequiresABranch(t *testing.T) {
 	mockClient := &applicationLaneMock{}
-	_, executeError := runApplicationCommand(t, mockClient, "demo", "fix-build", "app-1")
+	_, executeError := runApplicationCommand(t, mockClient, "demo", "fix-build", testApplicationID)
 	if executeError == nil {
 		t.Fatal("expected a missing --branch to fail")
 	}
@@ -499,7 +499,7 @@ func TestApplicationDemoFixBuildRequiresABranch(t *testing.T) {
 func TestApplicationDemoFixBuildSendsTheBranch(t *testing.T) {
 	mockClient := &applicationLaneMock{payload: json.RawMessage(`{"status":"dispatched"}`)}
 	_, executeError := runApplicationCommand(t, mockClient,
-		"demo", "fix-build", "app-1", "--branch", " feature/checkout ")
+		"demo", "fix-build", testApplicationID, "--branch", " feature/checkout ")
 	if executeError != nil {
 		t.Fatalf("demo fix-build error = %v", executeError)
 	}
@@ -518,7 +518,7 @@ func TestApplicationDemoFixBuildSendsTheBranch(t *testing.T) {
 func TestApplicationEnvSecretSetRefusesAnExplicitlyEmptyValue(t *testing.T) {
 	for _, argument := range []string{"--value=", "--value"} {
 		mockClient := &applicationLaneMock{}
-		arguments := []string{"env-secrets", "set", "app-1", "K", argument}
+		arguments := []string{"env-secrets", "set", testApplicationID, "K", argument}
 		if argument == "--value" {
 			arguments = append(arguments, "")
 		}
@@ -547,7 +547,7 @@ func TestApplicationEnvSecretRefusesAKeyThatIsNotAnEnvironmentVariableName(t *te
 	for _, secretKey := range []string{"..", ".", "A/B", "1LEADING_DIGIT", "has space", "has-dash", ""} {
 		for _, verb := range []string{"set", "delete"} {
 			mockClient := &applicationLaneMock{}
-			arguments := []string{"env-secrets", verb, "app-1", secretKey}
+			arguments := []string{"env-secrets", verb, testApplicationID, secretKey}
 			if verb == "set" {
 				arguments = append(arguments, "--value", "v")
 			} else {
@@ -569,7 +569,7 @@ func TestApplicationEnvSecretRefusesAKeyThatIsNotAnEnvironmentVariableName(t *te
 	// The rule must still accept an ordinary key.
 	mockClient := &applicationLaneMock{payload: json.RawMessage(`{"key":"DATABASE_URL"}`)}
 	if _, executeError := runApplicationCommand(t, mockClient,
-		"env-secrets", "set", "app-1", "DATABASE_URL", "--value", "v"); executeError != nil {
+		"env-secrets", "set", testApplicationID, "DATABASE_URL", "--value", "v"); executeError != nil {
 		t.Fatalf("a valid key was refused: %v", executeError)
 	}
 	if mockClient.envSecretSets != 1 {
@@ -603,7 +603,7 @@ func TestManifestAddonInstallRejectsADuplicateInputKey(t *testing.T) {
 func TestApplicationEnvSecretSetHintIsHumanOutputOnly(t *testing.T) {
 	mockClient := &applicationLaneMock{payload: json.RawMessage(`{"key":"K"}`)}
 	human, executeError := runApplicationCommand(t, mockClient,
-		"env-secrets", "set", "app-1", "K", "--value", "v")
+		"env-secrets", "set", testApplicationID, "K", "--value", "v")
 	if executeError != nil {
 		t.Fatalf("env-secrets set error = %v", executeError)
 	}
@@ -613,7 +613,7 @@ func TestApplicationEnvSecretSetHintIsHumanOutputOnly(t *testing.T) {
 
 	mockClient = &applicationLaneMock{payload: json.RawMessage(`{"key":"K"}`)}
 	structured, executeError := runApplicationCommand(t, mockClient,
-		"env-secrets", "set", "app-1", "K", "--value", "v", "-o", "json")
+		"env-secrets", "set", testApplicationID, "K", "--value", "v", "-o", "json")
 	if executeError != nil {
 		t.Fatalf("env-secrets set -o json error = %v", executeError)
 	}

--- a/cmd/application_registry.go
+++ b/cmd/application_registry.go
@@ -50,8 +50,12 @@ to - so you can compare them against where your builds actually push.`,
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
 				return formatError
 			}
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
 			payload, getError := apiClient.GetApplicationImageRegistry(command.Context(),
-				strings.TrimSpace(arguments[0]))
+				applicationID)
 			if getError != nil {
 				return getError
 			}
@@ -109,8 +113,12 @@ write your repository's Actions secrets unless you ask it to with
 				PasswordSecretName:   strings.TrimSpace(passwordSecretName),
 				ManageActionsSecrets: manageActionsSecrets,
 			}
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
 			payload, updateError := apiClient.UpdateApplicationImageRegistry(command.Context(),
-				strings.TrimSpace(arguments[0]),
+				applicationID,
 				client.UpdateApplicationImageRegistryRequest{ImageRegistry: declaration})
 			if updateError != nil {
 				return updateError
@@ -149,12 +157,15 @@ from - the organisation's provisioned registry project again.`,
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
 				return formatError
 			}
-			applicationID := strings.TrimSpace(arguments[0])
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
 			yes, _ := command.Flags().GetBool("yes")
 			if confirmError := confirmPrompt(
 				command.InOrStdin(), command.OutOrStdout(),
 				fmt.Sprintf("Clear the declared image registry of application %q? "+
-					"It will publish to the organisation's own registry again. [y/N]: ", applicationID),
+					"It will publish to the organisation's own registry again. [y/N]: ", strings.TrimSpace(arguments[0])),
 				yes,
 			); confirmError != nil {
 				return confirmError

--- a/cmd/application_registry_test.go
+++ b/cmd/application_registry_test.go
@@ -68,12 +68,12 @@ func TestApplicationRegistryGetRendersThePayload(t *testing.T) {
 	mockClient := &applicationRegistryMock{
 		payload: json.RawMessage(`{"declared":true,"host":"artifact.example.com","project":"commerce"}`),
 	}
-	output, executeError := runApplicationCommand(t, mockClient, "registry", "get", "app-1")
+	output, executeError := runApplicationCommand(t, mockClient, "registry", "get", testApplicationID)
 	if executeError != nil {
 		t.Fatalf("registry get error = %v", executeError)
 	}
-	if mockClient.getApplicationID != "app-1" {
-		t.Errorf("application id = %q, want app-1", mockClient.getApplicationID)
+	if mockClient.getApplicationID != testApplicationID {
+		t.Errorf("application id = %q, want %s", mockClient.getApplicationID, testApplicationID)
 	}
 	if !strings.Contains(output, "\"host\": \"artifact.example.com\"") {
 		t.Errorf("output is not indented JSON: %q", output)
@@ -83,7 +83,7 @@ func TestApplicationRegistryGetRendersThePayload(t *testing.T) {
 func TestApplicationRegistrySetMapsEveryFlag(t *testing.T) {
 	mockClient := &applicationRegistryMock{payload: json.RawMessage(`{"declared":true}`)}
 	_, executeError := runApplicationCommand(t, mockClient,
-		"registry", "set", "app-1",
+		"registry", "set", testApplicationID,
 		"--url", " oci://artifact.example.com/commerce ",
 		"--credential", "example-harbor",
 		"--api-url", "https://artifact.example.com",
@@ -114,7 +114,7 @@ func TestApplicationRegistrySetMapsEveryFlag(t *testing.T) {
 
 func TestApplicationRegistrySetRequiresURL(t *testing.T) {
 	mockClient := &applicationRegistryMock{}
-	_, executeError := runApplicationCommand(t, mockClient, "registry", "set", "app-1", "--credential", "harbor")
+	_, executeError := runApplicationCommand(t, mockClient, "registry", "set", testApplicationID, "--credential", "harbor")
 	if executeError == nil {
 		t.Fatal("expected a missing --url to fail")
 	}
@@ -133,7 +133,7 @@ func TestApplicationRegistrySetRequiresURL(t *testing.T) {
 func TestApplicationRegistrySetWarnsWithoutACredential(t *testing.T) {
 	mockClient := &applicationRegistryMock{payload: json.RawMessage(`{"declared":true}`)}
 	output, executeError := runApplicationCommand(t, mockClient,
-		"registry", "set", "app-1", "--url", "oci://artifact.example.com/commerce")
+		"registry", "set", testApplicationID, "--url", "oci://artifact.example.com/commerce")
 	if executeError != nil {
 		t.Fatalf("registry set error = %v", executeError)
 	}
@@ -149,7 +149,7 @@ func TestApplicationRegistrySetWarnsWithoutACredential(t *testing.T) {
 // key would leave the declaration in place.
 func TestApplicationRegistryClearSendsAnExplicitNull(t *testing.T) {
 	mockClient := &applicationRegistryMock{payload: json.RawMessage(`{"declared":false}`)}
-	_, executeError := runApplicationCommand(t, mockClient, "registry", "clear", "app-1", "--yes")
+	_, executeError := runApplicationCommand(t, mockClient, "registry", "clear", testApplicationID, "--yes")
 	if executeError != nil {
 		t.Fatalf("registry clear error = %v", executeError)
 	}
@@ -170,7 +170,7 @@ func TestApplicationRegistryClearSendsAnExplicitNull(t *testing.T) {
 
 func TestApplicationRegistryClearRefusesWhenDeclined(t *testing.T) {
 	mockClient := &applicationRegistryMock{}
-	_, executeError := runApplicationCommandWithInput(t, mockClient, "n\n", "registry", "clear", "app-1")
+	_, executeError := runApplicationCommandWithInput(t, mockClient, "n\n", "registry", "clear", testApplicationID)
 	if executeError == nil {
 		t.Fatal("a declined confirmation must fail")
 	}

--- a/cmd/application_resolve.go
+++ b/cmd/application_resolve.go
@@ -111,11 +111,18 @@ func resolveApplicationID(requestContext context.Context, applications APIClient
 	case 1:
 		return matchedIDs[0], nil
 	case 0:
-		return "", fmt.Errorf(
-			"no application named %q - run 'ankra application list' to see the available applications", reference)
+		// exitNotFound keeps the name path and the id path telling scripts the
+		// same thing: an id that does not exist reaches the API and comes back
+		// 404, which exitCodeFor already maps to exitNotFound, so a name that
+		// does not exist must not exit with the generic failure code instead.
+		return "", withExitCode(exitNotFound, fmt.Errorf(
+			"no application named %q - run 'ankra application list' to see the available applications", reference))
 	default:
-		return "", fmt.Errorf("%d applications are named %q - pass the application id instead (%s)",
-			len(matchedIDs), reference, strings.Join(matchedIDs, ", "))
+		// An ambiguous name is a bad argument, not a missing application: the
+		// invocation has to change before it can succeed.
+		return "", withExitCode(exitUsage,
+			fmt.Errorf("%d applications are named %q - pass the application id instead (%s)",
+				len(matchedIDs), reference, strings.Join(matchedIDs, ", ")))
 	}
 }
 

--- a/cmd/application_resolve.go
+++ b/cmd/application_resolve.go
@@ -10,10 +10,44 @@ import (
 )
 
 // maxApplicationLookupPageSize is the largest page_size the applications
-// endpoint accepts. The `search` filter runs server-side on the name, so one
-// page is more than enough to find an exact match (see
-// maxProfileLookupPageSize for the history of asking for more).
-const maxApplicationLookupPageSize = 100
+// endpoint accepts. It does not clamp an oversized value, it rejects the
+// request with a 422, so asking for one big page instead of paging is not an
+// option (see maxProfileLookupPageSize for what asking for more cost us
+// there).
+//
+// maxApplicationLookupPages bounds the walk against a backend that keeps
+// reporting more pages, matching listAllClusters and listAllHelmRegistries.
+const (
+	maxApplicationLookupPageSize = 100
+	maxApplicationLookupPages    = 100
+)
+
+// applicationListingPage is the slice of the applications listing the lookup
+// reads: the id/name pairs, and the paging metadata that says whether more
+// pages are waiting.
+type applicationListingPage struct {
+	Result []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"result"`
+	Pagination struct {
+		TotalPages int `json:"total_pages"`
+	} `json:"pagination"`
+}
+
+// applicationLookupFailure reports that a name could not be resolved because
+// the listing itself was unusable.
+//
+// The failure has to surface here. Only a name reaches the lookup - every
+// application id the platform issues is a canonical uuid, and looksLikeUUID
+// accepts every one of them - so handing the reference on unchanged would
+// put a name in a uuid-typed path parameter and reproduce the bare 500 this
+// resolver exists to prevent (PLA-786). The cause is wrapped so an
+// unauthorised or forbidden listing still classifies into its own exit code.
+func applicationLookupFailure(reference string, cause error) error {
+	return fmt.Errorf("could not look up the application named %q: %w - pass the application id "+
+		"to skip the lookup, or run 'ankra application list' to find it", reference, cause)
+}
 
 // resolveApplicationID accepts either an application id or an application
 // name.
@@ -27,33 +61,36 @@ func resolveApplicationID(requestContext context.Context, applications APIClient
 	if looksLikeUUID(reference) {
 		return reference, nil
 	}
-	payload, listError := applications.ListApplicationsRaw(requestContext, 1, maxApplicationLookupPageSize, reference)
-	if listError != nil {
-		// The lookup is a convenience, not the operation. If listing is
-		// unavailable, hand the reference to the API unchanged and let the
-		// real call decide - failing here would turn a working id into an
-		// error just because the search endpoint was unhappy.
-		return reference, nil
-	}
-	var listing struct {
-		Result []struct {
-			ID   string `json:"id"`
-			Name string `json:"name"`
-		} `json:"result"`
-	}
-	if unmarshalError := json.Unmarshal(payload, &listing); unmarshalError != nil {
-		return reference, nil
-	}
-	// The server-side search is a case-insensitive substring filter, so match
-	// exactly first and fall back to a case-insensitive match only when no
-	// exact one exists.
+	// The server-side `search` filter is a case-insensitive *substring* match
+	// (definition->>'name' ILIKE '%reference%') ordered by creation date, so
+	// the exact match has no reason to sit on the first page: an org with
+	// more than a page of applications whose names contain the reference
+	// would otherwise be told its application does not exist. Page until the
+	// listing is exhausted, the way resolveClusterID already does.
 	exactIDs := []string{}
 	foldedIDs := []string{}
-	for _, application := range listing.Result {
-		if application.Name == reference {
-			exactIDs = append(exactIDs, application.ID)
-		} else if strings.EqualFold(application.Name, reference) {
-			foldedIDs = append(foldedIDs, application.ID)
+	for page := 1; page <= maxApplicationLookupPages; page++ {
+		payload, listError := applications.ListApplicationsRaw(
+			requestContext, page, maxApplicationLookupPageSize, reference)
+		if listError != nil {
+			return "", applicationLookupFailure(reference, listError)
+		}
+		var listing applicationListingPage
+		if unmarshalError := json.Unmarshal(payload, &listing); unmarshalError != nil {
+			return "", applicationLookupFailure(reference, unmarshalError)
+		}
+		// Match exactly first, and keep case variants aside as a fallback for
+		// when no exact match exists anywhere in the listing.
+		for _, application := range listing.Result {
+			switch {
+			case application.Name == reference:
+				exactIDs = append(exactIDs, application.ID)
+			case strings.EqualFold(application.Name, reference):
+				foldedIDs = append(foldedIDs, application.ID)
+			}
+		}
+		if listing.Pagination.TotalPages <= page || len(listing.Result) == 0 {
+			break
 		}
 	}
 	matchedIDs := exactIDs

--- a/cmd/application_resolve.go
+++ b/cmd/application_resolve.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// maxApplicationLookupPageSize is the largest page_size the applications
+// endpoint accepts. The `search` filter runs server-side on the name, so one
+// page is more than enough to find an exact match (see
+// maxProfileLookupPageSize for the history of asking for more).
+const maxApplicationLookupPageSize = 100
+
+// resolveApplicationID accepts either an application id or an application
+// name.
+//
+// `application list` prints a name column, so a name is the obvious thing to
+// pass to the per-application commands; before this a name travelled to the
+// backend's uuid-typed lookup unchecked and came back as a bare
+// 500 Internal Server Error (PLA-786).
+func resolveApplicationID(requestContext context.Context, applications APIClient, reference string) (string, error) {
+	reference = strings.TrimSpace(reference)
+	if looksLikeUUID(reference) {
+		return reference, nil
+	}
+	payload, listError := applications.ListApplicationsRaw(requestContext, 1, maxApplicationLookupPageSize, reference)
+	if listError != nil {
+		// The lookup is a convenience, not the operation. If listing is
+		// unavailable, hand the reference to the API unchanged and let the
+		// real call decide - failing here would turn a working id into an
+		// error just because the search endpoint was unhappy.
+		return reference, nil
+	}
+	var listing struct {
+		Result []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"result"`
+	}
+	if unmarshalError := json.Unmarshal(payload, &listing); unmarshalError != nil {
+		return reference, nil
+	}
+	// The server-side search is a case-insensitive substring filter, so match
+	// exactly first and fall back to a case-insensitive match only when no
+	// exact one exists.
+	exactIDs := []string{}
+	foldedIDs := []string{}
+	for _, application := range listing.Result {
+		if application.Name == reference {
+			exactIDs = append(exactIDs, application.ID)
+		} else if strings.EqualFold(application.Name, reference) {
+			foldedIDs = append(foldedIDs, application.ID)
+		}
+	}
+	matchedIDs := exactIDs
+	if len(matchedIDs) == 0 {
+		matchedIDs = foldedIDs
+	}
+	switch len(matchedIDs) {
+	case 1:
+		return matchedIDs[0], nil
+	case 0:
+		return "", fmt.Errorf(
+			"no application named %q - run 'ankra application list' to see the available applications", reference)
+	default:
+		return "", fmt.Errorf("%d applications are named %q - pass the application id instead (%s)",
+			len(matchedIDs), reference, strings.Join(matchedIDs, ", "))
+	}
+}
+
+// resolveApplicationArgument resolves a command's leading <application-id>
+// argument, which every per-application command also accepts as a name.
+func resolveApplicationArgument(command *cobra.Command, arguments []string) (string, error) {
+	return resolveApplicationID(command.Context(), apiClient, arguments[0])
+}

--- a/cmd/application_resolve.go
+++ b/cmd/application_resolve.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -58,6 +59,15 @@ func applicationLookupFailure(reference string, cause error) error {
 // 500 Internal Server Error (PLA-786).
 func resolveApplicationID(requestContext context.Context, applications APIClient, reference string) (string, error) {
 	reference = strings.TrimSpace(reference)
+	if reference == "" {
+		// An empty reference must not reach the lookup: ListApplicationsRaw
+		// omits an empty `search`, so the filter disappears and the walk pages
+		// the whole organisation. Any application whose definition carries no
+		// name then matches the empty reference exactly, and an unset shell
+		// variable - `ankra application delete "$APP" --yes` - would act on
+		// it. It is a usage error, and it was one before this resolver too.
+		return "", withExitCode(exitUsage, errors.New("an application id or name is required"))
+	}
 	if looksLikeUUID(reference) {
 		return reference, nil
 	}

--- a/cmd/application_resolve.go
+++ b/cmd/application_resolve.go
@@ -79,6 +79,7 @@ func resolveApplicationID(requestContext context.Context, applications APIClient
 	// listing is exhausted, the way resolveClusterID already does.
 	exactIDs := []string{}
 	foldedIDs := []string{}
+	listingExhausted := false
 	for page := 1; page <= maxApplicationLookupPages; page++ {
 		payload, listError := applications.ListApplicationsRaw(
 			requestContext, page, maxApplicationLookupPageSize, reference)
@@ -100,8 +101,19 @@ func resolveApplicationID(requestContext context.Context, applications APIClient
 			}
 		}
 		if listing.Pagination.TotalPages <= page || len(listing.Result) == 0 {
+			listingExhausted = true
 			break
 		}
+	}
+	if !listingExhausted {
+		// Stopping at the cap means the listing was only partly read, and
+		// neither answer below can be trusted on partial data: a second
+		// application sharing the name could sit past the cap, so a lone match
+		// is not provably unique, and "no application named" is not provably
+		// absent. Same rule as a failed listing - say so rather than answer
+		// from what happened to fit.
+		return "", applicationLookupFailure(reference, fmt.Errorf(
+			"the application listing did not end within %d pages", maxApplicationLookupPages))
 	}
 	matchedIDs := exactIDs
 	if len(matchedIDs) == 0 {

--- a/cmd/application_resolve_test.go
+++ b/cmd/application_resolve_test.go
@@ -21,11 +21,13 @@ import (
 // which id the command actually sent.
 type applicationLookupMock struct {
 	baseMock
-	listPayload json.RawMessage
-	listError   error
-	searched    string
-	pageSize    int
-	requested   bool
+	listPayload  json.RawMessage
+	pagePayloads []json.RawMessage
+	listError    error
+	searched     string
+	pageSize     int
+	requested    bool
+	pagesAsked   []int
 
 	branchesID string
 }
@@ -34,16 +36,23 @@ type applicationLookupMock struct {
 // anything the real endpoint would reject, so a page size the API caps out is
 // a test failure here rather than a silent fallback in production (see the
 // stack-profiles lookup for the history).
-func (mock *applicationLookupMock) ListApplicationsRaw(_ context.Context, _ int, pageSize int, search string) (json.RawMessage, error) {
+func (mock *applicationLookupMock) ListApplicationsRaw(_ context.Context, page int, pageSize int, search string) (json.RawMessage, error) {
 	mock.requested = true
 	mock.pageSize = pageSize
 	mock.searched = search
+	mock.pagesAsked = append(mock.pagesAsked, page)
 	if pageSize > maxApplicationLookupPageSize {
 		return nil, fmt.Errorf("list applications failed (422): page_size %d exceeds the API maximum of %d",
 			pageSize, maxApplicationLookupPageSize)
 	}
 	if mock.listError != nil {
 		return nil, mock.listError
+	}
+	if len(mock.pagePayloads) > 0 {
+		if page < 1 || page > len(mock.pagePayloads) {
+			return nil, fmt.Errorf("page %d is outside the %d pages this listing has", page, len(mock.pagePayloads))
+		}
+		return mock.pagePayloads[page-1], nil
 	}
 	return mock.listPayload, nil
 }
@@ -54,13 +63,25 @@ func (mock *applicationLookupMock) GetApplicationBranches(_ context.Context, app
 }
 
 func applicationListingPayload(applications ...[2]string) json.RawMessage {
+	return applicationListingPagePayload(0, applications...)
+}
+
+// applicationListingPagePayload renders one page of the listing the way the
+// applications endpoint does, including the pagination block the lookup reads
+// to decide whether another page is waiting. A totalPages of 0 stands for the
+// single-page listings the other tests use.
+func applicationListingPagePayload(totalPages int, applications ...[2]string) json.RawMessage {
 	type item struct {
 		ID   string `json:"id"`
 		Name string `json:"name"`
 	}
+	type pagination struct {
+		TotalPages int `json:"total_pages"`
+	}
 	listing := struct {
-		Result []item `json:"result"`
-	}{Result: []item{}}
+		Result     []item     `json:"result"`
+		Pagination pagination `json:"pagination"`
+	}{Result: []item{}, Pagination: pagination{TotalPages: totalPages}}
 	for _, application := range applications {
 		listing.Result = append(listing.Result, item{ID: application[0], Name: application[1]})
 	}
@@ -110,6 +131,71 @@ func TestResolveApplicationIDResolvesAName(t *testing.T) {
 	}
 	if mock.pageSize > maxApplicationLookupPageSize {
 		t.Fatalf("requested page_size %d exceeds the API maximum of %d", mock.pageSize, maxApplicationLookupPageSize)
+	}
+}
+
+func TestResolveApplicationIDStopsAfterOnePageWhenThatIsTheWholeListing(t *testing.T) {
+	// Paging past the exact match would spend a round-trip per command on
+	// every org that fits in one page, which is nearly all of them.
+	mock := &applicationLookupMock{pagePayloads: []json.RawMessage{
+		applicationListingPagePayload(1, [2]string{"23298741-6a5a-401a-a681-66f31fbdebe1", "commerce"}),
+	}}
+
+	if _, resolveError := resolveApplicationID(context.Background(), mock, "commerce"); resolveError != nil {
+		t.Fatalf("resolving a name: %v", resolveError)
+	}
+	if len(mock.pagesAsked) != 1 {
+		t.Fatalf("a single-page listing must cost one request, got pages %v", mock.pagesAsked)
+	}
+}
+
+func TestResolveApplicationIDPagesUntilItFindsTheExactMatch(t *testing.T) {
+	// The server-side `search` filter is a case-insensitive substring match
+	// ordered by creation date, and the endpoint caps page_size at 100. In an
+	// org with more than a page of applications whose names contain the
+	// reference, the exact match can sit on a later page - a single-page
+	// lookup would tell the user it does not exist, which is the PLA-786
+	// symptom returning for exactly the orgs most likely to hit it.
+	firstPage := make([][2]string, 0, maxApplicationLookupPageSize)
+	for index := 0; index < maxApplicationLookupPageSize; index++ {
+		firstPage = append(firstPage,
+			[2]string{fmt.Sprintf("3cd57498-062c-4dd8-878a-cd0372e5fc%02d", index), fmt.Sprintf("commerce-%d", index)})
+	}
+	mock := &applicationLookupMock{pagePayloads: []json.RawMessage{
+		applicationListingPagePayload(2, firstPage...),
+		applicationListingPagePayload(2, [2]string{"23298741-6a5a-401a-a681-66f31fbdebe1", "commerce"}),
+	}}
+
+	resolved, resolveError := resolveApplicationID(context.Background(), mock, "commerce")
+
+	if resolveError != nil {
+		t.Fatalf("an exact match on a later page must still resolve: %v", resolveError)
+	}
+	if resolved != "23298741-6a5a-401a-a681-66f31fbdebe1" {
+		t.Fatalf("resolved to the wrong application: %q", resolved)
+	}
+	if len(mock.pagesAsked) != 2 || mock.pagesAsked[0] != 1 || mock.pagesAsked[1] != 2 {
+		t.Fatalf("the lookup must walk the pages in order, got %v", mock.pagesAsked)
+	}
+}
+
+func TestResolveApplicationIDReportsAnAmbiguousNameFoundAcrossPages(t *testing.T) {
+	// Ambiguity is only knowable once the whole listing has been read: two
+	// applications sharing a name can land on different pages, and picking
+	// the first one seen would act on an application the user did not name.
+	mock := &applicationLookupMock{pagePayloads: []json.RawMessage{
+		applicationListingPagePayload(2, [2]string{"aaaaaaaa-062c-4dd8-878a-cd0372e5fcf6", "commerce"}),
+		applicationListingPagePayload(2, [2]string{"23298741-6a5a-401a-a681-66f31fbdebe1", "commerce"}),
+	}}
+
+	_, resolveError := resolveApplicationID(context.Background(), mock, "commerce")
+
+	if resolveError == nil {
+		t.Fatal("a name shared across pages must be reported as ambiguous")
+	}
+	if !strings.Contains(resolveError.Error(), "aaaaaaaa-062c-4dd8-878a-cd0372e5fcf6") ||
+		!strings.Contains(resolveError.Error(), "23298741-6a5a-401a-a681-66f31fbdebe1") {
+		t.Fatalf("the error must list both candidate ids, got: %v", resolveError)
 	}
 }
 
@@ -179,32 +265,43 @@ func TestResolveApplicationIDReportsAnAmbiguousName(t *testing.T) {
 	}
 }
 
-func TestResolveApplicationIDFallsBackWhenLookupIsUnavailable(t *testing.T) {
-	// The listing is a convenience. If it fails, the reference still has to
-	// reach the API - failing here would break a working id because an
-	// unrelated endpoint was down.
-	mock := &applicationLookupMock{listError: errors.New("listing unavailable")}
+func TestResolveApplicationIDReportsAFailedLookupRatherThanPassingTheNameOn(t *testing.T) {
+	// Only a name gets this far - a uuid returned at the top - so passing the
+	// reference through on a failed listing would put a name in the backend's
+	// uuid-typed path parameter and reproduce the bare 500 this resolver
+	// exists to prevent. The safe fallback for an id is not the safe fallback
+	// for a name.
+	listingFailure := errors.New("listing unavailable")
+	mock := &applicationLookupMock{listError: listingFailure}
 
-	resolved, resolveError := resolveApplicationID(context.Background(), mock, "app-1")
+	resolved, resolveError := resolveApplicationID(context.Background(), mock, "commerce")
 
-	if resolveError != nil {
-		t.Fatalf("a failed lookup must not fail the command: %v", resolveError)
+	if resolveError == nil {
+		t.Fatalf("a failed lookup must be reported, not handed to the uuid-typed API as %q", resolved)
 	}
-	if resolved != "app-1" {
-		t.Fatalf("the reference must pass through unchanged, got %q", resolved)
+	if !errors.Is(resolveError, listingFailure) {
+		t.Fatalf("the underlying failure must survive for exit-code classification, got: %v", resolveError)
+	}
+	if !strings.Contains(resolveError.Error(), "commerce") {
+		t.Fatalf("the error must name the reference that could not be resolved, got: %v", resolveError)
+	}
+	if !strings.Contains(resolveError.Error(), "application list") ||
+		!strings.Contains(resolveError.Error(), "application id") {
+		t.Fatalf("the error must say what to do next, got: %v", resolveError)
 	}
 }
 
-func TestResolveApplicationIDFallsBackOnAMalformedListing(t *testing.T) {
+func TestResolveApplicationIDReportsAnUnreadableListing(t *testing.T) {
 	mock := &applicationLookupMock{listPayload: json.RawMessage(`"not-a-listing"`)}
 
-	resolved, resolveError := resolveApplicationID(context.Background(), mock, "app-1")
+	resolved, resolveError := resolveApplicationID(context.Background(), mock, "commerce")
 
-	if resolveError != nil {
-		t.Fatalf("an unreadable listing must not fail the command: %v", resolveError)
+	if resolveError == nil {
+		t.Fatalf("an unreadable listing must be reported, not handed to the uuid-typed API as %q", resolved)
 	}
-	if resolved != "app-1" {
-		t.Fatalf("the reference must pass through unchanged, got %q", resolved)
+	if !strings.Contains(resolveError.Error(), "application list") ||
+		!strings.Contains(resolveError.Error(), "application id") {
+		t.Fatalf("the error must say what to do next, got: %v", resolveError)
 	}
 }
 
@@ -238,5 +335,21 @@ func TestApplicationBranchesExplainsAnUnknownName(t *testing.T) {
 	}
 	if mock.branchesID != "" {
 		t.Fatalf("no branches request may be made for an unresolvable name, got %q", mock.branchesID)
+	}
+}
+
+func TestApplicationBranchesDoesNotSendANameWhenTheLookupFails(t *testing.T) {
+	// The end of the PLA-786 path: a name in the request path is what the
+	// backend answers 500 to, so a lookup that could not run must stop the
+	// command rather than send the name anyway.
+	mock := &applicationLookupMock{listError: errors.New("listing unavailable")}
+
+	_, executeError := runApplicationCommand(t, mock, "branches", "commerce")
+
+	if executeError == nil {
+		t.Fatal("a failed lookup must fail the command instead of sending a name to the API")
+	}
+	if mock.branchesID != "" {
+		t.Fatalf("a name must never reach the uuid-typed request path, got %q", mock.branchesID)
 	}
 }

--- a/cmd/application_resolve_test.go
+++ b/cmd/application_resolve_test.go
@@ -1,0 +1,242 @@
+package cmd
+
+// Regression cover for PLA-786 (ankra-83336): `application list` prints a
+// name column, so a name is what a user passes to the per-application
+// commands next - and before this it travelled to the backend's uuid-typed
+// lookup unchecked, which answered with a bare 500 Internal Server Error.
+// The application commands now resolve a name the way stack-profiles,
+// credentials and clusters already do.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// applicationLookupMock answers the application listing used to resolve a
+// name, and records the per-application calls that follow so a test can see
+// which id the command actually sent.
+type applicationLookupMock struct {
+	baseMock
+	listPayload json.RawMessage
+	listError   error
+	searched    string
+	pageSize    int
+	requested   bool
+
+	branchesID string
+}
+
+// ListApplicationsRaw records the paging the caller asked for and refuses
+// anything the real endpoint would reject, so a page size the API caps out is
+// a test failure here rather than a silent fallback in production (see the
+// stack-profiles lookup for the history).
+func (mock *applicationLookupMock) ListApplicationsRaw(_ context.Context, _ int, pageSize int, search string) (json.RawMessage, error) {
+	mock.requested = true
+	mock.pageSize = pageSize
+	mock.searched = search
+	if pageSize > maxApplicationLookupPageSize {
+		return nil, fmt.Errorf("list applications failed (422): page_size %d exceeds the API maximum of %d",
+			pageSize, maxApplicationLookupPageSize)
+	}
+	if mock.listError != nil {
+		return nil, mock.listError
+	}
+	return mock.listPayload, nil
+}
+
+func (mock *applicationLookupMock) GetApplicationBranches(_ context.Context, applicationID string) (json.RawMessage, error) {
+	mock.branchesID = applicationID
+	return json.RawMessage(`{"branches":[],"default_branch":null}`), nil
+}
+
+func applicationListingPayload(applications ...[2]string) json.RawMessage {
+	type item struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+	listing := struct {
+		Result []item `json:"result"`
+	}{Result: []item{}}
+	for _, application := range applications {
+		listing.Result = append(listing.Result, item{ID: application[0], Name: application[1]})
+	}
+	encoded, marshalError := json.Marshal(listing)
+	if marshalError != nil {
+		panic(marshalError)
+	}
+	return encoded
+}
+
+func TestResolveApplicationIDPassesAUUIDStraightThrough(t *testing.T) {
+	mock := &applicationLookupMock{listError: errors.New("listing must not be called for a uuid")}
+	const applicationID = "23298741-6a5a-401a-a681-66f31fbdebe1"
+
+	resolved, resolveError := resolveApplicationID(context.Background(), mock, applicationID)
+
+	if resolveError != nil {
+		t.Fatalf("a uuid must resolve to itself: %v", resolveError)
+	}
+	if resolved != applicationID {
+		t.Fatalf("expected %q, got %q", applicationID, resolved)
+	}
+	if mock.requested {
+		t.Fatal("resolving a uuid must not cost a listing round-trip")
+	}
+}
+
+func TestResolveApplicationIDResolvesAName(t *testing.T) {
+	mock := &applicationLookupMock{listPayload: applicationListingPayload(
+		[2]string{"3cd57498-062c-4dd8-878a-cd0372e5fcf6", "commerce-api"},
+		[2]string{"23298741-6a5a-401a-a681-66f31fbdebe1", "commerce"},
+	)}
+
+	resolved, resolveError := resolveApplicationID(context.Background(), mock, "commerce")
+
+	if resolveError != nil {
+		t.Fatalf("resolving a name printed by `list`: %v", resolveError)
+	}
+	if resolved != "23298741-6a5a-401a-a681-66f31fbdebe1" {
+		t.Fatalf("resolved to the wrong application: %q", resolved)
+	}
+	if !mock.requested {
+		t.Fatal("a non-uuid reference must consult the listing")
+	}
+	if mock.searched != "commerce" {
+		t.Fatalf("the name must be pushed down as the server-side search filter, got %q", mock.searched)
+	}
+	if mock.pageSize > maxApplicationLookupPageSize {
+		t.Fatalf("requested page_size %d exceeds the API maximum of %d", mock.pageSize, maxApplicationLookupPageSize)
+	}
+}
+
+func TestResolveApplicationIDPrefersTheExactNameOverACaseVariant(t *testing.T) {
+	mock := &applicationLookupMock{listPayload: applicationListingPayload(
+		[2]string{"aaaaaaaa-062c-4dd8-878a-cd0372e5fcf6", "Commerce"},
+		[2]string{"23298741-6a5a-401a-a681-66f31fbdebe1", "commerce"},
+	)}
+
+	resolved, resolveError := resolveApplicationID(context.Background(), mock, "commerce")
+
+	if resolveError != nil {
+		t.Fatalf("an exact name match must win outright: %v", resolveError)
+	}
+	if resolved != "23298741-6a5a-401a-a681-66f31fbdebe1" {
+		t.Fatalf("expected the exact match, got %q", resolved)
+	}
+}
+
+func TestResolveApplicationIDMatchesCaseInsensitivelyWhenNoExactMatchExists(t *testing.T) {
+	// The server-side search filter is already case-insensitive, so a user
+	// who types the case they remember should not be told the application
+	// does not exist when exactly one case variant does.
+	mock := &applicationLookupMock{listPayload: applicationListingPayload(
+		[2]string{"23298741-6a5a-401a-a681-66f31fbdebe1", "Commerce"},
+	)}
+
+	resolved, resolveError := resolveApplicationID(context.Background(), mock, "commerce")
+
+	if resolveError != nil {
+		t.Fatalf("a unique case-insensitive match must resolve: %v", resolveError)
+	}
+	if resolved != "23298741-6a5a-401a-a681-66f31fbdebe1" {
+		t.Fatalf("resolved to the wrong application: %q", resolved)
+	}
+}
+
+func TestResolveApplicationIDExplainsAnUnknownName(t *testing.T) {
+	mock := &applicationLookupMock{listPayload: applicationListingPayload(
+		[2]string{"23298741-6a5a-401a-a681-66f31fbdebe1", "commerce"},
+	)}
+
+	_, resolveError := resolveApplicationID(context.Background(), mock, "commerc")
+
+	if resolveError == nil {
+		t.Fatal("an unknown name must be reported, not passed to the API as a bogus uuid")
+	}
+	if !strings.Contains(resolveError.Error(), "application list") {
+		t.Fatalf("the error must point at how to find the right name, got: %v", resolveError)
+	}
+}
+
+func TestResolveApplicationIDReportsAnAmbiguousName(t *testing.T) {
+	mock := &applicationLookupMock{listPayload: applicationListingPayload(
+		[2]string{"aaaaaaaa-062c-4dd8-878a-cd0372e5fcf6", "commerce"},
+		[2]string{"23298741-6a5a-401a-a681-66f31fbdebe1", "commerce"},
+	)}
+
+	_, resolveError := resolveApplicationID(context.Background(), mock, "commerce")
+
+	if resolveError == nil {
+		t.Fatal("an ambiguous name must be reported, not resolved to an arbitrary application")
+	}
+	if !strings.Contains(resolveError.Error(), "aaaaaaaa-062c-4dd8-878a-cd0372e5fcf6") ||
+		!strings.Contains(resolveError.Error(), "23298741-6a5a-401a-a681-66f31fbdebe1") {
+		t.Fatalf("the error must list the candidate ids, got: %v", resolveError)
+	}
+}
+
+func TestResolveApplicationIDFallsBackWhenLookupIsUnavailable(t *testing.T) {
+	// The listing is a convenience. If it fails, the reference still has to
+	// reach the API - failing here would break a working id because an
+	// unrelated endpoint was down.
+	mock := &applicationLookupMock{listError: errors.New("listing unavailable")}
+
+	resolved, resolveError := resolveApplicationID(context.Background(), mock, "app-1")
+
+	if resolveError != nil {
+		t.Fatalf("a failed lookup must not fail the command: %v", resolveError)
+	}
+	if resolved != "app-1" {
+		t.Fatalf("the reference must pass through unchanged, got %q", resolved)
+	}
+}
+
+func TestResolveApplicationIDFallsBackOnAMalformedListing(t *testing.T) {
+	mock := &applicationLookupMock{listPayload: json.RawMessage(`"not-a-listing"`)}
+
+	resolved, resolveError := resolveApplicationID(context.Background(), mock, "app-1")
+
+	if resolveError != nil {
+		t.Fatalf("an unreadable listing must not fail the command: %v", resolveError)
+	}
+	if resolved != "app-1" {
+		t.Fatalf("the reference must pass through unchanged, got %q", resolved)
+	}
+}
+
+func TestApplicationBranchesResolvesAName(t *testing.T) {
+	// The customer-visible shape of PLA-786: `application branches commerce`
+	// answered 500 because "commerce" was interpolated into the request path.
+	mock := &applicationLookupMock{listPayload: applicationListingPayload(
+		[2]string{"23298741-6a5a-401a-a681-66f31fbdebe1", "commerce"},
+	)}
+
+	_, executeError := runApplicationCommand(t, mock, "branches", "commerce")
+
+	if executeError != nil {
+		t.Fatalf("branches by name: %v", executeError)
+	}
+	if mock.branchesID != "23298741-6a5a-401a-a681-66f31fbdebe1" {
+		t.Fatalf("the request must carry the resolved id, got %q", mock.branchesID)
+	}
+}
+
+func TestApplicationBranchesExplainsAnUnknownName(t *testing.T) {
+	mock := &applicationLookupMock{listPayload: applicationListingPayload()}
+
+	_, executeError := runApplicationCommand(t, mock, "branches", "no-such-app")
+
+	if executeError == nil {
+		t.Fatal("an unknown name must fail before any request is made")
+	}
+	if !strings.Contains(executeError.Error(), "application list") {
+		t.Fatalf("the error must point at `application list`, got: %v", executeError)
+	}
+	if mock.branchesID != "" {
+		t.Fatalf("no branches request may be made for an unresolvable name, got %q", mock.branchesID)
+	}
+}

--- a/cmd/application_resolve_test.go
+++ b/cmd/application_resolve_test.go
@@ -29,7 +29,8 @@ type applicationLookupMock struct {
 	requested    bool
 	pagesAsked   []int
 
-	branchesID string
+	branchesID       string
+	publishedAddonID string
 }
 
 // ListApplicationsRaw records the paging the caller asked for and refuses
@@ -60,6 +61,11 @@ func (mock *applicationLookupMock) ListApplicationsRaw(_ context.Context, page i
 func (mock *applicationLookupMock) GetApplicationBranches(_ context.Context, applicationID string) (json.RawMessage, error) {
 	mock.branchesID = applicationID
 	return json.RawMessage(`{"branches":[],"default_branch":null}`), nil
+}
+
+func (mock *applicationLookupMock) GetApplicationPublishedAddon(_ context.Context, applicationID string) (json.RawMessage, error) {
+	mock.publishedAddonID = applicationID
+	return json.RawMessage(`{"addon":null}`), nil
 }
 
 func applicationListingPayload(applications ...[2]string) json.RawMessage {
@@ -351,5 +357,65 @@ func TestApplicationBranchesDoesNotSendANameWhenTheLookupFails(t *testing.T) {
 	}
 	if mock.branchesID != "" {
 		t.Fatalf("a name must never reach the uuid-typed request path, got %q", mock.branchesID)
+	}
+}
+
+func TestResolveApplicationIDRefusesAnEmptyReference(t *testing.T) {
+	// An empty `search` is dropped from the query, so the filter disappears
+	// and the listing returns everything. An application whose definition
+	// carries no name then matches the empty reference exactly - so an unset
+	// shell variable could resolve to a real application and, on
+	// `delete --yes`, act on it.
+	for _, reference := range []string{"", "   "} {
+		mock := &applicationLookupMock{listPayload: applicationListingPayload(
+			[2]string{"23298741-6a5a-401a-a681-66f31fbdebe1", ""},
+		)}
+
+		resolved, resolveError := resolveApplicationID(context.Background(), mock, reference)
+
+		if resolveError == nil {
+			t.Fatalf("an empty reference (%q) must be refused, it resolved to %q", reference, resolved)
+		}
+		if mock.requested {
+			t.Fatalf("an empty reference (%q) must not run an unfiltered listing", reference)
+		}
+		if exitCodeFor(resolveError) != exitUsage {
+			t.Fatalf("an empty reference is a usage error, got exit code %d for %q",
+				exitCodeFor(resolveError), reference)
+		}
+	}
+}
+
+func TestApplicationBranchesRefusesAnEmptyArgument(t *testing.T) {
+	mock := &applicationLookupMock{listPayload: applicationListingPayload(
+		[2]string{"23298741-6a5a-401a-a681-66f31fbdebe1", ""},
+	)}
+
+	_, executeError := runApplicationCommand(t, mock, "branches", "")
+
+	if executeError == nil {
+		t.Fatal("an empty argument must fail before any request is made")
+	}
+	if mock.branchesID != "" {
+		t.Fatalf("no request may be made for an empty argument, got %q", mock.branchesID)
+	}
+}
+
+func TestApplicationPublishedAddonResolvesAName(t *testing.T) {
+	// published-addon takes <application-id> but has no resolution hunk of its
+	// own: it is built by newApplicationSubresourceCommand, so it inherits the
+	// lookup from the shared factory. Pin that down, because reading the diff
+	// alone cannot tell the difference between "inherited" and "missed".
+	mock := &applicationLookupMock{listPayload: applicationListingPayload(
+		[2]string{"23298741-6a5a-401a-a681-66f31fbdebe1", "commerce"},
+	)}
+
+	_, executeError := runApplicationCommand(t, mock, "published-addon", "commerce")
+
+	if executeError != nil {
+		t.Fatalf("published-addon by name: %v", executeError)
+	}
+	if mock.publishedAddonID != "23298741-6a5a-401a-a681-66f31fbdebe1" {
+		t.Fatalf("the request must carry the resolved id, got %q", mock.publishedAddonID)
 	}
 }

--- a/cmd/application_resolve_test.go
+++ b/cmd/application_resolve_test.go
@@ -419,3 +419,71 @@ func TestApplicationPublishedAddonResolvesAName(t *testing.T) {
 		t.Fatalf("the request must carry the resolved id, got %q", mock.publishedAddonID)
 	}
 }
+
+func TestResolveApplicationIDClassifiesAnUnknownNameAsNotFound(t *testing.T) {
+	// An id that does not exist reaches the API and comes back 404, which
+	// exitCodeFor maps to exitNotFound. A name that does not exist has to
+	// tell a script the same thing rather than the generic failure code.
+	mock := &applicationLookupMock{listPayload: applicationListingPayload(
+		[2]string{"23298741-6a5a-401a-a681-66f31fbdebe1", "commerce"},
+	)}
+
+	_, resolveError := resolveApplicationID(context.Background(), mock, "commerc")
+
+	if resolveError == nil {
+		t.Fatal("an unknown name must be reported")
+	}
+	if exitCodeFor(resolveError) != exitNotFound {
+		t.Fatalf("an unknown name is a not-found, got exit code %d", exitCodeFor(resolveError))
+	}
+}
+
+func TestResolveApplicationIDClassifiesAnAmbiguousNameAsAUsageError(t *testing.T) {
+	mock := &applicationLookupMock{listPayload: applicationListingPayload(
+		[2]string{"aaaaaaaa-062c-4dd8-878a-cd0372e5fcf6", "commerce"},
+		[2]string{"23298741-6a5a-401a-a681-66f31fbdebe1", "commerce"},
+	)}
+
+	_, resolveError := resolveApplicationID(context.Background(), mock, "commerce")
+
+	if resolveError == nil {
+		t.Fatal("an ambiguous name must be reported")
+	}
+	if exitCodeFor(resolveError) != exitUsage {
+		t.Fatalf("an ambiguous name is a usage error, got exit code %d", exitCodeFor(resolveError))
+	}
+}
+
+func TestApplicationEnvSecretsChecksTheKeyBeforeResolvingTheApplication(t *testing.T) {
+	// A malformed key is a purely local mistake. Resolving the name first
+	// would spend a listing round-trip only to fail on something that never
+	// needed the network.
+	// The flags differ per verb: `set` takes --value and has no --yes, so
+	// passing the wrong one makes cobra fail on an unknown flag before the
+	// command body runs and the test would pass without proving anything.
+	for _, testCase := range []struct {
+		verb      string
+		arguments []string
+	}{
+		{verb: "set", arguments: []string{"--value", "v"}},
+		{verb: "delete", arguments: []string{"--yes"}},
+	} {
+		mock := &applicationLookupMock{listPayload: applicationListingPayload(
+			[2]string{"23298741-6a5a-401a-a681-66f31fbdebe1", "commerce"},
+		)}
+		arguments := append([]string{"env-secrets", testCase.verb, "commerce", "bad key"},
+			testCase.arguments...)
+
+		_, executeError := runApplicationCommand(t, mock, arguments...)
+
+		if executeError == nil {
+			t.Fatalf("env-secrets %s must reject a malformed key", testCase.verb)
+		}
+		if strings.Contains(executeError.Error(), "unknown flag") {
+			t.Fatalf("env-secrets %s never reached the command body: %v", testCase.verb, executeError)
+		}
+		if mock.requested {
+			t.Fatalf("env-secrets %s resolved the application before checking the key", testCase.verb)
+		}
+	}
+}

--- a/cmd/application_resolve_test.go
+++ b/cmd/application_resolve_test.go
@@ -23,11 +23,14 @@ type applicationLookupMock struct {
 	baseMock
 	listPayload  json.RawMessage
 	pagePayloads []json.RawMessage
-	listError    error
-	searched     string
-	pageSize     int
-	requested    bool
-	pagesAsked   []int
+	// endless makes every page claim more pages are waiting, so the walk runs
+	// into maxApplicationLookupPages instead of exhausting the listing.
+	endless    bool
+	listError  error
+	searched   string
+	pageSize   int
+	requested  bool
+	pagesAsked []int
 
 	branchesID       string
 	publishedAddonID string
@@ -48,6 +51,14 @@ func (mock *applicationLookupMock) ListApplicationsRaw(_ context.Context, page i
 	}
 	if mock.listError != nil {
 		return nil, mock.listError
+	}
+	if mock.endless {
+		if page == 1 {
+			return applicationListingPagePayload(9999,
+				[2]string{"23298741-6a5a-401a-a681-66f31fbdebe1", "commerce"}), nil
+		}
+		return applicationListingPagePayload(9999,
+			[2]string{"3cd57498-062c-4dd8-878a-cd0372e5fcf6", "commerce-filler"}), nil
 	}
 	if len(mock.pagePayloads) > 0 {
 		if page < 1 || page > len(mock.pagePayloads) {
@@ -485,5 +496,27 @@ func TestApplicationEnvSecretsChecksTheKeyBeforeResolvingTheApplication(t *testi
 		if mock.requested {
 			t.Fatalf("env-secrets %s resolved the application before checking the key", testCase.verb)
 		}
+	}
+}
+
+func TestResolveApplicationIDRefusesToAnswerFromATruncatedListing(t *testing.T) {
+	// Hitting the page cap means the listing was only partly read. Even with a
+	// unique exact match already in hand, a second application sharing the
+	// name could sit past the cap - so the match is not provably unique and
+	// answering would be guessing, exactly what the failed-listing case
+	// refuses to do.
+	mock := &applicationLookupMock{endless: true}
+
+	resolved, resolveError := resolveApplicationID(context.Background(), mock, "commerce")
+
+	if resolveError == nil {
+		t.Fatalf("a truncated listing must not be answered from, it resolved to %q", resolved)
+	}
+	if len(mock.pagesAsked) != maxApplicationLookupPages {
+		t.Fatalf("the walk must stop at the cap, asked for %d pages", len(mock.pagesAsked))
+	}
+	if !strings.Contains(resolveError.Error(), "application list") ||
+		!strings.Contains(resolveError.Error(), "application id") {
+		t.Fatalf("the error must say what to do next, got: %v", resolveError)
 	}
 }

--- a/cmd/application_resources.go
+++ b/cmd/application_resources.go
@@ -63,7 +63,11 @@ func newApplicationSubresourceCommand(name string, short string, invoke applicat
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
 				return formatError
 			}
-			payload, invokeError := invoke(command, strings.TrimSpace(arguments[0]))
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			payload, invokeError := invoke(command, applicationID)
 			if invokeError != nil {
 				return invokeError
 			}
@@ -143,11 +147,14 @@ func newApplicationDeleteCommand() *cobra.Command {
 			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
 				return formatError
 			}
-			applicationID := strings.TrimSpace(arguments[0])
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
 			yes, _ := command.Flags().GetBool("yes")
 			if confirmError := confirmPrompt(
 				command.InOrStdin(), command.OutOrStdout(),
-				fmt.Sprintf("Delete application %q? This removes its platform record and cannot be undone! [y/N]: ", applicationID),
+				fmt.Sprintf("Delete application %q? This removes its platform record and cannot be undone! [y/N]: ", strings.TrimSpace(arguments[0])),
 				yes,
 			); confirmError != nil {
 				return confirmError
@@ -201,7 +208,11 @@ func newApplicationJobsCommand() *cobra.Command {
 			}
 			page, _ := command.Flags().GetInt("page")
 			pageSize, _ := command.Flags().GetInt("page-size")
-			payload, jobsError := apiClient.GetApplicationJobs(command.Context(), strings.TrimSpace(arguments[0]), page, pageSize)
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			payload, jobsError := apiClient.GetApplicationJobs(command.Context(), applicationID, page, pageSize)
 			if jobsError != nil {
 				return jobsError
 			}
@@ -245,7 +256,11 @@ deploy inputs declared by the application's chart.`,
 			if parseError != nil {
 				return withExitCode(exitUsage, parseError)
 			}
-			payload, deployError := apiClient.DeployApplication(command.Context(), strings.TrimSpace(arguments[0]),
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			payload, deployError := apiClient.DeployApplication(command.Context(), applicationID,
 				client.DeployApplicationRequest{
 					ClusterID:  clusterID,
 					Namespace:  strings.TrimSpace(namespace),
@@ -280,7 +295,11 @@ func newApplicationPlatformCommand() *cobra.Command {
 			if clusterID == "" {
 				return withExitCode(exitUsage, errors.New("--cluster is required"))
 			}
-			payload, platformError := apiClient.GetApplicationExistingPlatform(command.Context(), strings.TrimSpace(arguments[0]), clusterID)
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			payload, platformError := apiClient.GetApplicationExistingPlatform(command.Context(), applicationID, clusterID)
 			if platformError != nil {
 				return platformError
 			}
@@ -304,7 +323,11 @@ func newApplicationWorkflowRunsCommand() *cobra.Command {
 			status, _ := command.Flags().GetString("status")
 			page, _ := command.Flags().GetInt("page")
 			pageSize, _ := command.Flags().GetInt("page-size")
-			payload, runsError := apiClient.GetApplicationWorkflowRuns(command.Context(), strings.TrimSpace(arguments[0]),
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			payload, runsError := apiClient.GetApplicationWorkflowRuns(command.Context(), applicationID,
 				strings.TrimSpace(status), page, pageSize)
 			if runsError != nil {
 				return runsError
@@ -332,7 +355,11 @@ func newApplicationWorkflowRunJobsCommand() *cobra.Command {
 			if parseError != nil {
 				return parseError
 			}
-			payload, jobsError := apiClient.GetApplicationWorkflowRunJobs(command.Context(), strings.TrimSpace(arguments[0]), runID)
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			payload, jobsError := apiClient.GetApplicationWorkflowRunJobs(command.Context(), applicationID, runID)
 			if jobsError != nil {
 				return jobsError
 			}
@@ -356,7 +383,11 @@ func newApplicationRerunWorkflowCommand() *cobra.Command {
 			if parseError != nil {
 				return parseError
 			}
-			payload, rerunError := apiClient.RerunApplicationWorkflowRun(command.Context(), strings.TrimSpace(arguments[0]), runID)
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			payload, rerunError := apiClient.RerunApplicationWorkflowRun(command.Context(), applicationID, runID)
 			if rerunError != nil {
 				return rerunError
 			}
@@ -377,7 +408,11 @@ func newApplicationPullRequestReviewsCommand() *cobra.Command {
 				return formatError
 			}
 			limit, _ := command.Flags().GetInt("limit")
-			payload, reviewsError := apiClient.GetApplicationPullRequestReviews(command.Context(), strings.TrimSpace(arguments[0]), limit)
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			payload, reviewsError := apiClient.GetApplicationPullRequestReviews(command.Context(), applicationID, limit)
 			if reviewsError != nil {
 				return reviewsError
 			}
@@ -414,7 +449,11 @@ uploaded. Use --delete to remove a tracked path.`,
 				return parseError
 			}
 			commitMessage, _ := command.Flags().GetString("message")
-			payload, filesError := apiClient.UpdateApplicationFiles(command.Context(), strings.TrimSpace(arguments[0]),
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			payload, filesError := apiClient.UpdateApplicationFiles(command.Context(), applicationID,
 				client.UpdateApplicationFilesRequest{
 					Files:         files,
 					DeletedPaths:  deletedPaths,

--- a/cmd/application_resources_test.go
+++ b/cmd/application_resources_test.go
@@ -13,6 +13,12 @@ import (
 	"ankra/internal/client"
 )
 
+// testApplicationID is the application id the per-command tests pass where a
+// command takes <application-id>. It is a uuid because every id the platform
+// issues is one, so these tests exercise the command itself rather than the
+// name lookup, which a uuid short-circuits without a listing round-trip.
+const testApplicationID = "b7f4c1de-2a03-4d61-9f8e-51c0a6d3e742"
+
 type applicationResourceMock struct {
 	baseMock
 	payload json.RawMessage
@@ -123,12 +129,12 @@ func TestApplicationResourceCommandsRegistered(t *testing.T) {
 
 func TestApplicationSubresourceRendersJSON(t *testing.T) {
 	mockClient := &applicationResourceMock{payload: json.RawMessage(`{"deployments":[{"cluster_id":"c1"}]}`)}
-	output, executeError := runApplicationCommand(t, mockClient, "deployments", "app-1")
+	output, executeError := runApplicationCommand(t, mockClient, "deployments", testApplicationID)
 	if executeError != nil {
 		t.Fatalf("deployments error = %v", executeError)
 	}
-	if mockClient.deploymentsAppID != "app-1" {
-		t.Errorf("application id = %q, want app-1", mockClient.deploymentsAppID)
+	if mockClient.deploymentsAppID != testApplicationID {
+		t.Errorf("application id = %q, want %s", mockClient.deploymentsAppID, testApplicationID)
 	}
 	if !strings.Contains(output, "\"cluster_id\": \"c1\"") {
 		t.Errorf("output is not indented JSON: %q", output)
@@ -137,7 +143,7 @@ func TestApplicationSubresourceRendersJSON(t *testing.T) {
 
 func TestApplicationSubresourceRendersYAML(t *testing.T) {
 	mockClient := &applicationResourceMock{payload: json.RawMessage(`{"ready":true}`)}
-	output, executeError := runApplicationCommand(t, mockClient, "deployments", "app-1", "-o", "yaml")
+	output, executeError := runApplicationCommand(t, mockClient, "deployments", testApplicationID, "-o", "yaml")
 	if executeError != nil {
 		t.Fatalf("deployments error = %v", executeError)
 	}
@@ -148,7 +154,7 @@ func TestApplicationSubresourceRendersYAML(t *testing.T) {
 
 func TestApplicationDeployRequiresCluster(t *testing.T) {
 	mockClient := &applicationResourceMock{}
-	_, executeError := runApplicationCommand(t, mockClient, "deploy", "app-1")
+	_, executeError := runApplicationCommand(t, mockClient, "deploy", testApplicationID)
 	if executeError == nil {
 		t.Fatal("expected missing --cluster to fail")
 	}
@@ -163,7 +169,7 @@ func TestApplicationDeployRequiresCluster(t *testing.T) {
 func TestApplicationDeployMapsRequest(t *testing.T) {
 	mockClient := &applicationResourceMock{payload: json.RawMessage(`{"status":"queued"}`)}
 	_, executeError := runApplicationCommand(t, mockClient,
-		"deploy", "app-1",
+		"deploy", testApplicationID,
 		"--cluster", "cluster-1",
 		"--namespace", "prod",
 		"--mode", "high_availability",
@@ -187,7 +193,7 @@ func TestApplicationDeployMapsRequest(t *testing.T) {
 
 func TestApplicationDeployRejectsInvalidMode(t *testing.T) {
 	mockClient := &applicationResourceMock{}
-	_, executeError := runApplicationCommand(t, mockClient, "deploy", "app-1", "--cluster", "c1", "--mode", "turbo")
+	_, executeError := runApplicationCommand(t, mockClient, "deploy", testApplicationID, "--cluster", "c1", "--mode", "turbo")
 	if exitCodeFor(executeError) != exitUsage {
 		t.Errorf("exit code = %d, want %d: %v", exitCodeFor(executeError), exitUsage, executeError)
 	}
@@ -198,7 +204,7 @@ func TestApplicationDeployRejectsInvalidMode(t *testing.T) {
 
 func TestApplicationDemoDeployOnlySendsSetFlags(t *testing.T) {
 	mockClient := &applicationResourceMock{payload: json.RawMessage(`{"workspace_id":"w1"}`)}
-	_, executeError := runApplicationCommand(t, mockClient, "demo", "deploy", "app-1", "--branch", "feature/x")
+	_, executeError := runApplicationCommand(t, mockClient, "demo", "deploy", testApplicationID, "--branch", "feature/x")
 	if executeError != nil {
 		t.Fatalf("demo deploy error = %v", executeError)
 	}
@@ -221,7 +227,7 @@ func TestApplicationFilesReadsLocalFile(t *testing.T) {
 	}
 	mockClient := &applicationResourceMock{payload: json.RawMessage(`{"committed":true}`)}
 	_, executeError := runApplicationCommand(t, mockClient,
-		"files", "app-1",
+		"files", testApplicationID,
 		"--file", "Dockerfile="+localPath,
 		"--delete", "old/path.yaml",
 		"--message", "Update image",
@@ -247,7 +253,7 @@ func TestApplicationFilesReadsLocalFile(t *testing.T) {
 func TestApplicationFilesMissingLocalFile(t *testing.T) {
 	mockClient := &applicationResourceMock{}
 	_, executeError := runApplicationCommand(t, mockClient,
-		"files", "app-1",
+		"files", testApplicationID,
 		"--file", "Dockerfile="+filepath.Join(t.TempDir(), "missing"),
 	)
 	if exitCodeFor(executeError) != exitNotFound {
@@ -260,7 +266,7 @@ func TestApplicationFilesMissingLocalFile(t *testing.T) {
 
 func TestApplicationFilesRequiresChange(t *testing.T) {
 	mockClient := &applicationResourceMock{}
-	_, executeError := runApplicationCommand(t, mockClient, "files", "app-1")
+	_, executeError := runApplicationCommand(t, mockClient, "files", testApplicationID)
 	if exitCodeFor(executeError) != exitUsage {
 		t.Errorf("exit code = %d, want %d: %v", exitCodeFor(executeError), exitUsage, executeError)
 	}
@@ -268,7 +274,7 @@ func TestApplicationFilesRequiresChange(t *testing.T) {
 
 func TestApplicationWorkflowRunJobsParsesRunID(t *testing.T) {
 	mockClient := &applicationResourceMock{payload: json.RawMessage(`{"jobs":[]}`)}
-	_, executeError := runApplicationCommand(t, mockClient, "workflow-run-jobs", "app-1", "12345")
+	_, executeError := runApplicationCommand(t, mockClient, "workflow-run-jobs", testApplicationID, "12345")
 	if executeError != nil {
 		t.Fatalf("workflow-run-jobs error = %v", executeError)
 	}
@@ -279,7 +285,7 @@ func TestApplicationWorkflowRunJobsParsesRunID(t *testing.T) {
 
 func TestApplicationWorkflowRunJobsRejectsNonNumericRunID(t *testing.T) {
 	mockClient := &applicationResourceMock{}
-	_, executeError := runApplicationCommand(t, mockClient, "workflow-run-jobs", "app-1", "not-a-number")
+	_, executeError := runApplicationCommand(t, mockClient, "workflow-run-jobs", testApplicationID, "not-a-number")
 	if exitCodeFor(executeError) != exitUsage {
 		t.Errorf("exit code = %d, want %d: %v", exitCodeFor(executeError), exitUsage, executeError)
 	}
@@ -287,7 +293,7 @@ func TestApplicationWorkflowRunJobsRejectsNonNumericRunID(t *testing.T) {
 
 func TestApplicationRejectsInvalidOutputBeforeRequest(t *testing.T) {
 	mockClient := &applicationResourceMock{fail: errors.New("should not be called")}
-	_, executeError := runApplicationCommand(t, mockClient, "deployments", "app-1", "-o", "xml")
+	_, executeError := runApplicationCommand(t, mockClient, "deployments", testApplicationID, "-o", "xml")
 	if executeError == nil {
 		t.Fatal("expected invalid output format to fail")
 	}
@@ -298,7 +304,7 @@ func TestApplicationRejectsInvalidOutputBeforeRequest(t *testing.T) {
 
 func TestApplicationDelete_DeclineDoesNotDelete(t *testing.T) {
 	mockClient := &applicationResourceMock{payload: json.RawMessage(`{"success":true}`)}
-	_, executeError := runApplicationCommandWithInput(t, mockClient, "n\n", "delete", "app-1")
+	_, executeError := runApplicationCommandWithInput(t, mockClient, "n\n", "delete", testApplicationID)
 	if !errors.Is(executeError, errCancelled) {
 		t.Fatalf("expected errCancelled on decline, got %v", executeError)
 	}
@@ -312,7 +318,7 @@ func TestApplicationDelete_DeclineDoesNotDelete(t *testing.T) {
 
 func TestApplicationDelete_YesFlagProceeds(t *testing.T) {
 	mockClient := &applicationResourceMock{payload: json.RawMessage(`{"success":true}`)}
-	_, executeError := runApplicationCommandWithInput(t, mockClient, "", "delete", "app-1", "--yes")
+	_, executeError := runApplicationCommandWithInput(t, mockClient, "", "delete", testApplicationID, "--yes")
 	if executeError != nil {
 		t.Fatalf("expected success with --yes, got %v", executeError)
 	}
@@ -323,7 +329,7 @@ func TestApplicationDelete_YesFlagProceeds(t *testing.T) {
 
 func TestApplicationDelete_PipedYesProceeds(t *testing.T) {
 	mockClient := &applicationResourceMock{payload: json.RawMessage(`{"success":true}`)}
-	_, executeError := runApplicationCommandWithInput(t, mockClient, "y\n", "delete", "app-1")
+	_, executeError := runApplicationCommandWithInput(t, mockClient, "y\n", "delete", testApplicationID)
 	if executeError != nil {
 		t.Fatalf("expected success with piped y, got %v", executeError)
 	}


### PR DESCRIPTION
## What

Every per-application command (`application branches`, `demo list`, `demo config get`, `deploy`, `env-secrets`, `registry`, `ai-config`, `auto-deploy`, `publish-addon`, `published-addon`, …) now accepts the application **name** where it takes `<application-id>`, resolved through the same server-side search `application list` uses.

## Why

Customer report (Linear PLA-786 / Ankra #1082, org Smartoptics): `application demo list commerce`, `application demo config get commerce`, and `application branches commerce` all answered a raw **500 Internal Server Error**. `application list` prints names, so a name is the obvious thing to pass — but every command interpolated the raw argument into the URL path, and the backend binds it against a uuid column (Postgres 22P02 → 500, no hint that an id was required).

This is the same shape as the `cluster validate --cluster <name>` bug, and the fix mirrors the existing resolvers (`resolveStackProfileID`, `resolveCredentialID`, `resolveClusterID`):

- a uuid passes straight through with no extra round-trip;
- a name is pushed down as the server-side `search` filter and matched exactly (unique case-insensitive match as fallback, since the server filter is already case-insensitive), paging until the listing is exhausted;
- an unknown name errors with a pointer at `ankra application list`, and exits 3;
- a name two applications share lists the candidate ids instead of picking one, and exits 2;
- an empty argument is refused as a usage error;
- a lookup that cannot run reports that, rather than sending the name on to be rejected.

`application manifest-addon *` is untouched — those commands take an add-on id, not an application id.

The backend half (return a 4xx instead of 500 when a non-uuid reaches the applications API) is tracked separately as bead `ankra-gb2l2`.

## Review findings

Nine findings across four rounds, all answered inline. Each was checked against the actual endpoint (`appsapi.serveListApplications`, `applications.Dependencies.List`) rather than reasoned about; seven were real and fixed, one was declined with reasons, one was a false positive answered with a test.

**Round 1 (abebe42) — fixed in 93cc71f**

1. *Single-page lookup can miss an exact match* — real. `page_size` is validated with `queryBoundedInt(…, 1, 100)`, which **rejects** an oversized value with a 422 rather than clamping, and the filter is `definition->>'name' ILIKE '%…%'` ordered by `created_at DESC`. The lookup now pages with the repo's standard `TotalPages <= page || len(Result) == 0` idiom, which also made ambiguity detection correct across page boundaries.

2. *Fallback on listing failure reintroduces the 500 for names* — real, and worse than `[low]`. No uuid can reach that branch: `looksLikeUUID` returns at the top and accepts every canonical form in upper, lower and mixed hex, which is the only shape the platform issues (`ApplicationItem.ID` is `uuid.UUID.String()`). The set the pass-through protected was provably empty; the only value it could forward was a name, into the uuid-typed path parameter — the exact 500 this PR exists to eliminate. The same trap is recorded in `maxProfileLookupPageSize`'s comment. Both cases are split now, and the cause is wrapped so an unauthorised or forbidden listing still classifies into its own exit code.

**Round 2 (93cc71f) — fixed in 5e613e4**

3. *Empty reference falls through to an unfiltered search* — real, via a different mechanism than described. An empty `search` is dropped from the query rather than becoming `ILIKE '%%'`, so the filter disappears and the walk pages the whole organisation; and because `buildApplicationItem` yields `Name == ""` for a definition with no name key, such an application matches an empty reference **exactly** — so `delete --yes` with an unset variable could act on it. Now refused as a usage error before any request.

4. *published-addon appears not to have been migrated* — false positive. It is built by `newApplicationSubresourceCommand`, and that shared factory is migrated in this PR, so it resolves names like `branches` does. A regression test now proves it rather than leaving it to diff-reading.

**Round 3 (5e613e4) — fixed in edae8a8**

5. *Full page walk after a unique early match* — acknowledged, deliberately unchanged; stopping early would break ambiguity detection. The walk is bounded by how many applications *match the reference as a substring*, not by org size, so a large org with unrelated applications still costs one request.

6. *Name lookup runs before destructive confirmation* — declined with reasons. Resolving first means an unknown or ambiguous name is rejected **before** the irreversible-delete prompt appears, rather than after the user has already confirmed.

7. *Name resolution runs before local key validation* — real and fixed. `env-secrets set`/`delete` now validate the secret key first.

8. *Unknown/ambiguous name errors carry no exit-code classification* — real and fixed. An id that does not exist comes back 404 and maps to `exitNotFound`; a name that does not exist was exiting with the generic code, so the same mistake answered differently depending on which form was typed. Unknown name is now `exitNotFound`, ambiguous is `exitUsage`.

**Round 4 (edae8a8) — fixed in 377d302**

9. *Page-cap truncation is silent* — real, and the same mistake as finding 2: answering confidently from data known to be incomplete. A walk that ran into `maxApplicationLookupPages` fell through to the same answers as one that had read the listing to the end, so a lone exact match was not provably unique (the ambiguity guard failed open) and a not-found was not provably absent. The cap case now reports through the same `applicationLookupFailure` path.

A side effect worth recording: the per-command application tests passed `"app-1"` as `<application-id>`, so since the resolver first landed they had **all** been running through the failure pass-through on every assertion — 42 went red when it was removed. They now pass a uuid, which is what a real application id is.

`resolveStackProfileID` still has both round-1 defects (same pass-through, same single-page lookup, and its search is a substring `ILIKE` too). Filed as `ankra-qqakp` rather than widening this PR.

## Testing

- `go vet ./...` and `go test -race -count=1 -timeout=120s ./...` green locally; `golangci-lint` is not installed on this machine, so the lint gate was covered by CI's `lint-build` workflow only.
- Regression tests in `cmd/application_resolve_test.go`: uuid passthrough (no round-trip), search push-down and page-size cap, single-page listings costing exactly one request, paging to an exact match on a later page, ambiguity across pages, exact-over-case-variant, case-insensitive fallback, unknown/ambiguous/empty errors with their exit codes, failed-lookup and unreadable-listing errors (cause preserved), `published-addon` and `branches` by name, no request on an empty argument or a failed lookup, and `env-secrets` key-before-resolve ordering for both verbs.
- **Every new test was verified to fail without its fix** by neutering the fix, confirming a test actually ran (`=== RUN` present — a `-run` pattern that matches nothing exits 0 and proves nothing), and watching it go red. Highlights: the paging neuter reproduces the customer symptom verbatim (`no application named "commerce"`); the pass-through neuter shows the resolver returning `"commerce"`; the empty-guard neuter shows an empty reference resolving to a real application id; the factory neuter shows `"commerce"` reaching the request path for `published-addon`. Two neuter attempts were caught not proving what they appeared to: one test was passing for the wrong reason (a shared `--yes` flag that `env-secrets set` does not have, so cobra failed before the command body ran), and one neuter did not compile, so the test never ran and reported nothing rather than red. Both were redone and re-verified.

Bead: ankra-83336
Linear: https://linear.app/ankra/issue/PLA-786

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Merge note: one commit merged without a bot review

`377d302` (the round-4 fix, "refuse to answer a name lookup from a truncated listing") was **merged without an `ankra-platform[bot]` review**.

The bot reviewed every earlier push within about two minutes (`abebe42`→15:01:53Z, `93cc71f`→16:36:31Z, `5e613e4`→16:39:18Z/16:43:22Z, `edae8a8`→16:55:59Z). Its last review on this PR is **16:55:59Z**, which predates `377d302` at **17:02:09Z**. A further bounded wait produced nothing, so at merge time the final commit had been sitting unreviewed for ~55 minutes.

Naming it because "no new findings" and "the bot never looked" are indistinguishable from the outside, and recording the sha is the only thing that tells them apart later (`ankra-sepie`).

What stands behind `377d302` instead: the change is covered by `TestResolveApplicationIDRefusesToAnswerFromATruncatedListing`, which was independently verified to fail without it — the neuter (forcing the page walk to stop after page one) makes the resolver answer `"23298741-6a5a-401a-a681-66f31fbdebe1"` from a listing it had not read to the end. Details in the verification comment on this PR. CI (`lint-test-build`) is green on `377d302` itself.
