### PR TITLE
feat(credentials): say which repositories a GitHub credential actually covers (ankra-zesx5.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Ankra CLI Changelog
 
+## Unreleased
+
+### Added
+
+- **`ankra credentials repositories <id|name>` says which repositories a
+  GitHub credential can actually reach.** `credentials list` prints a REPOS
+  count and nothing anywhere broke it down, so when the count disagreed with
+  reality there was no way to see which repository was missing. That is
+  exactly the state a customer spent a day in: a credential reporting one
+  repository, up, available and freshly synced, while every call against the
+  repository it was bound to answered 404. The new command reads the
+  installation's repositories live from the provider, lists them against the
+  repositories Ankra needs from that credential, and names the ones required
+  but unreachable. Worth knowing why the old number misled: the REPOS count is
+  a cache refreshed by a sweep that only runs while the credential reports
+  healthy, so a credential that breaks stops refreshing the very rows that
+  would show it broke. This command does not read that cache. A listing that
+  could not be read is reported as exactly that, never as an installation that
+  reaches nothing. (PLA-786)
+
 ## v0.13.0-rc1 — 2026-08-24
 
 ### Added

--- a/cmd/credentials.go
+++ b/cmd/credentials.go
@@ -277,17 +277,100 @@ func looksLikeUUID(s string) bool {
 	return true
 }
 
+// renderRepositoryList prints one titled block of repository full names, or
+// says the set is empty. Kept separate from the unknown case below because an
+// empty set is an answer and an unread listing is not.
+func renderRepositoryList(title string, repositories []string, emptyNote string) {
+	if len(repositories) == 0 {
+		fmt.Printf("  %s: %s\n", title, emptyNote)
+		return
+	}
+	fmt.Printf("  %s (%d):\n", title, len(repositories))
+	for _, repository := range repositories {
+		fmt.Printf("    %s\n", repository)
+	}
+}
+
+var credentialsRepositoriesCmd = &cobra.Command{
+	Use:   "repositories <credential_id|name>",
+	Short: "Show which repositories a credential can actually reach",
+	Long: "Read the repositories a GitHub credential's installation can reach right now, " +
+		"against the repositories Ankra needs from it, and report where they disagree.\n\n" +
+		"The accessible list is read live from the provider rather than from the cached " +
+		"count shown in `ankra credentials list`, because that count is only refreshed " +
+		"while the credential reports healthy - so a credential that has stopped being " +
+		"able to read its repository keeps reporting the count it had before it broke.",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		credentialID, resolveError := resolveCredentialID(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
+
+		coverage, coverageError := apiClient.GetCredentialRepositories(credentialID)
+		if coverageError != nil {
+			return fmt.Errorf("reading credential repositories: %w", coverageError)
+		}
+
+		if rendered, err := renderStructured(cmd, coverage); rendered || err != nil {
+			return err
+		}
+
+		fmt.Printf("Credential: %s (%s)\n", coverage.Credential.Name, coverage.Credential.Provider)
+		if coverage.Credential.AccountLogin != nil && *coverage.Credential.AccountLogin != "" {
+			fmt.Printf("  Account:  %s\n", *coverage.Credential.AccountLogin)
+		}
+		fmt.Printf("  Coverage: %s\n", coverage.Coverage)
+		if coverage.CoverageMessage != "" {
+			fmt.Printf("  %s\n", coverage.CoverageMessage)
+		}
+		fmt.Println()
+
+		// A nil accessible list is the provider listing failing, which is a
+		// different fact from an installation that reaches nothing. Printing
+		// "none" for both would recreate the confusion this command exists to
+		// end, so the unread case says so and names the error.
+		if coverage.AccessibleRepositories == nil {
+			fmt.Printf("  Reachable now: could not be read\n")
+			if coverage.AccessibleRepositoriesError != nil && *coverage.AccessibleRepositoriesError != "" {
+				fmt.Printf("    %s\n", *coverage.AccessibleRepositoriesError)
+			}
+		} else {
+			renderRepositoryList("Reachable now", *coverage.AccessibleRepositories,
+				"none - the installation reaches no repository at all")
+			if !coverage.AccessibleRepositoriesComplete {
+				fmt.Printf("    (listing truncated; more repositories exist than were read)\n")
+			}
+		}
+
+		renderRepositoryList("Required by Ankra", coverage.RequiredRepositories,
+			"none - nothing is configured to use this credential yet")
+		if !coverage.RequiredRepositoriesComplete {
+			fmt.Printf("    (listing truncated; more repositories require this credential)\n")
+		}
+
+		if len(coverage.UnreachableRepositories) > 0 {
+			renderRepositoryList("Required but NOT reachable", coverage.UnreachableRepositories, "")
+		}
+		if len(coverage.UnverifiedRepositories) > 0 {
+			renderRepositoryList("Required but unverified", coverage.UnverifiedRepositories, "")
+		}
+		return nil
+	},
+}
+
 func init() {
 	credentialsListCmd.Flags().String("provider", "", "Filter by provider (e.g., github)")
 	credentialsDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
-	registerStructuredOutputFlags(credentialsListCmd, credentialsGetCmd)
+	registerStructuredOutputFlags(credentialsListCmd, credentialsGetCmd, credentialsRepositoriesCmd)
 	registerSortFlags(credentialsListCmd, credentialSortFields)
 
 	credentialsCmd.AddCommand(credentialsListCmd)
 	credentialsCmd.AddCommand(credentialsValidateCmd)
 	credentialsCmd.AddCommand(credentialsDeleteCmd)
 	credentialsCmd.AddCommand(credentialsGetCmd)
+	credentialsCmd.AddCommand(credentialsRepositoriesCmd)
 
 	rootCmd.AddCommand(credentialsCmd)
 }

--- a/cmd/credentials_repositories_test.go
+++ b/cmd/credentials_repositories_test.go
@@ -1,0 +1,192 @@
+package cmd
+
+// The credential repository-coverage command.
+//
+// The customer in PLA-786 had a credential reporting one repository while
+// every call against the repository it was bound to answered 404, and no
+// surface anywhere broke that count down. These pin the two distinctions the
+// command exists to keep: reachable-versus-required, and an unread listing
+// versus an installation that reaches nothing.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+// serveCoverage stands up a server answering the repositories route with the
+// supplied body and points the command's client at it.
+func serveCoverage(t *testing.T, body string) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		if !strings.HasSuffix(request.URL.Path, "/repositories") {
+			responseWriter.WriteHeader(http.StatusNotFound)
+			return
+		}
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, _ = responseWriter.Write([]byte(body))
+	}))
+	previousClient := apiClient
+	previousBaseURL := baseURL
+	apiClient = client.New("test-token", server.URL)
+	baseURL = server.URL
+	t.Cleanup(func() {
+		apiClient = previousClient
+		baseURL = previousBaseURL
+		server.Close()
+	})
+}
+
+// runRepositories drives the command and returns everything it printed. The
+// command prints with fmt.Printf like the rest of this package, so stdout is
+// what has to be captured.
+func runRepositories(t *testing.T, credentialID string) string {
+	t.Helper()
+	var runError error
+	output := captureStdout(t, func() {
+		runError = credentialsRepositoriesCmd.RunE(credentialsRepositoriesCmd, []string{credentialID})
+	})
+	if runError != nil {
+		t.Fatalf("command returned an error: %v", runError)
+	}
+	return output
+}
+
+const coveredBody = `{
+  "credential": {"id":"11111111-1111-4111-8111-111111111111","name":"github-app-example",
+    "provider":"github","state":"up","available":true,"account_login":"example-org",
+    "app_backed":true,"syncing":false},
+  "coverage": "complete",
+  "coverage_message": "The GitHub App installation behind this credential can reach every repository Ankra needs from it.",
+  "accessible_repositories": ["example-org/one","example-org/two"],
+  "accessible_repositories_complete": true,
+  "accessible_repositories_error": null,
+  "required_repositories": ["example-org/one"],
+  "required_repositories_complete": true,
+  "unreachable_repositories": [],
+  "unverified_repositories": []
+}`
+
+// The reported failure: required repositories the installation cannot see.
+const incompleteBody = `{
+  "credential": {"id":"11111111-1111-4111-8111-111111111111","name":"github-app-example",
+    "provider":"github","state":"up","available":true,"app_backed":true,"syncing":false},
+  "coverage": "incomplete",
+  "coverage_message": "This credential cannot reach every repository Ankra needs from it.",
+  "accessible_repositories": ["example-org/two"],
+  "accessible_repositories_complete": true,
+  "accessible_repositories_error": null,
+  "required_repositories": ["example-org/one"],
+  "required_repositories_complete": true,
+  "unreachable_repositories": ["example-org/one"],
+  "unverified_repositories": []
+}`
+
+// The listing itself failed. Null, not an empty array.
+const unknownBody = `{
+  "credential": {"id":"11111111-1111-4111-8111-111111111111","name":"github-app-example",
+    "provider":"github","state":"up","available":true,"app_backed":true,"syncing":false},
+  "coverage": "unknown",
+  "coverage_message": "Whether this credential covers what Ankra needs could not be established.",
+  "accessible_repositories": null,
+  "accessible_repositories_complete": false,
+  "accessible_repositories_error": "GitHub API returned status 502 while listing installation repositories.",
+  "required_repositories": ["example-org/one"],
+  "required_repositories_complete": true,
+  "unreachable_repositories": [],
+  "unverified_repositories": ["example-org/one"]
+}`
+
+// An installation that genuinely reaches nothing. Empty array, not null - the
+// opposite fact from unknownBody, and it must not render the same way.
+const reachesNothingBody = `{
+  "credential": {"id":"11111111-1111-4111-8111-111111111111","name":"github-app-example",
+    "provider":"github","state":"up","available":true,"app_backed":true,"syncing":false},
+  "coverage": "incomplete",
+  "coverage_message": "This credential cannot reach every repository Ankra needs from it.",
+  "accessible_repositories": [],
+  "accessible_repositories_complete": true,
+  "accessible_repositories_error": null,
+  "required_repositories": ["example-org/one"],
+  "required_repositories_complete": true,
+  "unreachable_repositories": ["example-org/one"],
+  "unverified_repositories": []
+}`
+
+func TestCredentialRepositoriesReportsCoverageAndBothSets(t *testing.T) {
+	serveCoverage(t, coveredBody)
+	output := runRepositories(t, "11111111-1111-4111-8111-111111111111")
+
+	for _, want := range []string{"complete", "example-org/one", "example-org/two", "Required by Ankra"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output = %q, want it to mention %q", output, want)
+		}
+	}
+}
+
+func TestCredentialRepositoriesNamesWhatIsRequiredButUnreachable(t *testing.T) {
+	serveCoverage(t, incompleteBody)
+	output := runRepositories(t, "11111111-1111-4111-8111-111111111111")
+
+	if !strings.Contains(output, "Required but NOT reachable") {
+		t.Fatalf("output = %q, want the unreachable section", output)
+	}
+	if !strings.Contains(output, "incomplete") {
+		t.Fatalf("output = %q, want the incomplete verdict", output)
+	}
+}
+
+// The distinction the whole endpoint exists for: "we could not check" must
+// never render as "it covers nothing", which is what the frozen REPOS count
+// effectively did.
+func TestCredentialRepositoriesSeparatesAnUnreadListingFromAnEmptyOne(t *testing.T) {
+	serveCoverage(t, unknownBody)
+	unread := runRepositories(t, "11111111-1111-4111-8111-111111111111")
+
+	if !strings.Contains(unread, "could not be read") {
+		t.Fatalf("output = %q, want the unread listing named as such", unread)
+	}
+	if !strings.Contains(unread, "502") {
+		t.Fatalf("output = %q, want the underlying error surfaced", unread)
+	}
+	if strings.Contains(unread, "reaches no repository at all") {
+		t.Fatalf("output = %q, must not claim the installation reaches nothing", unread)
+	}
+
+	serveCoverage(t, reachesNothingBody)
+	empty := runRepositories(t, "11111111-1111-4111-8111-111111111111")
+
+	if !strings.Contains(empty, "reaches no repository at all") {
+		t.Fatalf("output = %q, want an empty set stated plainly", empty)
+	}
+	if strings.Contains(empty, "could not be read") {
+		t.Fatalf("output = %q, an empty set is an answer and must not read as unknown", empty)
+	}
+}
+
+// The client model must keep null distinguishable from [] after decoding, or
+// the rendering above cannot tell them apart no matter what it does.
+func TestCredentialRepositoryCoverageDecodesNullAndEmptyDistinctly(t *testing.T) {
+	var unread client.CredentialRepositoryCoverage
+	if decodeError := json.Unmarshal([]byte(unknownBody), &unread); decodeError != nil {
+		t.Fatalf("decoding the unread body: %v", decodeError)
+	}
+	if unread.AccessibleRepositories != nil {
+		t.Fatalf("a null accessible list must decode to nil, got %v", *unread.AccessibleRepositories)
+	}
+
+	var empty client.CredentialRepositoryCoverage
+	if decodeError := json.Unmarshal([]byte(reachesNothingBody), &empty); decodeError != nil {
+		t.Fatalf("decoding the empty body: %v", decodeError)
+	}
+	if empty.AccessibleRepositories == nil {
+		t.Fatal("an empty accessible list must decode to a non-nil empty slice, not nil")
+	}
+	if len(*empty.AccessibleRepositories) != 0 {
+		t.Fatalf("accessible = %v, want empty", *empty.AccessibleRepositories)
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -796,6 +796,10 @@ func (m baseMock) GetCredential(credentialID string) (*client.CredentialDetail, 
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) GetCredentialRepositories(credentialID string) (*client.CredentialRepositoryCoverage, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) ListAPITokens() ([]client.APIToken, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -221,6 +221,7 @@ type APIClient interface {
 	ValidateCredentialName(name string) (*client.CredentialValidationResult, error)
 	DeleteCredential(ctx context.Context, credentialID, organisationID string) (*client.DeleteCredentialResult, error)
 	GetCredential(credentialID string) (*client.CredentialDetail, error)
+	GetCredentialRepositories(credentialID string) (*client.CredentialRepositoryCoverage, error)
 
 	ListAPITokens() ([]client.APIToken, error)
 	CreateAPIToken(name string, expiresAt *string, scopes []string) (*client.CreateAPITokenResponse, error)

--- a/internal/client/credentials.go
+++ b/internal/client/credentials.go
@@ -71,6 +71,43 @@ type DeleteCredentialResult struct {
 	Message string `json:"message"`
 }
 
+// CredentialRepositorySubject is the credential the coverage answer is about,
+// echoed back so a rendered report names what it inspected.
+type CredentialRepositorySubject struct {
+	ID             string  `json:"id"`
+	Name           string  `json:"name"`
+	Provider       string  `json:"provider"`
+	State          string  `json:"state"`
+	Available      bool    `json:"available"`
+	AccountLogin   *string `json:"account_login,omitempty"`
+	AccountType    *string `json:"account_type,omitempty"`
+	InstallationID *int64  `json:"installation_id,omitempty"`
+	AppBacked      bool    `json:"app_backed"`
+	LastSyncedAt   *string `json:"last_synced_at,omitempty"`
+	Syncing        bool    `json:"syncing"`
+}
+
+// CredentialRepositoryCoverage answers which repositories a credential can
+// actually reach against the ones Ankra needs from it.
+//
+// AccessibleRepositories is a pointer on purpose: the server sends null, not
+// an empty list, when the listing could not be read. The two mean opposite
+// things - "this credential reaches nothing" versus "we could not find out" -
+// and the whole point of the endpoint is that the second was previously
+// indistinguishable from a healthy credential (PLA-786).
+type CredentialRepositoryCoverage struct {
+	Credential                     CredentialRepositorySubject `json:"credential"`
+	Coverage                       string                      `json:"coverage"`
+	CoverageMessage                string                      `json:"coverage_message"`
+	AccessibleRepositories         *[]string                   `json:"accessible_repositories"`
+	AccessibleRepositoriesComplete bool                        `json:"accessible_repositories_complete"`
+	AccessibleRepositoriesError    *string                     `json:"accessible_repositories_error"`
+	RequiredRepositories           []string                    `json:"required_repositories"`
+	RequiredRepositoriesComplete   bool                        `json:"required_repositories_complete"`
+	UnreachableRepositories        []string                    `json:"unreachable_repositories"`
+	UnverifiedRepositories         []string                    `json:"unverified_repositories"`
+}
+
 func (c *Client) ListCredentials(provider *string) ([]Credential, error) {
 	url := c.BaseURL + "/api/v1/org/credentials"
 	if provider != nil && *provider != "" {
@@ -90,6 +127,20 @@ func (c *Client) GetCredential(credentialID string) (*CredentialDetail, error) {
 		return nil, err
 	}
 	return &cred, nil
+}
+
+// GetCredentialRepositories reads the credential's live repository coverage.
+// The route is separate from the credential detail because that one is gated
+// on credentials.reveal (it decrypts Vault material) while this names no
+// secret and needs only credentials.read.
+func (c *Client) GetCredentialRepositories(credentialID string) (*CredentialRepositoryCoverage, error) {
+	url := fmt.Sprintf("%s/api/v1/org/credentials/%s/repositories",
+		c.BaseURL, neturl.PathEscape(credentialID))
+	var coverage CredentialRepositoryCoverage
+	if err := c.getJSON(url, &coverage); err != nil {
+		return nil, err
+	}
+	return &coverage, nil
 }
 
 func (c *Client) ValidateCredentialName(name string) (*CredentialValidationResult, error) {


### PR DESCRIPTION
Bead: ankra-zesx5.7
Linear: PLA-786 (#1082)

CLI half of the credential repository-coverage read. Platform half: ankraio/cluster#1783 (merged, live in production).

## What was missing

`credentials list` prints a REPOS count and nothing anywhere broke it down. That is exactly the state the reporting customer spent a day in: the credential said `1` repository, `up`, `available`, synced four minutes ago, while every call against the repository it was bound to answered 404.

Worth knowing why that number misled, because it changes what the fix has to be: the REPOS count is a **cache**, refreshed by a sweep that only requeues while its parent credential reports healthy. So a credential that stops being able to read its repository also stops refreshing the rows that would show it. The count was not lying so much as fossilised from before the break. This command does not read that cache at all — the accessible set comes live from the provider.

Until now the endpoint was reachable only with curl, which is not an answer for a customer whose entire report was written from the CLI.

## What this adds

`ankra credentials repositories <credential_id|name>` — the credential and its coverage verdict, the repositories the installation can reach right now, the repositories Ankra needs from it, and the ones required but unreachable or unverified. Takes a name as well as an id via the existing `resolveCredentialID`, since `credentials list` prints names and that is what a user has to hand. Structured output (`-o json|yaml`) is wired.

## The one distinction that matters

`accessible_repositories` is a **pointer** in the client model, deliberately. The server sends `null` when the listing could not be read and `[]` when the installation genuinely reaches nothing. Those are opposite facts, and rendering both as "none" would rebuild precisely the confusion this endpoint was added to end.

So the unread case prints `could not be read` and surfaces the underlying provider error, and only a real empty set says the installation reaches nothing. Three tests hold that line: one asserting neither case ever renders as the other, and a decode test proving the model keeps `null` and `[]` distinguishable in the first place — without that, no amount of care in the rendering could tell them apart.

## Verification

Not just the mock. Built the binary and ran it against **production**, by name, against the reporting customer's own credential:

```
Credential: github-app-smartoptics-dwdm (github)
  Account:  smartoptics-dwdm
  Coverage: complete
  Reachable now (6): …/commerce …/sggame …/smartcollector …/smartinsight …/smartlab …/so-production-gitops
  Required by Ankra (2): …/commerce …/sggame
```

`-o json` verified too.

`go build`, `go vet`, `go test ./...` (all packages) and `golangci-lint run ./...` — 0 issues.

One note: `internal/client/credentials.go` shows under `gofmt -l`, but it already did on `master` (struct tag alignment in the pre-existing `Credential` type). My added code is gofmt-clean — I checked the `gofmt -d` output touches none of it — and I left the pre-existing misalignment alone rather than bury this diff in an unrelated reformat.

Ships in the next CLI release; not in v0.13.0-rc1.
