### PR TITLE
release: cut v0.13.0-rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Ankra CLI Changelog
 
-## Unreleased
+## v0.13.0-rc3 — 2026-08-25
 
 ### Added
 


### PR DESCRIPTION
Promotes the Unreleased section to v0.13.0-rc3 (prerelease, beta channel).

Carries, above v0.13.0-rc2: #151 (`cluster encrypt --key 'glob:<pattern>'`, PLA-798 / support #1094; requires cluster#1867), #150 (`org custom-dns-zones`; requires cluster#1852, deployed), #147, #148.

Merge and tag only after cluster#1867 is deployed to production. Release-notes extractor dry-run verified against the new heading.