### PR TITLE
feat(dns): declare the zones a cluster serves with your own credential (ankra-zesx5.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ### Added
 
+- **`ankra cluster custom-dns-zones` serves your own zones from a managed
+  external-dns.** The external-dns Ankra provisions publishes only under the
+  cluster's generated subdomain - its credential is scoped to that zone by the
+  DNS provider - so ingress hostnames on your own zones were dropped silently
+  and the answer was a hand-rolled second external-dns maintained outside the
+  platform. Now `ankra org dns credentials create` stores your webhook
+  credential (into the platform's secret store; no read surface returns it,
+  because the URL embeds the token), and `ankra cluster custom-dns-zones
+  add <cluster> --zone <zone> --credential <name>` has Ankra render and
+  reconcile one isolated controller for that zone, pinned to exactly it with
+  its own record ownership so it can never fight Ankra's controller, yours, or
+  another cluster's. `list` shows what a cluster serves, `remove` withdraws a
+  zone and tears down only the controller Ankra rendered - the zone's records
+  are yours and are left untouched. Re-creating a credential under the same
+  name re-points every binding at once, which is how a rotated token rolls
+  out. (PLA-788)
+
 - **`ankra credentials repositories <id|name>` says which repositories a
   GitHub credential can actually reach.** `credentials list` prints a REPOS
   count and nothing anywhere broke it down, so when the count disagreed with

--- a/cmd/cluster_custom_dns.go
+++ b/cmd/cluster_custom_dns.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+var clusterCustomDNSCmd = &cobra.Command{
+	Use:     "custom-dns-zones",
+	Aliases: []string{"custom-dns"},
+	Short:   "Zones the cluster serves with your own external-dns credential",
+	Long: `Declare, list, and withdraw the DNS zones a cluster serves with the
+organisation's own external-dns webhook credential, alongside the generated
+domain Ankra serves itself.
+
+The external-dns Ankra manages publishes only under the cluster's generated
+subdomain: its credential is scoped to that zone by the DNS provider, so
+ingress hostnames on your own zones are dropped silently. Declaring a zone
+here has Ankra render and reconcile a separate external-dns for it, using a
+DNS credential you supply ('ankra org dns credentials'). Each controller is
+pinned to exactly its zone with its own record ownership, so it can never
+fight Ankra's controller or another cluster's.
+
+Withdrawing a zone removes the controller Ankra rendered; the zone's records
+are yours and are left untouched.`,
+}
+
+var clusterCustomDNSListCmd = &cobra.Command{
+	Use:   "list <cluster>",
+	Short: "List the zones declared on a cluster",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		clusterID, resolveError := resolveClusterID(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
+		zones, listError := apiClient.ListClusterCustomDNSZones(clusterID)
+		if listError != nil {
+			return fmt.Errorf("listing custom dns zones: %w", listError)
+		}
+		if rendered, renderError := renderStructured(cmd, zones); rendered || renderError != nil {
+			return renderError
+		}
+		if len(zones) == 0 {
+			fmt.Println("No custom DNS zones declared. The cluster serves only its generated domain.")
+			return nil
+		}
+		zoneTable := table.NewWriter()
+		zoneTable.SetOutputMirror(os.Stdout)
+		zoneTable.SetStyle(table.StyleRounded)
+		zoneTable.AppendHeader(table.Row{"Zone", "Credential"})
+		for _, zone := range zones {
+			zoneTable.AppendRow(table.Row{zone.Zone, zone.CredentialName})
+		}
+		zoneTable.Render()
+		return nil
+	},
+}
+
+var (
+	clusterCustomDNSZone       string
+	clusterCustomDNSCredential string
+)
+
+var clusterCustomDNSAddCmd = &cobra.Command{
+	Use:   "add <cluster>",
+	Short: "Declare a zone the cluster also serves",
+	Long: `Declare a zone the cluster also serves, with the DNS credential that can
+publish into it. Ankra renders an external-dns for the zone on the next
+reconciler pass, scoped to exactly that zone.
+
+Refused when the zone is not a domain name, when the organisation has no DNS
+credential of that name, or when the zone overlaps the generated domain Ankra
+already serves for this cluster - that would put a second controller on names
+Ankra's own external-dns publishes.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		clusterID, resolveError := resolveClusterID(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
+		binding, addError := apiClient.AddClusterCustomDNSZone(
+			clusterID, clusterCustomDNSZone, clusterCustomDNSCredential)
+		if addError != nil {
+			return fmt.Errorf("declaring the custom dns zone: %w", addError)
+		}
+		if rendered, renderError := renderStructured(cmd, binding); rendered || renderError != nil {
+			return renderError
+		}
+		fmt.Printf("Zone %s declared with credential %s.\n", binding.Zone, binding.CredentialName)
+		fmt.Println("Ankra renders its external-dns on the next reconciler pass (within ~2 minutes).")
+		return nil
+	},
+}
+
+var clusterCustomDNSRemoveCmd = &cobra.Command{
+	Use:   "remove <cluster>",
+	Short: "Withdraw a declared zone",
+	Long: `Withdraw a declared zone. Ankra removes the controller it rendered on the
+next reconciler pass. The zone's records are yours and are left untouched.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		clusterID, resolveError := resolveClusterID(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
+		removedZone, removeError := apiClient.RemoveClusterCustomDNSZone(clusterID, clusterCustomDNSZone)
+		if removeError != nil {
+			return fmt.Errorf("withdrawing the custom dns zone: %w", removeError)
+		}
+		if rendered, renderError := renderStructured(cmd,
+			map[string]string{"zone": removedZone}); rendered || renderError != nil {
+			return renderError
+		}
+		fmt.Printf("Zone %s withdrawn. Its controller is removed on the next reconciler pass; the zone's records are untouched.\n", removedZone)
+		return nil
+	},
+}
+
+func init() {
+	clusterCustomDNSAddCmd.Flags().StringVar(&clusterCustomDNSZone, "zone", "", "Zone to declare, e.g. launch.example.com (required)")
+	clusterCustomDNSAddCmd.Flags().StringVar(&clusterCustomDNSCredential, "credential", "", "Name of the organisation DNS credential that publishes into the zone (required)")
+	_ = clusterCustomDNSAddCmd.MarkFlagRequired("zone")
+	_ = clusterCustomDNSAddCmd.MarkFlagRequired("credential")
+
+	clusterCustomDNSRemoveCmd.Flags().StringVar(&clusterCustomDNSZone, "zone", "", "Zone to withdraw (required)")
+	_ = clusterCustomDNSRemoveCmd.MarkFlagRequired("zone")
+
+	registerStructuredOutputFlags(clusterCustomDNSListCmd, clusterCustomDNSAddCmd, clusterCustomDNSRemoveCmd)
+
+	clusterCustomDNSCmd.AddCommand(clusterCustomDNSListCmd)
+	clusterCustomDNSCmd.AddCommand(clusterCustomDNSAddCmd)
+	clusterCustomDNSCmd.AddCommand(clusterCustomDNSRemoveCmd)
+	clusterCmd.AddCommand(clusterCustomDNSCmd)
+}

