### PR TITLE
release: cut v0.13.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Ankra CLI Changelog
 
-## Unreleased
+## v0.13.0-rc2 — 2026-08-24
 
 ### Added
 


### PR DESCRIPTION
Bead: ankra-jo5qx

Promotes `## Unreleased` to `v0.13.0-rc2`. CHANGELOG.md only, per the release convention.

Carries the CLI halves that three open support tickets are waiting on:
- `ankra cluster custom-dns-zones` + `ankra org dns credentials` (#145) — PLA-788, platform half live via cluster#1804
- `ankra credentials repositories` (#144) — PLA-786 issue 3, platform half live via cluster#1783
- `org ai-environment --help` preview-records correction (#143) — PLA-773

Release-notes extractor dry-run passes (36 lines, terminates at the rc1 heading). `-rc2` = prerelease, beta channel only.