### PR TITLE
fix(node-group): show availability zones in node-group list (ankra-yg2an)

### DIFF
--- a/cmd/cluster_node_group.go
+++ b/cmd/cluster_node_group.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"ankra/internal/client"
 
@@ -238,11 +239,28 @@ var clusterNodeGroupListCmd = &cobra.Command{
 			return nil
 		}
 		for _, nodeGroup := range result.NodeGroups {
-			fmt.Printf("%-20s  type=%-8s  count=%d  labels=%d  taints=%d\n",
-				nodeGroup.Name, nodeGroup.InstanceType, nodeGroup.Count, len(nodeGroup.Labels), len(nodeGroup.Taints))
+			fmt.Printf("%-20s  type=%-8s  count=%d  labels=%d  taints=%d%s\n",
+				nodeGroup.Name, nodeGroup.InstanceType, nodeGroup.Count,
+				len(nodeGroup.Labels), len(nodeGroup.Taints), nodeGroupZoneSuffix(nodeGroup))
 		}
 		return nil
 	},
+}
+
+// nodeGroupZoneSuffix renders a node group's availability zones for a list
+// line, or "" when the group requested none - so the line is unchanged for
+// every provider without zone placement, and against a platform that does
+// not serve the field yet.
+//
+// The zones are named rather than counted. "az=eu-west-par-c" on a group
+// called general-par-a is the entire reason this is on the list line: a
+// count would report "1" for a group correctly pinned to one zone and "1"
+// for a group that silently collapsed into the wrong one.
+func nodeGroupZoneSuffix(nodeGroup client.NodeGroupInfo) string {
+	if len(nodeGroup.AvailabilityZones) == 0 {
+		return ""
+	}
+	return "  az=" + strings.Join(nodeGroup.AvailabilityZones, ",")
 }
 
 // maxNodeGroupUserDataBytes mirrors the platform's refusal cap (the

