### PR TITLE
feat(org): reach the preview settings from the CLI, and stop 'org domain' reading as the only custom domain (ankra-ymkj8.18, ankra-ymkj8.20)

### DIFF
--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -595,6 +595,15 @@ func (m baseMock) SetOrganisationDomain(ctx context.Context, rootDomain string) 
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) GetOrganisationPreviewSettings(ctx context.Context) (*client.OrganisationPreviewSettings, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) UpdateOrganisationPreviewSettings(ctx context.Context,
+	changes map[string]*string) (*client.OrganisationPreviewSettings, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) MCPCatalog(ctx context.Context) (*client.MCPCatalogResult, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/org_ai_environment.go
+++ b/cmd/org_ai_environment.go
@@ -166,12 +166,15 @@ func renderOrganisationPreviewSettings(cmd *cobra.Command,
 	out := cmd.OutOrStdout()
 	if settings.DemoBaseDomain == "" {
 		_, _ = fmt.Fprintln(out, "Preview domain:    (none - demos use the staging cluster's Ankra subzone)")
-		return nil
+	} else {
+		_, _ = fmt.Fprintf(out, "Preview domain:    %s\n", settings.DemoBaseDomain)
+		_, _ = fmt.Fprintf(out, "Ingress class:     %s\n", orEmptyDefault(settings.DemoIngressClassName))
+		_, _ = fmt.Fprintf(out, "TLS secret:        %s\n", orEmptyDefault(settings.DemoTLSSecretName))
+		_, _ = fmt.Fprintf(out, "Certificate issuer:%s\n", " "+orEmptyDefault(settings.DemoCertIssuerName))
 	}
-	_, _ = fmt.Fprintf(out, "Preview domain:    %s\n", settings.DemoBaseDomain)
-	_, _ = fmt.Fprintf(out, "Ingress class:     %s\n", orEmptyDefault(settings.DemoIngressClassName))
-	_, _ = fmt.Fprintf(out, "TLS secret:        %s\n", orEmptyDefault(settings.DemoTLSSecretName))
-	_, _ = fmt.Fprintf(out, "Certificate issuer:%s\n", " "+orEmptyDefault(settings.DemoCertIssuerName))
+	// Printed whatever the fields say. The backend decides when previews
+	// lack TLS, and tying the display to a field here would put this command
+	// back in the business of second-guessing that.
 	if settings.PreviewTLSWarning != "" {
 		_, _ = fmt.Fprintf(out, "\n%s\n", settings.PreviewTLSWarning)
 	}

--- a/cmd/org_ai_environment.go
+++ b/cmd/org_ai_environment.go
@@ -1,0 +1,197 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+var orgAIEnvironmentCmd = &cobra.Command{
+	Use:   "ai-environment",
+	Short: "Show or change where PR demos are published",
+	Long: `Show or change the organisation's preview settings - where an on-demand
+demo or PR preview is published, and how it terminates TLS.
+
+  ankra org ai-environment get
+  ankra org ai-environment set --demo-base-domain previews.example.com
+  ankra org ai-environment set --demo-cert-issuer letsencrypt-prod
+  ankra org ai-environment set --demo-base-domain ""
+
+THE PREVIEW DOMAIN IS NOT THE ROOT DOMAIN
+
+Both settings live on the same portal screen (AI > Settings > Workspaces) and
+they are easy to confuse, so:
+
+  --demo-base-domain    "Preview domain". A wildcard zone YOU point at the
+  (this command)        staging cluster's ingress. Demos are published at
+                        <namespace>.<that domain>. Ankra writes nothing in it
+                        and nothing else changes. One field, no blockers.
+
+  ankra org domain      "Custom Ankra domain". The root every Ankra-generated
+                        hostname nests under. Ankra delegates a subzone in it,
+                        and the switch is refused while cluster DNS zones or
+                        DNS records still live under the old root.
+
+If you only want demos on your own domain, this command is the one you want.
+
+TLS ON YOUR OWN PREVIEW DOMAIN
+
+With a demo base domain set, Ankra will not order a certificate unless you say
+how. Give it one of:
+
+  --demo-tls-secret     An existing secret on the staging cluster holding a
+                        wildcard certificate for the preview domain.
+  --demo-cert-issuer    A cert-manager ClusterIssuer. Ankra annotates each demo
+                        ingress with it, so cert-manager issues a per-preview
+                        certificate. Use this when you hold no wildcard.
+
+With neither, previews are served over plain http.
+
+Reading requires organisation membership; changing it requires organisation
+admin.`,
+}
+
+var orgAIEnvironmentGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Show the organisation's preview settings",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out, formatError := structuredFormatFromFlags(cmd)
+		if formatError != nil {
+			return formatError
+		}
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+		defer cancel()
+
+		settings, requestError := apiClient.GetOrganisationPreviewSettings(ctx)
+		if requestError != nil {
+			return fmt.Errorf("get organisation preview settings: %w", requestError)
+		}
+		return renderOrganisationPreviewSettings(cmd, settings, out)
+	},
+}
+
+var orgAIEnvironmentSetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Change the organisation's preview settings",
+	Long: `Change where PR demos are published, and how they terminate TLS.
+
+Only the flags you pass are written; the rest keep their stored values. Pass a
+flag with an empty value to clear that field:
+
+  ankra org ai-environment set --demo-base-domain previews.example.com
+  ankra org ai-environment set --demo-cert-issuer letsencrypt-prod
+  ankra org ai-environment set --demo-cert-issuer ""
+
+--demo-cert-issuer only applies alongside a demo base domain: on the Ankra
+subzone Ankra picks the issuer itself, from the networking stack it can
+verify. Naming one without a base domain is refused rather than stored.
+
+Requires organisation admin.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out, formatError := structuredFormatFromFlags(cmd)
+		if formatError != nil {
+			return formatError
+		}
+
+		changes := map[string]*string{}
+		for flagName, field := range map[string]string{
+			"demo-base-domain":   "demo_base_domain",
+			"demo-ingress-class": "demo_ingress_class_name",
+			"demo-tls-secret":    "demo_tls_secret_name",
+			"demo-cert-issuer":   "demo_cert_issuer_name",
+		} {
+			flag := cmd.Flags().Lookup(flagName)
+			if flag == nil || !flag.Changed {
+				continue
+			}
+			if flag.Value.String() == "" {
+				changes[field] = nil
+				continue
+			}
+			value := flag.Value.String()
+			changes[field] = &value
+		}
+		if len(changes) == 0 {
+			return withExitCode(exitUsage, errors.New(
+				"pass at least one of --demo-base-domain, --demo-ingress-class, "+
+					"--demo-tls-secret or --demo-cert-issuer"))
+		}
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+		defer cancel()
+
+		settings, requestError := apiClient.UpdateOrganisationPreviewSettings(ctx, changes)
+		if requestError != nil {
+			return fmt.Errorf("set organisation preview settings: %w", requestError)
+		}
+		return renderOrganisationPreviewSettings(cmd, settings, out)
+	},
+}
+
+// renderOrganisationPreviewSettings prints the settings, naming what an empty
+// field falls back to. The TLS line is the one worth spelling out: a preview
+// domain with neither a secret nor an issuer serves plain http, which is the
+// state that used to be invisible until someone opened a preview.
+func renderOrganisationPreviewSettings(cmd *cobra.Command,
+	settings *client.OrganisationPreviewSettings, format outputFormat) error {
+	switch format {
+	case outputJSON:
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(settings)
+	case outputYAML:
+		encoder := yaml.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent(2)
+		defer func() { _ = encoder.Close() }()
+		return encoder.Encode(settings)
+	}
+
+	out := cmd.OutOrStdout()
+	if settings.DemoBaseDomain == "" {
+		_, _ = fmt.Fprintln(out, "Preview domain:    (none - demos use the staging cluster's Ankra subzone)")
+		return nil
+	}
+	_, _ = fmt.Fprintf(out, "Preview domain:    %s\n", settings.DemoBaseDomain)
+	_, _ = fmt.Fprintf(out, "Ingress class:     %s\n", orEmptyDefault(settings.DemoIngressClassName))
+	_, _ = fmt.Fprintf(out, "TLS secret:        %s\n", orEmptyDefault(settings.DemoTLSSecretName))
+	_, _ = fmt.Fprintf(out, "Certificate issuer:%s\n", " "+orEmptyDefault(settings.DemoCertIssuerName))
+	if settings.DemoTLSSecretName == "" && settings.DemoCertIssuerName == "" {
+		_, _ = fmt.Fprintln(out,
+			"\nPreviews on this domain are served over plain http. Set --demo-tls-secret to a\n"+
+				"wildcard certificate, or --demo-cert-issuer to a cert-manager ClusterIssuer for\n"+
+				"per-preview certificates.")
+	}
+	return nil
+}
+
+func orEmptyDefault(value string) string {
+	if value == "" {
+		return "(cluster default)"
+	}
+	return value
+}
+
+func init() {
+	registerStructuredOutputFlags(orgAIEnvironmentGetCmd, orgAIEnvironmentSetCmd)
+	orgAIEnvironmentSetCmd.Flags().String("demo-base-domain", "",
+		"Wildcard zone demos are published under; empty clears it")
+	orgAIEnvironmentSetCmd.Flags().String("demo-ingress-class", "",
+		"Ingress class for demo ingresses; empty clears it")
+	orgAIEnvironmentSetCmd.Flags().String("demo-tls-secret", "",
+		"Secret holding a wildcard certificate for the preview domain; empty clears it")
+	orgAIEnvironmentSetCmd.Flags().String("demo-cert-issuer", "",
+		"cert-manager ClusterIssuer for per-preview certificates; empty clears it")
+	orgAIEnvironmentCmd.AddCommand(orgAIEnvironmentGetCmd)
+	orgAIEnvironmentCmd.AddCommand(orgAIEnvironmentSetCmd)
+	orgCmd.AddCommand(orgAIEnvironmentCmd)
+}

--- a/cmd/org_ai_environment.go
+++ b/cmd/org_ai_environment.go
@@ -43,16 +43,19 @@ If you only want demos on your own domain, this command is the one you want.
 
 TLS ON YOUR OWN PREVIEW DOMAIN
 
-With a demo base domain set, Ankra will not order a certificate unless you say
-how. Give it one of:
+Demos on your own base domain request a per-preview certificate from the
+staging cluster's cert-manager issuer, the same way demos on an Ankra subzone
+do. Each demo hostname is concrete when the ingress is written, so an HTTP-01
+challenge answers for it; no wildcard is involved. Two flags change that:
 
-  --demo-tls-secret     An existing secret on the staging cluster holding a
-                        wildcard certificate for the preview domain.
-  --demo-cert-issuer    A cert-manager ClusterIssuer. Ankra annotates each demo
-                        ingress with it, so cert-manager issues a per-preview
-                        certificate. Use this when you hold no wildcard.
+  --demo-tls-secret     A secret already holding a certificate for the preview
+                        domain. Ankra serves it and requests nothing.
+  --demo-cert-issuer    A different cert-manager ClusterIssuer to ask, for a
+                        cluster whose issuer is not the one Ankra's networking
+                        stack installs.
 
-With neither, previews are served over plain http.
+A cluster carrying no ACME HTTP-01 issuer cannot be asked for a certificate,
+so its previews stay on plain http. 'get' says so when that is the case.
 
 Reading requires organisation membership; changing it requires organisation
 admin.`,
