### PR TITLE
feat(encrypt): --key 'glob:<pattern>' encrypts every key whose name matches, now and on later re-encrypts (ankra-q5lsn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ### Added
 
+- **`ankra cluster encrypt --key 'glob:<pattern>'` encrypts every key whose
+  name matches - now and on every later platform re-encrypt, including keys
+  added afterwards.** A pattern in `encrypted_paths` used to be escaped into
+  a literal that matched nothing, and a hand-widened `encrypted_regex` in
+  the sealed file was replaced by the platform's next write-back, so a
+  Secret with a growing set of `DB_*` keys needed one `encrypt` per key and
+  a new key committed in plaintext until someone noticed. `--key
+  'glob:stringData.DB_*'` (only `*` is a wildcard; a leading `data.` or
+  `stringData.` is accepted and ignored, as for an exact key) is recorded in
+  `encrypted_paths` as written, which is the form the platform re-expands
+  into the SOPS selector on every push. Exact keys keep their meaning
+  byte-for-byte - a literal key containing a dot or a star is still matched
+  literally; only the `glob:` prefix opts in. A pattern that matches no key
+  fails, the same way a misspelled exact key does. Requires cluster#1867 on
+  the platform. (PLA-798, support #1094)
+
 - **`ankra org custom-dns-zones` serves your own zone from every cluster in
   the organisation - the ones you have and the ones you create next.**
   `ankra cluster custom-dns-zones` declared a zone on one named cluster, so a

--- a/cmd/cluster_encrypt.go
+++ b/cmd/cluster_encrypt.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -21,7 +22,80 @@ import (
 const (
 	sopsMetadataKey          = "sops"
 	sopsEncryptedValuePrefix = "ENC["
+
+	// encryptKeyGlobPrefix marks a --key value as a key-name glob rather than
+	// an exact key: "glob:stringData.DB_*" encrypts every key whose name
+	// starts with DB_, including keys added later. It mirrors the platform's
+	// encrypted_paths grammar (clusterengine.EncryptedPathGlobPrefix in the
+	// cluster repo's enginekit) byte-for-byte, so the entry the CLI records
+	// in encrypted_paths is the entry the platform's push lane re-expands on
+	// every re-render. Only "*" is a wildcard; an optional leading "data." or
+	// "stringData." section is accepted and stripped, as it is for exact
+	// keys. TestEncryptKeyGlobGrammarMirrorsThePlatform pins both.
+	encryptKeyGlobPrefix   = "glob:"
+	encryptKeyGlobWildcard = "*"
 )
+
+// encryptKeySectionPrefixes are the Secret sections a --key value may name
+// in front of the key; the platform strips the same two.
+var encryptKeySectionPrefixes = []string{"data.", "stringData."}
+
+// isEncryptKeyGlob reports whether an encrypted_paths entry uses the glob
+// form.
+func isEncryptKeyGlob(entry string) bool {
+	return strings.HasPrefix(entry, encryptKeyGlobPrefix)
+}
+
+// parseEncryptKeyGlob compiles a glob: entry into an anchored key-name
+// matcher, refusing the shapes the platform refuses: nothing after the
+// prefix, a section with no pattern, no wildcard (an exact key in disguise
+// - pass it without the prefix), and a pattern that is only wildcards (it
+// would encrypt every key, metadata.name and kind included).
+func parseEncryptKeyGlob(entry string) (*regexp.Regexp, error) {
+	body := strings.TrimPrefix(entry, encryptKeyGlobPrefix)
+	if body == "" {
+		return nil, fmt.Errorf("invalid --key %q: the %s prefix must be followed by a key-name pattern such as glob:stringData.DB_*", entry, encryptKeyGlobPrefix)
+	}
+	keyPattern := body
+	for _, sectionPrefix := range encryptKeySectionPrefixes {
+		if strings.HasPrefix(body, sectionPrefix) {
+			keyPattern = body[len(sectionPrefix):]
+			break
+		}
+	}
+	if keyPattern == "" {
+		return nil, fmt.Errorf("invalid --key %q: names a section but no key-name pattern; add the pattern after the section, such as glob:stringData.DB_*", entry)
+	}
+	if !strings.Contains(keyPattern, encryptKeyGlobWildcard) {
+		return nil, fmt.Errorf("invalid --key %q: contains no * wildcard; pass the exact key name without the %s prefix", entry, encryptKeyGlobPrefix)
+	}
+	if strings.Trim(keyPattern, encryptKeyGlobWildcard) == "" {
+		return nil, fmt.Errorf("invalid --key %q: would match every key in the document; keep at least one literal character, such as glob:stringData.DB_*", entry)
+	}
+	literalPieces := strings.Split(keyPattern, encryptKeyGlobWildcard)
+	quotedPieces := make([]string, 0, len(literalPieces))
+	for _, piece := range literalPieces {
+		quotedPieces = append(quotedPieces, regexp.QuoteMeta(piece))
+	}
+	matcher, compileErr := regexp.Compile("^" + strings.Join(quotedPieces, ".*") + "$")
+	if compileErr != nil {
+		return nil, fmt.Errorf("invalid --key %q: %w", entry, compileErr)
+	}
+	return matcher, nil
+}
+
+// encryptKeyMatcher returns the key-name predicate for one encrypted_paths
+// entry: the glob's pattern, or exact equality for a leaf key.
+func encryptKeyMatcher(entry string) (func(keyName string) bool, error) {
+	if !isEncryptKeyGlob(entry) {
+		return func(keyName string) bool { return keyName == entry }, nil
+	}
+	matcher, parseErr := parseEncryptKeyGlob(entry)
+	if parseErr != nil {
+		return nil, parseErr
+	}
+	return matcher.MatchString, nil
+}
 
 var clusterSopsConfigCmd = &cobra.Command{
 	Use:   "sops-config",
@@ -75,6 +149,15 @@ normalised to its last segment. A key whose own name starts with a dot (such as
 literally. After encrypting, the CLI verifies every value is actually ENC[...]
 ciphertext and fails if any is not.
 
+--key glob:<pattern> encrypts every key whose name matches the pattern, now
+and on every later platform re-encrypt - including keys added afterwards.
+Only "*" is a wildcard (any run of characters); everything else is literal,
+and a leading "data." or "stringData." is accepted and ignored, exactly as for
+an exact key. The entry is recorded in encrypted_paths as written
+("glob:stringData.DB_*"), which is the form the platform re-expands into the
+SOPS encrypted_regex on every push. A pattern that matches no key fails, the
+same way a misspelled exact key does. Requires cluster#1867 on the platform.
+
 --all-data selects every key under data and stringData of a Kubernetes Secret
 manifest instead of naming keys individually; keys whose values are already
 encrypted are skipped. The manifest must be a Secret. --all-data and --key are
@@ -117,6 +200,9 @@ Examples:
   # Encrypt every data/stringData key of a Secret manifest
   ankra cluster encrypt manifest db-secret --all-data --cluster prod
 
+  # Encrypt every DB_* key, including ones added later
+  ankra cluster encrypt manifest db-secret --key 'glob:stringData.DB_*' --cluster prod
+
   # File mode
   ankra cluster encrypt manifest db-secret --key password -f cluster.yaml`,
 	Args: cobra.ExactArgs(1),
@@ -136,6 +222,13 @@ starts with a dot (such as ".dockerconfigjson") is kept literally. After
 encrypting, the CLI verifies every value is actually ENC[...] ciphertext and
 fails if any is not.
 
+--key glob:<pattern> encrypts every key whose name matches the pattern, now
+and on every later platform re-encrypt - including keys added afterwards.
+Only "*" is a wildcard; everything else is literal. The entry is recorded in
+encrypted_paths as written ("glob:*Password"). A pattern that matches no key
+fails, the same way a misspelled exact key does. Requires cluster#1867 on the
+platform.
+
 Two modes:
   Cluster mode (default): fetch the addon's values from a live cluster,
     encrypt the key, and push the result back via the partial-stack PATCH
@@ -154,6 +247,9 @@ Examples:
   # Encrypt several keys in one run
   ankra cluster encrypt addon --name grafana --key adminPassword --key smtpPassword
 
+  # Encrypt every *Password key, including ones added later
+  ankra cluster encrypt addon --name grafana --key 'glob:*Password' --cluster prod
+
   # File mode
   ankra cluster encrypt addon --name grafana --key adminPassword -f cluster.yaml`,
 	RunE: runEncryptAddon,
@@ -161,7 +257,7 @@ Examples:
 
 func init() {
 	clusterEncryptManifestCmd.Flags().StringVarP(&encryptClusterFile, "file", "f", "", "Path to a local cluster YAML (enables file mode)")
-	clusterEncryptManifestCmd.Flags().StringArrayVar(&encryptKeys, "key", nil, "YAML key name to encrypt (repeatable); dotted paths are normalised to the last segment, a leading-dot key like .dockerconfigjson is kept literally")
+	clusterEncryptManifestCmd.Flags().StringArrayVar(&encryptKeys, "key", nil, "YAML key name to encrypt (repeatable), or glob:<pattern> to encrypt every key whose name matches (only * is a wildcard, e.g. glob:stringData.DB_*); dotted paths are normalised to the last segment, a leading-dot key like .dockerconfigjson is kept literally")
 	clusterEncryptManifestCmd.Flags().BoolVar(&encryptAllData, "all-data", false, "Encrypt every key under data and stringData of a Secret manifest, skipping values that are already encrypted")
 	clusterEncryptManifestCmd.Flags().StringVar(&encryptClusterFlag, "cluster", "", "Target cluster (name or ID); defaults to the active selection (cluster mode)")
 	clusterEncryptManifestCmd.Flags().StringArrayVar(&encryptSetEntries, "set", nil, "Apply value edits in-memory before encrypting (same syntax as manifests upgrade --set, e.g. --set 'data.password=bmV3'); the plaintext value never reaches git (cluster mode only; repeatable)")
@@ -171,7 +267,7 @@ func init() {
 	clusterEncryptManifestCmd.MarkFlagsMutuallyExclusive("file", "set")
 
 	clusterEncryptAddonCmd.Flags().StringVarP(&encryptClusterFile, "file", "f", "", "Path to a local cluster YAML (enables file mode)")
-	clusterEncryptAddonCmd.Flags().StringArrayVar(&encryptKeys, "key", nil, "YAML key name to encrypt (required; repeatable); dotted paths are normalised to the last segment, a leading-dot key like .dockerconfigjson is kept literally")
+	clusterEncryptAddonCmd.Flags().StringArrayVar(&encryptKeys, "key", nil, "YAML key name to encrypt (required; repeatable), or glob:<pattern> to encrypt every key whose name matches (only * is a wildcard, e.g. glob:*Password); dotted paths are normalised to the last segment, a leading-dot key like .dockerconfigjson is kept literally")
 	clusterEncryptAddonCmd.Flags().StringVar(&encryptAddonName, "name", "", "Name of the addon (required)")
 	clusterEncryptAddonCmd.Flags().StringVar(&encryptClusterFlag, "cluster", "", "Target cluster (name or ID); defaults to the active selection (cluster mode)")
 	clusterEncryptAddonCmd.Flags().StringVar(&encryptStackFlag, "stack", "", "Stack name (cluster mode; required when the addon exists in multiple stacks)")
@@ -195,10 +291,20 @@ func init() {
 // A leading dot marks a literal key whose own name contains a dot, such as the
 // ".dockerconfigjson" key in a kubernetes.io/dockerconfigjson Secret. Those are
 // kept verbatim instead of being split on the dot.
+//
+// A glob: entry is validated against the platform's grammar and kept
+// verbatim, prefix included: the platform expands it into the SOPS
+// encrypted_regex itself, on this encrypt and on every later re-render.
 func normalizeEncryptKey(rawKey string) (string, error) {
 	trimmedKey := strings.TrimSpace(rawKey)
 	if trimmedKey == "" {
 		return "", fmt.Errorf("--key must not be empty")
+	}
+	if isEncryptKeyGlob(trimmedKey) {
+		if _, parseErr := parseEncryptKeyGlob(trimmedKey); parseErr != nil {
+			return "", parseErr
+		}
+		return trimmedKey, nil
 	}
 	if strings.HasPrefix(trimmedKey, ".") {
 		if trimmedKey == "." {
@@ -215,6 +321,12 @@ func normalizeEncryptKey(rawKey string) (string, error) {
 }
 
 func announceEncryptKeyNormalization(cmd *cobra.Command, rawKey, leafKey string) {
+	if isEncryptKeyGlob(leafKey) {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+			"Note: %s is recorded in encrypted_paths as written; every key whose name matches it is encrypted now and on every later platform re-encrypt, including keys added afterwards.\n",
+			leafKey)
+		return
+	}
 	if leafKey == strings.TrimSpace(rawKey) {
 		return
 	}
@@ -248,16 +360,28 @@ func normalizeAndAnnounceEncryptKeys(cmd *cobra.Command, rawKeys []string) ([]st
 }
 
 // describeEncryptKeys renders leaf keys for progress messages: `key "a"` for a
-// single key, `keys "a", "b"` for several.
+// single key, `keys "a", "b"` for several; a glob entry reads `keys matching
+// glob:DB_*` because it names a set, not one key.
 func describeEncryptKeys(leafKeys []string) string {
-	quotedKeys := make([]string, len(leafKeys))
-	for keyIndex, leafKey := range leafKeys {
-		quotedKeys[keyIndex] = fmt.Sprintf("%q", leafKey)
+	quotedKeys := make([]string, 0, len(leafKeys))
+	globEntries := make([]string, 0, len(leafKeys))
+	for _, leafKey := range leafKeys {
+		if isEncryptKeyGlob(leafKey) {
+			globEntries = append(globEntries, leafKey)
+			continue
+		}
+		quotedKeys = append(quotedKeys, fmt.Sprintf("%q", leafKey))
 	}
+	parts := make([]string, 0, 2)
 	if len(quotedKeys) == 1 {
-		return "key " + quotedKeys[0]
+		parts = append(parts, "key "+quotedKeys[0])
+	} else if len(quotedKeys) > 1 {
+		parts = append(parts, "keys "+strings.Join(quotedKeys, ", "))
 	}
-	return "keys " + strings.Join(quotedKeys, ", ")
+	if len(globEntries) > 0 {
+		parts = append(parts, "keys matching "+strings.Join(globEntries, ", "))
+	}
+	return strings.Join(parts, " and ")
 }
 
 // describeEncryptKeysCapitalised is describeEncryptKeys for sentence starts.
@@ -348,8 +472,14 @@ func announceSkippedEncryptedKeys(out io.Writer, alreadyEncryptedKeys []string) 
 // verifyKeyEncrypted guards against SOPS "succeeding" without encrypting
 // anything: it checks that the target key exists in the encrypted output and
 // that every value under it is ENC[...] ciphertext. Without this guard a bad
-// key silently produces a file with sops metadata and plaintext values.
+// key silently produces a file with sops metadata and plaintext values. A
+// glob: entry must select at least one key - a pattern matching nothing has
+// encrypted nothing - and every key it selects must be ciphertext.
 func verifyKeyEncrypted(encryptedYAML, keyName string) error {
+	keyMatches, matcherErr := encryptKeyMatcher(keyName)
+	if matcherErr != nil {
+		return matcherErr
+	}
 	decoder := yaml.NewDecoder(strings.NewReader(encryptedYAML))
 	matchedKeyCount := 0
 	plaintextValueCount := 0
@@ -366,15 +496,26 @@ func verifyKeyEncrypted(encryptedYAML, keyName string) error {
 		if rootNode.Kind == yaml.DocumentNode && len(rootNode.Content) > 0 {
 			rootNode = rootNode.Content[0]
 		}
-		inspectEncryptedKey(rootNode, keyName, true, &matchedKeyCount, &plaintextValueCount)
+		inspectEncryptedKey(rootNode, keyMatches, true, &matchedKeyCount, &plaintextValueCount)
 	}
 	if matchedKeyCount == 0 {
+		if isEncryptKeyGlob(keyName) {
+			return fmt.Errorf(
+				"no YAML key matching %s exists in the encrypted output, so SOPS encrypted nothing while still writing sops metadata; "+
+					"pass a pattern that selects at least one key in the document",
+				keyName)
+		}
 		return fmt.Errorf(
 			"no YAML key named %q exists in the encrypted output, so SOPS encrypted nothing while still writing sops metadata; "+
 				"pass the key name itself (for data.password use --key password)",
 			keyName)
 	}
 	if plaintextValueCount > 0 {
+		if isEncryptKeyGlob(keyName) {
+			return fmt.Errorf(
+				"a value under a key matching %s is still plaintext after encryption; refusing to write a file that only looks encrypted",
+				keyName)
+		}
 		return fmt.Errorf(
 			"value under key %q is still plaintext after encryption; refusing to write a file that only looks encrypted",
 			keyName)
@@ -382,7 +523,7 @@ func verifyKeyEncrypted(encryptedYAML, keyName string) error {
 	return nil
 }
 
-func inspectEncryptedKey(node *yaml.Node, keyName string, isDocumentRoot bool, matchedKeyCount, plaintextValueCount *int) {
+func inspectEncryptedKey(node *yaml.Node, keyMatches func(keyName string) bool, isDocumentRoot bool, matchedKeyCount, plaintextValueCount *int) {
 	if node == nil {
 		return
 	}
@@ -394,18 +535,18 @@ func inspectEncryptedKey(node *yaml.Node, keyName string, isDocumentRoot bool, m
 			if isDocumentRoot && keyNode.Value == sopsMetadataKey {
 				continue
 			}
-			if keyNode.Value == keyName {
+			if keyMatches(keyNode.Value) {
 				*matchedKeyCount++
 				if !isSubtreeEncrypted(valueNode) {
 					*plaintextValueCount++
 				}
 				continue
 			}
-			inspectEncryptedKey(valueNode, keyName, false, matchedKeyCount, plaintextValueCount)
+			inspectEncryptedKey(valueNode, keyMatches, false, matchedKeyCount, plaintextValueCount)
 		}
 	case yaml.SequenceNode:
 		for _, itemNode := range node.Content {
-			inspectEncryptedKey(itemNode, keyName, false, matchedKeyCount, plaintextValueCount)
+			inspectEncryptedKey(itemNode, keyMatches, false, matchedKeyCount, plaintextValueCount)
 		}
 	}
 }

--- a/cmd/cluster_encrypt_test.go
+++ b/cmd/cluster_encrypt_test.go
@@ -619,3 +619,142 @@ type: Opaque
 		t.Error("expected an error for a Secret without data or stringData keys")
 	}
 }
+
+// --- glob: key entries (PLA-798) ---
+
+const globPlainSecretManifestYAML = `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: web
+type: Opaque
+stringData:
+  DB_PASSWORD: hunter2
+  DB_USER: trinity
+  LOG_LEVEL: debug
+`
+
+const globSealedSecretManifestYAML = `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: web
+type: Opaque
+stringData:
+  DB_PASSWORD: ENC[AES256_GCM,data:pwd,iv:abc,tag:def,type:str]
+  DB_USER: ENC[AES256_GCM,data:usr,iv:abc,tag:def,type:str]
+  LOG_LEVEL: debug
+sops:
+  mac: ENC[AES256_GCM,data:mac]
+  encrypted_regex: ^(DB_.*)$
+`
+
+// The glob entry travels to the platform verbatim and lands in
+// encrypted_paths verbatim - the platform's push lane is what re-expands it
+// into the SOPS selector on every re-render, so the CLI must never rewrite
+// it into a leaf key.
+func TestRunEncryptManifest_FileModeGlobEntryRecordedVerbatim(t *testing.T) {
+	clusterPath, manifestPath := writeEncryptFileModeFixture(t, globPlainSecretManifestYAML)
+
+	mock := &upgradeMock{encryptResult: globSealedSecretManifestYAML}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "my-secret",
+		"--key", "glob:stringData.DB_*",
+		"-f", clusterPath,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+
+	if len(mock.encryptCalls) != 1 {
+		t.Fatalf("expected exactly one EncryptYAML call, got %d", len(mock.encryptCalls))
+	}
+	if paths := mock.encryptCalls[0].EncryptedPaths; len(paths) != 1 || paths[0] != "glob:stringData.DB_*" {
+		t.Errorf("encrypted paths sent to the platform = %v, want the glob entry verbatim", paths)
+	}
+	writtenManifest, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read written manifest: %v", err)
+	}
+	if string(writtenManifest) != globSealedSecretManifestYAML {
+		t.Errorf("manifest file = %q, want the sealed content", writtenManifest)
+	}
+	writtenCluster, err := os.ReadFile(clusterPath)
+	if err != nil {
+		t.Fatalf("read written cluster file: %v", err)
+	}
+	assertContainsAll(t, string(writtenCluster), []string{"- glob:stringData.DB_*"})
+	if strings.Contains(string(writtenCluster), "- DB_*") {
+		t.Errorf("glob entry was rewritten into a leaf key:\n%s", writtenCluster)
+	}
+	assertContainsAll(t, out.String(), []string{"Note: glob:stringData.DB_* is recorded in encrypted_paths as written"})
+}
+
+// A glob that selects nothing has encrypted nothing: the CLI refuses to
+// write the file the platform returned, exactly as it does for a misspelled
+// exact key.
+func TestRunEncryptManifest_FileModeGlobMatchingNoKeyRefused(t *testing.T) {
+	clusterPath, manifestPath := writeEncryptFileModeFixture(t, globPlainSecretManifestYAML)
+
+	inertResult := strings.Replace(globPlainSecretManifestYAML, "  LOG_LEVEL: debug\n",
+		"  LOG_LEVEL: debug\nsops:\n  mac: ENC[AES256_GCM,data:mac]\n  encrypted_regex: ^(REDIS_.*)$\n", 1)
+	mock := &upgradeMock{encryptResult: inertResult}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "my-secret",
+		"--key", "glob:stringData.REDIS_*",
+		"-f", clusterPath,
+	})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "SOPS encrypted nothing") {
+		t.Fatalf("expected the encrypted-nothing refusal, got %v\noutput: %s", err, out.String())
+	}
+	writtenManifest, readErr := os.ReadFile(manifestPath)
+	if readErr != nil {
+		t.Fatalf("read manifest: %v", readErr)
+	}
+	if string(writtenManifest) != globPlainSecretManifestYAML {
+		t.Errorf("manifest file was rewritten with a document that only looks encrypted:\n%s", writtenManifest)
+	}
+	writtenCluster, readErr := os.ReadFile(clusterPath)
+	if readErr != nil {
+		t.Fatalf("read cluster file: %v", readErr)
+	}
+	if strings.Contains(string(writtenCluster), "encrypted_paths") {
+		t.Errorf("cluster file must stay untouched after a refusal:\n%s", writtenCluster)
+	}
+}
+
+func TestRunEncryptManifest_InvalidGlobRefusedBeforeAnyCall(t *testing.T) {
+	clusterPath, _ := writeEncryptFileModeFixture(t, globPlainSecretManifestYAML)
+	mock := &upgradeMock{encryptResult: globSealedSecretManifestYAML}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "my-secret",
+		"--key", "glob:stringData.DB_PASSWORD",
+		"-f", clusterPath,
+	})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "contains no * wildcard") {
+		t.Fatalf("expected the grammar refusal, got %v", err)
+	}
+	if len(mock.encryptCalls) != 0 {
+		t.Errorf("must not call EncryptYAML for an invalid glob, got %d calls", len(mock.encryptCalls))
+	}
+}

--- a/cmd/encrypt_test.go
+++ b/cmd/encrypt_test.go
@@ -480,3 +480,137 @@ func TestUnionStringLists(t *testing.T) {
 		t.Errorf("union of empties = %v, want nil", merged)
 	}
 }
+
+// --- glob: key entries (PLA-798) ---
+
+// TestEncryptKeyGlobGrammarMirrorsThePlatform pins the prefix and the
+// rejection rules to the platform's encrypted_paths grammar
+// (clusterengine.EncryptedPathGlobPrefix / ParseEncryptedPathGlob in the
+// cluster repo's enginekit): the CLI cannot import that module, so the
+// literal and the four refusals are mirrored here and held by this test.
+func TestEncryptKeyGlobGrammarMirrorsThePlatform(t *testing.T) {
+	if encryptKeyGlobPrefix != "glob:" {
+		t.Fatalf("prefix drifted from the platform's: %q", encryptKeyGlobPrefix)
+	}
+	accepted := map[string][]string{
+		"glob:stringData.DB_*": {"DB_PASSWORD", "DB_"},
+		"glob:data.*_KEY":      {"API_KEY"},
+		"glob:*password*":      {"adminpassword", "password"},
+		"glob:cloud.*":         {"cloud.conf"},
+		"glob:.docker*":        {".dockerconfigjson"},
+		"glob:a+b(c)*":         {"a+b(c)d"},
+	}
+	rejectedKeys := map[string][]string{
+		"glob:stringData.DB_*": {"MYDB_PASSWORD", "db_password"},
+		"glob:cloud.*":         {"cloudXconf"},
+		"glob:.docker*":        {"dockerconfigjson"},
+		"glob:a+b(c)*":         {"aab(c)"},
+	}
+	for entry, keys := range accepted {
+		matcher, err := parseEncryptKeyGlob(entry)
+		if err != nil {
+			t.Fatalf("%s: %v", entry, err)
+		}
+		for _, key := range keys {
+			if !matcher.MatchString(key) {
+				t.Errorf("%s: key %q must match", entry, key)
+			}
+		}
+		for _, key := range rejectedKeys[entry] {
+			if matcher.MatchString(key) {
+				t.Errorf("%s: key %q must not match", entry, key)
+			}
+		}
+	}
+	rejected := map[string]string{
+		"glob:":                       "must be followed by a key-name pattern",
+		"glob:stringData.":            "names a section but no key-name pattern",
+		"glob:stringData.DB_PASSWORD": "contains no * wildcard",
+		"glob:*":                      "would match every key",
+		"glob:stringData.*":           "would match every key",
+		"glob:**":                     "would match every key",
+	}
+	for entry, reason := range rejected {
+		_, err := parseEncryptKeyGlob(entry)
+		if err == nil || !strings.Contains(err.Error(), reason) {
+			t.Errorf("%s: expected refusal mentioning %q, got %v", entry, reason, err)
+		}
+	}
+}
+
+func TestNormalizeEncryptKeyKeepsGlobEntriesVerbatim(t *testing.T) {
+	for _, rawKey := range []string{"glob:stringData.DB_*", "  glob:*Password  ", "glob:DB_*_KEY"} {
+		entry, err := normalizeEncryptKey(rawKey)
+		if err != nil {
+			t.Fatalf("normalizeEncryptKey(%q): %v", rawKey, err)
+		}
+		if entry != strings.TrimSpace(rawKey) {
+			t.Errorf("normalizeEncryptKey(%q) = %q, want the entry verbatim (prefix included, never split on dots)", rawKey, entry)
+		}
+	}
+	for _, rawKey := range []string{"glob:", "glob:stringData.DB_PASSWORD", "glob:*"} {
+		if entry, err := normalizeEncryptKey(rawKey); err == nil {
+			t.Errorf("normalizeEncryptKey(%q) accepted an invalid glob as %q", rawKey, entry)
+		}
+	}
+	// A literal that merely looks like a pattern is not one: the prefix is
+	// the opt-in, so "DB_*" stays an exact (and useless) key name.
+	if entry, err := normalizeEncryptKey("stringData.DB_*"); err != nil || entry != "DB_*" {
+		t.Errorf("literal with a star must stay a literal leaf key, got %q %v", entry, err)
+	}
+}
+
+func TestVerifyKeyEncryptedHonoursGlobEntries(t *testing.T) {
+	sealed := `apiVersion: v1
+kind: Secret
+stringData:
+  DB_PASSWORD: ENC[AES256_GCM,data:abc,iv:def,tag:ghi,type:str]
+  DB_USER: ENC[AES256_GCM,data:jkl,iv:mno,tag:pqr,type:str]
+  LOG_LEVEL: debug
+sops:
+  mac: ENC[AES256_GCM,data:mac]
+  encrypted_regex: ^(DB_.*)$
+`
+	t.Run("every glob-matched key sealed passes", func(t *testing.T) {
+		if err := verifyKeyEncrypted(sealed, "glob:stringData.DB_*"); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+	t.Run("glob matching no key fails", func(t *testing.T) {
+		err := verifyKeyEncrypted(sealed, "glob:stringData.REDIS_*")
+		if err == nil || !strings.Contains(err.Error(), "SOPS encrypted nothing") {
+			t.Errorf("expected the encrypted-nothing refusal, got %v", err)
+		}
+	})
+	t.Run("plaintext under a glob-matched key fails", func(t *testing.T) {
+		partiallySealed := strings.Replace(sealed, "DB_USER: ENC[AES256_GCM,data:jkl,iv:mno,tag:pqr,type:str]", "DB_USER: trinity", 1)
+		err := verifyKeyEncrypted(partiallySealed, "glob:stringData.DB_*")
+		if err == nil || !strings.Contains(err.Error(), "still plaintext") {
+			t.Errorf("expected the plaintext refusal, got %v", err)
+		}
+	})
+	t.Run("sops metadata keys never count", func(t *testing.T) {
+		if err := verifyKeyEncrypted(sealed, "glob:ma*"); err == nil {
+			t.Error("expected refusal: 'mac' only exists inside the sops metadata block")
+		}
+	})
+	t.Run("invalid glob is refused", func(t *testing.T) {
+		if err := verifyKeyEncrypted(sealed, "glob:*"); err == nil {
+			t.Error("expected refusal for a glob that would match every key")
+		}
+	})
+}
+
+func TestDescribeEncryptKeysRendersGlobEntries(t *testing.T) {
+	cases := map[string][]string{
+		`key "password"`:                                        {"password"},
+		`keys "password", "token"`:                              {"password", "token"},
+		`keys matching glob:stringData.DB_*`:                    {"glob:stringData.DB_*"},
+		`key "password" and keys matching glob:DB_*, glob:*Key`: {"password", "glob:DB_*", "glob:*Key"},
+	}
+	for expected, entries := range cases {
+		if actual := describeEncryptKeys(entries); actual != expected {
+			t.Errorf("describeEncryptKeys(%v) = %q, want %q", entries, actual, expected)
+		}
+	}
+}


### PR DESCRIPTION
Bead: ankra-q5lsn
Linear: PLA-798 (#1094)

CLI half of ankraio/cluster#1867 (the platform change that expands `glob:` entries in `encrypted_paths` into the SOPS `encrypted_regex`). Merge order does not matter for safety - against an older platform the entry is refused as an inert selector by the platform's own zero-match guard (cluster#1861) and by this CLI's `verifyKeyEncrypted` before anything is written - but the feature only works once that PR is deployed.

## What changes

`ankra cluster encrypt manifest|addon --key 'glob:<pattern>'` encrypts every key whose name matches the pattern, now and on every later platform re-encrypt, including keys added afterwards.

- `--key glob:stringData.DB_*` is validated with the platform's grammar (only `*` is a wildcard; a leading `data.` / `stringData.` is accepted and stripped, as for an exact key; nothing after the prefix, a section with no pattern, no wildcard, or only wildcards are refused with the platform's reasons) and then **kept verbatim, prefix included** - it goes to `/org/sops/encrypt` as-is and is recorded in `encrypted_paths` as-is, because the platform is what re-expands it on every push. The CLI never rewrites it into a leaf key.
- `verifyKeyEncrypted` understands globs: a glob must select at least one key in the encrypted output (a pattern matching nothing has encrypted nothing - same refusal as a misspelled exact key) and every key it selects must be `ENC[...]`; on refusal neither the manifest file nor `cluster.yaml` is touched.
- Exact keys keep their meaning byte-for-byte: `--key stringData.DB_*` (no prefix) is still normalised to the literal leaf `DB_*`. Only the prefix opts in.
- Help text, flag descriptions and examples for both commands; a note at run time says the entry is recorded as written and what that means.
- `--all-data` is unchanged.

The CLI cannot import the cluster repo's enginekit, so the prefix literal and the four grammar refusals are mirrored in `cmd/cluster_encrypt.go` and pinned by `TestEncryptKeyGlobGrammarMirrorsThePlatform` against the same accept/reject table as `enginekit/clusterengine/encryptedpaths_test.go`.

## Tests

- `TestEncryptKeyGlobGrammarMirrorsThePlatform`, `TestNormalizeEncryptKeyKeepsGlobEntriesVerbatim`, `TestVerifyKeyEncryptedHonoursGlobEntries`, `TestDescribeEncryptKeysRendersGlobEntries`.
- Command-level, through the cobra tree with the mock client: `TestRunEncryptManifest_FileModeGlobEntryRecordedVerbatim` (entry sent verbatim, sealed file written, `- glob:stringData.DB_*` in `cluster.yaml`, never `- DB_*`), `TestRunEncryptManifest_FileModeGlobMatchingNoKeyRefused` (nothing written), `TestRunEncryptManifest_InvalidGlobRefusedBeforeAnyCall` (no API call).

Gates: `gofmt -l` clean on the touched files, `go build ./... && go vet ./cmd/`, `go test -race -count=1 ./...` ok, `golangci-lint run ./...` 0 issues.

CHANGELOG: entry under `## Unreleased` / `### Added`.
