### PR TITLE
fix(stack-profiles): publish must not report a failure on work that landed (ankra-rs107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,20 @@
 
 ### Fixed
 
+- **Publishing a stack profile draft no longer reports a failure on work
+  that succeeded.** Publishing does its whole job on the request path in one
+  transaction (redact, derive parameters, insert the version, move
+  latest/current), and on a profile of any size that can take longer to
+  answer than the shared client's 30-second response-header deadline. The
+  transport gave up while the platform was still working and the CLI printed
+  `http2: timeout awaiting response headers`, on a publish that then landed.
+  Publishing and instantiating a profile now ride a lane without that
+  deadline, bounded by the overall five-minute timeout instead. If one does
+  still time out, the CLI no longer calls it an error: it says the server may
+  have completed the write, names the command that settles it, and names what
+  a blind retry would do. Publishing a still-open draft twice mints two
+  versions, which is exactly what the old message invited.
+
 - **Every per-application command now accepts the application's name where it
   takes `<application-id>`.** `application list` prints names, so a name is
   what a user passes to `application branches`, `application demo list`,

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -19,7 +19,19 @@ type Client struct {
 	// orgOverride, when non-empty, is sent as the orgOverrideHeader on every
 	// request so commands run against a non-selected organisation.
 	orgOverride string
+
+	// slowWriteTimeout bounds the writes that do their whole job on the
+	// request path (see slow_write.go). They drop the response-header
+	// deadline, so this is the only thing standing between a wedged server
+	// and a CLI that never returns.
+	slowWriteTimeout time.Duration
 }
+
+// defaultSlowWriteTimeout is the overall bound for a long synchronous
+// write. It matches the shared client's Timeout: the point of the slow
+// lane is to stop the transport giving up while the server is still
+// making progress, not to wait indefinitely.
+const defaultSlowWriteTimeout = 5 * time.Minute
 
 // orgOverrideTransport injects the organisation override header on every
 // request routed through the client, so no individual call site needs to be
@@ -42,8 +54,9 @@ func (t *orgOverrideTransport) RoundTrip(req *http.Request) (*http.Response, err
 // expected to already be validated and normalized via NormalizeBaseURL.
 func New(token, baseURL string) *Client {
 	c := &Client{
-		Token:   token,
-		BaseURL: baseURL,
+		Token:            token,
+		BaseURL:          baseURL,
+		slowWriteTimeout: defaultSlowWriteTimeout,
 	}
 	sharedBase := &http.Transport{
 		ResponseHeaderTimeout: 30 * time.Second,
@@ -88,8 +101,12 @@ func (c *Client) httpClientForSlowWrite() *http.Client {
 		ResponseHeaderTimeout: 0,
 	}
 	slowWriteTransport := &orgOverrideTransport{base: slowWriteBase, orgID: &c.orgOverride}
+	timeout := c.slowWriteTimeout
+	if timeout <= 0 {
+		timeout = defaultSlowWriteTimeout
+	}
 	return &http.Client{
-		Timeout:   5 * time.Minute,
+		Timeout:   timeout,
 		Transport: slowWriteTransport,
 	}
 }

--- a/internal/client/csrf.go
+++ b/internal/client/csrf.go
@@ -61,7 +61,20 @@ func (c *Client) applyAuthAndCSRFHeaders(request *http.Request) {
 }
 
 func (c *Client) doJSON(request *http.Request, target interface{}, operation string) error {
-	response, err := c.HTTP.Do(request)
+	return c.doJSONWithClient(c.HTTP, request, target, operation)
+}
+
+// doJSONWithClient is doJSON against a caller-chosen http.Client, so a
+// long synchronous write can ride a transport without the shared 30s
+// response-header deadline (see slow_write.go) while keeping one copy of
+// the status and body handling.
+func (c *Client) doJSONWithClient(
+	httpClient *http.Client,
+	request *http.Request,
+	target interface{},
+	operation string,
+) error {
+	response, err := httpClient.Do(request)
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}

--- a/internal/client/slow_write.go
+++ b/internal/client/slow_write.go
@@ -1,0 +1,147 @@
+package client
+
+// Long synchronous writes, and what to say when one times out.
+//
+// Some platform writes do their whole job on the request path inside one
+// transaction. Publishing a stack profile draft redacts the draft, derives
+// its parameters, inserts the version and moves latest/current before it
+// answers, so it can take longer to send response headers than the shared
+// client's 30s ResponseHeaderTimeout allows. When it does, the transport
+// gives up while the server is still working and the CLI reports
+//
+//	Error: publishing stack profile draft: request failed: Post
+//	"...": http2: timeout awaiting response headers
+//
+// on work that then completes. That happened publishing
+// claude-code-session v2 (ankra-rs107): the profile reached v2 and the
+// draft was consumed, and the CLI called it a hard failure.
+//
+// Two things follow, and this file is both of them.
+//
+// A client-side timeout on a NON-IDEMPOTENT write is not a failure - it is
+// an unknown outcome, and the two must not be reported the same way. The
+// natural response to "Error:" is to run the command again, and a second
+// publish of a still-open draft mints a SECOND version. So a timeout here
+// is wrapped in a WriteOutcomeUnknownError that says the work may have
+// landed and names the command that settles it.
+//
+// Removing the deadline is not enough on its own and not safe on its own:
+// a request still ends at the client's overall 5-minute Timeout, a laptop
+// still loses its network mid-flight, and either leaves the same unknown
+// outcome. The deadline change makes the timeout rare; the error type
+// makes it survivable.
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+)
+
+// WriteOutcomeUnknownError reports a write whose outcome the CLI could not
+// determine: the request was sent, and the answer never arrived. The
+// server may or may not have applied it.
+//
+// It deliberately does not read as a failure. Callers print it, and the
+// text has to stop someone from doing the one thing that turns an
+// already-succeeded write into a duplicate.
+type WriteOutcomeUnknownError struct {
+	// Operation is the human phrase for the write, e.g. "publish stack
+	// profile draft".
+	Operation string
+	// VerifyCommand settles the question, e.g.
+	// "ankra stack-profiles get <profile>".
+	VerifyCommand string
+	// RetryConsequence names what a blind retry would do when the write
+	// did land, e.g. "publish a second version".
+	RetryConsequence string
+	Cause            error
+}
+
+func (unknownError *WriteOutcomeUnknownError) Error() string {
+	message := fmt.Sprintf(
+		"%s: the request timed out waiting for a response, but the server may have completed it",
+		unknownError.Operation)
+	if unknownError.VerifyCommand != "" {
+		message += fmt.Sprintf("\n\nCheck before retrying:\n  %s", unknownError.VerifyCommand)
+	}
+	if unknownError.RetryConsequence != "" {
+		message += fmt.Sprintf("\n\nRetrying without checking would %s if the first call did land.",
+			unknownError.RetryConsequence)
+	}
+	if unknownError.Cause != nil {
+		message += fmt.Sprintf("\n\nUnderlying error: %v", unknownError.Cause)
+	}
+	return message
+}
+
+func (unknownError *WriteOutcomeUnknownError) Unwrap() error { return unknownError.Cause }
+
+// isTimeoutError reports whether the transport gave up waiting rather than
+// receiving an answer.
+//
+// It matches on behaviour, not on message text. The header deadline
+// surfaces as x/net/http2's errTimeout, the overall Client.Timeout as a
+// context deadline; both arrive wrapped in *url.Error, which forwards
+// Timeout(), so net.Error covers them and a request cancelled by its own
+// context is caught alongside.
+func isTimeoutError(requestError error) bool {
+	if requestError == nil {
+		return false
+	}
+	if errors.Is(requestError, context.DeadlineExceeded) {
+		return true
+	}
+	var netError net.Error
+	if errors.As(requestError, &netError) {
+		return netError.Timeout()
+	}
+	return false
+}
+
+// unknownOutcome wraps a timeout on a non-idempotent write, and returns
+// every other error untouched: a 4xx, a refused connection or a DNS
+// failure all mean the write did not happen, and saying "it may have
+// completed" about those would be worse than saying nothing.
+func unknownOutcome(requestError error, operation string, verifyCommand string, retryConsequence string) error {
+	if !isTimeoutError(requestError) {
+		return requestError
+	}
+	return &WriteOutcomeUnknownError{
+		Operation:        operation,
+		VerifyCommand:    verifyCommand,
+		RetryConsequence: retryConsequence,
+		Cause:            requestError,
+	}
+}
+
+// postCSRFJSONSlowWrite is postCSRFJSON for a write that legitimately
+// takes longer than the shared client's response-header deadline. The call
+// is bounded by the 5-minute overall client timeout instead, and a timeout
+// is reported as an unknown outcome rather than a failure.
+func (c *Client) postCSRFJSONSlowWrite(
+	requestURL string,
+	requestBody interface{},
+	target interface{},
+	operation string,
+	verifyCommand string,
+	retryConsequence string,
+) error {
+	payload, marshalError := marshalOptionalJSON(requestBody)
+	if marshalError != nil {
+		return marshalError
+	}
+	request, requestError := http.NewRequest(http.MethodPost, requestURL, bytes.NewReader(payload))
+	if requestError != nil {
+		return fmt.Errorf("create request: %w", requestError)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	c.applyAuthAndCSRFHeaders(request)
+
+	if doError := c.doJSONWithClient(c.httpClientForSlowWrite(), request, target, operation); doError != nil {
+		return unknownOutcome(doError, operation, verifyCommand, retryConsequence)
+	}
+	return nil
+}

--- a/internal/client/slow_write_test.go
+++ b/internal/client/slow_write_test.go
@@ -1,0 +1,198 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// slowHeaderHandler withholds the response headers for the given delay, the
+// way a publish that is still inside its transaction does.
+func slowHeaderServer(t *testing.T, headerDelay time.Duration, body string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		time.Sleep(headerDelay)
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// TestSlowWriteOutlivesTheSharedResponseHeaderDeadline pins the first half
+// of ankra-rs107. The shared client gives up after 30s of silence; a
+// publish that takes longer to answer must not be cut off by the transport
+// while the server is still working.
+func TestSlowWriteOutlivesTheSharedResponseHeaderDeadline(t *testing.T) {
+	sharedTransport, isTransport := New("token", "http://example.invalid").
+		HTTP.Transport.(*orgOverrideTransport)
+	if !isTransport {
+		t.Fatalf("shared transport = %T, want *orgOverrideTransport", sharedTransport)
+	}
+	retrying, isRetrying := sharedTransport.base.(*retryTransport)
+	if !isRetrying {
+		t.Fatalf("shared base = %T, want *retryTransport", sharedTransport.base)
+	}
+	sharedBase, isHTTPTransport := retrying.base.(*http.Transport)
+	if !isHTTPTransport {
+		t.Fatalf("shared inner = %T, want *http.Transport", retrying.base)
+	}
+	if sharedBase.ResponseHeaderTimeout == 0 {
+		t.Fatal("the shared transport is expected to keep a response-header deadline; " +
+			"this test exists because publish must NOT use it")
+	}
+
+	slowClient := New("token", "http://example.invalid").httpClientForSlowWrite()
+	slowTransport, isSlowTransport := slowClient.Transport.(*orgOverrideTransport)
+	if !isSlowTransport {
+		t.Fatalf("slow-write transport = %T", slowClient.Transport)
+	}
+	slowBase, isSlowHTTP := slowTransport.base.(*http.Transport)
+	if !isSlowHTTP {
+		t.Fatalf("slow-write base = %T, want *http.Transport", slowTransport.base)
+	}
+	if slowBase.ResponseHeaderTimeout != 0 {
+		t.Fatalf("slow-write ResponseHeaderTimeout = %v, want 0 (bounded by the client timeout instead)",
+			slowBase.ResponseHeaderTimeout)
+	}
+	if slowClient.Timeout == 0 {
+		t.Fatal("the slow-write client must still be bounded overall, or a hung server hangs the CLI forever")
+	}
+}
+
+// TestPublishOverTheSlowLaneStillParsesItsResult guards the refactor
+// rather than the deadline: moving publish onto a different http.Client
+// must not change how the response is read. It does not discriminate on
+// the deadline itself - 150ms is inside the shared 30s window too - which
+// is what the structural test above and the timeout test below are for.
+func TestPublishOverTheSlowLaneStillParsesItsResult(t *testing.T) {
+	server := slowHeaderServer(t, 150*time.Millisecond,
+		`{"profile":{"id":"p1","name":"claude-code-session"},"version":{"version":2}}`)
+	apiClient := New("token", server.URL)
+
+	result, publishError := apiClient.PublishStackProfileDraft("48e1f0b8", PublishStackProfileDraftRequest{})
+	if publishError != nil {
+		t.Fatalf("publish returned %v", publishError)
+	}
+	if result == nil {
+		t.Fatal("publish returned no result")
+	}
+	if result.Profile["name"] != "claude-code-session" {
+		t.Fatalf("profile = %v", result.Profile)
+	}
+}
+
+// TestPublishTimeoutReportsAnUnknownOutcome pins the second half, and the
+// one that actually cost a duplicate version: a client-side timeout on a
+// non-idempotent write must not read as a plain failure, because the
+// natural next move after "Error:" is to run the command again.
+func TestPublishTimeoutReportsAnUnknownOutcome(t *testing.T) {
+	server := slowHeaderServer(t, 2*time.Second, `{}`)
+	apiClient := New("token", server.URL)
+	// Bound this call far below the server's delay so the timeout is the
+	// deterministic outcome, without the test sleeping for the real one.
+	apiClient.slowWriteTimeout = 50 * time.Millisecond
+
+	_, publishError := apiClient.PublishStackProfileDraft("48e1f0b8", PublishStackProfileDraftRequest{})
+	if publishError == nil {
+		t.Fatal("a timed-out publish must report something")
+	}
+
+	var unknownError *WriteOutcomeUnknownError
+	if !errors.As(publishError, &unknownError) {
+		t.Fatalf("publish timeout = %T (%v), want *WriteOutcomeUnknownError", publishError, publishError)
+	}
+
+	message := unknownError.Error()
+	for _, required := range []string{
+		"may have completed",
+		"Check before retrying",
+		"ankra stack-profiles list",
+		"publish a second version",
+	} {
+		if !strings.Contains(message, required) {
+			t.Fatalf("timeout message missing %q:\n%s", required, message)
+		}
+	}
+	// It must not read as a completed failure.
+	if strings.Contains(strings.ToLower(message), "failed to publish") {
+		t.Fatalf("the message states a failure it cannot know about:\n%s", message)
+	}
+}
+
+// TestNonTimeoutErrorsAreNotDressedUpAsUnknown: a 4xx, a refused
+// connection or a DNS failure all mean the write did NOT happen. Telling
+// someone to go and check would be worse than saying nothing.
+func TestNonTimeoutErrorsAreNotDressedUpAsUnknown(t *testing.T) {
+	refusing := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusBadRequest)
+		_, _ = writer.Write([]byte(`{"detail":"draft already published"}`))
+	}))
+	defer refusing.Close()
+
+	apiClient := New("token", refusing.URL)
+	_, publishError := apiClient.PublishStackProfileDraft("48e1f0b8", PublishStackProfileDraftRequest{})
+	if publishError == nil {
+		t.Fatal("a 400 must surface")
+	}
+	var unknownError *WriteOutcomeUnknownError
+	if errors.As(publishError, &unknownError) {
+		t.Fatalf("a 400 was reported as an unknown outcome: %v", publishError)
+	}
+	if !strings.Contains(publishError.Error(), "draft already published") {
+		t.Fatalf("the server's detail was lost: %v", publishError)
+	}
+}
+
+// TestIsTimeoutErrorMatchesOnBehaviourNotText: the header deadline arrives
+// as x/net/http2's errTimeout wrapped in *url.Error, the overall client
+// timeout as a context deadline. Matching the message string would break
+// the first time Go rewords either.
+func TestIsTimeoutErrorMatchesOnBehaviourNotText(t *testing.T) {
+	timeoutCases := []struct {
+		name  string
+		given error
+	}{
+		{"context deadline", context.DeadlineExceeded},
+		{"wrapped context deadline", fmt.Errorf("request failed: %w", context.DeadlineExceeded)},
+		{"net.Error reporting a timeout", &net.OpError{Op: "read", Err: timeoutStub{}}},
+		{"wrapped net timeout", fmt.Errorf("request failed: %w", &net.OpError{Op: "read", Err: timeoutStub{}})},
+	}
+	for _, testCase := range timeoutCases {
+		if !isTimeoutError(testCase.given) {
+			t.Fatalf("%s must be a timeout", testCase.name)
+		}
+	}
+
+	notTimeouts := []struct {
+		name  string
+		given error
+	}{
+		{"nil", nil},
+		{"connection refused", errors.New("connect: connection refused")},
+		{"a 400 response", newUnexpectedResponseErrorWithMessage(400, "draft already published")},
+		{"context cancelled by the user", context.Canceled},
+	}
+	for _, testCase := range notTimeouts {
+		if isTimeoutError(testCase.given) {
+			t.Fatalf("%s must not be a timeout", testCase.name)
+		}
+	}
+}
+
+// timeoutStub is an error that reports itself as a timeout, standing in for
+// the transport's own timeout errors without depending on their text.
+type timeoutStub struct{}
+
+func (timeoutStub) Error() string { return "i/o timeout" }
+func (timeoutStub) Timeout() bool { return true }
+func (timeoutStub) Temporary() bool {
+	return true
+}