--- a/cmd/cluster_custom_dns_test.go
+++ b/cmd/cluster_custom_dns_test.go
@@ -1,0 +1,205 @@
+package cmd
+
+// The custom DNS zone verbs. The platform half (cluster#1804) renders one
+// isolated external-dns per declared zone; these pin the CLI's contract with
+// it: the request shapes, the refusal details surfaced verbatim, and the one
+// secrecy property the credential lane has - the webhook URL goes in and
+// never comes back out.
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+const customDNSClusterID = "22222222-2222-4222-8222-222222222222"
+
+// serveCustomDNS answers the custom-dns-zones and dns-credential routes with
+// scripted bodies and records what the CLI sent.
+type customDNSServer struct {
+	server        *httptest.Server
+	lastMethod    string
+	lastPath      string
+	lastBody      map[string]any
+	zonesByPath   map[string]string
+	refusalDetail string
+	refusalStatus int
+}
+
+func newCustomDNSServer(t *testing.T) *customDNSServer {
+	t.Helper()
+	recorder := &customDNSServer{zonesByPath: map[string]string{}}
+	recorder.server = httptest.NewServer(http.HandlerFunc(
+		func(responseWriter http.ResponseWriter, request *http.Request) {
+			recorder.lastMethod = request.Method
+			recorder.lastPath = request.URL.Path
+			recorder.lastBody = nil
+			if request.Body != nil {
+				raw, _ := io.ReadAll(request.Body)
+				if len(raw) > 0 {
+					decoded := map[string]any{}
+					if json.Unmarshal(raw, &decoded) == nil {
+						recorder.lastBody = decoded
+					}
+				}
+			}
+			if recorder.refusalStatus != 0 {
+				responseWriter.Header().Set("Content-Type", "application/json")
+				responseWriter.WriteHeader(recorder.refusalStatus)
+				_ = json.NewEncoder(responseWriter).Encode(map[string]string{"detail": recorder.refusalDetail})
+				return
+			}
+			responseWriter.Header().Set("Content-Type", "application/json")
+			body, isScripted := recorder.zonesByPath[request.Method+" "+request.URL.Path]
+			if !isScripted {
+				responseWriter.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(responseWriter).Encode(map[string]string{"detail": "unscripted route in test"})
+				return
+			}
+			_, _ = responseWriter.Write([]byte(body))
+		}))
+	previousClient := apiClient
+	previousBaseURL := baseURL
+	apiClient = client.New("test-token", recorder.server.URL)
+	baseURL = recorder.server.URL
+	t.Cleanup(func() {
+		apiClient = previousClient
+		baseURL = previousBaseURL
+		recorder.server.Close()
+	})
+	return recorder
+}
+
+func TestClusterCustomDNSListRendersZonesAndTheEmptyAnswer(t *testing.T) {
+	recorder := newCustomDNSServer(t)
+	listPath := "GET /api/v1/clusters/" + customDNSClusterID + "/custom-dns-zones"
+	recorder.zonesByPath[listPath] = `{"success":true,"zones":[
+		{"zone":"launch.example.com","credential_name":"example-dns"},
+		{"zone":"shop.example.net","credential_name":"example-dns"}]}`
+
+	output := captureStdout(t, func() {
+		if runError := clusterCustomDNSListCmd.RunE(clusterCustomDNSListCmd,
+			[]string{customDNSClusterID}); runError != nil {
+			t.Fatalf("list returned an error: %v", runError)
+		}
+	})
+	for _, want := range []string{"launch.example.com", "shop.example.net", "example-dns"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output = %q, want it to mention %q", output, want)
+		}
+	}
+
+	recorder.zonesByPath[listPath] = `{"success":true,"zones":[]}`
+	output = captureStdout(t, func() {
+		if runError := clusterCustomDNSListCmd.RunE(clusterCustomDNSListCmd,
+			[]string{customDNSClusterID}); runError != nil {
+			t.Fatalf("empty list returned an error: %v", runError)
+		}
+	})
+	if !strings.Contains(output, "No custom DNS zones declared") {
+		t.Fatalf("output = %q, want the empty answer stated, not a bare table", output)
+	}
+}
+
+func TestClusterCustomDNSAddSendsTheBindingAndReportsIt(t *testing.T) {
+	recorder := newCustomDNSServer(t)
+	recorder.zonesByPath["POST /api/v1/clusters/"+customDNSClusterID+"/custom-dns-zones"] =
+		`{"success":true,"zone":"launch.example.com","credential_name":"example-dns"}`
+
+	clusterCustomDNSZone = "Launch.Example.com"
+	clusterCustomDNSCredential = "example-dns"
+	output := captureStdout(t, func() {
+		if runError := clusterCustomDNSAddCmd.RunE(clusterCustomDNSAddCmd,
+			[]string{customDNSClusterID}); runError != nil {
+			t.Fatalf("add returned an error: %v", runError)
+		}
+	})
+
+	if recorder.lastBody["zone"] != "Launch.Example.com" || recorder.lastBody["credential_name"] != "example-dns" {
+		t.Fatalf("request body = %v, want the zone and credential as given (the platform normalises)", recorder.lastBody)
+	}
+	// The reported zone is the platform's normalised answer, not the input.
+	if !strings.Contains(output, "launch.example.com") {
+		t.Fatalf("output = %q, want the normalised zone reported back", output)
+	}
+}
+
+// The refusals are the platform's, and the CLI's job is to surface them
+// verbatim - an overlap with the delegated zone is an explanation, not a
+// generic failure.
+func TestClusterCustomDNSAddSurfacesTheRefusalDetail(t *testing.T) {
+	recorder := newCustomDNSServer(t)
+	recorder.refusalStatus = http.StatusBadRequest
+	recorder.refusalDetail = "the zone overlaps the delegated zone Ankra already serves for this cluster"
+
+	clusterCustomDNSZone = "sub.of.delegated.zone"
+	clusterCustomDNSCredential = "example-dns"
+	runError := clusterCustomDNSAddCmd.RunE(clusterCustomDNSAddCmd, []string{customDNSClusterID})
+	if runError == nil {
+		t.Fatal("a refused declaration must return an error")
+	}
+	if !strings.Contains(runError.Error(), "overlaps the delegated zone") {
+		t.Fatalf("error = %q, want the platform's refusal detail surfaced", runError)
+	}
+}
+
+func TestClusterCustomDNSRemoveEscapesTheZoneAndReportsTheWithdrawal(t *testing.T) {
+	recorder := newCustomDNSServer(t)
+	recorder.zonesByPath["DELETE /api/v1/clusters/"+customDNSClusterID+"/custom-dns-zones/launch.example.com"] =
+		`{"success":true,"zone":"launch.example.com"}`
+
+	clusterCustomDNSZone = "launch.example.com"
+	output := captureStdout(t, func() {
+		if runError := clusterCustomDNSRemoveCmd.RunE(clusterCustomDNSRemoveCmd,
+			[]string{customDNSClusterID}); runError != nil {
+			t.Fatalf("remove returned an error: %v", runError)
+		}
+	})
+	if !strings.Contains(output, "withdrawn") || !strings.Contains(output, "records are untouched") {
+		t.Fatalf("output = %q, want the withdrawal and the records-untouched promise stated", output)
+	}
+}
+
+func TestOrgDnsCredentialCreateNeverEchoesTheWebhookURL(t *testing.T) {
+	recorder := newCustomDNSServer(t)
+	recorder.zonesByPath["POST /api/v1/credentials/dns"] =
+		`{"success":true,"id":"cred-1","name":"example-dns"}`
+
+	orgDnsCredentialName = "example-dns"
+	orgDnsCredentialWebhookURL = "https://dns.example.com/api/external-dns/secret-token-value"
+	output := captureStdout(t, func() {
+		if runError := orgDnsCredentialsCreateCmd.RunE(orgDnsCredentialsCreateCmd, nil); runError != nil {
+			t.Fatalf("create returned an error: %v", runError)
+		}
+	})
+
+	if recorder.lastBody["webhook_provider_url"] != orgDnsCredentialWebhookURL {
+		t.Fatalf("request body = %v, want the webhook url sent", recorder.lastBody)
+	}
+	if strings.Contains(output, "secret-token-value") {
+		t.Fatalf("output = %q, the webhook url embeds the token and must never be printed", output)
+	}
+	if !strings.Contains(output, "will not be shown again") {
+		t.Fatalf("output = %q, want the secrecy stated so the operator saves it", output)
+	}
+}
+
+func TestOrgDnsCredentialListRendersNamesOnly(t *testing.T) {
+	recorder := newCustomDNSServer(t)
+	recorder.zonesByPath["GET /api/v1/credentials/dns"] =
+		`[{"id":"cred-1","name":"example-dns","provider":"dns","created_at":"2026-08-24T10:00:00Z"}]`
+
+	output := captureStdout(t, func() {
+		if runError := orgDnsCredentialsListCmd.RunE(orgDnsCredentialsListCmd, nil); runError != nil {
+			t.Fatalf("list returned an error: %v", runError)
+		}
+	})
+	if !strings.Contains(output, "example-dns") {
+		t.Fatalf("output = %q, want the credential named", output)
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -800,6 +800,26 @@ func (m baseMock) GetCredentialRepositories(credentialID string) (*client.Creden
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) ListClusterCustomDNSZones(clusterID string) ([]client.CustomDNSZone, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) AddClusterCustomDNSZone(clusterID string, zone string, credentialName string) (*client.CustomDNSZone, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) RemoveClusterCustomDNSZone(clusterID string, zone string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (m baseMock) ListDNSCredentials() ([]client.DNSCredentialSummary, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) CreateDNSCredential(name string, webhookProviderURL string) (*client.CreateDNSCredentialResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) ListAPITokens() ([]client.APIToken, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/org_dns_credentials.go
+++ b/cmd/org_dns_credentials.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+var orgDnsCredentialsCmd = &cobra.Command{
+	Use:     "credentials",
+	Aliases: []string{"credential"},
+	Short:   "DNS webhook credentials for zones you own",
+	Long: `Store and list the organisation's DNS webhook credentials - the ones the
+custom DNS zone lane serves your own zones with ('ankra cluster
+custom-dns-zones').
+
+The webhook provider URL embeds the provider token, so it is written to the
+platform's secret store on create and never returned by any read: 'list'
+shows names and ids only. Re-creating a credential under the same name
+re-points every cluster binding that names it, which is how a rotated token
+rolls out.`,
+}
+
+var orgDnsCredentialsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List the organisation's DNS credentials",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		credentials, listError := apiClient.ListDNSCredentials()
+		if listError != nil {
+			return fmt.Errorf("listing dns credentials: %w", listError)
+		}
+		if rendered, renderError := renderStructured(cmd, credentials); rendered || renderError != nil {
+			return renderError
+		}
+		if len(credentials) == 0 {
+			fmt.Println("No DNS credentials stored.")
+			return nil
+		}
+		credentialTable := table.NewWriter()
+		credentialTable.SetOutputMirror(os.Stdout)
+		credentialTable.SetStyle(table.StyleRounded)
+		credentialTable.AppendHeader(table.Row{"ID", "Name", "Created"})
+		for _, credential := range credentials {
+			credentialTable.AppendRow(table.Row{
+				credential.ID, credential.Name, formatTimeAgo(credential.CreatedAt)})
+		}
+		credentialTable.Render()
+		return nil
+	},
+}
+
+var (
+	orgDnsCredentialName       string
+	orgDnsCredentialWebhookURL string
+)
+
+var orgDnsCredentialsCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Store a DNS webhook credential",
+	Long: `Store a DNS webhook credential. The webhook provider URL is the external-dns
+webhook endpoint including its token; it goes to the platform's secret store
+and is never echoed back.
+
+Creating a credential under a name that already exists replaces its stored
+URL, which re-points every cluster binding that names it - the rotation path.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		response, createError := apiClient.CreateDNSCredential(
+			orgDnsCredentialName, orgDnsCredentialWebhookURL)
+		if createError != nil {
+			return fmt.Errorf("creating the dns credential: %w", createError)
+		}
+		if !response.Success {
+			message := "the platform refused the credential:"
+			for _, resourceError := range response.Errors {
+				message += fmt.Sprintf("\n  - %s: %s", resourceError.Key, resourceError.Message)
+			}
+			return errors.New(message)
+		}
+		if rendered, renderError := renderStructured(cmd, response); rendered || renderError != nil {
+			return renderError
+		}
+		fmt.Printf("DNS credential %s stored (id %s). The webhook URL is in the platform's secret store and will not be shown again.\n",
+			response.Name, response.ID)
+		return nil
+	},
+}
+
+func init() {
+	orgDnsCredentialsCreateCmd.Flags().StringVar(&orgDnsCredentialName, "name", "", "Credential name, referenced by 'cluster custom-dns-zones add --credential' (required)")
+	orgDnsCredentialsCreateCmd.Flags().StringVar(&orgDnsCredentialWebhookURL, "webhook-provider-url", "", "external-dns webhook endpoint including its token (required)")
+	_ = orgDnsCredentialsCreateCmd.MarkFlagRequired("name")
+	_ = orgDnsCredentialsCreateCmd.MarkFlagRequired("webhook-provider-url")
+
+	registerStructuredOutputFlags(orgDnsCredentialsListCmd, orgDnsCredentialsCreateCmd)
+
+	orgDnsCredentialsCmd.AddCommand(orgDnsCredentialsListCmd)
+	orgDnsCredentialsCmd.AddCommand(orgDnsCredentialsCreateCmd)
+	orgDnsCmd.AddCommand(orgDnsCredentialsCmd)
+}

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -222,6 +222,11 @@ type APIClient interface {
 	DeleteCredential(ctx context.Context, credentialID, organisationID string) (*client.DeleteCredentialResult, error)
 	GetCredential(credentialID string) (*client.CredentialDetail, error)
 	GetCredentialRepositories(credentialID string) (*client.CredentialRepositoryCoverage, error)
+	ListClusterCustomDNSZones(clusterID string) ([]client.CustomDNSZone, error)
+	AddClusterCustomDNSZone(clusterID string, zone string, credentialName string) (*client.CustomDNSZone, error)
+	RemoveClusterCustomDNSZone(clusterID string, zone string) (string, error)
+	ListDNSCredentials() ([]client.DNSCredentialSummary, error)
+	CreateDNSCredential(name string, webhookProviderURL string) (*client.CreateDNSCredentialResponse, error)
 
 	ListAPITokens() ([]client.APIToken, error)
 	CreateAPIToken(name string, expiresAt *string, scopes []string) (*client.CreateAPITokenResponse, error)

--- a/internal/client/customdns.go
+++ b/internal/client/customdns.go
@@ -1,0 +1,118 @@
+package client
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// Custom DNS zones: the zones a cluster also serves with the organisation's
+// own external-dns webhook credential, alongside the delegated zone Ankra
+// serves itself. The platform renders one isolated external-dns controller
+// per declared zone (cluster#1804); these calls only declare and withdraw
+// the bindings.
+
+// CustomDNSZone is one declared binding on a cluster.
+type CustomDNSZone struct {
+	Zone           string `json:"zone"`
+	CredentialName string `json:"credential_name"`
+}
+
+type listCustomDNSZonesResponse struct {
+	Success bool            `json:"success"`
+	Zones   []CustomDNSZone `json:"zones"`
+}
+
+// DNSCredentialSummary is one org DNS credential as the provider listing
+// reports it. The webhook provider URL is deliberately absent: it embeds the
+// token and the platform never echoes it.
+type DNSCredentialSummary struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Provider  string `json:"provider"`
+	CreatedAt string `json:"created_at"`
+}
+
+// CreateDNSCredentialResponse reports the stored credential's identity, and
+// never its webhook URL.
+type CreateDNSCredentialResponse struct {
+	Success bool            `json:"success"`
+	ID      string          `json:"id"`
+	Name    string          `json:"name"`
+	Errors  []ResourceError `json:"errors,omitempty"`
+}
+
+// ListClusterCustomDNSZones reads the zones declared on a cluster. An empty
+// list is a complete answer: the cluster serves none beyond its delegated
+// zone.
+func (c *Client) ListClusterCustomDNSZones(clusterID string) ([]CustomDNSZone, error) {
+	requestURL := fmt.Sprintf("%s/api/v1/clusters/%s/custom-dns-zones",
+		c.BaseURL, url.PathEscape(clusterID))
+	var response listCustomDNSZonesResponse
+	if err := c.getJSON(requestURL, &response); err != nil {
+		return nil, err
+	}
+	if response.Zones == nil {
+		return []CustomDNSZone{}, nil
+	}
+	return response.Zones, nil
+}
+
+// AddClusterCustomDNSZone declares a zone the cluster also serves. The
+// platform refuses a zone that is not a domain name, a credential the
+// organisation does not have, and a zone overlapping the delegated zone it
+// already serves; those come back as the response detail.
+func (c *Client) AddClusterCustomDNSZone(clusterID string, zone string,
+	credentialName string) (*CustomDNSZone, error) {
+	requestURL := fmt.Sprintf("%s/api/v1/clusters/%s/custom-dns-zones",
+		c.BaseURL, url.PathEscape(clusterID))
+	payload := map[string]string{"zone": zone, "credential_name": credentialName}
+	var response struct {
+		Success        bool   `json:"success"`
+		Zone           string `json:"zone"`
+		CredentialName string `json:"credential_name"`
+	}
+	if err := c.postCSRFJSON(requestURL, payload, &response, "declare custom dns zone"); err != nil {
+		return nil, err
+	}
+	return &CustomDNSZone{Zone: response.Zone, CredentialName: response.CredentialName}, nil
+}
+
+// RemoveClusterCustomDNSZone withdraws a declared zone. The platform tears
+// its controller down on the next reconciler pass; the zone's records are the
+// operator's and are left alone. A zone the cluster does not serve answers
+// 404 rather than succeeding silently.
+func (c *Client) RemoveClusterCustomDNSZone(clusterID string, zone string) (string, error) {
+	requestURL := fmt.Sprintf("%s/api/v1/clusters/%s/custom-dns-zones/%s",
+		c.BaseURL, url.PathEscape(clusterID), url.PathEscape(zone))
+	var response struct {
+		Success bool   `json:"success"`
+		Zone    string `json:"zone"`
+	}
+	if err := c.deleteCSRFJSON(requestURL, &response, "withdraw custom dns zone"); err != nil {
+		return "", err
+	}
+	return response.Zone, nil
+}
+
+// ListDNSCredentials lists the organisation's DNS webhook credentials.
+func (c *Client) ListDNSCredentials() ([]DNSCredentialSummary, error) {
+	requestURL := c.BaseURL + "/api/v1/credentials/dns"
+	var credentials []DNSCredentialSummary
+	if err := c.getJSON(requestURL, &credentials); err != nil {
+		return nil, err
+	}
+	return credentials, nil
+}
+
+// CreateDNSCredential stores an external-dns webhook credential for the
+// organisation. The webhook provider URL embeds the provider token; the
+// platform writes it to its secret store and no read surface returns it.
+func (c *Client) CreateDNSCredential(name string, webhookProviderURL string) (*CreateDNSCredentialResponse, error) {
+	requestURL := c.BaseURL + "/api/v1/credentials/dns"
+	payload := map[string]string{"name": name, "webhook_provider_url": webhookProviderURL}
+	var response CreateDNSCredentialResponse
+	if err := c.postCSRFJSON(requestURL, payload, &response, "create dns credential"); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}


### PR DESCRIPTION
Bead: ankra-zesx5.12
Linear: PLA-788 (#1084)

CLI half of the custom DNS zone lane. Platform half: ankraio/cluster#1804 — merged and **verified deployed to production** before this was written.

## What this adds

- `ankra org dns credentials create --name <n> --webhook-provider-url <url>` and `... list` — store and list the organisation's DNS webhook credentials. The URL embeds the provider token, so `create` sends it and **nothing ever prints it back**; the success message says "will not be shown again" at the one moment the operator can still save it, and a test pins that the token never reaches stdout.
- `ankra cluster custom-dns-zones list|add|remove <cluster>` (`add`: `--zone --credential`; cluster by name or id like its siblings) — declare and withdraw the zones a cluster serves with that credential. The platform's refusals (zone overlapping the delegated zone, credential the org doesn't have) surface verbatim rather than as generic failures, and `remove` states the promise that matters: only the controller Ankra rendered goes; the zone's records are the operator's and stay.

Re-creating a credential under the same name re-points every binding — the rotation path — and both the command help and the changelog say so.

## Tests

Six cases: list rendering + the stated empty answer; add sending the binding as-given and reporting the platform's *normalised* zone back; refusal detail surfaced verbatim; remove with the zone path-escaped and the records-untouched promise printed; **credential create never echoing the webhook URL**; credential list rendering names only. Client 404s keep their wrapped type, so the shared `exitCodeFor` mapping gives scripts exit 3 on a missing zone.

## Verification

- `go test -race -count=1 ./...` — all packages pass.
- `golangci-lint run` — 0 issues.
- Committed **through** the repo's pre-commit gate (`make hooks` first), not around it.
- **Against production**: built the binary and ran both list commands against the reporting customer's own org (read-only) — `cluster custom-dns-zones list so-gpu-chat` and `org dns credentials list` both answer correctly over the routes that deployed with cluster#1804. Cluster-name resolution works; no mutation was performed against the customer's org.

Note the two pre-existing `gofmt -l` hits (`cmd/chat_test.go`, `cmd/cluster_operation_results_test.go`) were already unformatted on `master` and are untouched here.

Ships in the next CLI release after v0.13.0-rc1; the docs page for the setup flow references these verbs and follows with the release.