@@ -94,6 +97,9 @@ flag with an empty value to clear that field:
 --demo-cert-issuer only applies alongside a demo base domain: on the Ankra
 subzone Ankra picks the issuer itself, from the networking stack it can
 verify. Naming one without a base domain is refused rather than stored.
+
+A write that leaves previews on plain http reports it in the output rather
+than succeeding silently.
 
 Requires organisation admin.`,
 	Args: cobra.NoArgs,
@@ -139,9 +145,10 @@ Requires organisation admin.`,
 }
 
 // renderOrganisationPreviewSettings prints the settings, naming what an empty
-// field falls back to. The TLS line is the one worth spelling out: a preview
-// domain with neither a secret nor an issuer serves plain http, which is the
-// state that used to be invisible until someone opened a preview.
+// field falls back to. The plain-http verdict is the backend's rather than
+// this command's: whether a certificate can be requested depends on what the
+// staging cluster carries, and that state used to be invisible until someone
+// opened a preview.
 func renderOrganisationPreviewSettings(cmd *cobra.Command,
 	settings *client.OrganisationPreviewSettings, format outputFormat) error {
 	switch format {
@@ -165,11 +172,8 @@ func renderOrganisationPreviewSettings(cmd *cobra.Command,
 	_, _ = fmt.Fprintf(out, "Ingress class:     %s\n", orEmptyDefault(settings.DemoIngressClassName))
 	_, _ = fmt.Fprintf(out, "TLS secret:        %s\n", orEmptyDefault(settings.DemoTLSSecretName))
 	_, _ = fmt.Fprintf(out, "Certificate issuer:%s\n", " "+orEmptyDefault(settings.DemoCertIssuerName))
-	if settings.DemoTLSSecretName == "" && settings.DemoCertIssuerName == "" {
-		_, _ = fmt.Fprintln(out,
-			"\nPreviews on this domain are served over plain http. Set --demo-tls-secret to a\n"+
-				"wildcard certificate, or --demo-cert-issuer to a cert-manager ClusterIssuer for\n"+
-				"per-preview certificates.")
+	if settings.PreviewTLSWarning != "" {
+		_, _ = fmt.Fprintf(out, "\n%s\n", settings.PreviewTLSWarning)
 	}
 	return nil
 }

--- a/cmd/org_ai_environment_test.go
+++ b/cmd/org_ai_environment_test.go
@@ -69,21 +69,24 @@ func TestRunOrgAIEnvironmentGet_NamesTheFallbackWhenNoPreviewDomainIsSet(t *test
 	}
 }
 
-// The silent state this lane exists to end: a preview domain with neither a
-// wildcard secret nor an issuer serves plain http (PLA-773).
-func TestRunOrgAIEnvironmentGet_WarnsWhenPreviewsWouldBePlainHTTP(t *testing.T) {
+// The silent state this lane exists to end. Whether previews really land on
+// plain http depends on what the staging cluster carries, so the verdict is
+// the backend's and this command only has to surface it (PLA-773).
+func TestRunOrgAIEnvironmentGet_SurfacesTheBackendsPlainHTTPWarning(t *testing.T) {
 	mock := &orgPreviewSettingsMock{settings: client.OrganisationPreviewSettings{
-		DemoBaseDomain: "previews.smartoptics.dev"}}
+		DemoBaseDomain: "previews.smartoptics.dev",
+		PreviewTLSWarning: "Demos on previews.smartoptics.dev will be served over plain http: " +
+			"the staging cluster carries no ACME HTTP-01 ClusterIssuer to request a certificate from."}}
 	output, executeError := runOrgAIEnvironment(t, mock, "org", "ai-environment", "get")
 	if executeError != nil {
 		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
 	}
 	if !strings.Contains(output, "plain http") {
-		t.Errorf("a preview domain with no TLS story must say so, got %s", output)
+		t.Errorf("the warning must reach the operator, got %s", output)
 	}
 }
 
-func TestRunOrgAIEnvironmentGet_StaysQuietOnceAnIssuerIsNamed(t *testing.T) {
+func TestRunOrgAIEnvironmentGet_StaysQuietWhenTheBackendReportsNoProblem(t *testing.T) {
 	mock := &orgPreviewSettingsMock{settings: client.OrganisationPreviewSettings{
 		DemoBaseDomain: "previews.smartoptics.dev", DemoCertIssuerName: "letsencrypt-prod"}}
 	output, executeError := runOrgAIEnvironment(t, mock, "org", "ai-environment", "get")
@@ -91,10 +94,27 @@ func TestRunOrgAIEnvironmentGet_StaysQuietOnceAnIssuerIsNamed(t *testing.T) {
 		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
 	}
 	if strings.Contains(output, "plain http") {
-		t.Errorf("a named issuer answers the TLS question, got %s", output)
+		t.Errorf("no warning from the backend means nothing to say, got %s", output)
 	}
 	if !strings.Contains(output, "letsencrypt-prod") {
 		t.Errorf("the stored issuer must be shown, got %s", output)
+	}
+}
+
+// A set that leaves previews on plain http must say so in its own output
+// rather than reporting success and nothing else.
+func TestRunOrgAIEnvironmentSet_ReportsThePlainHTTPWarningOnTheWrite(t *testing.T) {
+	mock := &orgPreviewSettingsMock{settings: client.OrganisationPreviewSettings{
+		DemoBaseDomain:    "previews.smartoptics.dev",
+		PreviewTLSWarning: "Demos on previews.smartoptics.dev will be served over plain http.",
+	}}
+	output, executeError := runOrgAIEnvironment(t, mock, "org", "ai-environment", "set",
+		"--demo-base-domain", "previews.smartoptics.dev")
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	if !strings.Contains(output, "plain http") {
+		t.Errorf("the write must not succeed silently, got %s", output)
 	}
 }
 

--- a/cmd/org_ai_environment_test.go
+++ b/cmd/org_ai_environment_test.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/pflag"
+)
+
+// orgPreviewSettingsMock captures the preview-settings reads and writes,
+// keeping the exact change map so the present-vs-absent contract can be
+// asserted: the endpoint distinguishes "not in the body" from "null".
+type orgPreviewSettingsMock struct {
+	baseMock
+
+	settings   client.OrganisationPreviewSettings
+	updateSeen []map[string]*string
+}
+
+func (m *orgPreviewSettingsMock) GetOrganisationPreviewSettings(
+	ctx context.Context) (*client.OrganisationPreviewSettings, error) {
+	settings := m.settings
+	return &settings, nil
+}
+
+func (m *orgPreviewSettingsMock) UpdateOrganisationPreviewSettings(ctx context.Context,
+	changes map[string]*string) (*client.OrganisationPreviewSettings, error) {
+	m.updateSeen = append(m.updateSeen, changes)
+	settings := m.settings
+	return &settings, nil
+}
+
+func resetOrgAIEnvironmentFlags(t *testing.T) {
+	t.Helper()
+	for _, flagged := range []interface{ Flags() *pflag.FlagSet }{
+		orgAIEnvironmentGetCmd, orgAIEnvironmentSetCmd,
+	} {
+		flagged.Flags().VisitAll(func(flag *pflag.Flag) {
+			_ = flag.Value.Set(flag.DefValue)
+			flag.Changed = false
+		})
+	}
+}
+
+func runOrgAIEnvironment(t *testing.T, mock *orgPreviewSettingsMock, args ...string) (string, error) {
+	t.Helper()
+	setMockClient(t, mock)
+	resetOrgAIEnvironmentFlags(t)
+	output := new(bytes.Buffer)
+	rootCmd.SetOut(output)
+	rootCmd.SetErr(output)
+	rootCmd.SetArgs(args)
+	executeError := rootCmd.Execute()
+	return output.String(), executeError
+}
+
+func TestRunOrgAIEnvironmentGet_NamesTheFallbackWhenNoPreviewDomainIsSet(t *testing.T) {
+	mock := &orgPreviewSettingsMock{}
+	output, executeError := runOrgAIEnvironment(t, mock, "org", "ai-environment", "get")
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	if !strings.Contains(output, "staging cluster's Ankra subzone") {
+		t.Errorf("an unset preview domain must say what it falls back to, got %s", output)
+	}
+}
+
+// The silent state this lane exists to end: a preview domain with neither a
+// wildcard secret nor an issuer serves plain http (PLA-773).
+func TestRunOrgAIEnvironmentGet_WarnsWhenPreviewsWouldBePlainHTTP(t *testing.T) {
+	mock := &orgPreviewSettingsMock{settings: client.OrganisationPreviewSettings{
+		DemoBaseDomain: "previews.smartoptics.dev"}}
+	output, executeError := runOrgAIEnvironment(t, mock, "org", "ai-environment", "get")
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	if !strings.Contains(output, "plain http") {
+		t.Errorf("a preview domain with no TLS story must say so, got %s", output)
+	}
+}
+
+func TestRunOrgAIEnvironmentGet_StaysQuietOnceAnIssuerIsNamed(t *testing.T) {
+	mock := &orgPreviewSettingsMock{settings: client.OrganisationPreviewSettings{
+		DemoBaseDomain: "previews.smartoptics.dev", DemoCertIssuerName: "letsencrypt-prod"}}
+	output, executeError := runOrgAIEnvironment(t, mock, "org", "ai-environment", "get")
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	if strings.Contains(output, "plain http") {
+		t.Errorf("a named issuer answers the TLS question, got %s", output)
+	}
+	if !strings.Contains(output, "letsencrypt-prod") {
+		t.Errorf("the stored issuer must be shown, got %s", output)
+	}
+}
+
+func TestRunOrgAIEnvironmentSet_SendsOnlyTheFlagsPassed(t *testing.T) {
+	mock := &orgPreviewSettingsMock{}
+	output, executeError := runOrgAIEnvironment(t, mock, "org", "ai-environment", "set",
+		"--demo-cert-issuer", "letsencrypt-prod")
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	if len(mock.updateSeen) != 1 {
+		t.Fatalf("update calls = %d", len(mock.updateSeen))
+	}
+	changes := mock.updateSeen[0]
+	if len(changes) != 1 {
+		t.Fatalf("an untouched field must stay out of the body entirely, got %v", changes)
+	}
+	if changes["demo_cert_issuer_name"] == nil || *changes["demo_cert_issuer_name"] != "letsencrypt-prod" {
+		t.Fatalf("changes = %v", changes)
+	}
+}
+
+func TestRunOrgAIEnvironmentSet_AnEmptyValueClearsTheField(t *testing.T) {
+	mock := &orgPreviewSettingsMock{}
+	output, executeError := runOrgAIEnvironment(t, mock, "org", "ai-environment", "set",
+		"--demo-base-domain", "")
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	changes := mock.updateSeen[0]
+	value, isPresent := changes["demo_base_domain"]
+	if !isPresent || value != nil {
+		t.Fatalf("an empty flag must send an explicit null, got %v", changes)
+	}
+}
+
+func TestRunOrgAIEnvironmentSet_RefusesACallThatChangesNothing(t *testing.T) {
+	mock := &orgPreviewSettingsMock{}
+	_, executeError := runOrgAIEnvironment(t, mock, "org", "ai-environment", "set")
+	if executeError == nil {
+		t.Fatalf("a set with no flags must be a usage error, not an empty PUT")
+	}
+	if len(mock.updateSeen) != 0 {
+		t.Fatalf("nothing should have been sent, got %v", mock.updateSeen)
+	}
+}

--- a/cmd/org_ai_environment_test.go
+++ b/cmd/org_ai_environment_test.go
@@ -161,3 +161,21 @@ func TestRunOrgAIEnvironmentSet_RefusesACallThatChangesNothing(t *testing.T) {
 		t.Fatalf("nothing should have been sent, got %v", mock.updateSeen)
 	}
 }
