### PR TITLE
feat(application): --component-repository on the image registry declaration (ankra-s8vc2)

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -91,6 +91,8 @@ registry added later leaves a workflow that logs in with the wrong one.`,
 		"Registry credential with project administrator rights, for Ankra to mint the application's robot")
 	addCommand.Flags().Bool("registry-flat-repositories", false,
 		"Publish monorepo components as <project>/<component> instead of <project>/<app>/<component>")
+	addCommand.Flags().StringArray("registry-component-repository", nil,
+		"Repository inside the project for one component, as <component>=<repository> (repeatable)")
 	registerStructuredOutputFlags(addCommand)
 	return addCommand
 }
@@ -107,6 +109,7 @@ var applicationAddRegistryFlags = []string{
 	"registry-manage-actions-secrets",
 	"registry-admin-credential",
 	"registry-flat-repositories",
+	"registry-component-repository",
 }
 
 // applicationAddImageRegistry reads the --registry-* flags into the optional
@@ -140,17 +143,23 @@ func applicationAddImageRegistry(command *cobra.Command) (*client.ApplicationIma
 	manageActionsSecrets, _ := command.Flags().GetBool("registry-manage-actions-secrets")
 	adminCredentialName, _ := command.Flags().GetString("registry-admin-credential")
 	flatRepositories, _ := command.Flags().GetBool("registry-flat-repositories")
+	componentRepositoryFlags, _ := command.Flags().GetStringArray("registry-component-repository")
+	componentRepositories, componentRepositoriesError := parseComponentRepositories(componentRepositoryFlags)
+	if componentRepositoriesError != nil {
+		return nil, componentRepositoriesError
+	}
 
 	return &client.ApplicationImageRegistry{
-		URL:                  registryURL,
-		CredentialName:       strings.TrimSpace(credentialName),
-		APIURL:               strings.TrimSpace(apiURL),
-		PullSecretName:       strings.TrimSpace(pullSecretName),
-		UsernameSecretName:   strings.TrimSpace(usernameSecretName),
-		PasswordSecretName:   strings.TrimSpace(passwordSecretName),
-		ManageActionsSecrets: manageActionsSecrets,
-		AdminCredentialName:  strings.TrimSpace(adminCredentialName),
-		FlatRepositories:     flatRepositories,
+		URL:                   registryURL,
+		CredentialName:        strings.TrimSpace(credentialName),
+		APIURL:                strings.TrimSpace(apiURL),
+		PullSecretName:        strings.TrimSpace(pullSecretName),
+		UsernameSecretName:    strings.TrimSpace(usernameSecretName),
+		PasswordSecretName:    strings.TrimSpace(passwordSecretName),
+		ManageActionsSecrets:  manageActionsSecrets,
+		AdminCredentialName:   strings.TrimSpace(adminCredentialName),
+		FlatRepositories:      flatRepositories,
+		ComponentRepositories: componentRepositories,
 	}, nil
 }
 

--- a/cmd/application_registry.go
+++ b/cmd/application_registry.go
@@ -113,17 +113,23 @@ secrets to you unless you ask it to write the declared credential with
 			manageActionsSecrets, _ := command.Flags().GetBool("manage-actions-secrets")
 			adminCredentialName, _ := command.Flags().GetString("admin-credential")
 			flatRepositories, _ := command.Flags().GetBool("flat-repositories")
+			componentRepositoryFlags, _ := command.Flags().GetStringArray("component-repository")
+			componentRepositories, componentRepositoriesError := parseComponentRepositories(componentRepositoryFlags)
+			if componentRepositoriesError != nil {
+				return componentRepositoriesError
+			}
 
 			declaration := &client.ApplicationImageRegistry{
-				URL:                  registryURL,
-				CredentialName:       strings.TrimSpace(credentialName),
-				APIURL:               strings.TrimSpace(apiURL),
-				PullSecretName:       strings.TrimSpace(pullSecretName),
-				UsernameSecretName:   strings.TrimSpace(usernameSecretName),
-				PasswordSecretName:   strings.TrimSpace(passwordSecretName),
-				ManageActionsSecrets: manageActionsSecrets,
-				AdminCredentialName:  strings.TrimSpace(adminCredentialName),
-				FlatRepositories:     flatRepositories,
+				URL:                   registryURL,
+				CredentialName:        strings.TrimSpace(credentialName),
+				APIURL:                strings.TrimSpace(apiURL),
+				PullSecretName:        strings.TrimSpace(pullSecretName),
+				UsernameSecretName:    strings.TrimSpace(usernameSecretName),
+				PasswordSecretName:    strings.TrimSpace(passwordSecretName),
+				ManageActionsSecrets:  manageActionsSecrets,
+				AdminCredentialName:   strings.TrimSpace(adminCredentialName),
+				FlatRepositories:      flatRepositories,
+				ComponentRepositories: componentRepositories,
 			}
 			applicationID, resolveError := resolveApplicationArgument(command, arguments)
 			if resolveError != nil {
@@ -155,6 +161,8 @@ secrets to you unless you ask it to write the declared credential with
 		"Registry credential with project administrator rights, for Ankra to mint the application's robot")
 	setCommand.Flags().Bool("flat-repositories", false,
 		"Publish monorepo components as <project>/<component> instead of <project>/<app>/<component>")
+	setCommand.Flags().StringArray("component-repository", nil,
+		"Repository inside the project for one component, as <component>=<repository> (repeatable)")
 	registerStructuredOutputFlags(setCommand)
 	return setCommand
 }
@@ -197,4 +205,24 @@ from - the organisation's provisioned registry project again.`,
 	clearCommand.Flags().Bool("yes", false, "Skip the confirmation prompt")
 	registerStructuredOutputFlags(clearCommand)
 	return clearCommand
