### PR TITLE
feat(tickets): work the AI board from the terminal, including a blocked ticket's decision (ankra-us966.2)

### DIFF
--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -3424,3 +3424,27 @@ func (m baseMock) GetApplicationRepositoryCredential(requestContext context.Cont
 func (m baseMock) SetApplicationRepositoryCredential(requestContext context.Context, applicationID string, credentialRequest client.SetApplicationRepositoryCredentialRequest) (json.RawMessage, error) {
 	return nil, errors.New("not implemented")
 }
+
+func (m baseMock) ListTickets(filter client.TicketListFilter) (*client.TicketListResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetTicket(ticketID string) (*client.Ticket, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ListTicketEvents(ticketID string, limit int) (*client.TicketEventListResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) CommentOnTicket(ticketID string, body string) (*client.TicketEvent, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) TransitionTicket(ticketID string, status string, note string) (*client.Ticket, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) DecideTicket(ticketID string, decision client.TicketDecision) (*client.Ticket, error) {
+	return nil, errors.New("not implemented")
+}

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -254,6 +254,13 @@ type APIClient interface {
 	GetAgentRunTranscript(runID string, since int64, limit int) (*client.AgentRunTranscript, error)
 	CancelAgentRun(runID string) (*client.CancelAgentRunResponse, error)
 
+	ListTickets(filter client.TicketListFilter) (*client.TicketListResponse, error)
+	GetTicket(ticketID string) (*client.Ticket, error)
+	ListTicketEvents(ticketID string, limit int) (*client.TicketEventListResponse, error)
+	CommentOnTicket(ticketID string, body string) (*client.TicketEvent, error)
+	TransitionTicket(ticketID string, status string, note string) (*client.Ticket, error)
+	DecideTicket(ticketID string, decision client.TicketDecision) (*client.Ticket, error)
+
 	GetAIProviderStatus() (*client.AIProviderStatus, error)
 	SetAIProvider(provider string) (*client.AIProviderStatus, error)
 	SaveAnthropicKey(apiKey string) (*client.AIAnthropicStatus, error)

--- a/cmd/tickets.go
+++ b/cmd/tickets.go
@@ -1,0 +1,398 @@
+package cmd
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+var ticketsCmd = &cobra.Command{
+	Use:   "tickets",
+	Short: "Work the AI board: list tickets, read one, comment, move it, answer a decision",
+	Long: `Work the organisation's AI board from the terminal.
+
+The AI board is where Ankra's agents track incidents, insights and requests
+as tickets. These commands list the board, show one ticket with its
+timeline, comment on it, move it through its lifecycle, and answer the
+decision a blocked ticket is waiting on - the same choice the ticket page
+renders as options plus "something else".
+
+A ticket is referenced by its number (8, T-8 or #8) or its UUID.`,
+}
+
+var ticketsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List the board's tickets, newest first",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		statuses, _ := cmd.Flags().GetStringSlice("status")
+		needsHuman, _ := cmd.Flags().GetBool("needs-human")
+		includeClosed, _ := cmd.Flags().GetBool("include-closed")
+		search, _ := cmd.Flags().GetString("search")
+		limit, _ := cmd.Flags().GetInt("limit")
+
+		response, err := apiClient.ListTickets(client.TicketListFilter{
+			Statuses: statuses, NeedsHuman: needsHuman, IncludeClosed: includeClosed,
+			Search: search, Limit: limit,
+		})
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, response); handled || renderError != nil {
+			return renderError
+		}
+		if len(response.Tickets) == 0 {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No tickets found.")
+			return nil
+		}
+		writer := table.NewWriter()
+		writer.SetOutputMirror(cmd.OutOrStdout())
+		writer.AppendHeader(table.Row{"TICKET", "TITLE", "STATUS", "PRIORITY", "ASSIGNEE", "WAITING ON"})
+		for _, ticket := range response.Tickets {
+			writer.AppendRow(table.Row{
+				"T-" + strconv.FormatInt(ticket.TicketNumber, 10),
+				truncateCell(ticket.Title, 60),
+				ticket.Status, ticket.Priority,
+				ticketAssigneeLabel(ticket), ticketWaitingLabel(ticket),
+			})
+		}
+		writer.Render()
+		if response.TotalCount > len(response.Tickets) {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Showing %d of %d tickets; raise --limit to see more.\n",
+				len(response.Tickets), response.TotalCount)
+		}
+		return nil
+	},
+}
+
+var ticketsGetCmd = &cobra.Command{
+	Use:   "get <ticket>",
+	Short: "Show one ticket, including the decision it is waiting on",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ticket, err := resolveTicketReference(args[0])
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, ticket); handled || renderError != nil {
+			return renderError
+		}
+		out := cmd.OutOrStdout()
+		_, _ = fmt.Fprintf(out, "Ticket:    T-%d  %s\n", ticket.TicketNumber, ticket.Title)
+		_, _ = fmt.Fprintf(out, "ID:        %s\n", ticket.ID)
+		_, _ = fmt.Fprintf(out, "Status:    %s (%s, %s)\n", ticket.Status, ticket.Kind, ticket.Priority)
+		_, _ = fmt.Fprintf(out, "Assignee:  %s\n", ticketAssigneeLabel(*ticket))
+		if ticket.ClusterName != nil {
+			_, _ = fmt.Fprintf(out, "Cluster:   %s\n", *ticket.ClusterName)
+		}
+		if ticket.PlanStatus != "" && ticket.PlanStatus != "none" {
+			_, _ = fmt.Fprintf(out, "Plan:      %s\n", ticket.PlanStatus)
+		}
+		if len(ticket.Labels) > 0 {
+			_, _ = fmt.Fprintf(out, "Labels:    %s\n", strings.Join(ticket.Labels, ", "))
+		}
+		if ticket.Resolution != nil {
+			_, _ = fmt.Fprintf(out, "Resolved:  %s\n", *ticket.Resolution)
+		}
+		_, _ = fmt.Fprintf(out, "Updated:   %s\n", ticket.UpdatedAt)
+		if strings.TrimSpace(ticket.Body) != "" {
+			_, _ = fmt.Fprintf(out, "\n%s\n", strings.TrimSpace(ticket.Body))
+		}
+		renderTicketDecision(cmd, *ticket)
+		return nil
+	},
+}
+
+var ticketsEventsCmd = &cobra.Command{
+	Use:   "events <ticket>",
+	Short: "Show a ticket's timeline, oldest first",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		limit, _ := cmd.Flags().GetInt("limit")
+		ticket, err := resolveTicketReference(args[0])
+		if err != nil {
+			return err
+		}
+		response, err := apiClient.ListTicketEvents(ticket.ID, limit)
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, response); handled || renderError != nil {
+			return renderError
+		}
+		if len(response.Events) == 0 {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No events yet.")
+			return nil
+		}
+		writer := table.NewWriter()
+		writer.SetOutputMirror(cmd.OutOrStdout())
+		writer.AppendHeader(table.Row{"#", "AT", "EVENT", "AUTHOR", "BODY"})
+		for _, event := range response.Events {
+			writer.AppendRow(table.Row{event.Sequence, event.CreatedAt, event.EventType,
+				ticketEventAuthorLabel(event), truncateCell(strings.ReplaceAll(event.Body, "\n", " "), 80)})
+		}
+		writer.Render()
+		return nil
+	},
+}
+
+var ticketsCommentCmd = &cobra.Command{
+	Use:   "comment <ticket>",
+	Short: "Post a comment on a ticket",
+	Long: `Post a comment on a ticket as yourself. A comment on a blocked ticket
+hands it back to its agent; to answer a choice the agent offered, use
+"ankra tickets decide" instead so the answer is recorded as the decision.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		body, _ := cmd.Flags().GetString("body")
+		if strings.TrimSpace(body) == "" {
+			return withExitCode(exitUsage, fmt.Errorf("--body is required"))
+		}
+		ticket, err := resolveTicketReference(args[0])
+		if err != nil {
+			return err
+		}
+		event, err := apiClient.CommentOnTicket(ticket.ID, strings.TrimSpace(body))
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, event); handled || renderError != nil {
+			return renderError
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Commented on T-%d (event #%d).\n", ticket.TicketNumber, event.Sequence)
+		return nil
+	},
+}
+
+var ticketsTransitionCmd = &cobra.Command{
+	Use:   "transition <ticket>",
+	Short: "Move a ticket to another status",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		status, _ := cmd.Flags().GetString("status")
+		note, _ := cmd.Flags().GetString("note")
+		if strings.TrimSpace(status) == "" {
+			return withExitCode(exitUsage, fmt.Errorf("--status is required"))
+		}
+		ticket, err := resolveTicketReference(args[0])
+		if err != nil {
+			return err
+		}
+		moved, err := apiClient.TransitionTicket(ticket.ID, strings.TrimSpace(status), strings.TrimSpace(note))
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, moved); handled || renderError != nil {
+			return renderError
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "T-%d is now %s.\n", moved.TicketNumber, moved.Status)
+		return nil
+	},
+}
+
+var ticketsDecideCmd = &cobra.Command{
+	Use:   "decide <ticket>",
+	Short: "Answer the choice a blocked ticket is waiting on",
+	Long: `Answer the decision a blocked ticket is waiting on. Pick one of the
+options the agent offered with --option <key> (see "ankra tickets get"),
+or give the decision in your own words with --answer. Both together record
+the option with your note beside it. The answer lands on the timeline as a
+"Decision:" comment and the agent resumes from it.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		optionKey, _ := cmd.Flags().GetString("option")
+		answer, _ := cmd.Flags().GetString("answer")
+		optionKey = strings.TrimSpace(optionKey)
+		answer = strings.TrimSpace(answer)
+		if optionKey == "" && answer == "" {
+			return withExitCode(exitUsage, fmt.Errorf("give --option <key> or --answer <text> (or both)"))
+		}
+		ticket, err := resolveTicketReference(args[0])
+		if err != nil {
+			return err
+		}
+		if ticket.Status != "blocked" || ticket.DecisionRequest == nil {
+			return withExitCode(exitUsage, fmt.Errorf(
+				"ticket T-%d is not waiting on a decision (status %s); use \"ankra tickets comment\" to talk to the agent",
+				ticket.TicketNumber, ticket.Status))
+		}
+		if optionKey != "" && findDecisionOption(*ticket.DecisionRequest, optionKey) == nil {
+			return withExitCode(exitUsage, fmt.Errorf("'%s' is not one of the offered options (%s)",
+				optionKey, strings.Join(decisionOptionKeys(*ticket.DecisionRequest), ", ")))
+		}
+		decision := client.TicketDecision{}
+		if optionKey != "" {
+			decision.OptionKey = &optionKey
+		}
+		if answer != "" {
+			decision.Answer = &answer
+		}
+		decided, err := apiClient.DecideTicket(ticket.ID, decision)
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, decided); handled || renderError != nil {
+			return renderError
+		}
+		if optionKey != "" {
+			option := findDecisionOption(*ticket.DecisionRequest, optionKey)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Decision recorded on T-%d: %s (option '%s'). The agent resumes with it.\n",
+				ticket.TicketNumber, option.Title, option.Key)
+			return nil
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Decision recorded on T-%d: something else - %s. The agent resumes with it.\n",
+			ticket.TicketNumber, answer)
+		return nil
+	},
+}
+
+var ticketUUIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// resolveTicketReference accepts a ticket UUID or a ticket number (8, T-8,
+// #8) and returns the ticket. Numbers are resolved by walking the listing,
+// closed tickets included, because the API addresses tickets by id.
+func resolveTicketReference(reference string) (*client.Ticket, error) {
+	trimmed := strings.TrimSpace(reference)
+	if ticketUUIDPattern.MatchString(trimmed) {
+		return apiClient.GetTicket(trimmed)
+	}
+	numberText := strings.TrimPrefix(strings.TrimPrefix(strings.ToUpper(trimmed), "T-"), "#")
+	number, parseError := strconv.ParseInt(numberText, 10, 64)
+	if parseError != nil || number < 1 {
+		return nil, withExitCode(exitUsage, fmt.Errorf(
+			"'%s' is not a ticket reference; use the ticket number (8, T-8) or its UUID", reference))
+	}
+	const pageSize = 200
+	for offset := 0; offset < pageSize*10; offset += pageSize {
+		page, listError := apiClient.ListTickets(client.TicketListFilter{
+			IncludeClosed: true, Limit: pageSize, Offset: offset,
+		})
+		if listError != nil {
+			return nil, listError
+		}
+		for index := range page.Tickets {
+			if page.Tickets[index].TicketNumber == number {
+				return &page.Tickets[index], nil
+			}
+		}
+		if len(page.Tickets) < pageSize {
+			break
+		}
+	}
+	return nil, withExitCode(exitNotFound, fmt.Errorf("ticket T-%d not found", number))
+}
+
+func ticketAssigneeLabel(ticket client.Ticket) string {
+	if ticket.AssigneeAgentName != nil && *ticket.AssigneeAgentName != "" {
+		return *ticket.AssigneeAgentName + " (agent)"
+	}
+	if ticket.AssigneeUserName != nil && *ticket.AssigneeUserName != "" {
+		return *ticket.AssigneeUserName
+	}
+	if ticket.AssigneeUserEmail != nil && *ticket.AssigneeUserEmail != "" {
+		return *ticket.AssigneeUserEmail
+	}
+	return "-"
+}
+
+// ticketWaitingLabel names what a parked ticket waits on, so the listing
+// tells a decision apart from a plain block and from a plan approval.
+func ticketWaitingLabel(ticket client.Ticket) string {
+	switch {
+	case ticket.Status == "blocked" && ticket.DecisionRequest != nil:
+		return "your decision"
+	case ticket.Status == "blocked":
+		return "a human"
+	case ticket.Status == "awaiting_approval":
+		return "your approval"
+	case ticket.Status == "awaiting_review":
+		return "review"
+	}
+	return ""
+}
+
+func ticketEventAuthorLabel(event client.TicketEvent) string {
+	if event.AuthorAgentName != nil && *event.AuthorAgentName != "" {
+		return *event.AuthorAgentName
+	}
+	if event.AuthorUserName != nil && *event.AuthorUserName != "" {
+		return *event.AuthorUserName
+	}
+	return event.AuthorKind
+}
+
+// renderTicketDecision prints the pending choice with the command that
+// answers it. Nothing is printed for a ticket that waits on no decision.
+func renderTicketDecision(cmd *cobra.Command, ticket client.Ticket) {
+	if ticket.Status != "blocked" || ticket.DecisionRequest == nil {
+		return
+	}
+	out := cmd.OutOrStdout()
+	request := *ticket.DecisionRequest
+	_, _ = fmt.Fprintf(out, "\nYour decision is needed: %s\n", request.Prompt)
+	for _, option := range request.Options {
+		marker := "  "
+		if option.Recommended {
+			marker = "* "
+		}
+		_, _ = fmt.Fprintf(out, "%s[%s] %s\n", marker, option.Key, option.Title)
+		if option.Summary != "" {
+			_, _ = fmt.Fprintf(out, "      %s\n", option.Summary)
+		}
+	}
+	_, _ = fmt.Fprintf(out, "  [ ] Something else - answer in your own words\n")
+	_, _ = fmt.Fprintf(out, "\nAnswer with: ankra tickets decide T-%d --option <key>   or   --answer \"...\"\n",
+		ticket.TicketNumber)
+	if len(request.Options) > 0 {
+		_, _ = fmt.Fprintln(out, "(* = the agent's recommendation)")
+	}
+}
+
+func findDecisionOption(request client.TicketDecisionRequest, key string) *client.TicketDecisionOption {
+	wanted := strings.ToLower(strings.TrimSpace(key))
+	for index := range request.Options {
+		if strings.ToLower(request.Options[index].Key) == wanted {
+			return &request.Options[index]
+		}
+	}
+	return nil
+}
+
+func decisionOptionKeys(request client.TicketDecisionRequest) []string {
+	keys := make([]string, 0, len(request.Options))
+	for _, option := range request.Options {
+		keys = append(keys, option.Key)
+	}
+	return keys
+}
+
+func init() {
+	ticketsListCmd.Flags().StringSlice("status", nil,
+		"Only these statuses (comma-separated: triage, investigating, planning, awaiting_review, awaiting_approval, executing, verifying, blocked, done, cancelled)")
+	ticketsListCmd.Flags().Bool("needs-human", false, "Only tickets waiting on a person")
+	ticketsListCmd.Flags().Bool("include-closed", false, "Include done and cancelled tickets")
+	ticketsListCmd.Flags().String("search", "", "Match on the title")
+	ticketsListCmd.Flags().Int("limit", 50, "Maximum tickets to list (up to 200)")
+	ticketsEventsCmd.Flags().Int("limit", 200, "Maximum events to show")
+	ticketsCommentCmd.Flags().String("body", "", "The comment (markdown)")
+	ticketsTransitionCmd.Flags().String("status", "", "The status to move to")
+	ticketsTransitionCmd.Flags().String("note", "", "Why the ticket is moving")
+	ticketsDecideCmd.Flags().String("option", "", "Key of the offered option to choose")
+	ticketsDecideCmd.Flags().String("answer", "", "The decision in your own words, or a note beside --option")
+	registerStructuredOutputFlags(ticketsListCmd, ticketsGetCmd, ticketsEventsCmd,
+		ticketsCommentCmd, ticketsTransitionCmd, ticketsDecideCmd)
+
+	ticketsCmd.AddCommand(ticketsListCmd)
+	ticketsCmd.AddCommand(ticketsGetCmd)
+	ticketsCmd.AddCommand(ticketsEventsCmd)
+	ticketsCmd.AddCommand(ticketsCommentCmd)
+	ticketsCmd.AddCommand(ticketsTransitionCmd)
+	ticketsCmd.AddCommand(ticketsDecideCmd)
+	rootCmd.AddCommand(ticketsCmd)
+}