+
+// The renderer must not decide for itself when a warning is relevant. Today
+// the backend only warns about an organisation's own preview domain, but a
+// display tied to that field would silently drop any future warning.
+func TestRunOrgAIEnvironmentGet_PrintsAWarningEvenWithNoPreviewDomain(t *testing.T) {
+	mock := &orgPreviewSettingsMock{settings: client.OrganisationPreviewSettings{
+		PreviewTLSWarning: "The staging cluster carries no ACME HTTP-01 ClusterIssuer."}}
+	output, executeError := runOrgAIEnvironment(t, mock, "org", "ai-environment", "get")
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	if !strings.Contains(output, "no ACME HTTP-01 ClusterIssuer") {
+		t.Errorf("the backend's warning must survive the no-preview-domain branch, got %s", output)
+	}
+	if !strings.Contains(output, "staging cluster's Ankra subzone") {
+		t.Errorf("the fallback line must still be printed, got %s", output)
+	}
+}

--- a/cmd/org_domain.go
+++ b/cmd/org_domain.go
@@ -29,9 +29,17 @@ refused otherwise, naming the nameservers to point at.
   ankra org domain set --default
 
 This is the same setting the portal writes at AI > Settings > Workspaces
-("Custom Ankra domain"). Changing it is refused while cluster DNS zones or DNS
-records still live under the old root; the refusal lists exactly what to
-remove. Use 'ankra org dns zones' and 'ankra org dns list' to inventory them,
+("Custom Ankra domain").
+
+The SECOND domain field on that screen, "Preview domain", is a different
+setting: it decides only where PR demos and on-demand previews are published,
+it changes nothing else, and it is not gated by the guard below. If previews
+on your own domain are what you are after, you want
+'ankra org ai-environment set --demo-base-domain', not this command.
+
+Changing the root domain is refused while cluster DNS zones or DNS records
+still live under the old root; the refusal lists exactly what to remove. Use
+'ankra org dns zones' and 'ankra org dns list' to inventory them, and
 'ankra cluster domain <cluster> --remove' and 'ankra org dns delete <record>'
 to clear them. Ankra re-creates the organisation zone under the new domain
 automatically once the switch is accepted.

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -80,6 +80,9 @@ type APIClient interface {
 	DeleteOrganisationDnsRecord(ctx context.Context, recordID string) error
 	ListOrganisationClusterDnsZones(ctx context.Context) (*client.DnsClusterZonesListResult, error)
 	GetOrganisationDomain(ctx context.Context) (*client.OrganisationDomain, error)
+	GetOrganisationPreviewSettings(ctx context.Context) (*client.OrganisationPreviewSettings, error)
+	UpdateOrganisationPreviewSettings(ctx context.Context,
+		changes map[string]*string) (*client.OrganisationPreviewSettings, error)
 	SetOrganisationDomain(ctx context.Context, rootDomain string) (*client.OrganisationDomain, error)
 
 	MCPCatalog(ctx context.Context) (*client.MCPCatalogResult, error)

--- a/internal/client/org_ai_environment.go
+++ b/internal/client/org_ai_environment.go
@@ -38,7 +38,7 @@ type organisationPreviewSettingsBody struct {
 
 // GetOrganisationPreviewSettings reads the organisation's preview settings.
 func (c *Client) GetOrganisationPreviewSettings(ctx context.Context) (*OrganisationPreviewSettings, error) {
-	body, requestError := c.doOrganisationDomainRequest(ctx, http.MethodGet, nil)
+	body, requestError := c.doAIEnvironmentRequest(ctx, http.MethodGet, nil)
 	if requestError != nil {
 		return nil, requestError
 	}
@@ -63,7 +63,7 @@ func (c *Client) UpdateOrganisationPreviewSettings(ctx context.Context,
 	if marshalError != nil {
 		return nil, fmt.Errorf("encode request: %w", marshalError)
 	}
-	body, requestError := c.doOrganisationDomainRequest(ctx, http.MethodPut, encoded)
+	body, requestError := c.doAIEnvironmentRequest(ctx, http.MethodPut, encoded)
 	if requestError != nil {
 		return nil, requestError
 	}

--- a/internal/client/org_ai_environment.go
+++ b/internal/client/org_ai_environment.go
@@ -1,0 +1,85 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// OrganisationPreviewSettings is the preview half of the organisation's AI
+// environment settings (GET/PUT /api/v1/org/ai-environment) - the fields that
+// decide where a PR demo is published and how it terminates TLS. The root
+// domain on the same endpoint is a different setting with a much wider blast
+// radius and stays with 'ankra org domain'.
+//
+// Empty means unset in every field: the demos then hang off the staging
+// cluster's own Ankra subzone, or stay in-cluster-only.
+type OrganisationPreviewSettings struct {
+	DemoBaseDomain       string `json:"demo_base_domain"`
+	DemoIngressClassName string `json:"demo_ingress_class_name"`
+	DemoTLSSecretName    string `json:"demo_tls_secret_name"`
+	DemoCertIssuerName   string `json:"demo_cert_issuer_name"`
+}
+
+type organisationPreviewSettingsBody struct {
+	DemoBaseDomain       *string `json:"demo_base_domain"`
+	DemoIngressClassName *string `json:"demo_ingress_class_name"`
+	DemoTLSSecretName    *string `json:"demo_tls_secret_name"`
+	DemoCertIssuerName   *string `json:"demo_cert_issuer_name"`
+}
+
+// GetOrganisationPreviewSettings reads the organisation's preview settings.
+func (c *Client) GetOrganisationPreviewSettings(ctx context.Context) (*OrganisationPreviewSettings, error) {
+	body, requestError := c.doOrganisationDomainRequest(ctx, http.MethodGet, nil)
+	if requestError != nil {
+		return nil, requestError
+	}
+	return decodeOrganisationPreviewSettings(body)
+}
+
+// UpdateOrganisationPreviewSettings writes only the fields present in
+// changes. The endpoint reads presence, not emptiness: a key carrying nil
+// clears that field, and a key left out of the map is not touched - so
+// setting one field never silently clears its neighbours.
+func (c *Client) UpdateOrganisationPreviewSettings(ctx context.Context,
+	changes map[string]*string) (*OrganisationPreviewSettings, error) {
+	payload := make(map[string]any, len(changes))
+	for field, value := range changes {
+		if value == nil {
+			payload[field] = nil
+			continue
+		}
+		payload[field] = *value
+	}
+	encoded, marshalError := json.Marshal(payload)
+	if marshalError != nil {
+		return nil, fmt.Errorf("encode request: %w", marshalError)
+	}
+	body, requestError := c.doOrganisationDomainRequest(ctx, http.MethodPut, encoded)
+	if requestError != nil {
+		return nil, requestError
+	}
+	return decodeOrganisationPreviewSettings(body)
+}
+
+func decodeOrganisationPreviewSettings(body []byte) (*OrganisationPreviewSettings, error) {
+	var decoded organisationPreviewSettingsBody
+	if unmarshalError := json.Unmarshal(body, &decoded); unmarshalError != nil {
+		return nil, fmt.Errorf("parse response: %w", unmarshalError)
+	}
+	settings := OrganisationPreviewSettings{}
+	if decoded.DemoBaseDomain != nil {
+		settings.DemoBaseDomain = *decoded.DemoBaseDomain
+	}
+	if decoded.DemoIngressClassName != nil {
+		settings.DemoIngressClassName = *decoded.DemoIngressClassName
+	}
+	if decoded.DemoTLSSecretName != nil {
+		settings.DemoTLSSecretName = *decoded.DemoTLSSecretName
+	}
+	if decoded.DemoCertIssuerName != nil {
+		settings.DemoCertIssuerName = *decoded.DemoCertIssuerName
+	}
+	return &settings, nil
+}

--- a/internal/client/org_ai_environment.go
+++ b/internal/client/org_ai_environment.go
@@ -20,6 +20,12 @@ type OrganisationPreviewSettings struct {
 	DemoIngressClassName string `json:"demo_ingress_class_name"`
 	DemoTLSSecretName    string `json:"demo_tls_secret_name"`
 	DemoCertIssuerName   string `json:"demo_cert_issuer_name"`
+
+	// PreviewTLSWarning is the backend's own verdict on whether these
+	// settings publish demos over plain http. It depends on what the
+	// staging cluster carries, so it cannot be worked out from the fields
+	// above alone. Empty when previews have a certificate story.
+	PreviewTLSWarning string `json:"demo_preview_tls_warning"`
 }
 
 type organisationPreviewSettingsBody struct {
@@ -27,6 +33,7 @@ type organisationPreviewSettingsBody struct {
 	DemoIngressClassName *string `json:"demo_ingress_class_name"`
 	DemoTLSSecretName    *string `json:"demo_tls_secret_name"`
 	DemoCertIssuerName   *string `json:"demo_cert_issuer_name"`
+	PreviewTLSWarning    *string `json:"demo_preview_tls_warning"`
 }
 
 // GetOrganisationPreviewSettings reads the organisation's preview settings.
@@ -80,6 +87,9 @@ func decodeOrganisationPreviewSettings(body []byte) (*OrganisationPreviewSetting
 	}
 	if decoded.DemoCertIssuerName != nil {
 		settings.DemoCertIssuerName = *decoded.DemoCertIssuerName
+	}
+	if decoded.PreviewTLSWarning != nil {
+		settings.PreviewTLSWarning = *decoded.PreviewTLSWarning
 	}
 	return &settings, nil
 }

--- a/internal/client/org_domain.go
+++ b/internal/client/org_domain.go
@@ -90,7 +90,7 @@ type organisationDomainSettings struct {
 
 // GetOrganisationDomain reads the organisation's Ankra root domain.
 func (c *Client) GetOrganisationDomain(ctx context.Context) (*OrganisationDomain, error) {
-	body, err := c.doOrganisationDomainRequest(ctx, http.MethodGet, nil)
+	body, err := c.doAIEnvironmentRequest(ctx, http.MethodGet, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func (c *Client) SetOrganisationDomain(ctx context.Context, rootDomain string) (
 	if marshalError != nil {
 		return nil, fmt.Errorf("encode request: %w", marshalError)
 	}
-	body, err := c.doOrganisationDomainRequest(ctx, http.MethodPut, encoded)
+	body, err := c.doAIEnvironmentRequest(ctx, http.MethodPut, encoded)
 	if err != nil {
 		return nil, err
 	}
@@ -130,11 +130,13 @@ func decodeOrganisationDomain(body []byte) (*OrganisationDomain, error) {
 	return &domain, nil
 }
 
-// doOrganisationDomainRequest sends an authenticated JSON request to the AI
-// environment settings routes. A 400 carrying the switch guard's blocker
-// inventory becomes an OrganisationDomainBlockedError; other 400/403 bodies
-// surface their detail verbatim - those texts are user-actionable.
-func (c *Client) doOrganisationDomainRequest(ctx context.Context, method string, body []byte) ([]byte, error) {
+// doAIEnvironmentRequest sends an authenticated JSON request to the org AI
+// environment settings route. That one endpoint backs both the root-domain
+// setting and the preview settings, so the name is deliberately neutral -
+// it does not belong to the domain lane. A 400 carrying the switch guard's
+// blocker inventory becomes an OrganisationDomainBlockedError; other 400/403
+// bodies surface their detail verbatim - those texts are user-actionable.
+func (c *Client) doAIEnvironmentRequest(ctx context.Context, method string, body []byte) ([]byte, error) {
 	var bodyReader io.Reader
 	if body != nil {
 		bodyReader = bytes.NewReader(body)


### PR DESCRIPTION
Bead: ankra-ymkj8.18, ankra-ymkj8.20
Reported as: PLA-773 (Smartoptics, #1081)

Two gaps the customer hit on the same day, both from the same root: the organisation's AI-environment settings live on one endpoint, and the CLI wrapped exactly one of its fields.

## 1. The preview settings were unreachable from the CLI (ankra-ymkj8.18)

`ankra org domain get|set` sends only `dns_root_domain`. `demo_base_domain`, `demo_ingress_class_name` and `demo_tls_secret_name` were portal/API-only — and they are precisely the fields you script when standing up on-demand environments on your own domain. The customer got there with a hand-written `PUT`.

```
ankra org ai-environment get
ankra org ai-environment set --demo-base-domain previews.example.com
ankra org ai-environment set --demo-cert-issuer letsencrypt-prod
ankra org ai-environment set --demo-tls-secret ""      # clears that field alone
```

Only the flags you pass are written. The endpoint reads **presence**, not emptiness, so setting one field never clears its neighbours, and a flag passed with an empty value sends an explicit `null`. A `set` with no flags is a usage error rather than an empty `PUT`.

`get` names what an empty field falls back to, and surfaces the backend's own verdict on whether previews will be served over plain http. That verdict is not guessable from the fields: once ankraio/cluster#1737 lands, a preview domain requests a per-preview certificate by default, and whether it can depends on what the staging cluster carries.

```
Preview domain:    previews.smartoptics.dev
Ingress class:     (cluster default)
TLS secret:        (cluster default)
Certificate issuer: (cluster default)

Demos on previews.smartoptics.dev will be served over plain http: the staging
cluster carries no ACME HTTP-01 ClusterIssuer to request a certificate from.
```

`set` prints the same warning, so a write that disables demo TLS says so rather than reporting success and nothing else. The customer's words: *"We would have set this and shipped demos on plain HTTP without ever being told."*

## 2. `org domain --help` read as *the* custom domain (ankra-ymkj8.20)

Reported verbatim: *"'ankra org domain set --help' says the custom domain lives at 'AI > Settings > Workspaces'. Given demo_base_domain and dns_root_domain are different fields with very different blast radius, that help text sending people to one page for 'the custom domain' is how we spent a day on the wrong one."*

Confirmed — and #134 did not fix it: the long help never mentioned "Preview domain" at all. It now names the second field, contrasts the blast radius (one ungated field write vs. a re-root gated by the cluster-zone guard), and sends that reader to `ankra org ai-environment set --demo-base-domain`.

## Verification

- `go build ./...`, `go test ./...` — all pass
- `golangci-lint run ./cmd/... ./internal/client/...` (v2.12.2, the CI pin) — 0 issues
- 6 new tests: the fallback line, the plain-http warning, the warning withdrawing once an issuer is named, present-vs-absent on `set`, empty-value-clears, and no-flags-is-a-usage-error
- Both help texts rendered from a built binary and read back

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZkNSXZEK5VJ6UpCPxPiCn
