### PR TITLE
fix(org): yaml output keys match json, and stored preview overrides stay visible (ankra-ymkj8.18)

### DIFF
--- a/cmd/org_ai_environment.go
+++ b/cmd/org_ai_environment.go
@@ -205,16 +205,30 @@ var previewSettingFlagFields = map[string]string{
 	"demo-cert-issuer":   "demo_cert_issuer_name",
 }
 
+// previewSettingFlagUsage is the help string for each flag in
+// previewSettingFlagFields. Kept beside it so registration can walk the field
+// map itself: a field added without a usage string then fails at init rather
+// than registering no flag at all, which the update loop would skip in
+// silence.
+var previewSettingFlagUsage = map[string]string{
+	"demo-base-domain":   "Wildcard zone demos are published under; empty clears it",
+	"demo-ingress-class": "Ingress class for demo ingresses; empty clears it",
+	"demo-tls-secret":    "Secret holding a certificate for the preview domain; empty clears it",
+	"demo-cert-issuer":   "cert-manager ClusterIssuer to ask instead of the cluster's own; empty clears it",
+}
+
 func init() {
 	registerStructuredOutputFlags(orgAIEnvironmentGetCmd, orgAIEnvironmentSetCmd)
-	for flagName, usage := range map[string]string{
-		"demo-base-domain":   "Wildcard zone demos are published under; empty clears it",
-		"demo-ingress-class": "Ingress class for demo ingresses; empty clears it",
-		"demo-tls-secret":    "Secret holding a certificate for the preview domain; empty clears it",
-		"demo-cert-issuer":   "cert-manager ClusterIssuer to ask instead of the cluster's own; empty clears it",
-	} {
-		if _, isKnown := previewSettingFlagFields[flagName]; !isKnown {
-			panic("preview setting flag " + flagName + " has no wire field")
+	// Both directions of drift are fatal here: walking the field map catches
+	// a field with no usage string, and the count check catches a usage
+	// string naming a flag that writes nothing.
+	if len(previewSettingFlagUsage) != len(previewSettingFlagFields) {
+		panic("preview setting flag usage and wire-field maps disagree")
+	}
+	for flagName := range previewSettingFlagFields {
+		usage, hasUsage := previewSettingFlagUsage[flagName]
+		if !hasUsage {
+			panic("preview setting flag " + flagName + " has no usage string")
 		}
 		orgAIEnvironmentSetCmd.Flags().String(flagName, "", usage)
 	}

--- a/cmd/org_ai_environment.go
+++ b/cmd/org_ai_environment.go
@@ -110,12 +110,7 @@ Requires organisation admin.`,
 		}
 
 		changes := map[string]*string{}
-		for flagName, field := range map[string]string{
-			"demo-base-domain":   "demo_base_domain",
-			"demo-ingress-class": "demo_ingress_class_name",
-			"demo-tls-secret":    "demo_tls_secret_name",
-			"demo-cert-issuer":   "demo_cert_issuer_name",
-		} {
+		for flagName, field := range previewSettingFlagFields {
 			flag := cmd.Flags().Lookup(flagName)
 			if flag == nil || !flag.Changed {
 				continue
@@ -164,13 +159,25 @@ func renderOrganisationPreviewSettings(cmd *cobra.Command,
 	}
 
 	out := cmd.OutOrStdout()
+	// The three overrides only take effect alongside a preview domain, but a
+	// stored value has to stay visible without one: clearing only the domain
+	// otherwise leaves settings on the organisation that nothing can show and
+	// that come back into force the moment a domain is set again.
+	hasStoredOverride := settings.DemoIngressClassName != "" ||
+		settings.DemoTLSSecretName != "" || settings.DemoCertIssuerName != ""
 	if settings.DemoBaseDomain == "" {
 		_, _ = fmt.Fprintln(out, "Preview domain:    (none - demos use the staging cluster's Ankra subzone)")
 	} else {
 		_, _ = fmt.Fprintf(out, "Preview domain:    %s\n", settings.DemoBaseDomain)
+	}
+	if settings.DemoBaseDomain != "" || hasStoredOverride {
 		_, _ = fmt.Fprintf(out, "Ingress class:     %s\n", orEmptyDefault(settings.DemoIngressClassName))
 		_, _ = fmt.Fprintf(out, "TLS secret:        %s\n", orEmptyDefault(settings.DemoTLSSecretName))
 		_, _ = fmt.Fprintf(out, "Certificate issuer:%s\n", " "+orEmptyDefault(settings.DemoCertIssuerName))
+	}
+	if settings.DemoBaseDomain == "" && hasStoredOverride {
+		_, _ = fmt.Fprintln(out,
+			"\nThese three apply only alongside a preview domain, so they are inert until one is set.")
 	}
 	// Printed whatever the fields say. The backend decides when previews
 	// lack TLS, and tying the display to a field here would put this command
@@ -188,16 +195,29 @@ func orEmptyDefault(value string) string {
 	return value
 }
 
+// previewSettingFlagFields maps each set flag to the wire field it writes.
+// Registration and parsing both read it, so a renamed flag cannot become a
+// silent no-op that cobra accepts and the update loop never matches.
+var previewSettingFlagFields = map[string]string{
+	"demo-base-domain":   "demo_base_domain",
+	"demo-ingress-class": "demo_ingress_class_name",
+	"demo-tls-secret":    "demo_tls_secret_name",
+	"demo-cert-issuer":   "demo_cert_issuer_name",
+}
+
 func init() {
 	registerStructuredOutputFlags(orgAIEnvironmentGetCmd, orgAIEnvironmentSetCmd)
-	orgAIEnvironmentSetCmd.Flags().String("demo-base-domain", "",
-		"Wildcard zone demos are published under; empty clears it")
-	orgAIEnvironmentSetCmd.Flags().String("demo-ingress-class", "",
-		"Ingress class for demo ingresses; empty clears it")
-	orgAIEnvironmentSetCmd.Flags().String("demo-tls-secret", "",
-		"Secret holding a wildcard certificate for the preview domain; empty clears it")
-	orgAIEnvironmentSetCmd.Flags().String("demo-cert-issuer", "",
-		"cert-manager ClusterIssuer for per-preview certificates; empty clears it")
+	for flagName, usage := range map[string]string{
+		"demo-base-domain":   "Wildcard zone demos are published under; empty clears it",
+		"demo-ingress-class": "Ingress class for demo ingresses; empty clears it",
+		"demo-tls-secret":    "Secret holding a certificate for the preview domain; empty clears it",
+		"demo-cert-issuer":   "cert-manager ClusterIssuer to ask instead of the cluster's own; empty clears it",
+	} {
+		if _, isKnown := previewSettingFlagFields[flagName]; !isKnown {
+			panic("preview setting flag " + flagName + " has no wire field")
+		}
+		orgAIEnvironmentSetCmd.Flags().String(flagName, "", usage)
+	}
 	orgAIEnvironmentCmd.AddCommand(orgAIEnvironmentGetCmd)
 	orgAIEnvironmentCmd.AddCommand(orgAIEnvironmentSetCmd)
 	orgCmd.AddCommand(orgAIEnvironmentCmd)

--- a/cmd/org_ai_environment_test.go
+++ b/cmd/org_ai_environment_test.go
@@ -233,6 +233,27 @@ func TestRunOrgAIEnvironmentGet_StaysTerseWhenNothingIsStored(t *testing.T) {
 	}
 }
 
+// The two maps have to stay in step in both directions: a wire field with no
+// usage string would register no flag (and the update loop would skip it in
+// silence), and a usage string naming no field would register a flag that
+// writes nothing. init() panics on either; this pins the pairing itself.
+func TestPreviewSettingFlagMapsAgree(t *testing.T) {
+	if len(previewSettingFlagUsage) != len(previewSettingFlagFields) {
+		t.Fatalf("usage map has %d entries, wire-field map has %d",
+			len(previewSettingFlagUsage), len(previewSettingFlagFields))
+	}
+	for flagName := range previewSettingFlagFields {
+		if previewSettingFlagUsage[flagName] == "" {
+			t.Errorf("wire field %q has no usage string, so init() would register no flag", flagName)
+		}
+	}
+	for flagName := range previewSettingFlagUsage {
+		if previewSettingFlagFields[flagName] == "" {
+			t.Errorf("usage string %q names no wire field, so the flag would write nothing", flagName)
+		}
+	}
+}
+
 // Registration and parsing read one map, so a renamed flag cannot become a
 // flag cobra accepts and the update loop never matches.
 func TestPreviewSettingFlagsAreRegisteredForEveryWireField(t *testing.T) {

--- a/cmd/org_ai_environment_test.go
+++ b/cmd/org_ai_environment_test.go
@@ -179,3 +179,74 @@ func TestRunOrgAIEnvironmentGet_PrintsAWarningEvenWithNoPreviewDomain(t *testing
 		t.Errorf("the fallback line must still be printed, got %s", output)
 	}
 }
+
+// -o yaml went through gopkg.in/yaml.v3, which ignores json tags and
+// lowercases the Go field names, so it emitted demobasedomain while -o json
+// emitted demo_base_domain. Anything scripted against the yaml form read the
+// wrong keys.
+func TestRunOrgAIEnvironmentGet_YAMLKeysMatchTheJSONKeys(t *testing.T) {
+	mock := &orgPreviewSettingsMock{settings: client.OrganisationPreviewSettings{
+		DemoBaseDomain: "previews.smartoptics.dev", DemoCertIssuerName: "letsencrypt-prod"}}
+	output, executeError := runOrgAIEnvironment(t, mock, "org", "ai-environment", "get", "-o", "yaml")
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	for _, key := range []string{
+		"demo_base_domain:", "demo_ingress_class_name:", "demo_tls_secret_name:",
+		"demo_cert_issuer_name:", "demo_preview_tls_warning:",
+	} {
+		if !strings.Contains(output, key) {
+			t.Errorf("yaml output is missing %q, got %s", key, output)
+		}
+	}
+	if strings.Contains(output, "demobasedomain") {
+		t.Errorf("yaml fell back to the lowercased Go field names, got %s", output)
+	}
+}
+
+// Clearing only the preview domain used to hide the three overrides, leaving
+// stored values nothing could show and that take effect again the moment a
+// domain is set.
+func TestRunOrgAIEnvironmentGet_ShowsStoredOverridesWithNoPreviewDomain(t *testing.T) {
+	mock := &orgPreviewSettingsMock{settings: client.OrganisationPreviewSettings{
+		DemoTLSSecretName: "previews-wildcard-tls"}}
+	output, executeError := runOrgAIEnvironment(t, mock, "org", "ai-environment", "get")
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	if !strings.Contains(output, "previews-wildcard-tls") {
+		t.Errorf("a stored override must stay visible, got %s", output)
+	}
+	if !strings.Contains(output, "inert until one is set") {
+		t.Errorf("and must say it is not in force, got %s", output)
+	}
+}
+
+func TestRunOrgAIEnvironmentGet_StaysTerseWhenNothingIsStored(t *testing.T) {
+	mock := &orgPreviewSettingsMock{}
+	output, executeError := runOrgAIEnvironment(t, mock, "org", "ai-environment", "get")
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	if strings.Contains(output, "Ingress class") || strings.Contains(output, "inert") {
+		t.Errorf("nothing stored means nothing to list, got %s", output)
+	}
+}
+
+// Registration and parsing read one map, so a renamed flag cannot become a
+// flag cobra accepts and the update loop never matches.
+func TestPreviewSettingFlagsAreRegisteredForEveryWireField(t *testing.T) {
+	for flagName := range previewSettingFlagFields {
+		if orgAIEnvironmentSetCmd.Flags().Lookup(flagName) == nil {
+			t.Errorf("flag %q maps to a wire field but is not registered", flagName)
+		}
+	}
+	orgAIEnvironmentSetCmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		if !strings.HasPrefix(flag.Name, "demo-") {
+			return
+		}
+		if _, isKnown := previewSettingFlagFields[flag.Name]; !isKnown {
+			t.Errorf("flag %q is registered but writes no wire field", flag.Name)
+		}
+	})
+}

--- a/internal/client/org_ai_environment.go
+++ b/internal/client/org_ai_environment.go
@@ -16,16 +16,16 @@ import (
 // Empty means unset in every field: the demos then hang off the staging
 // cluster's own Ankra subzone, or stay in-cluster-only.
 type OrganisationPreviewSettings struct {
-	DemoBaseDomain       string `json:"demo_base_domain"`
-	DemoIngressClassName string `json:"demo_ingress_class_name"`
-	DemoTLSSecretName    string `json:"demo_tls_secret_name"`
-	DemoCertIssuerName   string `json:"demo_cert_issuer_name"`
+	DemoBaseDomain       string `json:"demo_base_domain" yaml:"demo_base_domain"`
+	DemoIngressClassName string `json:"demo_ingress_class_name" yaml:"demo_ingress_class_name"`
+	DemoTLSSecretName    string `json:"demo_tls_secret_name" yaml:"demo_tls_secret_name"`
+	DemoCertIssuerName   string `json:"demo_cert_issuer_name" yaml:"demo_cert_issuer_name"`
 
 	// PreviewTLSWarning is the backend's own verdict on whether these
 	// settings publish demos over plain http. It depends on what the
 	// staging cluster carries, so it cannot be worked out from the fields
 	// above alone. Empty when previews have a certificate story.
-	PreviewTLSWarning string `json:"demo_preview_tls_warning"`
+	PreviewTLSWarning string `json:"demo_preview_tls_warning" yaml:"demo_preview_tls_warning"`
 }
 
 type organisationPreviewSettingsBody struct {


### PR DESCRIPTION
Bead: ankra-ymkj8.18
Follow-up to ankraio/ankra-cli#137 — inline review findings that were not addressed before it merged.

## 1. `-o yaml` emitted different keys from `-o json` (user-facing)

`OrganisationPreviewSettings` carried `json` tags only, and `renderOrganisationPreviewSettings` also encodes it with `gopkg.in/yaml.v3`, which ignores `json` tags and lowercases the Go field names. Reproduced against production before the fix:

```
$ ankra org ai-environment get -o yaml     $ ankra org ai-environment get -o json
demobasedomain: ""                         "demo_base_domain": ""
demoingressclassname: ""                   "demo_ingress_class_name": ""
demotlssecretname: ""                      "demo_tls_secret_name": ""
democertissuername: ""                     "demo_cert_issuer_name": ""
previewtlswarning: ""                      "demo_preview_tls_warning": ""
```

Anything scripted against the YAML form was reading keys that do not exist in the documented contract. `yaml` tags added; verified against production that both forms now agree.

## 2. `get` hid stored overrides whenever no preview domain was set

The early return meant a stored ingress class, TLS secret or certificate issuer became invisible — which is exactly when you need to see them. Clearing only `--demo-base-domain` left values on the organisation that nothing could show and that come back into force the moment a domain is set again. They are now listed, with a line saying they are inert until a domain is set. Nothing extra is printed when nothing is stored.

## 3. Flag names were duplicated between `RunE` and `init()`

Two literal lists of the same four flag names. Renaming one side would have left a flag cobra parses, `Changed` never matches, and the user gets "pass at least one of" despite passing a valid flag. Both sites now read one `previewSettingFlagFields` map, and registration panics on a flag with no wire field.

## Verification

- `go build ./...`, `go test ./...` — all pass
- `golangci-lint run ./cmd/... ./internal/client/...` (v2.12.2, the CI pin) — 0 issues
- 4 new tests: YAML keys match JSON and never fall back to the lowercased names; stored overrides visible and marked inert with no domain; nothing extra printed when nothing is stored; every wire field has a registered flag and vice versa
- The YAML fix confirmed against the live production API, not just in tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZkNSXZEK5VJ6UpCPxPiCn
