### PR TITLE
fix(cluster): read EXTERNAL-IP and ADDRESS from status.loadBalancer (ankra-o196x)

### DIFF
--- a/cmd/cluster_k8s.go
+++ b/cmd/cluster_k8s.go
@@ -61,6 +61,103 @@ func getNestedMap(obj map[string]interface{}, key string) (map[string]interface{
 	return m, ok
 }
 
+// loadBalancerAddresses reads the ip-or-hostname list out of a
+// status.loadBalancer.ingress[] array - the field kubectl derives both a
+// Service's EXTERNAL-IP and an Ingress's ADDRESS from. Entries carrying
+// neither, and repeats, are skipped; the API's order is kept. kubectl elides
+// this to 16 columns unless asked for -o wide, which these commands do not
+// offer, so the addresses are rendered in full.
+func loadBalancerAddresses(obj map[string]interface{}) []string {
+	statusMap, ok := getNestedMap(obj, "status")
+	if !ok {
+		return nil
+	}
+	loadBalancer, ok := getNestedMap(statusMap, "loadBalancer")
+	if !ok {
+		return nil
+	}
+	entries, ok := loadBalancer["ingress"].([]interface{})
+	if !ok {
+		return nil
+	}
+	addresses := make([]string, 0, len(entries))
+	seen := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		entryMap, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		address := getNestedString(entryMap, "ip")
+		if address == "" {
+			address = getNestedString(entryMap, "hostname")
+		}
+		if address == "" || seen[address] {
+			continue
+		}
+		seen[address] = true
+		addresses = append(addresses, address)
+	}
+	return addresses
+}
+
+// stringListField reads a list-of-strings field one level down, such as
+// spec.externalIPs, skipping entries that are not non-empty strings.
+func stringListField(obj map[string]interface{}, parentKey string, key string) []string {
+	parent, ok := getNestedMap(obj, parentKey)
+	if !ok {
+		return nil
+	}
+	rawList, ok := parent[key].([]interface{})
+	if !ok {
+		return nil
+	}
+	values := make([]string, 0, len(rawList))
+	for _, raw := range rawList {
+		if value, ok := raw.(string); ok && value != "" {
+			values = append(values, value)
+		}
+	}
+	return values
+}
+
+// serviceExternalIP renders the EXTERNAL-IP cell the way kubectl does: a
+// LoadBalancer reports whatever the cloud controller wrote into
+// status.loadBalancer.ingress (plus any spec.externalIPs), and <pending>
+// while that status is still empty; an ExternalName reports its target; every
+// other type reports only spec.externalIPs.
+func serviceExternalIP(obj map[string]interface{}) string {
+	externalIPs := stringListField(obj, "spec", "externalIPs")
+	switch getNestedString(obj, "spec", "type") {
+	case "ExternalName":
+		if externalName := getNestedString(obj, "spec", "externalName"); externalName != "" {
+			return externalName
+		}
+		return "<none>"
+	case "LoadBalancer":
+		addresses := append(loadBalancerAddresses(obj), externalIPs...)
+		if len(addresses) > 0 {
+			return strings.Join(addresses, ",")
+		}
+		return "<pending>"
+	default:
+		if len(externalIPs) > 0 {
+			return strings.Join(externalIPs, ",")
+		}
+		return "<none>"
+	}
+}
+
+// ingressPorts mirrors kubectl: an ingress serves 80, and 443 as well once it
+// carries any TLS block.
+func ingressPorts(obj map[string]interface{}) string {
+	if specMap, ok := getNestedMap(obj, "spec"); ok {
+		if tlsList, ok := specMap["tls"].([]interface{}); ok && len(tlsList) > 0 {
+			return "80, 443"
+		}
+	}
+	return "80"
+}
+
 func formatK8sAge(timestamp string) string {
 	if timestamp == "" {
 		return ""
@@ -157,16 +254,12 @@ var kindConfigs = []kindConfig{
 					}
 				}
 			}
-			externalIP := getNestedString(obj, "spec", "externalIP")
-			if externalIP == "" {
-				externalIP = "<none>"
-			}
 			return table.Row{
 				getNestedString(obj, "metadata", "name"),
 				getNestedString(obj, "metadata", "namespace"),
 				getNestedString(obj, "spec", "type"),
 				getNestedString(obj, "spec", "clusterIP"),
-				externalIP,
+				serviceExternalIP(obj),
 				ports,
 				formatK8sAge(getNestedString(obj, "metadata", "creationTimestamp")),
 			}
@@ -256,7 +349,9 @@ var kindConfigs = []kindConfig{
 			return table.Row{
 				getNestedString(obj, "metadata", "name"),
 				getNestedString(obj, "metadata", "namespace"),
-				hosts, "", "",
+				hosts,
+				strings.Join(loadBalancerAddresses(obj), ","),
+				ingressPorts(obj),
 				formatK8sAge(getNestedString(obj, "metadata", "creationTimestamp")),
 			}
 		},

