### PR TITLE
feat(dns): ankra org custom-dns-zones serves your own zone from every cluster in the organisation (ankra-nglfk)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Ankra CLI Changelog
 
+## Unreleased
+
+### Added
+
+- **`ankra org custom-dns-zones` serves your own zone from every cluster in
+  the organisation - the ones you have and the ones you create next.**
+  `ankra cluster custom-dns-zones` declared a zone on one named cluster, so a
+  freshly created cluster came up with its ingress hostnames on your own
+  domain dropped silently and its certificates stuck waiting for DNS that
+  nothing was publishing. `ankra org custom-dns-zones add --zone <zone>
+  --credential <name>` declares the zone once for the organisation: Ankra
+  renders and reconciles one isolated external-dns for it on every cluster,
+  each pinned to exactly the zone with its own record ownership, and on
+  every cluster created afterwards without further declaration. `list` shows
+  the organisation's declarations; `remove` withdraws one and tears down
+  only the controllers Ankra rendered - clusters that declared the zone
+  themselves keep theirs, and the zone's records are yours and are left
+  untouched. `ankra cluster custom-dns-zones list` now shows a SOURCE column
+  telling an inherited zone apart from the cluster's own, and a cluster's own
+  declaration of a zone takes precedence over the organisation's on that
+  cluster - the way to serve one zone with a different credential on one
+  cluster. Requires cluster#1852 on the platform.
+
+### Fixed
+
+- **`ankra org domain --help` described the custom-domain lane as it was
+  before cluster#1841.** It still said Ankra confines itself to one
+  `<org_short_id>.<domain>` subzone and pins each cluster's external-dns to
+  that cluster's subzone alone; a registered domain is adopted as the
+  organisation's zone apex and every cluster's external-dns publishes
+  anywhere under it. The help now says so, and points a zone hosted outside
+  Ankra's own DNS account at `ankra org custom-dns-zones` instead.
+
 ## v0.13.0-rc2 — 2026-08-24
 
 ### Added

--- a/cmd/cluster_custom_dns.go
+++ b/cmd/cluster_custom_dns.go
@@ -24,6 +24,13 @@ DNS credential you supply ('ankra org dns credentials'). Each controller is
 pinned to exactly its zone with its own record ownership, so it can never
 fight Ankra's controller or another cluster's.
 