--- a/cmd/tickets_test.go
+++ b/cmd/tickets_test.go
@@ -1,0 +1,274 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+type ticketsMock struct {
+	baseMock
+	tickets       []client.Ticket
+	events        []client.TicketEvent
+	listFilters   []client.TicketListFilter
+	comments      []string
+	transitions   []string
+	decisions     []client.TicketDecision
+	decisionError error
+}
+
+func (m *ticketsMock) ListTickets(filter client.TicketListFilter) (*client.TicketListResponse, error) {
+	m.listFilters = append(m.listFilters, filter)
+	if filter.Offset >= len(m.tickets) {
+		return &client.TicketListResponse{Tickets: []client.Ticket{}, TotalCount: len(m.tickets)}, nil
+	}
+	return &client.TicketListResponse{Tickets: m.tickets[filter.Offset:], TotalCount: len(m.tickets)}, nil
+}
+
+func (m *ticketsMock) GetTicket(ticketID string) (*client.Ticket, error) {
+	for index := range m.tickets {
+		if m.tickets[index].ID == ticketID {
+			return &m.tickets[index], nil
+		}
+	}
+	return nil, client.NewUnexpectedResponseError(404, "Ticket not found.")
+}
+
+func (m *ticketsMock) ListTicketEvents(ticketID string, limit int) (*client.TicketEventListResponse, error) {
+	return &client.TicketEventListResponse{Events: m.events}, nil
+}
+
+func (m *ticketsMock) CommentOnTicket(ticketID string, body string) (*client.TicketEvent, error) {
+	m.comments = append(m.comments, body)
+	return &client.TicketEvent{Sequence: 12, EventType: "comment", Body: body}, nil
+}
+
+func (m *ticketsMock) TransitionTicket(ticketID string, status string, note string) (*client.Ticket, error) {
+	m.transitions = append(m.transitions, status)
+	moved := m.tickets[0]
+	moved.Status = status
+	return &moved, nil
+}
+
+func (m *ticketsMock) DecideTicket(ticketID string, decision client.TicketDecision) (*client.Ticket, error) {
+	m.decisions = append(m.decisions, decision)
+	if m.decisionError != nil {
+		return nil, m.decisionError
+	}
+	decided := m.tickets[0]
+	decided.DecisionRequest = nil
+	return &decided, nil
+}
+
+const ticketsTestID = "c5bde475-eda1-4067-9c08-83c2aff6cdb0"
+
+func blockedTicketWithChoice() client.Ticket {
+	agent := "DevOps"
+	return client.Ticket{
+		ID: ticketsTestID, TicketNumber: 8,
+		Title: "launch-site-demo publishes to the wrong registry",
+		Body:  "Two ways out.",
+		Kind:  "chore", Status: "blocked", Priority: "medium",
+		AssigneeAgentName: &agent, PlanStatus: "none", Labels: []string{},
+		CreatedAt: "2026-08-25T09:12:00Z", UpdatedAt: "2026-08-25T09:40:00Z",
+		DecisionRequest: &client.TicketDecisionRequest{
+			Prompt: "Which registry should launch-site-demo publish to?",
+			Options: []client.TicketDecisionOption{
+				{Key: "a", Title: "Re-point the declaration", Summary: "No runtime change.", Recommended: true},
+				{Key: "b", Title: "Move publishing to Harbor", Summary: "Rewrites the workflow."},
+			},
+		},
+	}
+}
+
+func TestTicketsListShowsWhatEachTicketWaitsOn(t *testing.T) {
+	investigating := blockedTicketWithChoice()
+	investigating.TicketNumber = 9
+	investigating.ID = "d0ce0e4b-ebf6-493c-a608-17b9d29420b3"
+	investigating.Status = "investigating"
+	investigating.DecisionRequest = nil
+	mock := &ticketsMock{tickets: []client.Ticket{blockedTicketWithChoice(), investigating}}
+
+	out, err := runConfirmCommand(t, mock, "", []*cobra.Command{ticketsListCmd},
+		"tickets", "list", "--needs-human")
+	if err != nil {
+		t.Fatalf("tickets list failed: %v", err)
+	}
+	if !strings.Contains(out, "T-8") || !strings.Contains(out, "your decision") {
+		t.Fatalf("listing must flag the ticket waiting on a decision: %s", out)
+	}
+	if !strings.Contains(out, "T-9") || strings.Contains(out, "T-9") && !strings.Contains(out, "DevOps (agent)") {
+		t.Fatalf("listing missing the second ticket or its assignee: %s", out)
+	}
+	if len(mock.listFilters) != 1 || !mock.listFilters[0].NeedsHuman {
+		t.Fatalf("--needs-human must reach the API filter: %+v", mock.listFilters)
+	}
+}
+
+func TestTicketsGetRendersTheDecisionWithItsOptions(t *testing.T) {
+	mock := &ticketsMock{tickets: []client.Ticket{blockedTicketWithChoice()}}
+
+	out, err := runConfirmCommand(t, mock, "", []*cobra.Command{ticketsGetCmd}, "tickets", "get", "T-8")
+	if err != nil {
+		t.Fatalf("tickets get failed: %v", err)
+	}
+	for _, want := range []string{
+		"Your decision is needed: Which registry should launch-site-demo publish to?",
+		"* [a] Re-point the declaration",
+		"  [b] Move publishing to Harbor",
+		"No runtime change.",
+		"Something else",
+		"ankra tickets decide T-8 --option <key>",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("tickets get output lacks %q:\n%s", want, out)
+		}
+	}
+	// A number resolves through the listing, closed tickets included.
+	if len(mock.listFilters) == 0 || !mock.listFilters[0].IncludeClosed {
+		t.Fatalf("a ticket number must be resolved through the closed-inclusive listing: %+v", mock.listFilters)
+	}
+}
+
+func TestTicketsGetByUUIDDoesNotWalkTheListing(t *testing.T) {
+	mock := &ticketsMock{tickets: []client.Ticket{blockedTicketWithChoice()}}
+
+	out, err := runConfirmCommand(t, mock, "", []*cobra.Command{ticketsGetCmd}, "tickets", "get", ticketsTestID)
+	if err != nil {
+		t.Fatalf("tickets get failed: %v", err)
+	}
+	if !strings.Contains(out, "T-8") || len(mock.listFilters) != 0 {
+		t.Fatalf("a UUID must be fetched directly: listFilters=%+v out=%s", mock.listFilters, out)
+	}
+}
+
+func TestTicketsGetOffersNoDecisionOnAPlainBlock(t *testing.T) {
+	plain := blockedTicketWithChoice()
+	plain.DecisionRequest = nil
+	mock := &ticketsMock{tickets: []client.Ticket{plain}}
+
+	out, err := runConfirmCommand(t, mock, "", []*cobra.Command{ticketsGetCmd}, "tickets", "get", "8")
+	if err != nil {
+		t.Fatalf("tickets get failed: %v", err)
+	}
+	if strings.Contains(out, "Your decision is needed") {
+		t.Fatalf("a blocked ticket without a request has nothing to choose from: %s", out)
+	}
+}
+
+func TestTicketsGetUnknownNumberUsesExitNotFound(t *testing.T) {
+	mock := &ticketsMock{tickets: []client.Ticket{blockedTicketWithChoice()}}
+
+	_, err := runConfirmCommand(t, mock, "", []*cobra.Command{ticketsGetCmd}, "tickets", "get", "T-404")
+	if err == nil {
+		t.Fatal("expected an error for a missing ticket")
+	}
+	if got := exitCodeFor(err); got != exitNotFound {
+		t.Errorf("expected exit code %d, got %d", exitNotFound, got)
+	}
+}
+
+func TestTicketsDecideSendsTheChosenOption(t *testing.T) {
+	mock := &ticketsMock{tickets: []client.Ticket{blockedTicketWithChoice()}}
+
+	out, err := runConfirmCommand(t, mock, "", []*cobra.Command{ticketsDecideCmd},
+		"tickets", "decide", "T-8", "--option", "A", "--answer", "Before the launch.")
+	if err != nil {
+		t.Fatalf("tickets decide failed: %v", err)
+	}
+	if len(mock.decisions) != 1 || mock.decisions[0].OptionKey == nil || *mock.decisions[0].OptionKey != "A" ||
+		mock.decisions[0].Answer == nil || *mock.decisions[0].Answer != "Before the launch." {
+		t.Fatalf("decision sent = %+v", mock.decisions)
+	}
+	if !strings.Contains(out, "Decision recorded on T-8: Re-point the declaration (option 'a')") {
+		t.Fatalf("confirmation missing: %s", out)
+	}
+}
+
+func TestTicketsDecideSendsSomethingElse(t *testing.T) {
+	mock := &ticketsMock{tickets: []client.Ticket{blockedTicketWithChoice()}}
+
+	out, err := runConfirmCommand(t, mock, "", []*cobra.Command{ticketsDecideCmd},
+		"tickets", "decide", "8", "--answer", "Publish to both for a week, then decide.")
+	if err != nil {
+		t.Fatalf("tickets decide failed: %v", err)
+	}
+	if len(mock.decisions) != 1 || mock.decisions[0].OptionKey != nil ||
+		*mock.decisions[0].Answer != "Publish to both for a week, then decide." {
+		t.Fatalf("decision sent = %+v", mock.decisions)
+	}
+	if !strings.Contains(out, "something else - Publish to both") {
+		t.Fatalf("confirmation missing: %s", out)
+	}
+}
+
+func TestTicketsDecideRefusesLocallyWhatTheServerWould(t *testing.T) {
+	mock := &ticketsMock{tickets: []client.Ticket{blockedTicketWithChoice()}}
+
+	_, err := runConfirmCommand(t, mock, "", []*cobra.Command{ticketsDecideCmd},
+		"tickets", "decide", "T-8", "--option", "c")
+	if err == nil || !strings.Contains(err.Error(), "not one of the offered options (a, b)") {
+		t.Fatalf("an unknown option must be refused before the call, got %v", err)
+	}
+	resetTreeFlags(t, ticketsDecideCmd)
+	_, err = runConfirmCommand(t, mock, "", []*cobra.Command{ticketsDecideCmd}, "tickets", "decide", "T-8")
+	if err == nil || !strings.Contains(err.Error(), "--option") {
+		t.Fatalf("an empty decision must be refused, got %v", err)
+	}
+	plain := blockedTicketWithChoice()
+	plain.Status = "investigating"
+	plain.DecisionRequest = nil
+	mock = &ticketsMock{tickets: []client.Ticket{plain}}
+	resetTreeFlags(t, ticketsDecideCmd)
+	_, err = runConfirmCommand(t, mock, "", []*cobra.Command{ticketsDecideCmd},
+		"tickets", "decide", "T-8", "--option", "a")
+	if err == nil || !strings.Contains(err.Error(), "not waiting on a decision") {
+		t.Fatalf("a ticket without a pending choice must be refused, got %v", err)
+	}
+	if len(mock.decisions) != 0 {
+		t.Fatalf("no decision must be sent for a refused call: %+v", mock.decisions)
+	}
+}
+
+func TestTicketsCommentAndTransition(t *testing.T) {
+	mock := &ticketsMock{tickets: []client.Ticket{blockedTicketWithChoice()}}
+
+	out, err := runConfirmCommand(t, mock, "", []*cobra.Command{ticketsCommentCmd},
+		"tickets", "comment", "T-8", "--body", "  Looking into it.  ")
+	if err != nil {
+		t.Fatalf("tickets comment failed: %v", err)
+	}
+	if len(mock.comments) != 1 || mock.comments[0] != "Looking into it." || !strings.Contains(out, "event #12") {
+		t.Fatalf("comment = %+v out=%s", mock.comments, out)
+	}
+
+	out, err = runConfirmCommand(t, mock, "", []*cobra.Command{ticketsTransitionCmd},
+		"tickets", "transition", "T-8", "--status", "investigating", "--note", "Resuming.")
+	if err != nil {
+		t.Fatalf("tickets transition failed: %v", err)
+	}
+	if len(mock.transitions) != 1 || mock.transitions[0] != "investigating" || !strings.Contains(out, "T-8 is now investigating") {
+		t.Fatalf("transition = %+v out=%s", mock.transitions, out)
+	}
+}
+
+func TestTicketsEventsListsTheTimeline(t *testing.T) {
+	author := "DevOps"
+	mock := &ticketsMock{
+		tickets: []client.Ticket{blockedTicketWithChoice()},
+		events: []client.TicketEvent{{Sequence: 7, EventType: "status_change", AuthorKind: "agent",
+			AuthorAgentName: &author, Body: "Investigation conclusive.", CreatedAt: "2026-08-25T12:21:03Z"}},
+	}
+
+	out, err := runConfirmCommand(t, mock, "", []*cobra.Command{ticketsEventsCmd}, "tickets", "events", "T-8")
+	if err != nil {
+		t.Fatalf("tickets events failed: %v", err)
+	}
+	if !strings.Contains(out, "status_change") || !strings.Contains(out, "DevOps") ||
+		!strings.Contains(out, "Investigation conclusive.") {
+		t.Fatalf("timeline missing fields: %s", out)
+	}
+}

