### PR TITLE
feat(cluster domain): report the cluster public domain (ankra-ehxts)

### DIFF
--- a/cmd/cluster_domain.go
+++ b/cmd/cluster_domain.go
@@ -17,6 +17,16 @@ organisation's Ankra-managed root - ankra.cc by default, or the organisation's
 own domain when one is registered (portal: AI > Settings > Workspaces, field
 "Custom Ankra domain"; CLI: 'ankra org domain').
 
+The read also reports the cluster's PUBLIC domain: the domain hostnames on the
+cluster are published under, and what ${{ ankra.cluster_domain }} resolves to
+in stacks and stack profiles. It is the organisation's preview domain
+('ankra org ai-environment set --demo-base-domain') whenever a custom DNS zone
+declared for the organisation or the cluster ('ankra org custom-dns-zones',
+'ankra cluster custom-dns-zones') covers it - the cluster's own external-dns
+then publishes every hostname under it - and the generated domain otherwise.
+An organisation whose domain cannot be registered as the Ankra root (it lives
+in its own DNS account) gets its own domain as the cluster domain this way.
+
 The plain command is a read: it never creates a zone. A cluster that has no
 domain reports state "none", and 'ankra org dns zones' lists every cluster in
 the organisation that does have one.
@@ -83,6 +93,7 @@ for it keeps the same --txt-owner-id.`,
 		// the CLI answer a removal with an "run --enable" hint.
 		if result.State == clusterDomainStateNone && !clusterDomainEnable && !clusterDomainRemove {
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Domain: (none)\nState:  none\n")
+			printClusterPublicDomain(cmd, result)
 			if result.OptedOut {
 				// A removal that reports "none" is the exact moment PLA-771
 				// was watched from. Saying only "run --enable to create one"
@@ -106,6 +117,7 @@ for it keeps the same --txt-owner-id.`,
 		if result.OptedOut {
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Opted out: yes\n")
 		}