--- a/cmd/cluster_k8s_test.go
+++ b/cmd/cluster_k8s_test.go
@@ -333,3 +333,171 @@ func TestResourcesGroupHint(t *testing.T) {
 		})
 	}
 }
+
+// formatRowFor returns the table row a kind's formatter renders for obj.
+func formatRowFor(t *testing.T, commandName string, obj map[string]interface{}) []interface{} {
+	t.Helper()
+	for _, config := range kindConfigs {
+		if config.commandName == commandName {
+			if config.formatRow == nil {
+				t.Fatalf("%s has no formatRow", commandName)
+			}
+			return config.formatRow(obj)
+		}
+	}
+	t.Fatalf("no kind config named %s", commandName)
+	return nil
+}
+
+// loadBalancerStatus builds a status.loadBalancer.ingress[] array from
+// ip-or-hostname entries, matching the shape the API serves.
+func loadBalancerStatus(entries ...map[string]interface{}) map[string]interface{} {
+	ingress := make([]interface{}, 0, len(entries))
+	for _, entry := range entries {
+		ingress = append(ingress, entry)
+	}
+	return map[string]interface{}{
+		"loadBalancer": map[string]interface{}{"ingress": ingress},
+	}
+}
+
+// TestServiceExternalIPReadsLoadBalancerStatus pins the EXTERNAL-IP column to
+// kubectl's rule. The old code read a spec.externalIP field that the Service
+// API does not have, so a healthy LoadBalancer holding a public address
+// printed '<none>' - which a customer reasonably read as "the load balancer
+// was never provisioned".
+func TestServiceExternalIPReadsLoadBalancerStatus(t *testing.T) {
+	const externalIPCell = 4
+
+	cases := []struct {
+		name    string
+		service map[string]interface{}
+		want    string
+	}{
+		{
+			name: "load_balancer_with_dual_stack_status",
+			service: map[string]interface{}{
+				"spec":   map[string]interface{}{"type": "LoadBalancer"},
+				"status": loadBalancerStatus(map[string]interface{}{"ip": "129.212.253.107"}, map[string]interface{}{"ip": "2a03:b0c0:3:f0:0:2:b564:e000"}),
+			},
+			want: "129.212.253.107,2a03:b0c0:3:f0:0:2:b564:e000",
+		},
+		{
+			name: "load_balancer_with_hostname",
+			service: map[string]interface{}{
+				"spec":   map[string]interface{}{"type": "LoadBalancer"},
+				"status": loadBalancerStatus(map[string]interface{}{"hostname": "lb.example.com"}),
+			},
+			want: "lb.example.com",
+		},
+		{
+			name: "load_balancer_awaiting_the_cloud_controller",
+			service: map[string]interface{}{
+				"spec":   map[string]interface{}{"type": "LoadBalancer"},
+				"status": map[string]interface{}{"loadBalancer": map[string]interface{}{}},
+			},
+			want: "<pending>",
+		},
+		{
+			name: "load_balancer_also_carrying_spec_external_ips",
+			service: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"type":        "LoadBalancer",
+					"externalIPs": []interface{}{"203.0.113.9"},
+				},
+				"status": loadBalancerStatus(map[string]interface{}{"ip": "129.212.253.107"}),
+			},
+			want: "129.212.253.107,203.0.113.9",
+		},
+		{
+			name: "cluster_ip_with_external_ips",
+			service: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"type":        "ClusterIP",
+					"externalIPs": []interface{}{"203.0.113.9", "203.0.113.10"},
+				},
+			},
+			want: "203.0.113.9,203.0.113.10",
+		},
+		{
+			name:    "cluster_ip_without_external_ips",
+			service: map[string]interface{}{"spec": map[string]interface{}{"type": "ClusterIP"}},
+			want:    "<none>",
+		},
+		{
+			name: "external_name",
+			service: map[string]interface{}{
+				"spec": map[string]interface{}{"type": "ExternalName", "externalName": "db.example.com"},
+			},
+			want: "db.example.com",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			row := formatRowFor(t, "services", testCase.service)
+			if got := row[externalIPCell]; got != testCase.want {
+				t.Errorf("EXTERNAL-IP = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestIngressAddressAndPortsFromStatus covers the other half of the same
+// defect: the ingress row hardcoded its ADDRESS and PORTS cells to empty
+// strings, so every ingress looked unrouted no matter what the API served.
+func TestIngressAddressAndPortsFromStatus(t *testing.T) {
+	const (
+		addressCell = 3
+		portsCell   = 4
+	)
+
+	cases := []struct {
+		name        string
+		ingress     map[string]interface{}
+		wantAddress string
+		wantPorts   string
+	}{
+		{
+			name: "published_ingress",
+			ingress: map[string]interface{}{
+				"spec":   map[string]interface{}{"rules": []interface{}{map[string]interface{}{"host": "demo.example.com"}}},
+				"status": loadBalancerStatus(map[string]interface{}{"ip": "129.212.253.107"}),
+			},
+			wantAddress: "129.212.253.107",
+			wantPorts:   "80",
+		},
+		{
+			name: "tls_ingress_serves_443_too",
+			ingress: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"rules": []interface{}{map[string]interface{}{"host": "demo.example.com"}},
+					"tls":   []interface{}{map[string]interface{}{"secretName": "demo-tls"}},
+				},
+				"status": loadBalancerStatus(map[string]interface{}{"ip": "129.212.253.107"}),
+			},
+			wantAddress: "129.212.253.107",
+			wantPorts:   "80, 443",
+		},
+		{
+			name: "ingress_with_no_address_yet",
+			ingress: map[string]interface{}{
+				"spec": map[string]interface{}{"rules": []interface{}{map[string]interface{}{"host": "demo.example.com"}}},
+			},
+			wantAddress: "",
+			wantPorts:   "80",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			row := formatRowFor(t, "ingresses", testCase.ingress)
+			if got := row[addressCell]; got != testCase.wantAddress {
+				t.Errorf("ADDRESS = %v, want %v", got, testCase.wantAddress)
+			}
+			if got := row[portsCell]; got != testCase.wantPorts {
+				t.Errorf("PORTS = %v, want %v", got, testCase.wantPorts)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Bead: ankra-o196x
Linear: https://linear.app/ankra/issue/PLA-787

## What was wrong

`ankra cluster get services -A` printed `EXTERNAL-IP  <none>` for every service and
`ankra cluster get ingresses -A` printed a blank `ADDRESS` and `PORTS` for every ingress —
regardless of what the API actually served.

- `cmd/cluster_k8s.go` read `spec.externalIP` for the service row. The Service API has no
  such field; the real ones are `spec.externalIPs` (a list) and `status.loadBalancer.ingress[]`.
  So the lookup always returned `""` and the column always rendered `<none>`.
- The ingress row hardcoded its `Address` and `Ports` cells to `""`.

## What this changes

Both columns now follow kubectl's rule:

| case | EXTERNAL-IP |
|---|---|
| `LoadBalancer` with `status.loadBalancer.ingress` | those ips/hostnames, plus any `spec.externalIPs` |
| `LoadBalancer` with empty status | `<pending>` |
| `ExternalName` | `spec.externalName` |
| anything else | `spec.externalIPs`, or `<none>` |

An ingress takes its `ADDRESS` from the same `status.loadBalancer.ingress[]` field, and its
`PORTS` is `80`, or `80, 443` once it carries any TLS block.

One deliberate deviation from kubectl: kubectl truncates the address list to 16 columns
unless you pass `-o wide`. These commands reject `-o wide`, so truncating would reintroduce
the same "column doesn't tell the truth" problem; addresses render in full.

## Why it matters

This is a display bug that cost real debugging time. The reporting customer read `<none>`
and a blank `ADDRESS` on a **healthy** DigitalOcean load balancer as evidence that the LB
had been unprovisioned for 31 days, and reported that to support as fact — twice sending
the investigation down the wrong path. The address was populated in
`status.loadBalancer.ingress` the whole time and visible via `get resources ... -o json`.

## Tests

`cmd/cluster_k8s_test.go` gains two table-driven tests covering LoadBalancer (including the
reporter's dual-stack IPv4+IPv6 Traefik service), pending LoadBalancer, hostname-based LB,
`spec.externalIPs` alongside a LB address, ClusterIP with and without external IPs,
ExternalName, and the ingress address/ports cells with and without TLS. Both fail on
`master` and pass here.

## Validation

- `go test ./cmd/...` — pass
- `go vet ./cmd/` — clean
- `go build ./...` — clean
- `gofmt -l cmd/` — clean for the touched files (`cmd/chat_test.go` and
  `cmd/cluster_operation_results_test.go` are unformatted on `master` already; left alone)
- `golangci-lint` is not installed on this machine — CI's lint gate has not been run locally

## Scope note

PLA-787 reports three bugs. This PR is bug 2 only. Bug 1 (`demo_base_domain` mints preview
hostnames that the cluster's external-dns credential is not scoped to publish) is
`ankra-gmb0u` and needs a product decision; bug 3 (platform-published external-dns webhook
Secret drifts from the live token and ships as plaintext `stringData`) is `ankra-b3p58` and
needs someone with cluster access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