+To serve a zone from every cluster in the organisation - including clusters
+created later - declare it once with 'ankra org custom-dns-zones add'
+instead. 'list' shows those inherited zones with source 'organisation'; a
+zone declared here on the cluster itself takes precedence over the
+organisation's on this cluster, which is how one cluster serves a zone with
+a different credential.
+
 Withdrawing a zone removes the controller Ankra rendered; the zone's records
 are yours and are left untouched.`,
 }
@@ -51,13 +58,23 @@ var clusterCustomDNSListCmd = &cobra.Command{
 		zoneTable := table.NewWriter()
 		zoneTable.SetOutputMirror(os.Stdout)
 		zoneTable.SetStyle(table.StyleRounded)
-		zoneTable.AppendHeader(table.Row{"Zone", "Credential"})
+		zoneTable.AppendHeader(table.Row{"Zone", "Credential", "Source"})
 		for _, zone := range zones {
-			zoneTable.AppendRow(table.Row{zone.Zone, zone.CredentialName})
+			zoneTable.AppendRow(table.Row{zone.Zone, zone.CredentialName, customDNSZoneSourceLabel(zone.Source)})
 		}
 		zoneTable.Render()
 		return nil
 	},
+}
+
+// customDNSZoneSourceLabel names where a listed zone was declared. A platform
+// that predates the organisation-wide lane sends no source; that is the
+// cluster's own declaration, the only kind it could hold.
+func customDNSZoneSourceLabel(source string) string {
+	if source == "" {
+		return "cluster"
+	}
+	return source
 }
 
 var (

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -812,6 +812,18 @@ func (m baseMock) RemoveClusterCustomDNSZone(clusterID string, zone string) (str
 	return "", errors.New("not implemented")
 }
 
+func (m baseMock) ListOrganisationCustomDNSZones() ([]client.OrganisationCustomDNSZone, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) AddOrganisationCustomDNSZone(zone string, credentialName string) (*client.OrganisationCustomDNSZone, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) RemoveOrganisationCustomDNSZone(zone string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
 func (m baseMock) ListDNSCredentials() ([]client.DNSCredentialSummary, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/org_custom_dns.go
+++ b/cmd/org_custom_dns.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+var orgCustomDNSCmd = &cobra.Command{
+	Use:     "custom-dns-zones",
+	Aliases: []string{"custom-dns"},
+	Short:   "Zones every cluster in the organisation serves with your own credential",
+	Long: `Declare, list, and withdraw the DNS zones every cluster in the organisation
+serves with the organisation's own external-dns webhook credential -
+alongside the generated domain Ankra serves itself.
+
+A zone declared here behaves like the generated domain: every cluster in the
+organisation, the ones that exist and the ones created later, gets its own
+external-dns for it, rendered and reconciled by Ankra with a DNS credential
+you supply ('ankra org dns credentials'). Each cluster's controller is pinned
+to exactly the zone with its own record ownership, so it can never fight
+Ankra's controller, another cluster's, or records you publish yourself.
+
+'ankra cluster custom-dns-zones' declares the same thing for one cluster. A
+cluster's own declaration of a zone wins over the organisation's on that
+cluster, which is how one cluster serves the zone with a different
+credential.
+
+Withdrawing a zone removes the controllers Ankra rendered from every cluster
+that inherited it; clusters that declared the zone themselves keep theirs,
+and the zone's records are yours and are left untouched.`,
+}
+
+var orgCustomDNSListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List the zones declared for every cluster in the organisation",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		zones, listError := apiClient.ListOrganisationCustomDNSZones()
+		if listError != nil {
+			return fmt.Errorf("listing the organisation's custom dns zones: %w", listError)
+		}
+		if rendered, renderError := renderStructured(cmd, zones); rendered || renderError != nil {
+			return renderError
+		}
+		if len(zones) == 0 {
+			fmt.Println("No organisation-wide custom DNS zones declared. Clusters serve their generated domain and whatever 'ankra cluster custom-dns-zones' declares on them.")
+			return nil
+		}
+		zoneTable := table.NewWriter()
+		zoneTable.SetOutputMirror(os.Stdout)
+		zoneTable.SetStyle(table.StyleRounded)
+		zoneTable.AppendHeader(table.Row{"Zone", "Credential"})
+		for _, zone := range zones {
+			zoneTable.AppendRow(table.Row{zone.Zone, zone.CredentialName})
+		}
+		zoneTable.Render()
+		return nil
+	},
+}
+
+var (
+	orgCustomDNSZone       string
+	orgCustomDNSCredential string
+)
+
+var orgCustomDNSAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Declare a zone every cluster in the organisation serves",
+	Long: `Declare a zone every cluster in the organisation serves, with the DNS
+credential that can publish into it. Ankra renders an external-dns for the
+zone on each cluster on the next reconciler pass, and on every cluster
+created afterwards without further declaration.
+
+Refused when the zone is not a domain name, when the organisation has no DNS
+credential of that name, or when the zone overlaps the domain Ankra already
+serves for the organisation - that would put a second controller on names
+Ankra's own external-dns publishes.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		declaration, addError := apiClient.AddOrganisationCustomDNSZone(orgCustomDNSZone, orgCustomDNSCredential)
+		if addError != nil {
+			return fmt.Errorf("declaring the organisation custom dns zone: %w", addError)
+		}
+		if rendered, renderError := renderStructured(cmd, declaration); rendered || renderError != nil {
+			return renderError
+		}
+		fmt.Printf("Zone %s declared for every cluster in the organisation with credential %s.\n",
+			declaration.Zone, declaration.CredentialName)
+		fmt.Println("Ankra renders its external-dns on each cluster on the next reconciler pass (within ~2 minutes), and on every cluster created from now on.")
+		return nil
+	},
+}
+
+var orgCustomDNSRemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Withdraw an organisation-wide zone",
+	Long: `Withdraw an organisation-wide zone. Ankra removes the controllers it rendered
+from every cluster that inherited the zone on the next reconciler pass;
+clusters that declared the zone themselves keep theirs. The zone's records
+are yours and are left untouched.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		removedZone, removeError := apiClient.RemoveOrganisationCustomDNSZone(orgCustomDNSZone)
+		if removeError != nil {
+			return fmt.Errorf("withdrawing the organisation custom dns zone: %w", removeError)
+		}
+		if rendered, renderError := renderStructured(cmd,
+			map[string]string{"zone": removedZone}); rendered || renderError != nil {
+			return renderError
+		}
+		fmt.Printf("Zone %s withdrawn from the organisation. Its controllers are removed from every inheriting cluster on the next reconciler pass; the zone's records are untouched.\n", removedZone)
+		return nil
+	},
+}
+
+func init() {
+	orgCustomDNSAddCmd.Flags().StringVar(&orgCustomDNSZone, "zone", "", "Zone to declare for every cluster, e.g. example.com (required)")
+	orgCustomDNSAddCmd.Flags().StringVar(&orgCustomDNSCredential, "credential", "", "Name of the organisation DNS credential that publishes into the zone (required)")
+	_ = orgCustomDNSAddCmd.MarkFlagRequired("zone")
+	_ = orgCustomDNSAddCmd.MarkFlagRequired("credential")
+
+	orgCustomDNSRemoveCmd.Flags().StringVar(&orgCustomDNSZone, "zone", "", "Zone to withdraw (required)")
+	_ = orgCustomDNSRemoveCmd.MarkFlagRequired("zone")
+
+	registerStructuredOutputFlags(orgCustomDNSListCmd, orgCustomDNSAddCmd, orgCustomDNSRemoveCmd)
+
+	orgCustomDNSCmd.AddCommand(orgCustomDNSListCmd)
+	orgCustomDNSCmd.AddCommand(orgCustomDNSAddCmd)
+	orgCustomDNSCmd.AddCommand(orgCustomDNSRemoveCmd)
+	orgCmd.AddCommand(orgCustomDNSCmd)
+}