+		printClusterPublicDomain(cmd, result)
 		switch {
 		case clusterDomainRemove:
 			_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
@@ -123,6 +135,30 @@ for it keeps the same --txt-owner-id.`,
 // clusterDomainStateNone is the state the read surface reports for a cluster
 // that holds no DNS zone at all.
 const clusterDomainStateNone = "none"
+
+// clusterPublicDomainSourcePreviewDomain is the public_domain_source a backend
+// reports when the cluster domain is the organisation's preview domain,
+// published by a custom DNS zone the cluster serves.
+const clusterPublicDomainSourcePreviewDomain = "preview_domain"
+
+// printClusterPublicDomain reports the domain hostnames on the cluster are
+// actually published under when the backend resolved one that is not simply
+// the generated zone - the organisation's own preview domain, which is what
+// "the cluster domain" means to an organisation that configured one. A
+// backend too old to report it, or a public domain equal to the generated
+// zone, prints nothing extra.
+func printClusterPublicDomain(cmd *cobra.Command, result *client.ClusterDNSZoneResponse) {
+	if result.PublicDomain == "" || result.PublicDomain == result.FQDN {
+		return
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Public domain: %s\n", result.PublicDomain)
+	if result.PublicDomainSource == clusterPublicDomainSourcePreviewDomain {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+			"\nThe cluster domain (${{ ankra.cluster_domain }}) is the organisation's preview domain %s: "+
+				"a custom DNS zone this cluster serves (%s) publishes every hostname under it.\n",
+			result.PublicDomain, result.PublicDomainPublishedZone)
+	}
+}
 
 var (
 	clusterDomainEnable bool

--- a/cmd/cluster_domain_test.go
+++ b/cmd/cluster_domain_test.go
@@ -201,3 +201,59 @@ func TestRunClusterDomain_ReportsAHeldRemoval(t *testing.T) {
 		t.Errorf("a held removal is not an empty cluster:\n%s", output)
 	}
 }
+
+func TestRunClusterDomain_ReportsThePreviewDomainAsThePublicDomain(t *testing.T) {
+	// ankra-ehxts: the organisation's preview domain is published by a custom
+	// DNS zone the cluster serves, so "the cluster domain" is that domain and
+	// the generated ankra.cc zone is only the row behind it.
+	mock := &clusterDomainMock{zone: client.ClusterDNSZoneResponse{
+		Success: true, FQDN: "41k4sso94j.qh4thi04cs.ankra.cc", State: "active",
+		PublicDomain: "smartoptics.dev", PublicDomainSource: clusterPublicDomainSourcePreviewDomain,
+		PublicDomainPublishedZone: "smartoptics.dev"}}
+
+	output, executeError := runClusterDomain(t, mock, domainTestClusterID)
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	if !strings.Contains(output, "Domain: 41k4sso94j.qh4thi04cs.ankra.cc") {
+		t.Errorf("the generated zone must still be reported:\n%s", output)
+	}
+	if !strings.Contains(output, "Public domain: smartoptics.dev") {
+		t.Errorf("the public domain must be reported:\n%s", output)
+	}
+	if !strings.Contains(output, "${{ ankra.cluster_domain }}") || !strings.Contains(output, "custom DNS zone") {
+		t.Errorf("the explanation must tie the public domain to the built-in and the custom zone:\n%s", output)
+	}
+}
+
+func TestRunClusterDomain_OmitsThePublicDomainWhenItIsTheGeneratedZone(t *testing.T) {
+	mock := &clusterDomainMock{zone: client.ClusterDNSZoneResponse{
+		Success: true, FQDN: "abc.org1234.ankra.cc", State: "active",
+		PublicDomain: "abc.org1234.ankra.cc", PublicDomainSource: "cluster_zone",
+		PublicDomainPublishedZone: "abc.org1234.ankra.cc"}}
+
+	output, executeError := runClusterDomain(t, mock, domainTestClusterID)
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	if strings.Contains(output, "Public domain:") {
+		t.Errorf("a public domain equal to the generated zone adds nothing:\n%s", output)
+	}
+}
+
+func TestRunClusterDomain_ReportsThePublicDomainOnAClusterWithoutAZone(t *testing.T) {
+	// No generated zone at all, but the organisation's custom zone publishes
+	// the preview domain from this cluster: hostnames still have a home.
+	mock := &clusterDomainMock{zone: client.ClusterDNSZoneResponse{
+		Success: true, State: clusterDomainStateNone,
+		PublicDomain: "smartoptics.dev", PublicDomainSource: clusterPublicDomainSourcePreviewDomain,
+		PublicDomainPublishedZone: "smartoptics.dev"}}
+
+	output, executeError := runClusterDomain(t, mock, domainTestClusterID)
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	if !strings.Contains(output, "Domain: (none)") || !strings.Contains(output, "Public domain: smartoptics.dev") {
+		t.Errorf("both the missing zone and the public domain must be reported:\n%s", output)
+	}
+}

--- a/internal/client/cluster_dns_zone.go
+++ b/internal/client/cluster_dns_zone.go
@@ -13,11 +13,21 @@ import (
 // had a zone, or one was removed and the removal is being held so nothing
 // re-creates it. Older backends omit the member and it reads false, which is
 // the right answer for every cluster they know about.
+//
+// PublicDomain is the domain hostnames on the cluster are published under -
+// what ${{ ankra.cluster_domain }} resolves to: the organisation's preview
+// domain when a custom DNS zone on the cluster publishes it
+// (PublicDomainSource "preview_domain", PublicDomainPublishedZone the zone),
+// otherwise the generated zone itself ("cluster_zone"), or nothing ("none").
+// Older backends omit the members and they read empty.
 type ClusterDNSZoneResponse struct {
-	Success  bool   `json:"success"`
-	FQDN     string `json:"fqdn"`
-	State    string `json:"state"`
-	OptedOut bool   `json:"opted_out"`
+	Success                   bool   `json:"success"`
+	FQDN                      string `json:"fqdn"`
+	State                     string `json:"state"`
+	OptedOut                  bool   `json:"opted_out"`
+	PublicDomain              string `json:"public_domain"`
+	PublicDomainSource        string `json:"public_domain_source"`
+	PublicDomainPublishedZone string `json:"public_domain_published_zone"`
 }
 
 // GetClusterDNSZone reads the cluster's generated public DNS zone without


### PR DESCRIPTION
Bead: ankra-ehxts

Companion to the cluster PR for ankra-ehxts, where `GET /api/v1/clusters/{id}/dns-zone` gains `public_domain`, `public_domain_source` (`preview_domain` | `cluster_zone` | `none`) and `public_domain_published_zone`: the domain hostnames on the cluster are published under, and what `${{ ankra.cluster_domain }}` resolves to. It is the organisation's preview domain whenever a custom DNS zone declared for the organisation or the cluster covers it (the cluster's own external-dns publishes every hostname under it), and the generated zone otherwise.

`ankra cluster domain <cluster>` now prints a **Public domain** line whenever it differs from the generated zone - including on a cluster that has no generated zone at all - and explains on stderr which custom zone publishes it. The help text describes the rule. Older backends omit the members and the output is byte-for-byte what it was.

For Smartoptics (preview domain `smartoptics.dev`, organisation-wide zone `smartoptics.dev`):

```
Domain: 41k4sso94j.qh4thi04cs.ankra.cc
State:  active
Public domain: smartoptics.dev
```

Verified: `go build ./...`, `go test ./cmd/ -run ClusterDomain` (three new cases: preview domain reported, generated-zone public domain omitted, public domain on a zoneless cluster); the pre-commit hook ran the full test suite and the linter.

Release note: the new output ships with the next ankra-cli tag; `reference/cli` regenerates from the help text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nepM7NBnmoP4YXQp8wiJ6