--- a/cmd/cluster_node_group.go
+++ b/cmd/cluster_node_group.go
@@ -704,7 +704,7 @@ func init() {
 	clusterNodeGroupAddCmd.Flags().String("name", "", "Node group name (required)")
 	clusterNodeGroupAddCmd.Flags().String("instance-type", "", "Server type / flavor / plan for nodes (required)")
 	clusterNodeGroupAddCmd.Flags().Int("count", 1, "Number of nodes")
-	clusterNodeGroupAddCmd.Flags().String("availability-zone", "", "Pin every node of the group to one availability zone, on OVH 3-AZ regions (e.g. eu-west-par-b). See 'ankra cluster ovh regions --with-zones'. Pin the group when it runs zonal storage: an OVH volume cannot attach from another zone")
+	clusterNodeGroupAddCmd.Flags().String("availability-zone", "", "Pin every node of the group to one availability zone, on OVH 3-AZ regions (e.g. eu-west-par-b). See 'ankra cluster ovh regions --with-zones'. Pin the group when it runs zonal storage: an OVH volume cannot attach from another zone. Omitted on a zone-spread cluster, each node takes the zone with the fewest instances cluster-wide, so a one-node group lands wherever the cluster is thinnest, not where its name suggests; on a cluster with no zone pool OVH chooses")
 	clusterNodeGroupAddCmd.Flags().String("user-data-file", "", "Path to a cloud-init user-data file for the group (OVH clusters only). Applied verbatim at first boot by every instance the group ever creates, replacements included; Ankra sends no cloud-init of its own, so the document is not merged with anything. Max 65535 bytes. Use for provision-time disk layouts, e.g. carving a partition for LUKS before growpart runs")
 	_ = clusterNodeGroupAddCmd.MarkFlagRequired("name")
 	_ = clusterNodeGroupAddCmd.MarkFlagRequired("instance-type")

--- a/cmd/cluster_node_group_test.go
+++ b/cmd/cluster_node_group_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"ankra/internal/client"
 )
 
 func TestReadNodeGroupUserDataFileEmptyPathMeansUnset(t *testing.T) {
@@ -47,5 +49,30 @@ func TestReadNodeGroupUserDataFileRefusesOversizedDocuments(t *testing.T) {
 	_, err := readNodeGroupUserDataFile(path)
 	if err == nil || !strings.Contains(err.Error(), "65535") {
 		t.Fatalf("error = %v, want the size-cap refusal naming the limit", err)
+	}
+}
+
+func TestNodeGroupZoneSuffixIsEmptyWithoutZonePlacement(t *testing.T) {
+	// Every provider but OVH, and an OVH group created before zone
+	// placement existed: the list line must read exactly as it always did.
+	if suffix := nodeGroupZoneSuffix(client.NodeGroupInfo{Name: "default"}); suffix != "" {
+		t.Fatalf("suffix = %q, want empty for a group with no zones", suffix)
+	}
+}
+
+func TestNodeGroupZoneSuffixNamesTheZones(t *testing.T) {
+	// The shape that matters: a group whose name promises one zone and
+	// whose nodes are all in another has to be readable off the list line.
+	drifted := client.NodeGroupInfo{Name: "general-par-a", AvailabilityZones: []string{"eu-west-par-c"}}
+	if suffix := nodeGroupZoneSuffix(drifted); suffix != "  az=eu-west-par-c" {
+		t.Fatalf("suffix = %q, want the single zone named", suffix)
+	}
+
+	spread := client.NodeGroupInfo{
+		Name:              "ts",
+		AvailabilityZones: []string{"eu-west-par-a", "eu-west-par-b", "eu-west-par-c"},
+	}
+	if suffix := nodeGroupZoneSuffix(spread); suffix != "  az=eu-west-par-a,eu-west-par-b,eu-west-par-c" {
+		t.Fatalf("suffix = %q, want every zone of a spread group", suffix)
 	}
 }

--- a/cmd/ovh_cluster.go
+++ b/cmd/ovh_cluster.go
@@ -928,7 +928,7 @@ func init() {
 	ovhNodeGroupAddCmd.Flags().Int("count", 1, "Number of nodes (0-100)")
 	ovhNodeGroupAddCmd.Flags().String("labels", "", "Comma-separated key=value labels to apply to the node group")
 	ovhNodeGroupAddCmd.Flags().String("taints", "", "Comma-separated key=value:Effect taints to apply to the node group")
-	ovhNodeGroupAddCmd.Flags().String("availability-zone", "", "Pin every node of the group to one availability zone, in a 3-AZ region (e.g. eu-west-par-b). See 'ankra cluster ovh regions --with-zones'. Pin the group when it runs zonal storage: an OVH volume cannot attach from another zone")
+	ovhNodeGroupAddCmd.Flags().String("availability-zone", "", "Pin every node of the group to one availability zone, in a 3-AZ region (e.g. eu-west-par-b). See 'ankra cluster ovh regions --with-zones'. Pin the group when it runs zonal storage: an OVH volume cannot attach from another zone. Omitted on a zone-spread cluster, each node takes the zone with the fewest instances cluster-wide, so a one-node group lands wherever the cluster is thinnest, not where its name suggests; on a cluster with no zone pool OVH chooses")
 	_ = ovhNodeGroupAddCmd.MarkFlagRequired("name")
 	registerAsyncWriteFlags(ovhNodeGroupAddCmd)
 	registerAsyncWriteFlags(ovhNodeGroupScaleCmd)

--- a/cmd/ovh_cluster.go
+++ b/cmd/ovh_cluster.go
@@ -643,8 +643,9 @@ var ovhNodeGroupListCmd = &cobra.Command{
 			return nil
 		}
 		for _, ng := range result.NodeGroups {
-			fmt.Printf("%-20s  type=%-8s  count=%d  labels=%d  taints=%d\n",
-				ng.Name, ng.InstanceType, ng.Count, len(ng.Labels), len(ng.Taints))
+			fmt.Printf("%-20s  type=%-8s  count=%d  labels=%d  taints=%d%s\n",
+				ng.Name, ng.InstanceType, ng.Count, len(ng.Labels), len(ng.Taints),
+				nodeGroupZoneSuffix(ng))
 		}
 		return nil
 	},

--- a/internal/client/hetzner_clusters.go
+++ b/internal/client/hetzner_clusters.go
@@ -227,6 +227,11 @@ type NodeGroupInfo struct {
 	AutoscalingEnabled bool              `json:"autoscaling_enabled"`
 	Labels             map[string]string `json:"labels"`
 	Taints             []NodeTaint       `json:"taints"`
+	// AvailabilityZones lists the zones the group's nodes were requested
+	// into, on OVH 3-AZ regions. Empty for every provider without zone
+	// placement, for a group created before it existed, and against a
+	// platform that predates the field.
+	AvailabilityZones []string `json:"availability_zones,omitempty"`
 }
 
 type NodeGroupListResult struct {


### PR DESCRIPTION
Bead: ankra-yg2an
Linear: https://linear.app/ankra/issue/PLA-795/1091-az-drift-verified-server-side-general-par-a-and-general-par-b

**Depends on ankraio/cluster#1838** — that PR adds `availability_zones` to the
node-group listing. This one renders it. Merging this first is harmless (the
field is simply absent and the output is unchanged), but it does nothing until
the platform side ships.

## Why

A customer with an OVH 3-AZ cluster found two node groups named `general-par-a`
and `general-par-b` whose nodes all sat in `eu-west-par-c`. Their point about
the CLI, quoted:

> node-group list shows no AZ field at all; only per-node `ovh nodes get` does

That is accurate. Seeing a group's placement currently means one API call per
node, which is why the drift went unnoticed on a cluster explicitly built for
multi-AZ.

## What this changes

- `client.NodeGroupInfo` gains `AvailabilityZones`. Without it the new field is
  dropped by the typed decode even under `-o json`.
- The generic `cluster node-group list` and `cluster ovh node-group list` lines
  print `az=<zones>` for a group that has any.

The zones are **named, not counted**: a count reads `1` both for a group
correctly pinned to one zone and for a group that silently collapsed into the
wrong one — the exact ambiguity this is meant to end.

```
general-par-a         type=b3-32     count=1  labels=0  taints=0  az=eu-west-par-c
ts-par-a              type=r3-128    count=1  labels=1  taints=1  az=eu-west-par-a
```

## Compatibility

The suffix is empty when a group carries no zones, so the list line is
byte-for-byte what it was for every provider without zone placement, for OVH
groups created before zone placement existed, and against a platform that does
not serve the field yet. The three provider-specific listings that can never
carry zones (Hetzner, UpCloud, DigitalOcean) are deliberately untouched.

## Testing

- New unit tests for `nodeGroupZoneSuffix`: empty without zones, the single zone
  named for a collapsed group, all three for a spread one.
- `go test ./cmd/... ./internal/client/...` passes; `go build ./...` clean;
  `gofmt -l` clean on all four touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
