### PR TITLE
docs(cluster): say that --include-dns scopes external-dns to the generated subdomain (ankra-hfo1h)

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -43,9 +43,16 @@ func isLikelyClusterID(value string) bool {
 // resolve and get a certificate without bringing your own domain. external-dns
 // itself ships inside the networking stack, so opting out of that stack leaves
 // the zone delegated but unused.
+//
+// The help text has to name the boundary. The cluster's DNS credential is
+// pinned to the delegated subzone, so external-dns manages hostnames under it
+// and silently ignores every other ingress host - it logs "All records are
+// already up to date" and publishes nothing. A user who reads "an ingress
+// hostname" as "any ingress hostname" only finds out when their own zone never
+// resolves and HTTP-01 issuance stalls behind it.
 func registerIncludeDNSFlag(cmds ...*cobra.Command) {
 	for _, cmd := range cmds {
-		cmd.Flags().Bool("include-dns", true, "Give the cluster its own subdomain under ankra.cc and install external-dns, so an ingress hostname gets its DNS record and TLS certificate with no manual setup (default on; pass --include-dns=false to skip)")
+		cmd.Flags().Bool("include-dns", true, "Give the cluster its own subdomain under ankra.cc and install external-dns, so an ingress hostname under that subdomain gets its DNS record and TLS certificate with no manual setup. Scope: external-dns only manages the generated subdomain - ingress hosts on your own domains are ignored, and their DNS records stay yours to create (default on; pass --include-dns=false to skip)")
 	}
 }
 

--- a/cmd/cluster_test.go
+++ b/cmd/cluster_test.go
@@ -53,6 +53,27 @@ func TestProviderCreateCommandsExposeTheFlagTrio(t *testing.T) {
 	}
 }
 
+// external-dns runs with a credential pinned to the generated subzone, so it
+// ignores ingress hosts on any other domain without saying so. The help text
+// is the only place a user learns that before they hit it, so pin the scope
+// sentence rather than let a reword drop it (PLA-788).
+func TestIncludeDNSHelpNamesItsScope(t *testing.T) {
+	for _, cmd := range []*cobra.Command{
+		upcloudCreateCmd, digitaloceanCreateCmd, hetznerCreateCmd,
+		ovhCreateCmd, proxmoxCreateCmd, morpheusCreateCmd,
+	} {
+		flag := cmd.Flags().Lookup("include-dns")
+		if flag == nil {
+			t.Fatalf("%s create must expose --include-dns", cmd.Name())
+		}
+		for _, want := range []string{"only manages the generated subdomain", "your own domains are ignored"} {
+			if !strings.Contains(flag.Usage, want) {
+				t.Errorf("--include-dns usage on %q is missing %q; it reads: %s", cmd.CommandPath(), want, flag.Usage)
+			}
+		}
+	}
+}
+
 func TestResolveCloudProviderNetworking(t *testing.T) {
 	tests := []struct {
 		name              string


### PR DESCRIPTION
## What & why

`--include-dns` help currently reads:

> Give the cluster its own subdomain under ankra.cc and install external-dns, so **an ingress
> hostname** gets its DNS record and TLS certificate with no manual setup

external-dns on the cluster runs with an Avura credential pinned to the delegated subzone
(`cluster` `scheduler/go/internal/dnszone/dnszone.go`, package doc — the blast-radius invariant),
and the webhook negotiation returns exactly that one zone, so external-dns manages hostnames
**under the generated subdomain** and drops every other ingress host without a word: the sync
logs `All records are already up to date` and publishes nothing.

A customer read "an ingress hostname" as "any ingress hostname", pointed ingress at hosts on
their own zone, and found out only when nothing resolved and cert-manager HTTP-01 issuance
stalled behind the missing A records ([PLA-788](https://linear.app/ankra/issue/PLA-788/1084-external-dns-from-include-dns-is-scoped-to-the-generated-ankracc)).
The Go doc comment above the flag already knew the limit ("without bringing your own domain");
the user-facing string never said it.

This is the wording half only. **No behaviour change.** Whether org-owned/verified zones should
be admittable to the domain filter at all — and whether clusters get a first-class custom-domain
setting — is the open product decision tracked on `ankra-gmb0u`, which the same ticket feeds.

Bead: ankra-hfo1h

## Test plan

- New `TestIncludeDNSHelpNamesItsScope` pins the scope sentence across all six provider create
  commands. Verified it **fails** against the old help text and passes with the new one.
- `go test ./cmd/` green; `go vet ./cmd/` clean; `gofmt` clean.

## Docs checklist

- [ ] No user-facing command/flag changes — no docs needed
- [x] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); ensure `Short`/`Long`/`Example` on new commands are written for docs readers
- [ ] Broader behaviour changes — docs updated in [ankra-docs](https://github.com/ankraio/ankra-docs) (link the PR): <!-- PR link -->

The public `reference/cli/cluster` table is generated from this `Usage` string by the
`docs-sync` workflow on the next stable release tag, so no ankra-docs PR is needed here.

🤖 Opened by the Ankra tech-agent from PLA-788. Draft on purpose — not for merge without human review.