--- a/cmd/org_custom_dns_test.go
+++ b/cmd/org_custom_dns_test.go
@@ -1,0 +1,126 @@
+package cmd
+
+// The organisation-wide custom DNS zone verbs. The platform half
+// (cluster#1852) renders one isolated external-dns per zone on every cluster
+// in the organisation; these pin the CLI's contract with it: the request
+// shapes, the refusal details surfaced verbatim, and the source column the
+// per-cluster listing gained.
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestOrgCustomDNSListRendersZonesAndTheEmptyAnswer(t *testing.T) {
+	recorder := newCustomDNSServer(t)
+	listPath := "GET /api/v1/org/custom-dns-zones"
+	recorder.zonesByPath[listPath] = `{"success":true,"zones":[
+		{"zone":"smartoptics.dev","credential_name":"avura-smartoptics"}]}`
+
+	output := captureStdout(t, func() {
+		if runError := orgCustomDNSListCmd.RunE(orgCustomDNSListCmd, nil); runError != nil {
+			t.Fatalf("list returned an error: %v", runError)
+		}
+	})
+	for _, want := range []string{"smartoptics.dev", "avura-smartoptics"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output = %q, want it to mention %q", output, want)
+		}
+	}
+
+	recorder.zonesByPath[listPath] = `{"success":true,"zones":[]}`
+	output = captureStdout(t, func() {
+		if runError := orgCustomDNSListCmd.RunE(orgCustomDNSListCmd, nil); runError != nil {
+			t.Fatalf("empty list returned an error: %v", runError)
+		}
+	})
+	if !strings.Contains(output, "No organisation-wide custom DNS zones declared") {
+		t.Fatalf("output = %q, want the empty answer stated, not a bare table", output)
+	}
+}
+
+func TestOrgCustomDNSAddSendsTheDeclarationAndReportsItsReach(t *testing.T) {
+	recorder := newCustomDNSServer(t)
+	recorder.zonesByPath["POST /api/v1/org/custom-dns-zones"] =
+		`{"success":true,"zone":"smartoptics.dev","credential_name":"avura-smartoptics"}`
+
+	orgCustomDNSZone = "Smartoptics.DEV."
+	orgCustomDNSCredential = "avura-smartoptics"
+	output := captureStdout(t, func() {
+		if runError := orgCustomDNSAddCmd.RunE(orgCustomDNSAddCmd, nil); runError != nil {
+			t.Fatalf("add returned an error: %v", runError)
+		}
+	})
+
+	if recorder.lastBody["zone"] != "Smartoptics.DEV." || recorder.lastBody["credential_name"] != "avura-smartoptics" {
+		t.Fatalf("request body = %v, want the zone and credential as given (the platform normalises)", recorder.lastBody)
+	}
+	if !strings.Contains(output, "smartoptics.dev") || !strings.Contains(output, "every cluster") {
+		t.Fatalf("output = %q, want the normalised zone and its organisation-wide reach reported", output)
+	}
+	if !strings.Contains(output, "created from now on") {
+		t.Fatalf("output = %q, want it said that future clusters inherit the zone too", output)
+	}
+}
+
+// The refusals are the platform's, surfaced verbatim - an overlap with the
+// domain Ankra already serves for the organisation is an explanation, not a
+// generic failure.
+func TestOrgCustomDNSAddSurfacesTheRefusalDetail(t *testing.T) {
+	recorder := newCustomDNSServer(t)
+	recorder.refusalStatus = http.StatusBadRequest
+	recorder.refusalDetail = "Custom DNS zone overlaps the zone Ankra already serves for this organisation"
+
+	orgCustomDNSZone = "app.ankra.cc"
+	orgCustomDNSCredential = "avura-smartoptics"
+	runError := orgCustomDNSAddCmd.RunE(orgCustomDNSAddCmd, nil)
+	if runError == nil {
+		t.Fatal("a refused declaration must return an error")
+	}
+	if !strings.Contains(runError.Error(), "already serves for this organisation") {
+		t.Fatalf("error = %q, want the platform's refusal detail surfaced", runError)
+	}
+}
+
+func TestOrgCustomDNSRemoveEscapesTheZoneAndReportsTheWithdrawal(t *testing.T) {
+	recorder := newCustomDNSServer(t)
+	recorder.zonesByPath["DELETE /api/v1/org/custom-dns-zones/smartoptics.dev"] =
+		`{"success":true,"zone":"smartoptics.dev"}`
+
+	orgCustomDNSZone = "smartoptics.dev"
+	output := captureStdout(t, func() {
+		if runError := orgCustomDNSRemoveCmd.RunE(orgCustomDNSRemoveCmd, nil); runError != nil {
+			t.Fatalf("remove returned an error: %v", runError)
+		}
+	})
+	if !strings.Contains(output, "withdrawn") || !strings.Contains(output, "records are untouched") {
+		t.Fatalf("output = %q, want the withdrawal and the records-untouched promise stated", output)
+	}
+	if !strings.Contains(output, "every inheriting cluster") {
+		t.Fatalf("output = %q, want the organisation-wide reach of the withdrawal stated", output)
+	}
+}
+
+// A cluster listing tells the two scopes apart, and reads a platform that
+// predates the organisation-wide lane (no source member) as the cluster's own.
+func TestClusterCustomDNSListShowsWhereEachZoneWasDeclared(t *testing.T) {
+	recorder := newCustomDNSServer(t)
+	recorder.zonesByPath["GET /api/v1/clusters/"+customDNSClusterID+"/custom-dns-zones"] = `{"success":true,"zones":[
+		{"zone":"smartoptics.dev","credential_name":"avura-smartoptics","source":"organisation"},
+		{"zone":"launch.example.com","credential_name":"example-dns","source":"cluster"},
+		{"zone":"legacy.example.net","credential_name":"example-dns"}]}`
+
+	output := captureStdout(t, func() {
+		if runError := clusterCustomDNSListCmd.RunE(clusterCustomDNSListCmd,
+			[]string{customDNSClusterID}); runError != nil {
+			t.Fatalf("list returned an error: %v", runError)
+		}
+	})
+	if !strings.Contains(output, "organisation") {
+		t.Fatalf("output = %q, want the inherited zone marked as the organisation's", output)
+	}
+	if strings.Count(output, "cluster") < 2 {
+		t.Fatalf("output = %q, want both the declared and the source-less zone marked as the cluster's own", output)
+	}
+}

