### PR TITLE
feat(application): --flat-repositories and application credential get|set (ankra-s8vc2)

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -89,6 +89,8 @@ registry added later leaves a workflow that logs in with the wrong one.`,
 		"Let Ankra write the named credential into the repository's Actions secrets")
 	addCommand.Flags().String("registry-admin-credential", "",
 		"Registry credential with project administrator rights, for Ankra to mint the application's robot")
+	addCommand.Flags().Bool("registry-flat-repositories", false,
+		"Publish monorepo components as <project>/<component> instead of <project>/<app>/<component>")
 	registerStructuredOutputFlags(addCommand)
 	return addCommand
 }
@@ -104,6 +106,7 @@ var applicationAddRegistryFlags = []string{
 	"registry-password-secret",
 	"registry-manage-actions-secrets",
 	"registry-admin-credential",
+	"registry-flat-repositories",
 }
 
 // applicationAddImageRegistry reads the --registry-* flags into the optional
@@ -136,6 +139,7 @@ func applicationAddImageRegistry(command *cobra.Command) (*client.ApplicationIma
 	passwordSecretName, _ := command.Flags().GetString("registry-password-secret")
 	manageActionsSecrets, _ := command.Flags().GetBool("registry-manage-actions-secrets")
 	adminCredentialName, _ := command.Flags().GetString("registry-admin-credential")
+	flatRepositories, _ := command.Flags().GetBool("registry-flat-repositories")
 
 	return &client.ApplicationImageRegistry{
 		URL:                  registryURL,
@@ -146,6 +150,7 @@ func applicationAddImageRegistry(command *cobra.Command) (*client.ApplicationIma
 		PasswordSecretName:   strings.TrimSpace(passwordSecretName),
 		ManageActionsSecrets: manageActionsSecrets,
 		AdminCredentialName:  strings.TrimSpace(adminCredentialName),
+		FlatRepositories:     flatRepositories,
 	}, nil
 }
 

--- a/cmd/application_credential.go
+++ b/cmd/application_credential.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"ankra/internal/client"
+)
+
+// The application repository-credential commands. The GitHub credential an
+// application names decides which GitHub App installation every call for its
+// repository rides on; until these existed it was set once at create time and
+// an application bound to an installation that could not reach its repository
+// answered 404 on every build, deploy and secrets write.
+
+func newApplicationCredentialCommand() *cobra.Command {
+	credentialCommand := &cobra.Command{
+		Use:     "credential",
+		Aliases: []string{"repository-credential"},
+		Short:   "Inspect and re-bind the GitHub credential an application's repository calls ride on",
+		Long: `Inspect and re-bind the GitHub credential an application's repository calls
+ride on.
+
+An application is bound to one GitHub credential of the organisation; its App
+installation must reach the repository for builds, deploys and Actions secrets
+to work. Move an application onto another credential when its installation
+lost - or never had - access to the repository.`,
+	}
+	credentialCommand.AddCommand(newApplicationCredentialGetCommand())
+	credentialCommand.AddCommand(newApplicationCredentialSetCommand())
+	return credentialCommand
+}
+
+func newApplicationCredentialGetCommand() *cobra.Command {
+	getCommand := &cobra.Command{
+		Use:     "get <application-id>",
+		Short:   "Show the GitHub credential an application is bound to",
+		Example: "  ankra application credential get 23298741-6a5a-401a-a681-66f31fbdebe1",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+				return formatError
+			}
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			payload, getError := apiClient.GetApplicationRepositoryCredential(command.Context(), applicationID)
+			if getError != nil {
+				return getError
+			}
+			return renderApplicationPayload(command, payload)
+		},
+	}
+	registerStructuredOutputFlags(getCommand)
+	return getCommand
+}
+
+func newApplicationCredentialSetCommand() *cobra.Command {
+	setCommand := &cobra.Command{
+		Use:   "set <application-id> --credential <name>",
+		Short: "Re-bind an application to another GitHub credential of the organisation",
+		Long: `Re-bind an application to another GitHub credential of the organisation.
+
+The credential must exist. Whether its App installation reaches the repository
+is reported in the answer (resolved / message) rather than refused, since a
+re-bind is usually how an application gets off an installation that cannot.`,
+		Example: "  ankra application credential set 67f4ba9c-2dbe-42e2-8e93-a3431bb464fb --credential github-app-acme",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+				return formatError
+			}
+			credentialName, _ := command.Flags().GetString("credential")
+			credentialName = strings.TrimSpace(credentialName)
+			if credentialName == "" {
+				return withExitCode(exitUsage,
+					errors.New("--credential is required: a GitHub credential of this organisation"))
+			}
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			payload, setError := apiClient.SetApplicationRepositoryCredential(command.Context(), applicationID,
+				client.SetApplicationRepositoryCredentialRequest{CredentialName: credentialName})
+			if setError != nil {
+				return setError
+			}
+			return renderApplicationPayload(command, payload)
+		},
+	}
+	setCommand.Flags().String("credential", "", "GitHub credential of this organisation to bind the application to (required)")
+	registerStructuredOutputFlags(setCommand)
+	return setCommand
+}

--- a/cmd/application_credential_test.go
+++ b/cmd/application_credential_test.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type applicationCredentialMock struct {
+	baseMock
+	payload json.RawMessage
+
+	getCalls      int
+	setCalls      int
+	setRequest    client.SetApplicationRepositoryCredentialRequest
+	applicationID string
+}
+
+func (mock *applicationCredentialMock) GetApplicationRepositoryCredential(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	mock.getCalls++
+	mock.applicationID = applicationID
+	return mock.payload, nil
+}
+
+func (mock *applicationCredentialMock) SetApplicationRepositoryCredential(requestContext context.Context, applicationID string, credentialRequest client.SetApplicationRepositoryCredentialRequest) (json.RawMessage, error) {
+	mock.setCalls++
+	mock.applicationID = applicationID
+	mock.setRequest = credentialRequest
+	return mock.payload, nil
+}
+
+func TestApplicationCredentialCommandsRegistered(t *testing.T) {
+	registered := map[string]bool{}
+	for _, subcommand := range newApplicationCommand().Commands() {
+		if subcommand.Name() != "credential" {
+			continue
+		}
+		for _, child := range subcommand.Commands() {
+			registered[child.Name()] = true
+		}
+	}
+	for _, expected := range []string{"get", "set"} {
+		if !registered[expected] {
+			t.Errorf("credential subcommand %q is not registered", expected)
+		}
+	}
+}
+
+func TestApplicationCredentialGetRendersThePayload(t *testing.T) {
+	mockClient := &applicationCredentialMock{payload: json.RawMessage(`{"credential_name":"github-app-acme","resolved":true}`)}
+	output, executeError := runApplicationCommand(t, mockClient, "credential", "get", testApplicationID)
+	if executeError != nil {
+		t.Fatalf("credential get error = %v", executeError)
+	}
+	if mockClient.getCalls != 1 || mockClient.applicationID != testApplicationID {
+		t.Errorf("get calls = %d for %q", mockClient.getCalls, mockClient.applicationID)
+	}
+	if !strings.Contains(output, "\"credential_name\": \"github-app-acme\"") {
+		t.Errorf("output is not indented JSON: %q", output)
+	}
+}
+
+func TestApplicationCredentialSetSendsTheTrimmedName(t *testing.T) {
+	mockClient := &applicationCredentialMock{payload: json.RawMessage(`{"credential_name":"github-app-acme","resolved":true}`)}
+	_, executeError := runApplicationCommand(t, mockClient, "credential", "set", testApplicationID, "--credential", " github-app-acme ")
+	if executeError != nil {
+		t.Fatalf("credential set error = %v", executeError)
+	}
+	if mockClient.setCalls != 1 || mockClient.setRequest.CredentialName != "github-app-acme" {
+		t.Errorf("set calls = %d request = %+v", mockClient.setCalls, mockClient.setRequest)
+	}
+}
+
+func TestApplicationCredentialSetRequiresTheCredential(t *testing.T) {
+	mockClient := &applicationCredentialMock{}
+	_, executeError := runApplicationCommand(t, mockClient, "credential", "set", testApplicationID)
+	if executeError == nil || exitCodeFor(executeError) != exitUsage {
+		t.Fatalf("expected a usage error, got %v", executeError)
+	}
+	if mockClient.setCalls != 0 {
+		t.Errorf("set calls = %d, want 0", mockClient.setCalls)
+	}
+}

--- a/cmd/application_registry.go
+++ b/cmd/application_registry.go
@@ -112,6 +112,7 @@ secrets to you unless you ask it to write the declared credential with
 			passwordSecretName, _ := command.Flags().GetString("password-secret")
 			manageActionsSecrets, _ := command.Flags().GetBool("manage-actions-secrets")
 			adminCredentialName, _ := command.Flags().GetString("admin-credential")
+			flatRepositories, _ := command.Flags().GetBool("flat-repositories")
 
 			declaration := &client.ApplicationImageRegistry{
 				URL:                  registryURL,
@@ -122,6 +123,7 @@ secrets to you unless you ask it to write the declared credential with
 				PasswordSecretName:   strings.TrimSpace(passwordSecretName),
 				ManageActionsSecrets: manageActionsSecrets,
 				AdminCredentialName:  strings.TrimSpace(adminCredentialName),
+				FlatRepositories:     flatRepositories,
 			}
 			applicationID, resolveError := resolveApplicationArgument(command, arguments)
 			if resolveError != nil {
@@ -151,6 +153,8 @@ secrets to you unless you ask it to write the declared credential with
 		"Let Ankra write the named credential into the repository's Actions secrets")
 	setCommand.Flags().String("admin-credential", "",
 		"Registry credential with project administrator rights, for Ankra to mint the application's robot")
+	setCommand.Flags().Bool("flat-repositories", false,
+		"Publish monorepo components as <project>/<component> instead of <project>/<app>/<component>")
 	registerStructuredOutputFlags(setCommand)
 	return setCommand
 }

--- a/cmd/application_resources.go
+++ b/cmd/application_resources.go
@@ -129,6 +129,7 @@ func registerApplicationResourceCommands(applicationCommand *cobra.Command) {
 	)
 	applicationCommand.AddCommand(newApplicationDemoCommand())
 	applicationCommand.AddCommand(newApplicationRegistryCommand())
+	applicationCommand.AddCommand(newApplicationCredentialCommand())
 	applicationCommand.AddCommand(newApplicationAIConfigCommand())
 	applicationCommand.AddCommand(newApplicationPublishAddonCommand())
 	applicationCommand.AddCommand(newApplicationPublishedAddonCommand())

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -3416,3 +3416,11 @@ func (m baseMock) EnsureApplicationRegistryRobot(requestContext context.Context,
 func (m baseMock) RevokeApplicationRegistryRobot(requestContext context.Context, applicationID string) (json.RawMessage, error) {
 	return nil, errors.New("not implemented")
 }
+
+func (m baseMock) GetApplicationRepositoryCredential(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) SetApplicationRepositoryCredential(requestContext context.Context, applicationID string, credentialRequest client.SetApplicationRepositoryCredentialRequest) (json.RawMessage, error) {
+	return nil, errors.New("not implemented")
+}

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -193,6 +193,8 @@ type APIClient interface {
 	GetApplicationRegistryRobot(requestContext context.Context, applicationID string) (json.RawMessage, error)
 	EnsureApplicationRegistryRobot(requestContext context.Context, applicationID string, robotRequest client.EnsureApplicationRegistryRobotRequest) (json.RawMessage, error)
 	RevokeApplicationRegistryRobot(requestContext context.Context, applicationID string) (json.RawMessage, error)
+	GetApplicationRepositoryCredential(requestContext context.Context, applicationID string) (json.RawMessage, error)
+	SetApplicationRepositoryCredential(requestContext context.Context, applicationID string, credentialRequest client.SetApplicationRepositoryCredentialRequest) (json.RawMessage, error)
 	GetApplicationAIConfig(requestContext context.Context, applicationID string) (json.RawMessage, error)
 	UpdateApplicationAIConfig(requestContext context.Context, applicationID string, configuration json.RawMessage) (json.RawMessage, error)
 	ResetApplicationAIConfig(requestContext context.Context, applicationID string) (json.RawMessage, error)

--- a/internal/client/application_resources.go
+++ b/internal/client/application_resources.go
@@ -82,6 +82,16 @@ type ApplicationImageRegistry struct {
 	// mint and rotate the application's own push robot on a registry the
 	// organisation operates.
 	AdminCredentialName string `json:"admin_credential_name,omitempty"`
+	// FlatRepositories publishes monorepo components as <project>/<component>
+	// instead of <project>/<app>/<component>, matching a registry laid out
+	// flat before Ankra.
+	FlatRepositories bool `json:"flat_repositories,omitempty"`
+}
+
+// SetApplicationRepositoryCredentialRequest mirrors the repository-credential
+// body: the GitHub credential the application's repository calls ride on.
+type SetApplicationRepositoryCredentialRequest struct {
+	CredentialName string `json:"credential_name"`
 }
 
 // EnsureApplicationRegistryRobotRequest mirrors the registry-robot body:
@@ -363,6 +373,16 @@ func (client *Client) EnsureApplicationRegistryRobot(requestContext context.Cont
 
 func (client *Client) RevokeApplicationRegistryRobot(requestContext context.Context, applicationID string) (json.RawMessage, error) {
 	return client.applicationResourceRequest(requestContext, http.MethodDelete, applicationPath(applicationID, "/registry-robot"), nil, nil)
+}
+
+// --- repository credential ---
+
+func (client *Client) GetApplicationRepositoryCredential(requestContext context.Context, applicationID string) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodGet, applicationPath(applicationID, "/repository-credential"), nil, nil)
+}
+
+func (client *Client) SetApplicationRepositoryCredential(requestContext context.Context, applicationID string, credentialRequest SetApplicationRepositoryCredentialRequest) (json.RawMessage, error) {
+	return client.applicationResourceRequest(requestContext, http.MethodPut, applicationPath(applicationID, "/repository-credential"), nil, credentialRequest)
 }
 
 // --- AI lane configuration ---


### PR DESCRIPTION
Bead: ankra-s8vc2 · backend: the cluster PR for the same bead

- `ankra application registry set --flat-repositories` and `application add --registry-flat-repositories`: declare a registry that lays monorepo components out as `<project>/<component>` (Smartoptics' `commerce-images/backend`), so readiness and the deploy gate look where the pipeline actually publishes.
- `ankra application credential get|set --credential <name>`: read and re-bind the GitHub credential an application's repository calls ride on (`GET`/`PUT /api/v1/org/applications/{id}/repository-credential`), for an application bound to an App installation that cannot reach its repository.

`go build`, `go vet`, `go test ./cmd/ ./internal/client/` green; new tests for registration, `get`, the trimmed `set`, and the required `--credential`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