--- a/internal/client/tickets.go
+++ b/internal/client/tickets.go
@@ -1,0 +1,193 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// TicketDecisionOption is one alternative an agent offered when it blocked
+// a ticket on a choice.
+type TicketDecisionOption struct {
+	Key         string `json:"key"`
+	Title       string `json:"title"`
+	Summary     string `json:"summary"`
+	Recommended bool   `json:"recommended"`
+}
+
+// TicketDecisionRequest is the choice a blocked ticket waits on: the
+// agent's question and the options it offered. The person picks one or
+// answers with something else in their own words.
+type TicketDecisionRequest struct {
+	Prompt  string                 `json:"prompt"`
+	Options []TicketDecisionOption `json:"options"`
+}
+
+// Ticket mirrors one AI board ticket from /api/v1/org/ai-tickets. Only the
+// fields the CLI renders are declared; the rest of the wire shape is
+// ignored on decode.
+type Ticket struct {
+	ID                string                 `json:"id"`
+	TicketNumber      int64                  `json:"ticket_number"`
+	Title             string                 `json:"title"`
+	Body              string                 `json:"body"`
+	Kind              string                 `json:"kind"`
+	Status            string                 `json:"status"`
+	Priority          string                 `json:"priority"`
+	AssigneeAgentName *string                `json:"assignee_agent_name"`
+	AssigneeUserEmail *string                `json:"assignee_user_email"`
+	AssigneeUserName  *string                `json:"assignee_user_name"`
+	ClusterName       *string                `json:"cluster_name"`
+	PlanStatus        string                 `json:"plan_status"`
+	Labels            []string               `json:"labels"`
+	Resolution        *string                `json:"resolution"`
+	CreatedAt         string                 `json:"created_at"`
+	UpdatedAt         string                 `json:"updated_at"`
+	ClosedAt          *string                `json:"closed_at"`
+	DecisionRequest   *TicketDecisionRequest `json:"decision_request"`
+}
+
+// TicketListResponse is the GET /api/v1/org/ai-tickets body.
+type TicketListResponse struct {
+	Tickets    []Ticket `json:"tickets"`
+	TotalCount int      `json:"total_count"`
+}
+
+// TicketEvent is one timeline entry on a ticket.
+type TicketEvent struct {
+	ID              string                 `json:"id"`
+	Sequence        int64                  `json:"sequence"`
+	EventType       string                 `json:"event_type"`
+	AuthorKind      string                 `json:"author_kind"`
+	AuthorAgentName *string                `json:"author_agent_name"`
+	AuthorUserName  *string                `json:"author_user_name"`
+	Body            string                 `json:"body"`
+	Payload         map[string]interface{} `json:"payload"`
+	CreatedAt       string                 `json:"created_at"`
+}
+
+// TicketEventListResponse is the GET /api/v1/org/ai-tickets/{id}/events body.
+type TicketEventListResponse struct {
+	Events []TicketEvent `json:"events"`
+}
+
+// TicketListFilter narrows a ticket listing.
+type TicketListFilter struct {
+	Statuses      []string
+	NeedsHuman    bool
+	IncludeClosed bool
+	Search        string
+	Limit         int
+	Offset        int
+}
+
+// TicketDecision is the answer to a ticket's pending decision request: the
+// key of an offered option, or the answer in the person's own words when no
+// option fits (a note beside a chosen option is allowed too).
+type TicketDecision struct {
+	OptionKey *string `json:"option_key"`
+	Answer    *string `json:"answer"`
+}
+
+const ticketsBasePath = "/api/v1/org/ai-tickets"
+
+// ListTickets lists the organisation's AI board tickets.
+func (c *Client) ListTickets(filter TicketListFilter) (*TicketListResponse, error) {
+	query := url.Values{}
+	if len(filter.Statuses) > 0 {
+		query.Set("status", joinComma(filter.Statuses))
+	}
+	if filter.NeedsHuman {
+		query.Set("needs_human", "true")
+	}
+	if filter.IncludeClosed {
+		query.Set("include_closed", "true")
+	}
+	if filter.Search != "" {
+		query.Set("search", filter.Search)
+	}
+	if filter.Limit > 0 {
+		query.Set("limit", strconv.Itoa(filter.Limit))
+	}
+	if filter.Offset > 0 {
+		query.Set("offset", strconv.Itoa(filter.Offset))
+	}
+	requestURL := c.BaseURL + ticketsBasePath
+	if encoded := query.Encode(); encoded != "" {
+		requestURL += "?" + encoded
+	}
+	var response TicketListResponse
+	if err := c.getJSON(requestURL, &response); err != nil {
+		return nil, fmt.Errorf("listing tickets: %w", err)
+	}
+	return &response, nil
+}
+
+// GetTicket fetches one ticket by id.
+func (c *Client) GetTicket(ticketID string) (*Ticket, error) {
+	var ticket Ticket
+	if err := c.getJSON(c.BaseURL+ticketsBasePath+"/"+url.PathEscape(ticketID), &ticket); err != nil {
+		return nil, fmt.Errorf("getting ticket: %w", err)
+	}
+	return &ticket, nil
+}
+
+// ListTicketEvents reads a ticket's timeline, oldest first.
+func (c *Client) ListTicketEvents(ticketID string, limit int) (*TicketEventListResponse, error) {
+	requestURL := c.BaseURL + ticketsBasePath + "/" + url.PathEscape(ticketID) + "/events"
+	if limit > 0 {
+		requestURL += "?limit=" + strconv.Itoa(limit)
+	}
+	var response TicketEventListResponse
+	if err := c.getJSON(requestURL, &response); err != nil {
+		return nil, fmt.Errorf("listing ticket events: %w", err)
+	}
+	return &response, nil
+}
+
+// CommentOnTicket posts a comment on the ticket as the caller.
+func (c *Client) CommentOnTicket(ticketID string, body string) (*TicketEvent, error) {
+	var event TicketEvent
+	requestURL := c.BaseURL + ticketsBasePath + "/" + url.PathEscape(ticketID) + "/comments"
+	if err := c.sendJSON(http.MethodPost, requestURL, map[string]string{"body": body}, &event); err != nil {
+		return nil, fmt.Errorf("commenting on ticket: %w", err)
+	}
+	return &event, nil
+}
+
+// TransitionTicket moves the ticket to a new status with an optional note.
+func (c *Client) TransitionTicket(ticketID string, status string, note string) (*Ticket, error) {
+	payload := map[string]interface{}{"status": status}
+	if note != "" {
+		payload["note"] = note
+	}
+	var ticket Ticket
+	requestURL := c.BaseURL + ticketsBasePath + "/" + url.PathEscape(ticketID) + "/transition"
+	if err := c.sendJSON(http.MethodPost, requestURL, payload, &ticket); err != nil {
+		return nil, fmt.Errorf("moving ticket: %w", err)
+	}
+	return &ticket, nil
+}
+
+// DecideTicket answers the choice a blocked ticket waits on; the agent
+// resumes from the recorded answer.
+func (c *Client) DecideTicket(ticketID string, decision TicketDecision) (*Ticket, error) {
+	var ticket Ticket
+	requestURL := c.BaseURL + ticketsBasePath + "/" + url.PathEscape(ticketID) + "/decision"
+	if err := c.sendJSON(http.MethodPost, requestURL, decision, &ticket); err != nil {
+		return nil, fmt.Errorf("recording the decision: %w", err)
+	}
+	return &ticket, nil
+}
+
+func joinComma(values []string) string {
+	joined := ""
+	for index, value := range values {
+		if index > 0 {
+			joined += ","
+		}
+		joined += value
+	}
+	return joined
+}