--- a/internal/client/stack_profile_drafts.go
+++ b/internal/client/stack_profile_drafts.go
@@ -123,10 +123,22 @@ func (c *Client) DeleteStackProfileDraft(draftID string) (*DeleteStackProfileDra
 
 // PublishStackProfileDraft publishes the draft as a new profile version
 // (or a brand-new profile for a draft opened with a name).
+//
+// Publishing does its whole job on the request path in one transaction -
+// redact, derive parameters, insert the version, move latest/current - so
+// it rides the slow-write lane rather than the shared client's 30s
+// response-header deadline, and a timeout is reported as an unknown
+// outcome. It is not idempotent: publishing a still-open draft twice mints
+// two versions, which is exactly what a retry after a misreported failure
+// would do (ankra-rs107).
 func (c *Client) PublishStackProfileDraft(draftID string, request PublishStackProfileDraftRequest) (*PublishStackProfileDraftResult, error) {
 	var result PublishStackProfileDraftResult
-	if err := c.postCSRFJSON(c.stackProfileDraftsBasePath()+"/"+url.PathEscape(draftID)+"/publish",
-		request, &result, "publish stack profile draft"); err != nil {
+	if err := c.postCSRFJSONSlowWrite(
+		c.stackProfileDraftsBasePath()+"/"+url.PathEscape(draftID)+"/publish",
+		request, &result, "publish stack profile draft",
+		"ankra stack-profiles list   # the draft is consumed and the profile carries a new version when it landed",
+		"publish a second version of the same profile",
+	); err != nil {
 		return nil, err
 	}
 	return &result, nil

--- a/internal/client/stack_profiles.go
+++ b/internal/client/stack_profiles.go
@@ -242,6 +242,11 @@ func (c *Client) GetStackProfile(profileID string) (*StackProfileDetail, error) 
 	return &result, nil
 }
 
+// InstantiateStackProfile materialises a profile onto a cluster as a new
+// stack. Like publishing, it does its work synchronously and is not
+// idempotent - a second call adds a second stack - so it rides the
+// slow-write lane and reports a timeout as an unknown outcome rather than
+// a failure (ankra-rs107).
 func (c *Client) InstantiateStackProfile(ctx context.Context, clusterID string, instantiateRequest InstantiateStackProfileRequest) (*InstantiateStackProfileResult, error) {
 	requestURL := fmt.Sprintf("%s/api/v1/org/clusters/imported/%s/stacks/from-profile",
 		c.BaseURL, neturl.PathEscape(clusterID))
@@ -255,9 +260,12 @@ func (c *Client) InstantiateStackProfile(ctx context.Context, clusterID string, 
 	}
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Authorization", "Bearer "+c.Token)
-	response, err := c.HTTP.Do(request)
+	response, err := c.httpClientForSlowWrite().Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, unknownOutcome(fmt.Errorf("request failed: %w", err),
+			"instantiate stack profile",
+			"ankra cluster stacks list   # against this cluster; the stack is present when it landed",
+			"create a second stack from the same profile")
 	}
 	defer closeBody(response)
 	body, err := readResponseBody(response)


### PR DESCRIPTION
## The defect

`ankra stack-profiles drafts publish` answered

```
Error: publishing stack profile draft: request failed: Post ".../publish":
http2: timeout awaiting response headers
```

on a publish that had **succeeded**. The profile was at v2 and the draft was consumed (hit publishing claude-code-session v2, 2026-08-22).

Publishing does its whole job on the request path in one transaction: redact, derive parameters, insert the version, move latest/current. On a profile of any size that can take longer to send response headers than the shared client's 30s `ResponseHeaderTimeout` allows, so the transport gives up while the platform is still working.

Two separate defects, and the second is the one that costs something.

## 1. The deadline

Publish and instantiate now ride `httpClientForSlowWrite`, which drops `ResponseHeaderTimeout` so the call is bounded by the overall client timeout instead of by silence. That timeout became a named constant on the `Client` rather than a literal, because it is the only thing left standing between a wedged server and a CLI that never returns. `doJSON` gained a `doJSONWithClient` sibling so status and body handling stays in one place.

## 2. The reporting, which matters more

A client-side timeout on a **non-idempotent** write is not a failure. It is an unknown outcome, and the two must not print the same way: the natural response to `Error:` is to run the command again, and a second publish of a still-open draft mints a **second version**.

A timeout on these writes now returns a `WriteOutcomeUnknownError` that says the server may have completed it, names the command that settles the question, and names what a blind retry would do:

```
publish stack profile draft: the request timed out waiting for a response,
but the server may have completed it

Check before retrying:
  ankra stack-profiles list   # the draft is consumed and the profile carries a new version when it landed

Retrying without checking would publish a second version of the same profile if the first call did land.
```

Every other error is returned untouched. A 4xx, a refused connection or a DNS failure all mean the write did not happen, and saying "it may have completed" about those would be worse than saying nothing.

Removing the deadline alone would not have been enough, which is why both halves are here: a request still ends at the overall timeout, and a laptop still loses its network mid-flight. The deadline change makes the timeout rare; the error type makes it survivable.

## Detection

Timeouts are matched on **behaviour, not message text**: `net.Error`'s `Timeout()` plus `context.DeadlineExceeded`. Both the header deadline (x/net http2's `errTimeout`) and the overall `Client.Timeout` arrive wrapped in `*url.Error`, which forwards `Timeout()`, so this keeps working when Go rewords the transport's own errors.

## Verification

- `TestPublishTimeoutReportsAnUnknownOutcome` was verified to **fail without the fix** by reverting publish to `postCSRFJSON` and re-running.
- `TestNonTimeoutErrorsAreNotDressedUpAsUnknown` pins that a 400 still surfaces the server's own detail and is not relabelled.
- `TestIsTimeoutErrorMatchesOnBehaviourNotText` covers context deadlines, wrapped net timeouts, and the negatives (connection refused, a 400, a user-cancelled context).
- `TestSlowWriteOutlivesTheSharedResponseHeaderDeadline` asserts the structural difference between the two transports, and that the slow one is still bounded overall.
- The happy-path test is named for what it actually proves, that moving publish to another `http.Client` did not change how the response is read. It does not discriminate on the deadline, and says so.

`go test -race -count=1 ./...` passes. The two files `gofmt` flags (`cmd/chat_test.go`, `cmd/cluster_operation_results_test.go`) are unformatted on pristine `origin/master` and are untouched here.

## Scope

The bead notes the same reasoning applies to other long writes. Publish and instantiate are covered; the primitives (`postCSRFJSONSlowWrite`, `unknownOutcome`) are there for the rest as they are found to need it, rather than reclassifying every write speculatively in one pass.

Bead: ankra-rs107

🤖 Generated with [Claude Code](https://claude.com/claude-code)
