### PR TITLE
docs(readme): point community links at community.ankra.ai (ankra-a8u1e)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,11 +235,11 @@ and flag descriptions in `cmd/`.
 - **Documentation**: [docs.ankra.ai](https://docs.ankra.ai)
 - **CLI Command Reference**: [docs.ankra.ai/reference/cli](https://docs.ankra.ai/reference/cli)
 - **Blog & Tutorials**: [ankra.ai/blog](https://ankra.ai/blog)
-- **Community**: [community.ankra.io](https://community.ankra.io)
+- **Community**: [community.ankra.ai](https://community.ankra.ai)
 
 ## Support
 
 - Issues: https://github.com/ankraio/ankra-cli/issues
 - Documentation: [docs.ankra.ai](https://docs.ankra.ai)
-- Community Slack: [community.ankra.io](https://community.ankra.io)
+- Community Slack: [community.ankra.ai](https://community.ankra.ai)
 - Email: hello@ankra.io


### PR DESCRIPTION
## What

Replace both `community.ankra.io` links in the README with `community.ankra.ai`.

## Why

`community.ankra.ai` is the community Slack entrypoint now (Cloudflare 302 to the current shared invite). The old `community.ankra.io` host still 301s, but to a rotated invite link. Org-wide code search confirms this README was the only place in ankraio still referencing the old host.

Bead: ankra-a8u1e

🤖 Generated with [Claude Code](https://claude.com/claude-code)