### PR DESCRIPTION
Bead: ankra-us966.2

## Why

The CLI had no AI-board surface at all, so the decision a blocked ticket waits on (cluster#1904) could only be answered on the ticket page. This adds the board to the terminal, with the decision as a first-class command.

## What

`ankra tickets` - a ticket is referenced by number (`8`, `T-8`, `#8`) or UUID:

- `list [--status ...] [--needs-human] [--include-closed] [--search] [--limit]` - table with a **WAITING ON** column that tells "your decision" from "a human", "your approval" and "review".
- `get <ticket>` - the ticket, and when it is blocked on a choice, the agent's question with every option (`* [a] ...` marks the recommendation), **Something else**, and the exact `decide` invocation.
- `events <ticket>`, `comment <ticket> --body`, `transition <ticket> --status [--note]`.
- `decide <ticket> --option <key> | --answer "..."` (both together = option + note). Refuses locally what the server would - no option and no answer, an option that was not offered, a ticket not waiting on a decision - before making the call.

All commands support `-o json|yaml`. Client methods live in `internal/client/tickets.go` over the existing `/api/v1/org/ai-tickets` endpoints; a number resolves through the closed-inclusive listing because the API addresses tickets by id.

## Verification

- `go test ./...` green; `golangci-lint run ./...` 0 issues.
- `cmd/tickets_test.go`: 9 tests over a service mock (listing labels, decision rendering, UUID vs number resolution, exit codes, option/something-else payloads, local refusals, comment/transition/events).

Docs: ankraio/ankra-docs `docs/ticket-decision-parity` (the generated `reference/cli` regenerates on the next stable tag).