+}
+
+// parseComponentRepositories reads the repeatable --component-repository
+// flags (<component>=<repository>) into the declaration's map.
+func parseComponentRepositories(flags []string) (map[string]string, error) {
+	if len(flags) == 0 {
+		return nil, nil
+	}
+	repositories := map[string]string{}
+	for _, flag := range flags {
+		componentName, repository, found := strings.Cut(flag, "=")
+		componentName = strings.TrimSpace(componentName)
+		repository = strings.TrimSpace(repository)
+		if !found || componentName == "" || repository == "" {
+			return nil, withExitCode(exitUsage,
+				fmt.Errorf("--component-repository %q must be <component>=<repository>", flag))
+		}
+		repositories[componentName] = repository
+	}
+	return repositories, nil
 }

--- a/cmd/application_registry_test.go
+++ b/cmd/application_registry_test.go
@@ -181,3 +181,23 @@ func TestApplicationRegistryClearRefusesWhenDeclined(t *testing.T) {
 		t.Errorf("UpdateApplicationImageRegistry calls = %d, want 0", mockClient.updateCalls)
 	}
 }
+
+func TestApplicationRegistrySetParsesComponentRepositories(t *testing.T) {
+	mockClient := &applicationRegistryMock{payload: json.RawMessage(`{"declared":true}`)}
+	_, executeError := runApplicationCommand(t, mockClient,
+		"registry", "set", testApplicationID, "--url", "oci://artifact.example.com/sggame-images",
+		"--component-repository", "backend=suitcase-backend", "--component-repository", " frontend = suitcase-frontend ")
+	if executeError != nil {
+		t.Fatalf("registry set error = %v", executeError)
+	}
+	repositories := mockClient.updateRequest.ImageRegistry.ComponentRepositories
+	if repositories["backend"] != "suitcase-backend" || repositories["frontend"] != "suitcase-frontend" {
+		t.Errorf("component repositories = %+v", repositories)
+	}
+	_, malformedError := runApplicationCommand(t, mockClient,
+		"registry", "set", testApplicationID, "--url", "oci://artifact.example.com/sggame-images",
+		"--component-repository", "backend")
+	if malformedError == nil || exitCodeFor(malformedError) != exitUsage {
+		t.Fatalf("a flag without '=' must be a usage error, got %v", malformedError)
+	}
+}

--- a/internal/client/application_resources.go
+++ b/internal/client/application_resources.go
@@ -86,6 +86,9 @@ type ApplicationImageRegistry struct {
 	// instead of <project>/<app>/<component>, matching a registry laid out
 	// flat before Ankra.
 	FlatRepositories bool `json:"flat_repositories,omitempty"`
+	// ComponentRepositories names a component's repository inside the project
+	// outright, keyed by component name.
+	ComponentRepositories map[string]string `json:"component_repositories,omitempty"`
 }
 
 // SetApplicationRepositoryCredentialRequest mirrors the repository-credential


### PR DESCRIPTION
Bead: ankra-s8vc2 · backend: the cluster PR "name a component's repository outright on a declared registry"

`image_registry.component_repositories` — the repository inside the project for a component, keyed by component name — for a registry whose layout follows neither Ankra's nesting nor the flat component name (Smartoptics' `commerce-images/commerce-backend`, `sggame-images/suitcase-backend`). Unnamed components keep the derived path.

- CLI: `--component-repository <component>=<repository>` (repeatable) on `application registry set`, `--registry-component-repository` on `application add`; a flag without `=` is a usage error. Tests added.
- Portal: one **Repository for <component>** field per component of a monorepo under Settings → Image registry; an emptied field keeps the derived path. Test added; schema tolerates the field absent.
- Docs: field row and changelog sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