--- a/cmd/org_dns_credentials.go
+++ b/cmd/org_dns_credentials.go
@@ -14,8 +14,9 @@ var orgDnsCredentialsCmd = &cobra.Command{
 	Aliases: []string{"credential"},
 	Short:   "DNS webhook credentials for zones you own",
 	Long: `Store and list the organisation's DNS webhook credentials - the ones the
-custom DNS zone lane serves your own zones with ('ankra cluster
-custom-dns-zones').
+custom DNS zone lane serves your own zones with ('ankra org
+custom-dns-zones' for every cluster in the organisation, 'ankra cluster
+custom-dns-zones' for one cluster).
 
 The webhook provider URL embeds the provider token, so it is written to the
 platform's secret store on create and never returned by any read: 'list'
@@ -89,7 +90,7 @@ URL, which re-points every cluster binding that names it - the rotation path.`,
 }
 
 func init() {
-	orgDnsCredentialsCreateCmd.Flags().StringVar(&orgDnsCredentialName, "name", "", "Credential name, referenced by 'cluster custom-dns-zones add --credential' (required)")
+	orgDnsCredentialsCreateCmd.Flags().StringVar(&orgDnsCredentialName, "name", "", "Credential name, referenced by 'org custom-dns-zones add --credential' and 'cluster custom-dns-zones add --credential' (required)")
 	orgDnsCredentialsCreateCmd.Flags().StringVar(&orgDnsCredentialWebhookURL, "webhook-provider-url", "", "external-dns webhook endpoint including its token (required)")
 	_ = orgDnsCredentialsCreateCmd.MarkFlagRequired("name")
 	_ = orgDnsCredentialsCreateCmd.MarkFlagRequired("webhook-provider-url")

--- a/cmd/org_domain.go
+++ b/cmd/org_domain.go
@@ -46,16 +46,20 @@ automatically once the switch is accepted.
 
 WHAT ANKRA TOUCHES IN YOUR DOMAIN
 
-Ankra creates one subzone in the domain you register - <org_short_id>.<domain>
-- and works only inside it. It does not read, write or delete records anywhere
-else in the domain. Records you already publish at the apex or under any other
-name are untouched by registering the domain, by the switch itself, and by
-everything Ankra does afterwards. A domain that already serves your production
-hostnames is safe to register on that count.
+The domain you register becomes the organisation's zone itself: Ankra adopts
+it as the apex rather than carving a subzone out of it, and each cluster
+gets its own <cluster_short_id>.<domain> subzone under it. The external-dns
+Ankra installs on every cluster in the organisation holds a token pinned to
+the whole domain, so an Ingress on any hostname under it - a top-level name
+like app.<domain> included - is published by the cluster serving it, with no
+credential of your own. Records you already publish that no cluster's
+Ingress claims are left alone: each cluster's external-dns owns only the
+records it created.
 
-The delegation is strict below that too: each cluster gets its own subzone
-under the organisation zone, and the external-dns Ankra installs on a cluster
-holds a token pinned to that cluster's subzone alone.
+That is the lane for a domain hosted in Ankra's own DNS account. For a zone
+you hold in your own provider account, declare it with your own credential
+instead ('ankra org dns credentials create' + 'ankra org custom-dns-zones
+add').
 
 WHAT A SWITCH DOES NOT CHANGE
 

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -225,6 +225,9 @@ type APIClient interface {
 	ListClusterCustomDNSZones(clusterID string) ([]client.CustomDNSZone, error)
 	AddClusterCustomDNSZone(clusterID string, zone string, credentialName string) (*client.CustomDNSZone, error)
 	RemoveClusterCustomDNSZone(clusterID string, zone string) (string, error)
+	ListOrganisationCustomDNSZones() ([]client.OrganisationCustomDNSZone, error)
+	AddOrganisationCustomDNSZone(zone string, credentialName string) (*client.OrganisationCustomDNSZone, error)
+	RemoveOrganisationCustomDNSZone(zone string) (string, error)
 	ListDNSCredentials() ([]client.DNSCredentialSummary, error)
 	CreateDNSCredential(name string, webhookProviderURL string) (*client.CreateDNSCredentialResponse, error)
 

--- a/internal/client/customdns.go
+++ b/internal/client/customdns.go
@@ -7,12 +7,23 @@ import (
 
 // Custom DNS zones: the zones a cluster also serves with the organisation's
 // own external-dns webhook credential, alongside the delegated zone Ankra
-// serves itself. The platform renders one isolated external-dns controller
-// per declared zone (cluster#1804); these calls only declare and withdraw
-// the bindings.
+// serves itself. A zone is declared on one cluster or, organisation-wide, on
+// every cluster in the organisation - existing and future. The platform
+// renders one isolated external-dns controller per zone per cluster
+// (cluster#1804, cluster#1852); these calls only declare and withdraw the
+// bindings.
 
-// CustomDNSZone is one declared binding on a cluster.
+// CustomDNSZone is one binding a cluster serves. Source names the scope it
+// was declared at: "cluster" for the cluster's own declaration,
+// "organisation" for one every cluster in the organisation inherits.
 type CustomDNSZone struct {
+	Zone           string `json:"zone"`
+	CredentialName string `json:"credential_name"`
+	Source         string `json:"source,omitempty"`
+}
+
+// OrganisationCustomDNSZone is one organisation-wide declaration.
+type OrganisationCustomDNSZone struct {
 	Zone           string `json:"zone"`
 	CredentialName string `json:"credential_name"`
 }
@@ -20,6 +31,11 @@ type CustomDNSZone struct {
 type listCustomDNSZonesResponse struct {
 	Success bool            `json:"success"`
 	Zones   []CustomDNSZone `json:"zones"`
+}
+
+type listOrganisationCustomDNSZonesResponse struct {
+	Success bool                        `json:"success"`
+	Zones   []OrganisationCustomDNSZone `json:"zones"`
 }
 
 // DNSCredentialSummary is one org DNS credential as the provider listing
@@ -89,6 +105,55 @@ func (c *Client) RemoveClusterCustomDNSZone(clusterID string, zone string) (stri
 		Zone    string `json:"zone"`
 	}
 	if err := c.deleteCSRFJSON(requestURL, &response, "withdraw custom dns zone"); err != nil {
+		return "", err
+	}
+	return response.Zone, nil
+}
+
+// ListOrganisationCustomDNSZones reads the zones declared for every cluster
+// in the organisation. An empty list is a complete answer.
+func (c *Client) ListOrganisationCustomDNSZones() ([]OrganisationCustomDNSZone, error) {
+	requestURL := c.BaseURL + "/api/v1/org/custom-dns-zones"
+	var response listOrganisationCustomDNSZonesResponse
+	if err := c.getJSON(requestURL, &response); err != nil {
+		return nil, err
+	}
+	if response.Zones == nil {
+		return []OrganisationCustomDNSZone{}, nil
+	}
+	return response.Zones, nil
+}
+
+// AddOrganisationCustomDNSZone declares a zone every cluster in the
+// organisation serves. The platform refuses a zone that is not a domain
+// name, a credential the organisation does not have, and a zone overlapping
+// the domain it already serves for the organisation; those come back as the
+// response detail.
+func (c *Client) AddOrganisationCustomDNSZone(zone string, credentialName string) (*OrganisationCustomDNSZone, error) {
+	requestURL := c.BaseURL + "/api/v1/org/custom-dns-zones"
+	payload := map[string]string{"zone": zone, "credential_name": credentialName}
+	var response struct {
+		Success        bool   `json:"success"`
+		Zone           string `json:"zone"`
+		CredentialName string `json:"credential_name"`
+	}
+	if err := c.postCSRFJSON(requestURL, payload, &response, "declare organisation custom dns zone"); err != nil {
+		return nil, err
+	}
+	return &OrganisationCustomDNSZone{Zone: response.Zone, CredentialName: response.CredentialName}, nil
+}
+
+// RemoveOrganisationCustomDNSZone withdraws an organisation-wide zone. The
+// platform tears the inherited controllers down on the next reconciler pass;
+// a zone the organisation does not declare answers 404 rather than succeeding
+// silently.
+func (c *Client) RemoveOrganisationCustomDNSZone(zone string) (string, error) {
+	requestURL := c.BaseURL + "/api/v1/org/custom-dns-zones/" + url.PathEscape(zone)
+	var response struct {
+		Success bool   `json:"success"`
+		Zone    string `json:"zone"`
+	}
+	if err := c.deleteCSRFJSON(requestURL, &response, "withdraw organisation custom dns zone"); err != nil {
 		return "", err
 	}
 	return response.Zone, nil


### PR DESCRIPTION
Bead: ankra-nglfk
Platform half: ankraio/cluster#1852

## Why

`ankra cluster custom-dns-zones add` declares a zone on one named cluster, so a freshly created cluster (`so-gpu-chat`, 2026-08-24) came up with its `smartoptics.dev` ingress hostnames dropped silently and cert-manager stuck waiting for DNS nothing was publishing. The organisation's own domain should be served on every cluster by default, like the generated domain is.

## What

- **`ankra org custom-dns-zones list|add|remove`** (alias `custom-dns`) — declare a zone once for the organisation with `--zone` / `--credential`; the platform renders one isolated external-dns for it on every cluster, existing and future. `remove` withdraws it (inherited controllers torn down; clusters that declared the zone themselves keep theirs).
- **`ankra cluster custom-dns-zones list`** gains a `SOURCE` column (`cluster` / `organisation`); a platform that predates the lane (no `source` member) reads as `cluster`. Long help explains the precedence of a cluster's own declaration.
- **Client**: `ListOrganisationCustomDNSZones`, `AddOrganisationCustomDNSZone`, `RemoveOrganisationCustomDNSZone` against `/api/v1/org/custom-dns-zones`; `CustomDNSZone.Source`. `APIClient` interface and `baseMock` extended.
- **`ankra org domain --help`** no longer describes the pre-cluster#1841 subzone model (it said Ankra confines itself to `<org_short_id>.<domain>` and pins each cluster's token to its subzone; the domain is adopted as the apex and every cluster publishes anywhere under it), and points a zone hosted outside Ankra's DNS account at the new verb.
- CHANGELOG `## Unreleased` entries.

## Verification

- `go build ./...`, `go vet`, `go test -race -count=1 ./cmd/ ./internal/client/` green; `golangci-lint run ./...` 0 issues; pre-commit hook ran both again on commit.
- New tests: `TestOrgCustomDNSListRendersZonesAndTheEmptyAnswer`, `TestOrgCustomDNSAddSendsTheDeclarationAndReportsItsReach`, `TestOrgCustomDNSAddSurfacesTheRefusalDetail`, `TestOrgCustomDNSRemoveEscapesTheZoneAndReportsTheWithdrawal`, `TestClusterCustomDNSListShowsWhereEachZoneWasDeclared`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
