### PR TITLE
feat(skills): install into every AI assistant; 22 skills covering onboarding, cluster creation, domains and apps (ankra-f7ddh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,77 @@
 # Ankra CLI Changelog
 
+## Unreleased
+
+### Added
+
+- **`ankra skills install` now installs into every AI assistant you use, not
+  just Cursor and Claude Code.** `--editor cursor|claude-code` covered two of
+  the tools a team actually has open, so everyone else - Codex, GitHub
+  Copilot, Windsurf, Gemini CLI, OpenCode, Cline, Zed, OpenClaw, the Claude
+  app - either went without the skills or hand-copied them somewhere their
+  assistant never read. `--client` replaces `--editor` (kept as a deprecated
+  alias) and takes a repeatable, comma-separated list, `all`, or `auto`; with
+  no `--client` at all, install now detects the assistants configured on the
+  machine and does them together, falling back to Claude Code and Cursor when
+  it finds none. `ankra skills clients` lists every supported assistant, what
+  was detected, and where each one's skills would land.
+
+- **Assistants that have no skills directory now get an index instead of
+  nothing.** Claude Code and Cursor discover `SKILL.md` files by themselves;
+  Codex, Copilot, Gemini, Windsurf and everything behind `AGENTS.md` do not.
+  For those, install writes the skills into a client-neutral library and adds
+  an index to the assistant's always-loaded instructions file - naming each
+  skill, what it covers, and the path to open - inside the same managed block
+  that already carried the Ankra routing rule. A project-scoped index names
+  the repository-relative directory, so a committed `AGENTS.md` or
+  `.github/copilot-instructions.md` works on every teammate's machine.
+
+- **`ankra skills install --client claude-app` writes uploadable skill
+  bundles.** The Claude app cannot read your filesystem, so install produces
+  one `.zip` per skill - the skill directory at the archive root - ready to
+  upload at claude.ai under Settings, Capabilities, Skills.
+
+- **Ankra workflow commands are installed alongside the skills.** Skills are
+  matched against whatever the user happens to say; a workflow is a named
+  entry point for a job that spans several of them. `/ankra-ship-service`,
+  `/ankra-connect-app`, `/ankra-triage`, `/ankra-promote`, `/ankra-harden`
+  and `/ankra-profile` are written in each assistant's own command format
+  (Claude Code and Cursor commands, Codex prompts, Copilot `.prompt.md`,
+  Gemini TOML, Windsurf workflows, Cline workflows). Skip them with
+  `--no-workflows`.
+
+- **Six new skills covering the work that spans several parts of the
+  platform.** `ankra-applications` (source code to a running deployment on one
+  or many clusters, registries, environment secrets, auto-deploy, PR demos,
+  publishing as a catalogue add-on), `ankra-app-integrations` (wiring an app
+  to an LLM gateway, Harbor, a database or an internal API with the
+  credentials that already exist), `ankra-stack-profiles` (builder drafts,
+  parameters, option sets, publishing and launching across a fleet),
+  `ankra-troubleshooting` (operations, events, `--previous` logs, `top`,
+  PromQL, and what each symptom classifies as), `ankra-security` (tokens and
+  MCP scopes, roles, cluster access grants, credential scope, scanning
+  findings, agent autonomy) and `ankra-ai-agents` (model provider and
+  catalogue, MCP tool servers and per-tool role grants, agent runs and
+  transcripts, the AI board).
+
+### Changed
+
+- **The `ankra-cli`, `ankra-sops-secrets`, `ankra-stacks-addons`,
+  `ankra-cicd` and `ankra-platform-principles` skills now match the CLI they
+  describe.** `ankra-cli` documented `ankra org select`, which does not
+  exist - the command is `ankra org switch` - and predated applications,
+  stack profiles, tickets, agents and the exit-code contract.
+  `ankra-sops-secrets` documented `ankra cluster encrypt -f <file>`, which is
+  not the signature: `encrypt` names keys with `--key` and takes cluster mode
+  or file mode, and `encrypt --set` is how a new secret value is changed
+  without committing plaintext first. `ankra-platform-principles` gained the
+  routing map from a request to the right skill.
+
+- **`ankra skills uninstall` with no `--client` now undoes what install
+  did.** It resolves to the assistants that actually carry an Ankra install,
+  rather than defaulting to Cursor, and a full uninstall also removes the
+  workflow commands it wrote.
+
 ## v0.13.0-rc3 — 2026-08-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,36 @@
   the per-provider instance-family guide, role sizing, GPU node groups, the
   create-flag map and the cost traps.
 
+- **`ankra-import-cluster` and `ankra-observability` taught the silently-broken
+  `parents` shorthand.** Both showed `parents: - manifest: <name>` in their YAML
+  examples, and the import skill's field reference endorsed it - but the
+  parser requires a `kind` + `name` pair and silently drops anything else, so
+  every dependency edge written that way vanishes while local and server-side
+  validation both pass. This is the exact trap `ankra-stacks-addons` already
+  warned about; the other two skills were teaching it. Both now use the
+  `kind`/`name` form, and the import skill documents the trap and the
+  `ankra cluster stacks list <stack> -o json` verification.
+
+- **`ankra-alerts-webhooks` rewritten against the real `ankra alerts`
+  surface.** The skill predated the CLI entirely - no commands, just concepts.
+  It now covers destinations (webhook URLs, Slack/Teams bot channels via
+  `destinations channels`, payload templates), routes (kind/severity/cluster
+  filters, include/exclude modes, priorities and `--stop-on-match`),
+  `routes preview` with the `--alert-id` dedup caveat, and the
+  `test`/`test-url` delivery checks that exit non-zero for CI.
+
+- **Gaps filled across the catalogue.** `ankra-helm-registries` gained the
+  registry management surface (`registries create|sync|sync-jobs`, spec-file
+  form, `--exclude-charts`) and chart discovery (`ankra charts
+  list|search|info|values|template`); `ankra-observability` gained the
+  metrics wiring and reading surface (`cluster metrics`, `top`);
+  `ankra-getting-started` gained the organisation playground as the
+  zero-credential first cluster; `ankra-cli` gained the support-request
+  surface and the beta update channel; `ankra-gitops` gained
+  `ankra cluster gitops status` and the create-time `--gitops-repository`
+  wiring. `ankra-gitops` and `ankra-cicd` no longer credit syncing to
+  ArgoCD - deploys roll out via the Ankra engine.
+
 - **The `ankra-cli`, `ankra-sops-secrets`, `ankra-stacks-addons`,
   `ankra-cicd` and `ankra-platform-principles` skills now match the CLI they
   describe.** `ankra-cli` documented `ankra org select`, which does not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,17 @@
   Gemini TOML, Windsurf workflows, Cline workflows). Skip them with
   `--no-workflows`.
 
+- **Two new skills for the parts of onboarding that had none, and a
+  `/ankra-new-cluster` workflow.** `ankra-getting-started` is the ordered path
+  from an empty organisation to a running application - credentials, the
+  GitOps repository and the domain settled before the first cluster, because
+  all three are wired at create time and painful to retrofit.
+  `ankra-domains-dns` separates the four things that get conflated: the
+  organisation root domain, a cluster's generated subdomain, a custom DNS zone
+  served with your own credential, and the preview domain PR demos publish
+  under - including that Ankra publishes nothing on a preview domain you own,
+  so an unpublished wildcard costs you the URL and the TLS together.
+
 - **Six new skills covering the work that spans several parts of the
   platform.** `ankra-applications` (source code to a running deployment on one
   or many clusters, registries, environment secrets, auto-deploy, PR demos,
@@ -55,6 +66,30 @@
   transcripts, the AI board).
 
 ### Changed
+
+- **`ankra-cloud-clusters` and `ankra-managed-kubernetes` documented commands
+  and flags that do not exist.** Between them they told an agent to run
+  `ankra cluster ovh node-group|upgrade|scale|ssh-keys` (all removed in favour
+  of the provider-agnostic `ankra cluster node-group|upgrade|scale|ssh-keys`),
+  `--wait` on a provider `create` (never existed), `deprovision --auto-delete`
+  (removed), `ankra cluster managed options` and `managed upgrades` (neither
+  exists), `--provider mks` (it is `ovh_mks`), `--cluster-id` on
+  `managed import` (it is `--provider-cluster-id`), and
+  `--node-pool-autoscaling-min/max` / `--autoscaling-enabled` (they are
+  `--autoscaling`, `--autoscaling-min`, `--autoscaling-max`). Every one of
+  those makes an agent emit a command that fails. `ankra-cloud-clusters` also
+  claimed `provision`/`deprovision` were a power-off, when deprovision is a
+  teardown that releases cloud resources and uninstalls every stack.
+
+- **`ankra-cloud-clusters` now covers cluster creation properly**: all seven
+  providers, the discovery commands that list the regions and instance
+  families a credential can actually deploy, k3s vs kubeadm and etcd topology,
+  the `--external-cloud-provider` / `--include-networking` / `--include-dns`
+  batteries, committing the generated stack to a GitOps repository with
+  `--gitops-repository` at create time, OVH availability zones, and the
+  difference between power, teardown and delete. A new `reference.md` carries
+  the per-provider instance-family guide, role sizing, GPU node groups, the
+  create-flag map and the cost traps.
 
 - **The `ankra-cli`, `ankra-sops-secrets`, `ankra-stacks-addons`,
   `ankra-cicd` and `ankra-platform-principles` skills now match the CLI they

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,11 @@ the un-injected fallback; never bump it for a release.
 - `internal/kubeconfig` — kubeconfig read/merge/write.
 - `internal/skills` — embedded agent skills, vendored from the sibling
   `ankra-skills` repo (`make generate` / `make verify-skills`; in the split
-  repo the embedded copy is canonical).
+  repo the embedded copy is canonical). `clients.go` is the table of every
+  assistant `ankra skills install` targets: supporting one more is a registry
+  entry (paths per scope, rule/command/hook format), not a new branch. `clients.go` is the table of every
+  assistant `ankra skills install` targets: supporting one more is a registry
+  entry (paths per scope, rule/command/hook format), not a new branch.
 - `tools/gendocs` — generates the Mintlify CLI reference; run on release tags
   by `.github/workflows/docs-sync.yml`, which PRs `ankraio/ankra-docs`.
 - `systemtest/` — end-to-end lifecycle shell test (CI: `systemtest.yml`).

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -16,6 +16,13 @@ version; running one prints a warning pointing at the replacement.
 
 ## Upcoming removals
 
+### v0.15.0
+
+| Deprecated | Deprecated in | Replacement | Notes |
+|---|---|---|---|
+| `ankra skills <list\|install\|uninstall> --editor <name>` | v0.14.0 | `--client <name>` | `--client` takes a repeatable, comma-separated list plus `all` and `auto`, and reaches every supported assistant rather than only Cursor and Claude Code. `--editor` still resolves as an alias and warns. |
+| `ankra skills <list\|install\|uninstall> --personal` | v0.14.0 | *(nothing — it is the default)* | A home-directory install is what happens without `--project`; the flag never did anything else. |
+
 ### v0.10.0
 
 | Deprecated | Deprecated in | Replacement | Notes |

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -23,10 +23,11 @@ var skillsCmd = &cobra.Command{
 	Short: "Install Ankra Agent Skills into your AI coding assistants",
 	Long: `Install the curated Ankra Agent Skills into the AI assistants you use.
 
-The skills teach an agent to follow Ankra's practices for the CLI, ImportCluster
-YAML, stacks and addons, applications and their CI/CD, stack profiles, GitOps,
-SOPS secrets, Helm registries, observability, troubleshooting, security, and the
-AI agent surface.
+The skills teach an agent to follow Ankra's practices for the CLI, getting
+started, building and importing clusters (provider, region, instance family),
+domains/DNS/TLS, ImportCluster YAML, stacks and addons, applications and their
+CI/CD, stack profiles, GitOps, SOPS secrets, Helm registries, observability,
+troubleshooting, security, and the AI agent surface.
 
 Claude Code, the Claude app, Cursor, Codex, GitHub Copilot, Windsurf, Gemini CLI,
 OpenCode, Cline, Zed and OpenClaw are supported, plus any assistant that reads
@@ -39,9 +40,9 @@ Three things are installed per client:
   rule       an always-applied instruction making Ankra the default route for
              Kubernetes work, plus an index of the skills for clients that do
              not discover them on their own (skip with --no-rules)
-  workflows  named multi-step entry points (/ankra-ship-service,
-             /ankra-triage, ...) for clients with slash commands
-             (skip with --no-workflows)
+  workflows  named multi-step entry points (/ankra-new-cluster,
+             /ankra-ship-service, /ankra-triage, ...) for clients with
+             slash commands (skip with --no-workflows)
 
 Add --with-hooks to also install an agent hook that pauses direct kubectl/helm
 cluster mutations for confirmation.

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -13,55 +13,115 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// skillsCmd installs the curated Ankra Agent Skills (SKILL.md files) into a
-// Cursor/Claude Code skills directory. The skills are embedded in the binary,
-// so installation works offline and is versioned with the CLI release. This is
-// distinct from `ankra openclaw skill`, which generates a per-cluster skill.
+// skillsCmd installs the curated Ankra Agent Skills (SKILL.md files) into
+// every agent client on the machine. The skills are embedded in the binary,
+// so installation works offline and is versioned with the CLI release. This
+// is distinct from `ankra openclaw skill`, which generates a per-cluster
+// skill.
 var skillsCmd = &cobra.Command{
 	Use:   "skills",
-	Short: "Install Ankra Agent Skills into your editor",
-	Long: `Install the curated Ankra Agent Skills into a Cursor/Claude Code skills
-directory. The skills teach your agent to follow Ankra's recommended practices
-for the CLI, ImportCluster YAML, stacks/addons, GitOps, CI/CD, SOPS secrets,
-Helm registries, observability, alerts, Terraform, and cloud clusters.
+	Short: "Install Ankra Agent Skills into your AI coding assistants",
+	Long: `Install the curated Ankra Agent Skills into the AI assistants you use.
 
-Because skills are only picked up when they match the conversation, install
-also writes a small always-applied rule (Cursor rule / CLAUDE.md block) that
-tells the agent Kubernetes here is managed by Ankra and to route changes
-through the GitOps repo or the ankra CLI instead of raw kubectl/helm. Skip it
-with --no-rules. Add --with-hooks to also install an agent hook that pauses
-direct kubectl/helm cluster mutations for confirmation.
+The skills teach an agent to follow Ankra's practices for the CLI, ImportCluster
+YAML, stacks and addons, applications and their CI/CD, stack profiles, GitOps,
+SOPS secrets, Helm registries, observability, troubleshooting, security, and the
+AI agent surface.
 
-Skills are embedded in the CLI, so installation works offline.
+Claude Code, the Claude app, Cursor, Codex, GitHub Copilot, Windsurf, Gemini CLI,
+OpenCode, Cline, Zed and OpenClaw are supported, plus any assistant that reads
+AGENTS.md. With no --client, install picks the assistants configured on this
+machine; 'ankra skills clients' shows what was detected.
 
+Three things are installed per client:
+
+  skills     the SKILL.md files themselves
+  rule       an always-applied instruction making Ankra the default route for
+             Kubernetes work, plus an index of the skills for clients that do
+             not discover them on their own (skip with --no-rules)
+  workflows  named multi-step entry points (/ankra-ship-service,
+             /ankra-triage, ...) for clients with slash commands
+             (skip with --no-workflows)
+
+Add --with-hooks to also install an agent hook that pauses direct kubectl/helm
+cluster mutations for confirmation.
+
+  ankra skills clients
   ankra skills list
   ankra skills install
-  ankra skills install --editor claude-code
-  ankra skills install --project .
+  ankra skills install --client all
+  ankra skills install --client claude-code --client cursor
+  ankra skills install --client copilot --project .
+  ankra skills install --client claude-app
   ankra skills install --with-hooks
   ankra skills install ankra-cli ankra-gitops`,
-}
-
-type skillsEditor struct {
-	Name                   string
-	ConfigurationDirectory string
-	GuardFormat            string
-}
-
-type skillsTarget struct {
-	Directory  string
-	Scope      string
-	EditorName string
-	// Root anchors the editor's non-skill artefacts: the user's home
-	// directory for personal scope, the project directory for project scope.
-	Root   string
-	Editor skillsEditor
 }
 
 type skillListEntry struct {
 	Name        string `json:"name" yaml:"name"`
 	Description string `json:"description" yaml:"description"`
 	Installed   bool   `json:"installed" yaml:"installed"`
+}
+
+type clientListEntry struct {
+	ID          string `json:"id" yaml:"id"`
+	DisplayName string `json:"display_name" yaml:"display_name"`
+	Detected    bool   `json:"detected" yaml:"detected"`
+	Installed   bool   `json:"installed" yaml:"installed"`
+	Scope       string `json:"scope" yaml:"scope"`
+	Directory   string `json:"directory" yaml:"directory"`
+	Delivery    string `json:"delivery" yaml:"delivery"`
+}
+
+var skillsClientsCmd = &cobra.Command{
+	Use:   "clients",
+	Short: "List the AI assistants skills can be installed into",
+	Long: `List every supported assistant, whether it is configured here, and where
+skills would be installed for it. Detection is what --client auto (the default)
+selects; pass --project <DIR> to see the repository-scoped locations instead.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		scope, root, err := skillsScope(cmd)
+		if err != nil {
+			return err
+		}
+		detected := make(map[string]bool)
+		for _, client := range skills.DetectClients(root, scope) {
+			detected[client.ID] = true
+		}
+		entries := make([]clientListEntry, 0, len(skills.Clients()))
+		for _, client := range skills.Clients() {
+			target, targetError := skills.ResolveTarget(client, scope, root)
+			if targetError != nil {
+				continue
+			}
+			entries = append(entries, clientListEntry{
+				ID:          client.ID,
+				DisplayName: client.DisplayName,
+				Detected:    detected[client.ID],
+				Installed:   skillsDirectoryHasAnkraSkills(target),
+				Scope:       scope,
+				Directory:   skills.DisplayPath(target.SkillsDirectory),
+				Delivery:    clientDelivery(client),
+			})
+		}
+		if rendered, renderError := renderStructured(cmd, entries); rendered || renderError != nil {
+			return renderError
+		}
+		for _, entry := range entries {
+			marker := ""
+			switch {
+			case entry.Installed:
+				marker = " [installed]"
+			case entry.Detected:
+				marker = " [detected]"
+			}
+			fmt.Printf("%s%s\n  %s — %s, installs to %s\n",
+				entry.ID, marker, entry.DisplayName, entry.Delivery, entry.Directory)
+		}
+		fmt.Printf("\nInstall with: ankra skills install --client <id> (or --client all).\n")
+		return nil
+	},
 }
 
 var skillsListCmd = &cobra.Command{
@@ -73,7 +133,7 @@ var skillsListCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		target, err := skillsTargetForCommand(cmd)
+		targets, err := skillsTargetsForCommand(cmd)
 		if err != nil {
 			return err
 		}
@@ -82,11 +142,11 @@ var skillsListCmd = &cobra.Command{
 			return err
 		}
 		entries := make([]skillListEntry, 0, len(list))
-		for _, s := range list {
+		for _, skill := range list {
 			entries = append(entries, skillListEntry{
-				Name:        s.Name,
-				Description: s.Description,
-				Installed:   dirExists(filepath.Join(target.Directory, s.Name)),
+				Name:        skill.Name,
+				Description: skill.Description,
+				Installed:   skillInstalledInAnyTarget(targets, skill.Name),
 			})
 		}
 		if rendered, err := renderStructured(cmd, entries); rendered || err != nil {
@@ -106,67 +166,55 @@ var skillsListCmd = &cobra.Command{
 
 var skillsInstallCmd = &cobra.Command{
 	Use:   "install [skill ...]",
-	Short: "Install Ankra skills into your skills directory",
+	Short: "Install Ankra skills into your AI assistants",
 	Long: `Install all skills (default) or only the named ones.
 
-By default skills install into ~/.cursor/skills/ (personal, available in every
-project). Use --editor claude-code to install into ~/.claude/skills/ instead.
-Use --project <DIR> to install into the selected editor's project skills
-directory (--project . for the current directory).
+Without --client, install targets every assistant configured on this machine
+(see 'ankra skills clients'), falling back to Claude Code and Cursor when none
+is detected. --client all installs everywhere; --client <id> (repeatable, or
+comma-separated) picks specific ones.
+
+By default skills install for your user, available in every project. Use
+--project <DIR> to install into a repository instead (--project . for the
+current directory) - the right scope for GitHub Copilot, whose instructions
+file is per repository.
+
+The Claude app cannot read your filesystem, so --client claude-app writes one
+uploadable .zip bundle per skill and prints where to upload them.
 
 Install also writes an always-applied rule so the agent treats Ankra as the
-default route for Kubernetes work (skip with --no-rules): a local Cursor
-plugin rule or project .cursor/rules/ankra.mdc for Cursor, a managed CLAUDE.md
-block for Claude Code. With --with-hooks it additionally installs an agent
+default route for Kubernetes work, and - for clients that do not discover
+skills on their own - an index naming each skill and its path (skip both with
+--no-rules). Clients with slash commands additionally get the Ankra workflow
+commands (skip with --no-workflows). With --with-hooks it installs the agent
 hook ('ankra skills guard') that intercepts direct kubectl/helm cluster
-mutations and asks for confirmation, pointing back at the Ankra workflow.`,
+mutations and asks for confirmation.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fsys, err := skillsSourceFS(cmd)
 		if err != nil {
 			return err
 		}
-		target, err := skillsTargetForCommand(cmd)
+		targets, err := skillsTargetsForCommand(cmd)
 		if err != nil {
 			return err
 		}
-		force, _ := cmd.Flags().GetBool("force")
+		options := skillsInstallOptions{}
+		options.force, _ = cmd.Flags().GetBool("force")
 		noRules, _ := cmd.Flags().GetBool("no-rules")
-		withHooks, _ := cmd.Flags().GetBool("with-hooks")
+		noWorkflows, _ := cmd.Flags().GetBool("no-workflows")
+		options.rules = !noRules
+		options.workflows = !noWorkflows
+		options.hooks, _ = cmd.Flags().GetBool("with-hooks")
 
-		if err := os.MkdirAll(target.Directory, 0o755); err != nil {
-			return fmt.Errorf("could not create %s: %w", target.Directory, err)
-		}
-
-		installed, skipped, err := skills.Install(fsys, target.Directory, args, force)
-		if err != nil {
-			return err
-		}
-
-		for _, name := range installed {
-			fmt.Printf("installed %s\n", name)
-		}
-		for _, name := range skipped {
-			fmt.Printf("skipped   %s (already exists; use --force to overwrite)\n", name)
-		}
-
-		if !noRules {
-			rulePath, err := installAgentRule(target)
-			if err != nil {
-				return fmt.Errorf("could not install the agent rule: %w", err)
+		for index, target := range targets {
+			if index > 0 {
+				fmt.Println()
 			}
-			fmt.Printf("rule      %s (always applied; makes Ankra the default for Kubernetes work)\n", rulePath)
-		}
-		if withHooks {
-			hookPath, err := installAgentHook(target)
-			if err != nil {
-				return fmt.Errorf("could not install the agent hook: %w", err)
+			if err := installForTarget(fsys, target, args, options); err != nil {
+				return err
 			}
-			fmt.Printf("hook      %s (kubectl/helm cluster mutations ask for confirmation)\n", hookPath)
 		}
-
-		fmt.Printf("\nInstalled %d skill(s) to %s (%s, skipped %d).\n",
-			len(installed), target.Directory, target.Scope, len(skipped))
-		fmt.Printf("Restart %s to load the skills.\n", target.EditorName)
+		fmt.Printf("\nRestart your assistant to load the skills. Ask it to \"use ankra-platform-principles\" to check.\n")
 		return nil
 	},
 }
@@ -176,60 +224,37 @@ var skillsUninstallCmd = &cobra.Command{
 	Short: "Remove installed Ankra skills",
 	Long: `Remove the named skills, or all Ankra skills when none are given.
 
-A full uninstall (no skill names) also removes the always-applied agent rule
-and the 'ankra skills guard' hook that install added for this editor and
-scope; uninstalling named skills leaves them in place.`,
+The client selection works as it does for install, except that --client auto
+(the default) resolves to the assistants that actually have Ankra skills
+installed, so a plain 'ankra skills uninstall' undoes a plain install.
+
+A full uninstall (no skill names) also removes the always-applied rule, the
+workflow commands, and the 'ankra skills guard' hook that install added for
+each client and scope; uninstalling named skills leaves them in place.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		target, err := skillsTargetForCommand(cmd)
+		targets, err := skillsUninstallTargets(cmd)
 		if err != nil {
 			return err
 		}
 		names := args
 		if len(names) == 0 {
-			fsys, err := skillsSourceFS(cmd)
-			if err != nil {
+			fsys, sourceError := skillsSourceFS(cmd)
+			if sourceError != nil {
+				return sourceError
+			}
+			names, sourceError = skills.Names(fsys)
+			if sourceError != nil {
+				return sourceError
+			}
+		}
+		for index, target := range targets {
+			if index > 0 {
+				fmt.Println()
+			}
+			if err := uninstallForTarget(target, names, len(args) == 0); err != nil {
 				return err
 			}
-			names, err = skills.Names(fsys)
-			if err != nil {
-				return err
-			}
 		}
-		// Validate every name before removing anything, so one bad argument
-		// (e.g. "." or "../x") cannot delete the skills directory or escape it.
-		for _, name := range names {
-			if err := validateSkillName(target.Directory, name); err != nil {
-				return err
-			}
-		}
-		removed := 0
-		for _, name := range names {
-			dest := filepath.Join(target.Directory, name)
-			if dirExists(dest) {
-				if err := os.RemoveAll(dest); err != nil {
-					return fmt.Errorf("could not remove %s: %w", dest, err)
-				}
-				fmt.Printf("removed %s\n", name)
-				removed++
-			}
-		}
-		if len(args) == 0 {
-			rulePath, found, err := removeAgentRule(target)
-			if err != nil {
-				return fmt.Errorf("could not remove the agent rule: %w", err)
-			}
-			if found {
-				fmt.Printf("removed rule %s\n", rulePath)
-			}
-			hookPath, found, err := removeAgentHook(target)
-			if err != nil {
-				return fmt.Errorf("could not remove the agent hook: %w", err)
-			}
-			if found {
-				fmt.Printf("removed hook %s\n", hookPath)
-			}
-		}
-		fmt.Printf("\nRemoved %d skill(s) from %s (%s).\n", removed, target.Directory, target.Scope)
 		return nil
 	},
 }
@@ -267,29 +292,170 @@ read-only commands and anything unparseable pass through unchanged.`,
 	},
 }
 
-// installAgentRule writes the always-applied rule for the target editor and
-// scope, returning the path of what was written. Cursor has no supported
+type skillsInstallOptions struct {
+	force     bool
+	rules     bool
+	workflows bool
+	hooks     bool
+}
+
+// installForTarget installs the selected skills and the client's supporting
+// artefacts (rule, skill index, workflow commands, guard hook) for one
+// target, reporting each step.
+func installForTarget(fsys fs.FS, target skills.Target, names []string, options skillsInstallOptions) error {
+	fmt.Printf("%s (%s) → %s\n", target.Client.DisplayName, target.Scope, skills.DisplayPath(target.SkillsDirectory))
+
+	if err := os.MkdirAll(target.SkillsDirectory, 0o755); err != nil {
+		return fmt.Errorf("could not create %s: %w", target.SkillsDirectory, err)
+	}
+
+	installed, skipped, err := installSkillPayload(fsys, target, names, options.force)
+	if err != nil {
+		return err
+	}
+	for _, name := range installed {
+		fmt.Printf("  skill     %s\n", name)
+	}
+	if len(skipped) > 0 {
+		fmt.Printf("  skipped   %s (already present; use --force to overwrite)\n", strings.Join(skipped, ", "))
+	}
+
+	if options.rules {
+		rulePath, ruleError := installAgentRule(target)
+		if ruleError != nil {
+			return fmt.Errorf("could not install the agent rule for %s: %w", target.Client.DisplayName, ruleError)
+		}
+		if rulePath != "" {
+			fmt.Printf("  rule      %s\n", skills.DisplayPath(rulePath))
+		}
+	}
+
+	if options.workflows {
+		written, workflowError := skills.WriteWorkflows(target)
+		if workflowError != nil {
+			return fmt.Errorf("could not install the workflow commands for %s: %w", target.Client.DisplayName, workflowError)
+		}
+		if len(written) > 0 {
+			fmt.Printf("  workflows %d in %s\n", len(written), skills.DisplayPath(target.CommandsDirectory))
+		}
+	}
+
+	if options.hooks {
+		if !target.SupportsHooks() {
+			fmt.Printf("  hook      not supported by %s; skipped\n", target.Client.DisplayName)
+		} else {
+			hookPath, hookError := installAgentHook(target)
+			if hookError != nil {
+				return fmt.Errorf("could not install the agent hook for %s: %w", target.Client.DisplayName, hookError)
+			}
+			fmt.Printf("  hook      %s (kubectl/helm cluster mutations ask for confirmation)\n", skills.DisplayPath(hookPath))
+		}
+	}
+
+	if target.Client.Note != "" {
+		fmt.Printf("  note      %s\n", target.Client.Note)
+	}
+	return nil
+}
+
+// installSkillPayload copies the skills into the target, as directories for
+// clients that read the filesystem and as uploadable bundles for those that
+// cannot.
+func installSkillPayload(fsys fs.FS, target skills.Target, names []string, force bool) (installed, skipped []string, err error) {
+	if target.Client.Packaged {
+		return skills.PackageBundles(fsys, target.SkillsDirectory, names, force)
+	}
+	return skills.Install(fsys, target.SkillsDirectory, names, force)
+}
+
+// uninstallForTarget removes the named skills from one target and, on a full
+// uninstall, the rule, workflow commands and hook install wrote for it.
+func uninstallForTarget(target skills.Target, names []string, full bool) error {
+	fmt.Printf("%s (%s) → %s\n", target.Client.DisplayName, target.Scope, skills.DisplayPath(target.SkillsDirectory))
+
+	for _, name := range names {
+		if err := validateSkillName(target.SkillsDirectory, name); err != nil {
+			return err
+		}
+	}
+	removed := 0
+	if target.Client.Packaged {
+		count, err := skills.RemoveBundles(target.SkillsDirectory, names)
+		if err != nil {
+			return err
+		}
+		removed = count
+	} else {
+		for _, name := range names {
+			destination := filepath.Join(target.SkillsDirectory, name)
+			if !dirExists(destination) {
+				continue
+			}
+			if err := os.RemoveAll(destination); err != nil {
+				return fmt.Errorf("could not remove %s: %w", destination, err)
+			}
+			removed++
+		}
+	}
+	fmt.Printf("  removed   %d skill(s)\n", removed)
+
+	if !full {
+		return nil
+	}
+	rulePath, found, err := removeAgentRule(target)
+	if err != nil {
+		return fmt.Errorf("could not remove the agent rule: %w", err)
+	}
+	if found {
+		fmt.Printf("  rule      removed %s\n", skills.DisplayPath(rulePath))
+	}
+	workflowCount, err := skills.RemoveWorkflows(target)
+	if err != nil {
+		return fmt.Errorf("could not remove the workflow commands: %w", err)
+	}
+	if workflowCount > 0 {
+		fmt.Printf("  workflows removed %d from %s\n", workflowCount, skills.DisplayPath(target.CommandsDirectory))
+	}
+	hookPath, found, err := removeAgentHook(target)
+	if err != nil {
+		return fmt.Errorf("could not remove the agent hook: %w", err)
+	}
+	if found {
+		fmt.Printf("  hook      removed from %s\n", skills.DisplayPath(hookPath))
+	}
+	return nil
+}
+
+// installAgentRule writes the always-applied rule for a target, returning the
+// path written (empty when the client takes no rule). Cursor has no supported
 // user-level rules directory, so personal scope installs a local plugin
-// (~/.cursor/plugins/local/ankra) whose rules apply to every project.
-func installAgentRule(target skillsTarget) (string, error) {
-	switch target.Editor.GuardFormat {
+// (~/.cursor/plugins/local/ankra) whose rules apply to every project. Every
+// other client takes a managed block in its instructions file, which also
+// carries the index of installed skills.
+func installAgentRule(target skills.Target) (string, error) {
+	switch target.Client.RuleFormat {
 	case "cursor":
-		if target.Scope == "personal" {
+		if target.Scope == skills.ScopePersonal {
 			return skills.WriteCursorPlugin(cursorPluginDir(target), version)
 		}
 		return skills.WriteCursorRule(filepath.Join(target.Root, ".cursor", "rules"))
+	case "block":
+		if target.InstructionsPath == "" {
+			return "", nil
+		}
+		block := skills.InstructionsBlock(target, installedSkillsIn(target))
+		return target.InstructionsPath, skills.UpsertManagedBlock(target.InstructionsPath, block)
 	default:
-		path := claudeMemoryPath(target)
-		return path, skills.UpsertClaudeRule(path)
+		return "", nil
 	}
 }
 
 // removeAgentRule undoes installAgentRule, reporting whether anything was
 // found to remove.
-func removeAgentRule(target skillsTarget) (string, bool, error) {
-	switch target.Editor.GuardFormat {
+func removeAgentRule(target skills.Target) (string, bool, error) {
+	switch target.Client.RuleFormat {
 	case "cursor":
-		if target.Scope == "personal" {
+		if target.Scope == skills.ScopePersonal {
 			dir := cursorPluginDir(target)
 			found, err := skills.RemoveCursorPlugin(dir)
 			return dir, found, err
@@ -297,66 +463,111 @@ func removeAgentRule(target skillsTarget) (string, bool, error) {
 		rulesDir := filepath.Join(target.Root, ".cursor", "rules")
 		found, err := skills.RemoveCursorRule(rulesDir)
 		return filepath.Join(rulesDir, skills.CursorRuleFilename), found, err
+	case "block":
+		if target.InstructionsPath == "" {
+			return "", false, nil
+		}
+		found, err := skills.RemoveManagedBlock(target.InstructionsPath)
+		return target.InstructionsPath, found, err
 	default:
-		path := claudeMemoryPath(target)
-		found, err := skills.RemoveClaudeRule(path)
-		return path, found, err
+		return "", false, nil
 	}
 }
 
-// installAgentHook wires the guard into the editor's hook config for the
+// installAgentHook wires the guard into the client's hook config for the
 // target scope, returning the config path it wrote.
-func installAgentHook(target skillsTarget) (string, error) {
-	path := hookConfigPath(target)
-	guardCommand := skills.GuardCommandLine(currentExecutable(), target.Editor.GuardFormat)
-	if target.Editor.GuardFormat == "cursor" {
-		return path, skills.UpsertCursorHook(path, guardCommand)
+func installAgentHook(target skills.Target) (string, error) {
+	guardCommand := skills.GuardCommandLine(currentExecutable(), target.Client.HookFormat)
+	if target.Client.HookFormat == "cursor" {
+		return target.HooksPath, skills.UpsertCursorHook(target.HooksPath, guardCommand)
 	}
-	return path, skills.UpsertClaudeHook(path, guardCommand)
+	return target.HooksPath, skills.UpsertClaudeHook(target.HooksPath, guardCommand)
 }
 
 // removeAgentHook undoes installAgentHook, reporting whether a guard entry
 // was found.
-func removeAgentHook(target skillsTarget) (string, bool, error) {
-	path := hookConfigPath(target)
-	if target.Editor.GuardFormat == "cursor" {
-		found, err := skills.RemoveCursorHook(path)
-		return path, found, err
+func removeAgentHook(target skills.Target) (string, bool, error) {
+	if !target.SupportsHooks() {
+		return "", false, nil
 	}
-	found, err := skills.RemoveClaudeHook(path)
-	return path, found, err
-}
-
-func cursorPluginDir(target skillsTarget) string {
-	return filepath.Join(target.Root, ".cursor", "plugins", "local", skills.CursorPluginName)
-}
-
-// claudeMemoryPath returns the CLAUDE.md Claude Code actually loads for the
-// scope: ~/.claude/CLAUDE.md for personal, <project>/CLAUDE.md for projects.
-func claudeMemoryPath(target skillsTarget) string {
-	if target.Scope == "personal" {
-		return filepath.Join(target.Root, ".claude", "CLAUDE.md")
+	if target.Client.HookFormat == "cursor" {
+		found, err := skills.RemoveCursorHook(target.HooksPath)
+		return target.HooksPath, found, err
 	}
-	return filepath.Join(target.Root, "CLAUDE.md")
-}
-
-// hookConfigPath returns the hook config file for the target: Cursor's
-// hooks.json or Claude Code's settings.json, at the matching scope.
-func hookConfigPath(target skillsTarget) string {
-	if target.Editor.GuardFormat == "cursor" {
-		return filepath.Join(target.Root, ".cursor", "hooks.json")
-	}
-	return filepath.Join(target.Root, ".claude", "settings.json")
+	found, err := skills.RemoveClaudeHook(target.HooksPath)
+	return target.HooksPath, found, err
 }
 
 // currentExecutable resolves the running binary so hook configs keep working
 // regardless of PATH; the install path is stable across 'ankra upgrade'.
 func currentExecutable() string {
-	exe, err := os.Executable()
-	if err != nil || exe == "" {
+	executable, err := os.Executable()
+	if err != nil || executable == "" {
 		return "ankra"
 	}
-	return exe
+	return executable
+}
+
+func cursorPluginDir(target skills.Target) string {
+	return filepath.Join(target.Root, ".cursor", "plugins", "local", skills.CursorPluginName)
+}
+
+// installedSkillsIn reads back what is actually present in a target's skills
+// directory, so the managed index names the skills the agent can really open
+// rather than everything the binary carries.
+func installedSkillsIn(target skills.Target) []skills.Skill {
+	if target.Client.Packaged {
+		return nil
+	}
+	list, err := skills.List(os.DirFS(target.SkillsDirectory))
+	if err != nil {
+		return nil
+	}
+	return list
+}
+
+// skillsDirectoryHasAnkraSkills reports whether a target already carries an
+// Ankra install, for the [installed] marker in 'skills clients'.
+func skillsDirectoryHasAnkraSkills(target skills.Target) bool {
+	if target.Client.Packaged {
+		entries, err := os.ReadDir(target.SkillsDirectory)
+		if err != nil {
+			return false
+		}
+		for _, entry := range entries {
+			if strings.HasPrefix(entry.Name(), "ankra-") && strings.HasSuffix(entry.Name(), ".zip") {
+				return true
+			}
+		}
+		return false
+	}
+	return len(installedSkillsIn(target)) > 0
+}
+
+func skillInstalledInAnyTarget(targets []skills.Target, name string) bool {
+	for _, target := range targets {
+		if target.Client.Packaged {
+			if _, err := os.Stat(filepath.Join(target.SkillsDirectory, name+".zip")); err == nil {
+				return true
+			}
+			continue
+		}
+		if dirExists(filepath.Join(target.SkillsDirectory, name)) {
+			return true
+		}
+	}
+	return false
+}
+
+func clientDelivery(client skills.Client) string {
+	switch {
+	case client.Packaged:
+		return "uploadable bundles"
+	case client.LoadsSkillsNatively:
+		return "native skills directory"
+	default:
+		return "skills directory + indexed instructions"
+	}
 }
 
 // validateSkillName rejects skill arguments that would resolve outside dir
@@ -385,72 +596,102 @@ func skillsSourceFS(cmd *cobra.Command) (fs.FS, error) {
 	return skills.EmbeddedFS()
 }
 
-// skillsTargetDir resolves the install directory and a human-readable scope.
-func skillsTargetDir(cmd *cobra.Command) (string, string, error) {
-	target, err := skillsTargetForCommand(cmd)
-	if err != nil {
-		return "", "", err
-	}
-	return target.Directory, target.Scope, nil
-}
-
-func skillsTargetForCommand(cmd *cobra.Command) (skillsTarget, error) {
-	editor, err := skillsEditorForCommand(cmd)
-	if err != nil {
-		return skillsTarget{}, err
-	}
+// skillsScope resolves the install scope and its root directory: the project
+// directory when --project is given, the home directory otherwise.
+func skillsScope(cmd *cobra.Command) (scope, root string, err error) {
 	projectFlag := cmd.Flags().Lookup("project")
 	if projectFlag != nil && projectFlag.Changed {
-		dir := projectFlag.Value.String()
-		if dir == "" {
-			dir = "."
+		directory := projectFlag.Value.String()
+		if directory == "" {
+			directory = "."
 		}
-		return skillsTarget{
-			Directory:  filepath.Join(dir, editor.ConfigurationDirectory, "skills"),
-			Scope:      "project",
-			EditorName: editor.Name,
-			Root:       dir,
-			Editor:     editor,
-		}, nil
+		return skills.ScopeProject, directory, nil
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return skillsTarget{}, fmt.Errorf("could not determine home directory: %w", err)
+		return "", "", fmt.Errorf("could not determine home directory: %w", err)
 	}
-	return skillsTarget{
-		Directory:  filepath.Join(home, editor.ConfigurationDirectory, "skills"),
-		Scope:      "personal",
-		EditorName: editor.Name,
-		Root:       home,
-		Editor:     editor,
-	}, nil
+	return skills.ScopePersonal, home, nil
 }
 
-func skillsEditorForCommand(cmd *cobra.Command) (skillsEditor, error) {
-	editor, _ := cmd.Flags().GetString("editor")
-	switch strings.ToLower(strings.TrimSpace(editor)) {
-	case "", "cursor":
-		return skillsEditor{Name: "Cursor", ConfigurationDirectory: ".cursor", GuardFormat: "cursor"}, nil
-	case "claude", "claude-code", "claudecode":
-		return skillsEditor{Name: "Claude Code", ConfigurationDirectory: ".claude", GuardFormat: "claude"}, nil
-	default:
-		return skillsEditor{}, fmt.Errorf("unsupported editor %q (expected cursor or claude-code)", editor)
+// skillsTargetsForCommand resolves --client (and the deprecated --editor)
+// into the install targets for the current scope.
+func skillsTargetsForCommand(cmd *cobra.Command) ([]skills.Target, error) {
+	scope, root, err := skillsScope(cmd)
+	if err != nil {
+		return nil, err
 	}
+	selected, err := skills.ResolveClients(skillsRequestedClients(cmd), root, scope)
+	if err != nil {
+		return nil, withExitCode(exitUsage, err)
+	}
+	targets := make([]skills.Target, 0, len(selected))
+	for _, client := range selected {
+		target, targetError := skills.ResolveTarget(client, scope, root)
+		if targetError != nil {
+			return nil, targetError
+		}
+		targets = append(targets, target)
+	}
+	return targets, nil
+}
+
+// skillsUninstallTargets resolves the uninstall targets. With no explicit
+// --client, it narrows the detected set to the clients that actually carry an
+// Ankra install, so a plain uninstall undoes a plain install and does not
+// report on assistants that never had the skills.
+func skillsUninstallTargets(cmd *cobra.Command) ([]skills.Target, error) {
+	targets, err := skillsTargetsForCommand(cmd)
+	if err != nil {
+		return nil, err
+	}
+	if len(skillsRequestedClients(cmd)) > 0 {
+		return targets, nil
+	}
+	withInstall := make([]skills.Target, 0, len(targets))
+	for _, target := range targets {
+		if skillsDirectoryHasAnkraSkills(target) {
+			withInstall = append(withInstall, target)
+		}
+	}
+	if len(withInstall) == 0 {
+		return targets, nil
+	}
+	return withInstall, nil
+}
+
+// skillsRequestedClients merges --client with the deprecated --editor alias.
+func skillsRequestedClients(cmd *cobra.Command) []string {
+	requested, _ := cmd.Flags().GetStringArray("client")
+	editorFlag := cmd.Flags().Lookup("editor")
+	if editorFlag != nil && editorFlag.Changed {
+		requested = append(requested, editorFlag.Value.String())
+	}
+	return requested
 }
 
 func init() {
-	for _, c := range []*cobra.Command{skillsListCmd, skillsInstallCmd, skillsUninstallCmd} {
-		c.Flags().Bool("personal", false, "install into the selected editor's personal skills directory (default)")
-		c.Flags().String("project", "", "install into <DIR>/<editor config>/skills (use \".\" for the current directory)")
-		c.Flags().String("editor", "cursor", "skills app to target: cursor or claude-code")
-		c.Flags().String("source", "", "read skills from a local directory instead of the embedded copy")
+	for _, command := range []*cobra.Command{skillsListCmd, skillsInstallCmd, skillsUninstallCmd, skillsClientsCmd} {
+		command.Flags().String("project", "", "install into <DIR> instead of your home directory (use \".\" for the current directory)")
+		command.Flags().StringArray("client", nil,
+			"assistant to target, repeatable or comma-separated: "+strings.Join(skills.ClientIDs(), ", ")+
+				", plus \"all\" and \"auto\" (default: the assistants configured here)")
+		command.Flags().String("editor", "", "deprecated alias for --client")
+		_ = command.Flags().MarkDeprecated("editor", "use --client instead")
+		command.Flags().Bool("personal", false, "install for your user (default)")
+		_ = command.Flags().MarkDeprecated("personal", "personal scope is the default; use --project for a repository install")
+	}
+	for _, command := range []*cobra.Command{skillsListCmd, skillsInstallCmd, skillsUninstallCmd} {
+		command.Flags().String("source", "", "read skills from a local directory instead of the embedded copy")
 	}
 	skillsInstallCmd.Flags().Bool("force", false, "overwrite existing skills without prompting")
-	skillsInstallCmd.Flags().Bool("no-rules", false, "skip installing the always-applied agent rule")
+	skillsInstallCmd.Flags().Bool("no-rules", false, "skip the always-applied agent rule and skill index")
+	skillsInstallCmd.Flags().Bool("no-workflows", false, "skip the Ankra workflow commands")
 	skillsInstallCmd.Flags().Bool("with-hooks", false, "also install the agent hook that gates direct kubectl/helm cluster mutations")
 	skillsGuardCmd.Flags().String("format", "cursor", "hook event format: cursor or claude")
-	registerStructuredOutputFlags(skillsListCmd)
+	registerStructuredOutputFlags(skillsListCmd, skillsClientsCmd)
 
+	skillsCmd.AddCommand(skillsClientsCmd)
 	skillsCmd.AddCommand(skillsListCmd)
 	skillsCmd.AddCommand(skillsInstallCmd)
 	skillsCmd.AddCommand(skillsUninstallCmd)

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -206,11 +206,16 @@ mutations and asks for confirmation.`,
 		options.workflows = !noWorkflows
 		options.hooks, _ = cmd.Flags().GetBool("with-hooks")
 
+		// Several assistants share the client-neutral library, so the same
+		// directory can be the target twice in one run. Copying it again would
+		// report every skill as "already present, use --force", which is both
+		// noise and wrong advice.
+		writtenDirectories := make(map[string]string)
 		for index, target := range targets {
 			if index > 0 {
 				fmt.Println()
 			}
-			if err := installForTarget(fsys, target, args, options); err != nil {
+			if err := installForTarget(fsys, target, args, options, writtenDirectories); err != nil {
 				return err
 			}
 		}
@@ -302,22 +307,27 @@ type skillsInstallOptions struct {
 // installForTarget installs the selected skills and the client's supporting
 // artefacts (rule, skill index, workflow commands, guard hook) for one
 // target, reporting each step.
-func installForTarget(fsys fs.FS, target skills.Target, names []string, options skillsInstallOptions) error {
+func installForTarget(fsys fs.FS, target skills.Target, names []string, options skillsInstallOptions, writtenDirectories map[string]string) error {
 	fmt.Printf("%s (%s) → %s\n", target.Client.DisplayName, target.Scope, skills.DisplayPath(target.SkillsDirectory))
 
 	if err := os.MkdirAll(target.SkillsDirectory, 0o755); err != nil {
 		return fmt.Errorf("could not create %s: %w", target.SkillsDirectory, err)
 	}
 
-	installed, skipped, err := installSkillPayload(fsys, target, names, options.force)
-	if err != nil {
-		return err
-	}
-	for _, name := range installed {
-		fmt.Printf("  skill     %s\n", name)
-	}
-	if len(skipped) > 0 {
-		fmt.Printf("  skipped   %s (already present; use --force to overwrite)\n", strings.Join(skipped, ", "))
+	if owner, shared := writtenDirectories[target.SkillsDirectory]; shared {
+		fmt.Printf("  skills    already written here for %s\n", owner)
+	} else {
+		installed, skipped, err := installSkillPayload(fsys, target, names, options.force)
+		if err != nil {
+			return err
+		}
+		for _, name := range installed {
+			fmt.Printf("  skill     %s\n", name)
+		}
+		if len(skipped) > 0 {
+			fmt.Printf("  skipped   %s (already present; use --force to overwrite)\n", strings.Join(skipped, ", "))
+		}
+		writtenDirectories[target.SkillsDirectory] = target.Client.DisplayName
 	}
 
 	if options.rules {

--- a/cmd/skills_commands_test.go
+++ b/cmd/skills_commands_test.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"io/fs"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"ankra/internal/skills"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// A skill that documents a command the CLI does not have is worse than one
+// that documents nothing: the agent runs it and the user gets an error with
+// no idea the guidance was wrong. Two shipped skills accumulated thirteen of
+// these - provider verbs that moved to the generic group, flags that were
+// renamed, a --wait that never existed - and review did not catch any of
+// them, because every line looked plausible. This test resolves every `ankra
+// ...` invocation in the embedded skills against the real command tree, so
+// the next rename fails here instead of in someone's terminal.
+
+// commandNode is one command in the tree, with the flags it accepts.
+type commandNode struct {
+	children map[string]*commandNode
+	flags    map[string]bool
+	// runnable is true when the command does work itself, so a trailing word
+	// may be a positional argument rather than a bad subcommand.
+	runnable bool
+}
+
+func buildCommandTree(command *cobra.Command) *commandNode {
+	node := &commandNode{
+		children: make(map[string]*commandNode),
+		flags:    make(map[string]bool),
+		runnable: command.Runnable(),
+	}
+	// Cobra registers the help flag lazily, so a command that has never run
+	// reports none. It is valid on every command.
+	node.flags["help"] = true
+	collect := func(flag *pflag.Flag) { node.flags[flag.Name] = true }
+	command.LocalFlags().VisitAll(collect)
+	command.InheritedFlags().VisitAll(collect)
+	command.PersistentFlags().VisitAll(collect)
+	for _, child := range command.Commands() {
+		if child.Hidden || child.Name() == "help" {
+			continue
+		}
+		childNode := buildCommandTree(child)
+		node.children[child.Name()] = childNode
+		for _, alias := range child.Aliases {
+			node.children[alias] = childNode
+		}
+	}
+	return node
+}
+
+// documentedCommand is one `ankra ...` line found in a skill.
+type documentedCommand struct {
+	file string
+	line int
+	text string
+}
+
+var (
+	inlineCommandPattern = regexp.MustCompile("`(ankra [^`]+)`")
+	continuationPattern  = regexp.MustCompile(`\\\n\s*`)
+	flagPattern          = regexp.MustCompile(`(?:^|[\s=])--([a-z0-9][a-z0-9-]*)`)
+	// placeholderPattern marks an invocation as illustrative rather than
+	// literal: "..." elisions, "a|b" alternations, and shell/YAML fragments.
+	placeholderPattern = regexp.MustCompile(`\.\.\.|\||\$\{|^\s*ankra\s*=`)
+)
+
+// collectDocumentedCommands reads every embedded skill and returns the ankra
+// invocations in it, with backslash continuations joined.
+func collectDocumentedCommands(t *testing.T) []documentedCommand {
+	t.Helper()
+	fsys, err := skills.EmbeddedFS()
+	if err != nil {
+		t.Fatalf("EmbeddedFS: %v", err)
+	}
+	var found []documentedCommand
+	walkError := fs.WalkDir(fsys, ".", func(path string, entry fs.DirEntry, err error) error {
+		if err != nil || entry.IsDir() || filepath.Ext(path) != ".md" {
+			return err
+		}
+		data, readError := fs.ReadFile(fsys, path)
+		if readError != nil {
+			return readError
+		}
+		joined := continuationPattern.ReplaceAllString(string(data), " ")
+		for number, line := range strings.Split(joined, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "ankra ") {
+				found = append(found, documentedCommand{path, number + 1, stripComment(trimmed)})
+				continue
+			}
+			for _, match := range inlineCommandPattern.FindAllStringSubmatch(trimmed, -1) {
+				found = append(found, documentedCommand{path, number + 1, match[1]})
+			}
+		}
+		return nil
+	})
+	if walkError != nil {
+		t.Fatalf("walking the embedded skills: %v", walkError)
+	}
+	return found
+}
+
+func stripComment(line string) string {
+	if index := strings.Index(line, " #"); index > 0 {
+		return strings.TrimSpace(line[:index])
+	}
+	return line
+}
+
+// argumentPattern matches a token that is clearly a positional argument or a
+// value rather than a subcommand name.
+var argumentPattern = regexp.MustCompile(`^[<"'{/.$-]|^[A-Z]|[/.=]|^\d`)
+
+// resolveChain walks the tokens as far as they name real subcommands and
+// returns the node reached, the chain consumed, and the first token that was
+// not a subcommand.
+func resolveChain(root *commandNode, tokens []string) (*commandNode, []string, string) {
+	node := root
+	var chain []string
+	for _, token := range tokens {
+		if strings.HasPrefix(token, "-") {
+			break
+		}
+		child, known := node.children[token]
+		if !known {
+			return node, chain, token
+		}
+		node = child
+		chain = append(chain, token)
+	}
+	return node, chain, ""
+}
+
+func TestSkillsDocumentOnlyRealCommands(t *testing.T) {
+	root := buildCommandTree(rootCmd)
+	documented := collectDocumentedCommands(t)
+	if len(documented) < 100 {
+		t.Fatalf("only found %d documented commands; the extractor is broken", len(documented))
+	}
+
+	checked := 0
+	for _, entry := range documented {
+		if placeholderPattern.MatchString(entry.text) {
+			continue
+		}
+		tokens := strings.Fields(entry.text)
+		if len(tokens) < 2 || tokens[0] != "ankra" {
+			continue
+		}
+		node, chain, unresolved := resolveChain(root, tokens[1:])
+		if len(chain) == 0 {
+			// A bare `ankra --version` or similar; nothing to verify.
+			continue
+		}
+		checked++
+
+		// An unresolved word under a command group that cannot run on its own
+		// has to be a subcommand, and it is not one.
+		if unresolved != "" && !node.runnable && !argumentPattern.MatchString(unresolved) {
+			t.Errorf("%s:%d: %q is not a subcommand of `ankra %s`\n    %s",
+				entry.file, entry.line, unresolved, strings.Join(chain, " "), entry.text)
+			continue
+		}
+
+		for _, match := range flagPattern.FindAllStringSubmatch(entry.text, -1) {
+			flag := match[1]
+			if !node.flags[flag] {
+				t.Errorf("%s:%d: `ankra %s` has no --%s flag\n    %s",
+					entry.file, entry.line, strings.Join(chain, " "), flag, entry.text)
+			}
+		}
+	}
+	t.Logf("verified %d of %d documented ankra invocations against the command tree",
+		checked, len(documented))
+}

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"archive/zip"
 	"bytes"
 	"encoding/json"
 	"os"
@@ -17,7 +18,8 @@ func newSkillsTestCmd() *cobra.Command {
 	c := &cobra.Command{Use: "x", Run: func(*cobra.Command, []string) {}}
 	c.Flags().Bool("personal", false, "")
 	c.Flags().String("project", "", "")
-	c.Flags().String("editor", "cursor", "")
+	c.Flags().StringArray("client", nil, "")
+	c.Flags().String("editor", "", "")
 	c.Flags().String("source", "", "")
 	return c
 }
@@ -27,96 +29,147 @@ func newSkillsInstallTestCmd() *cobra.Command {
 	c := newSkillsTestCmd()
 	c.Flags().Bool("force", false, "")
 	c.Flags().Bool("no-rules", false, "")
+	c.Flags().Bool("no-workflows", false, "")
 	c.Flags().Bool("with-hooks", false, "")
 	return c
 }
 
-func TestSkillsTargetDirPersonalDefault(t *testing.T) {
-	dir, scope, err := skillsTargetDir(newSkillsTestCmd())
+// skillsTestCmdFor builds a command already scoped to a project and client.
+func skillsTestCmdFor(t *testing.T, base *cobra.Command, project, client string) *cobra.Command {
+	t.Helper()
+	if project != "" {
+		if err := base.Flags().Set("project", project); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if client != "" {
+		if err := base.Flags().Set("client", client); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return base
+}
+
+func targetFor(t *testing.T, project, client string) skills.Target {
+	t.Helper()
+	targets, err := skillsTargetsForCommand(skillsTestCmdFor(t, newSkillsTestCmd(), project, client))
+	if err != nil {
+		t.Fatalf("skillsTargetsForCommand(%s): %v", client, err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected exactly one target for %s, got %d", client, len(targets))
+	}
+	return targets[0]
+}
+
+func TestSkillsTargetPersonalDefaultsToDetectedClients(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	targets, err := skillsTargetsForCommand(newSkillsTestCmd())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if scope != "personal" {
-		t.Fatalf("expected personal scope, got %q", scope)
+	if len(targets) != 1 || targets[0].Client.ID != "claude-code" {
+		t.Fatalf("expected the detected claude-code target, got %+v", targets)
 	}
-	if filepath.Base(dir) != "skills" || filepath.Base(filepath.Dir(dir)) != ".cursor" {
-		t.Fatalf("unexpected personal dir: %s", dir)
+	if targets[0].Scope != skills.ScopePersonal {
+		t.Fatalf("expected personal scope, got %q", targets[0].Scope)
+	}
+	want := filepath.Join(home, ".claude", "skills")
+	if targets[0].SkillsDirectory != want {
+		t.Fatalf("got %s want %s", targets[0].SkillsDirectory, want)
 	}
 }
 
-func TestSkillsTargetDirProject(t *testing.T) {
-	c := newSkillsTestCmd()
-	if err := c.Flags().Set("project", "/tmp/foo"); err != nil {
-		t.Fatal(err)
-	}
-	dir, scope, err := skillsTargetDir(c)
+func TestSkillsTargetPersonalFallsBackWhenNothingDetected(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	targets, err := skillsTargetsForCommand(newSkillsTestCmd())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if scope != "project" {
-		t.Fatalf("expected project scope, got %q", scope)
+	got := make([]string, 0, len(targets))
+	for _, target := range targets {
+		got = append(got, target.Client.ID)
 	}
-	want := filepath.Join("/tmp/foo", ".cursor", "skills")
-	if dir != want {
-		t.Fatalf("got %s want %s", dir, want)
+	if strings.Join(got, ",") != "claude-code,cursor" {
+		t.Fatalf("expected the claude-code+cursor fallback, got %v", got)
 	}
 }
 
-func TestSkillsTargetDirClaudeCodePersonal(t *testing.T) {
+func TestSkillsTargetProjectPaths(t *testing.T) {
+	project := t.TempDir()
+	for _, testCase := range []struct {
+		client string
+		want   string
+	}{
+		{"cursor", filepath.Join(project, ".cursor", "skills")},
+		{"claude-code", filepath.Join(project, ".claude", "skills")},
+		{"claude", filepath.Join(project, ".claude", "skills")},
+		{"codex", filepath.Join(project, ".ankra", "skills")},
+		{"copilot", filepath.Join(project, ".ankra", "skills")},
+		{"gemini", filepath.Join(project, ".ankra", "skills")},
+	} {
+		t.Run(testCase.client, func(t *testing.T) {
+			target := targetFor(t, project, testCase.client)
+			if target.Scope != skills.ScopeProject {
+				t.Fatalf("expected project scope, got %q", target.Scope)
+			}
+			if target.SkillsDirectory != testCase.want {
+				t.Fatalf("got %s want %s", target.SkillsDirectory, testCase.want)
+			}
+		})
+	}
+}
+
+func TestSkillsTargetRejectsUnknownClient(t *testing.T) {
+	c := skillsTestCmdFor(t, newSkillsTestCmd(), t.TempDir(), "emacs-doctor")
+	_, err := skillsTargetsForCommand(c)
+	if err == nil {
+		t.Fatal("expected unsupported client error")
+	}
+	if code := exitCodeFor(err); code != exitUsage {
+		t.Fatalf("exit code %d, want %d (err: %v)", code, exitUsage, err)
+	}
+}
+
+func TestSkillsTargetAllSelectsEveryClient(t *testing.T) {
+	targets, err := skillsTargetsForCommand(skillsTestCmdFor(t, newSkillsTestCmd(), t.TempDir(), "all"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != len(skills.Clients()) {
+		t.Fatalf("--client all resolved %d of %d clients", len(targets), len(skills.Clients()))
+	}
+}
+
+// The deprecated --editor flag keeps working as an alias for --client.
+func TestSkillsEditorFlagStillSelectsAClient(t *testing.T) {
+	project := t.TempDir()
 	c := newSkillsTestCmd()
+	if err := c.Flags().Set("project", project); err != nil {
+		t.Fatal(err)
+	}
 	if err := c.Flags().Set("editor", "claude-code"); err != nil {
 		t.Fatal(err)
 	}
-	dir, scope, err := skillsTargetDir(c)
+	targets, err := skillsTargetsForCommand(c)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if scope != "personal" {
-		t.Fatalf("expected personal scope, got %q", scope)
-	}
-	if filepath.Base(dir) != "skills" || filepath.Base(filepath.Dir(dir)) != ".claude" {
-		t.Fatalf("unexpected claude code personal dir: %s", dir)
+	if len(targets) != 1 || targets[0].Client.ID != "claude-code" {
+		t.Fatalf("--editor claude-code resolved to %+v", targets)
 	}
 }
 
-func TestSkillsTargetDirClaudeCodeProject(t *testing.T) {
-	c := newSkillsTestCmd()
-	if err := c.Flags().Set("editor", "claude"); err != nil {
-		t.Fatal(err)
+func TestSkillsInstallCommandHasClientFlag(t *testing.T) {
+	if skillsInstallCmd.Flags().Lookup("client") == nil {
+		t.Fatal("expected client flag on skills install command")
 	}
-	if err := c.Flags().Set("project", "/tmp/foo"); err != nil {
-		t.Fatal(err)
-	}
-	dir, scope, err := skillsTargetDir(c)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if scope != "project" {
-		t.Fatalf("expected project scope, got %q", scope)
-	}
-	want := filepath.Join("/tmp/foo", ".claude", "skills")
-	if dir != want {
-		t.Fatalf("got %s want %s", dir, want)
-	}
-}
-
-func TestSkillsTargetDirInvalidEditor(t *testing.T) {
-	c := newSkillsTestCmd()
-	if err := c.Flags().Set("editor", "zed"); err != nil {
-		t.Fatal(err)
-	}
-	if _, _, err := skillsTargetDir(c); err == nil {
-		t.Fatal("expected unsupported editor error")
-	}
-}
-
-func TestSkillsInstallCommandHasEditorFlag(t *testing.T) {
-	flag := skillsInstallCmd.Flags().Lookup("editor")
-	if flag == nil {
-		t.Fatal("expected editor flag on skills install command")
-	}
-	if flag.DefValue != "cursor" {
-		t.Fatalf("expected cursor default, got %q", flag.DefValue)
+	if skillsInstallCmd.Flags().Lookup("editor") == nil {
+		t.Fatal("the deprecated editor alias should still be accepted")
 	}
 }
 
@@ -133,6 +186,9 @@ func TestSkillsSourceFSDefaultsToEmbedded(t *testing.T) {
 func TestSkillsCommandIsAuthFree(t *testing.T) {
 	if commandRequiresAuth(skillsListCmd) {
 		t.Error("ankra skills should not require auth")
+	}
+	if commandRequiresAuth(skillsClientsCmd) {
+		t.Error("ankra skills clients should not require auth")
 	}
 }
 
@@ -152,10 +208,12 @@ func seedInstalledSkill(t *testing.T, project, name string) string {
 
 func runSkillsUninstall(t *testing.T, project string, args []string) error {
 	t.Helper()
-	c := newSkillsTestCmd()
-	if err := c.Flags().Set("project", project); err != nil {
-		t.Fatal(err)
-	}
+	return runSkillsUninstallForClient(t, project, "cursor", args)
+}
+
+func runSkillsUninstallForClient(t *testing.T, project, client string, args []string) error {
+	t.Helper()
+	c := skillsTestCmdFor(t, newSkillsTestCmd(), project, client)
 	var err error
 	captureStdout(t, func() {
 		err = skillsUninstallCmd.RunE(c, args)
@@ -223,15 +281,9 @@ func TestSkillsUninstallRemovesNamedSkill(t *testing.T) {
 	}
 }
 
-func runSkillsInstall(t *testing.T, project, editor string, withHooks bool, args []string) error {
+func runSkillsInstall(t *testing.T, project, client string, withHooks bool, args []string) error {
 	t.Helper()
-	c := newSkillsInstallTestCmd()
-	if err := c.Flags().Set("project", project); err != nil {
-		t.Fatal(err)
-	}
-	if err := c.Flags().Set("editor", editor); err != nil {
-		t.Fatal(err)
-	}
+	c := skillsTestCmdFor(t, newSkillsInstallTestCmd(), project, client)
 	if withHooks {
 		if err := c.Flags().Set("with-hooks", "true"); err != nil {
 			t.Fatal(err)
@@ -244,25 +296,10 @@ func runSkillsInstall(t *testing.T, project, editor string, withHooks bool, args
 	return err
 }
 
-func runSkillsUninstallForEditor(t *testing.T, project, editor string, args []string) error {
-	t.Helper()
-	c := newSkillsTestCmd()
-	if err := c.Flags().Set("project", project); err != nil {
-		t.Fatal(err)
-	}
-	if err := c.Flags().Set("editor", editor); err != nil {
-		t.Fatal(err)
-	}
-	var err error
-	captureStdout(t, func() {
-		err = skillsUninstallCmd.RunE(c, args)
-	})
-	return err
-}
-
 // The full install/uninstall cycle for a Cursor project: skills, the
-// always-applied rule, and the guard hook all appear and disappear together.
-func TestSkillsInstallCursorProjectWritesRuleAndHook(t *testing.T) {
+// always-applied rule, the workflow commands, and the guard hook all appear
+// and disappear together.
+func TestSkillsInstallCursorProjectWritesRuleWorkflowsAndHook(t *testing.T) {
 	project := t.TempDir()
 	if err := runSkillsInstall(t, project, "cursor", true, nil); err != nil {
 		t.Fatalf("install: %v", err)
@@ -279,6 +316,10 @@ func TestSkillsInstallCursorProjectWritesRuleAndHook(t *testing.T) {
 	if !strings.Contains(string(rule), "alwaysApply: true") {
 		t.Error("rule is not always-applied")
 	}
+	workflowPath := filepath.Join(project, ".cursor", "commands", "ankra-ship-service.md")
+	if _, err := os.Stat(workflowPath); err != nil {
+		t.Errorf("workflow command not written: %v", err)
+	}
 	hooksPath := filepath.Join(project, ".cursor", "hooks.json")
 	hooksData, err := os.ReadFile(hooksPath)
 	if err != nil {
@@ -288,7 +329,7 @@ func TestSkillsInstallCursorProjectWritesRuleAndHook(t *testing.T) {
 		t.Errorf("guard not wired: %s", hooksData)
 	}
 
-	if err := runSkillsUninstallForEditor(t, project, "cursor", nil); err != nil {
+	if err := runSkillsUninstallForClient(t, project, "cursor", nil); err != nil {
 		t.Fatalf("uninstall: %v", err)
 	}
 	if dirExists(filepath.Join(project, ".cursor", "skills", "ankra-cli")) {
@@ -296,6 +337,9 @@ func TestSkillsInstallCursorProjectWritesRuleAndHook(t *testing.T) {
 	}
 	if _, err := os.Stat(rulePath); !os.IsNotExist(err) {
 		t.Error("rule not removed")
+	}
+	if _, err := os.Stat(workflowPath); !os.IsNotExist(err) {
+		t.Error("workflow command not removed")
 	}
 	if _, err := os.Stat(hooksPath); !os.IsNotExist(err) {
 		t.Error("hooks.json not removed")
@@ -340,7 +384,7 @@ func TestSkillsInstallClaudeProjectWritesRuleAndHook(t *testing.T) {
 		t.Errorf("guard not wired: %s", settingsData)
 	}
 
-	if err := runSkillsUninstallForEditor(t, project, "claude-code", nil); err != nil {
+	if err := runSkillsUninstallForClient(t, project, "claude-code", nil); err != nil {
 		t.Fatalf("uninstall: %v", err)
 	}
 	memory, err = os.ReadFile(claudeMd)
@@ -358,14 +402,96 @@ func TestSkillsInstallClaudeProjectWritesRuleAndHook(t *testing.T) {
 	}
 }
 
-// Named uninstalls must leave the rule and hook alone: only a full uninstall
-// tears down the steering.
+// Clients that do not discover skills on their own get an index naming each
+// installed skill, so the agent knows the files exist and where to open them.
+func TestSkillsInstallIndexedClientWritesSkillIndex(t *testing.T) {
+	project := t.TempDir()
+	if err := runSkillsInstall(t, project, "codex", false, nil); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if !dirExists(filepath.Join(project, ".ankra", "skills", "ankra-cli")) {
+		t.Fatal("skills not installed into the shared library")
+	}
+	agents, err := os.ReadFile(filepath.Join(project, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("AGENTS.md not written: %v", err)
+	}
+	for _, want := range []string{"ANKRA MANAGED BLOCK", "Ankra skills installed here", ".ankra/skills", "`ankra-cli`"} {
+		if !strings.Contains(string(agents), want) {
+			t.Errorf("AGENTS.md missing %q:\n%s", want, agents)
+		}
+	}
+
+	if err := runSkillsUninstallForClient(t, project, "codex", nil); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(project, "AGENTS.md")); !os.IsNotExist(err) {
+		t.Error("an AGENTS.md holding only the managed block should be removed")
+	}
+}
+
+// Copilot's project instructions file is what GitHub actually reads, and its
+// prompt files carry the .prompt.md suffix.
+func TestSkillsInstallCopilotWritesInstructionsAndPromptFiles(t *testing.T) {
+	project := t.TempDir()
+	if err := runSkillsInstall(t, project, "copilot", false, nil); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	instructions, err := os.ReadFile(filepath.Join(project, ".github", "copilot-instructions.md"))
+	if err != nil {
+		t.Fatalf("copilot-instructions.md not written: %v", err)
+	}
+	if !strings.Contains(string(instructions), "Ankra skills installed here") {
+		t.Error("copilot instructions missing the skill index")
+	}
+	prompt, err := os.ReadFile(filepath.Join(project, ".github", "prompts", "ankra-triage.prompt.md"))
+	if err != nil {
+		t.Fatalf("prompt file not written: %v", err)
+	}
+	if !strings.HasPrefix(string(prompt), "---\nmode: agent\n") {
+		t.Errorf("copilot prompt missing its mode header:\n%s", prompt)
+	}
+}
+
+// The Claude app cannot read the filesystem, so its install is a directory of
+// uploadable bundles rather than loose skills.
+func TestSkillsInstallClaudeAppWritesBundles(t *testing.T) {
+	project := t.TempDir()
+	if err := runSkillsInstall(t, project, "claude-app", false, nil); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	bundle := filepath.Join(project, ".ankra", "claude-app", "ankra-cli.zip")
+	archive, err := zip.OpenReader(bundle)
+	if err != nil {
+		t.Fatalf("bundle not written: %v", err)
+	}
+	defer func() { _ = archive.Close() }()
+	found := false
+	for _, file := range archive.File {
+		if file.Name == "ankra-cli/SKILL.md" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("bundle does not contain ankra-cli/SKILL.md at its root")
+	}
+
+	if err := runSkillsUninstallForClient(t, project, "claude-app", nil); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	if _, err := os.Stat(bundle); !os.IsNotExist(err) {
+		t.Error("bundle not removed")
+	}
+}
+
+// Named uninstalls must leave the rule, workflows and hook alone: only a full
+// uninstall tears down the steering.
 func TestSkillsNamedUninstallKeepsRuleAndHook(t *testing.T) {
 	project := t.TempDir()
 	if err := runSkillsInstall(t, project, "cursor", true, nil); err != nil {
 		t.Fatalf("install: %v", err)
 	}
-	if err := runSkillsUninstallForEditor(t, project, "cursor", []string{"ankra-cli"}); err != nil {
+	if err := runSkillsUninstallForClient(t, project, "cursor", []string{"ankra-cli"}); err != nil {
 		t.Fatalf("uninstall: %v", err)
 	}
 	if !dirExists(filepath.Join(project, ".cursor", "skills", "ankra-gitops")) {
@@ -374,18 +500,21 @@ func TestSkillsNamedUninstallKeepsRuleAndHook(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(project, ".cursor", "rules", "ankra.mdc")); err != nil {
 		t.Error("rule should survive a named uninstall")
 	}
+	if _, err := os.Stat(filepath.Join(project, ".cursor", "commands", "ankra-triage.md")); err != nil {
+		t.Error("workflows should survive a named uninstall")
+	}
 	if _, err := os.Stat(filepath.Join(project, ".cursor", "hooks.json")); err != nil {
 		t.Error("hook should survive a named uninstall")
 	}
 }
 
-func TestSkillsInstallNoRulesSkipsRule(t *testing.T) {
+func TestSkillsInstallNoRulesAndNoWorkflowsSkipThem(t *testing.T) {
 	project := t.TempDir()
-	c := newSkillsInstallTestCmd()
-	if err := c.Flags().Set("project", project); err != nil {
+	c := skillsTestCmdFor(t, newSkillsInstallTestCmd(), project, "cursor")
+	if err := c.Flags().Set("no-rules", "true"); err != nil {
 		t.Fatal(err)
 	}
-	if err := c.Flags().Set("no-rules", "true"); err != nil {
+	if err := c.Flags().Set("no-workflows", "true"); err != nil {
 		t.Fatal(err)
 	}
 	var err error
@@ -398,8 +527,23 @@ func TestSkillsInstallNoRulesSkipsRule(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(project, ".cursor", "rules", "ankra.mdc")); !os.IsNotExist(err) {
 		t.Error("--no-rules must not write the rule")
 	}
+	if _, err := os.Stat(filepath.Join(project, ".cursor", "commands")); !os.IsNotExist(err) {
+		t.Error("--no-workflows must not write the workflow commands")
+	}
 	if _, err := os.Stat(filepath.Join(project, ".cursor", "hooks.json")); !os.IsNotExist(err) {
 		t.Error("hooks are opt-in and must not be written by default")
+	}
+}
+
+// --with-hooks against a client with no hook mechanism is a skip, not an
+// error, so '--client all --with-hooks' installs everywhere it can.
+func TestSkillsInstallWithHooksSkipsClientsWithoutHooks(t *testing.T) {
+	project := t.TempDir()
+	if err := runSkillsInstall(t, project, "codex", true, nil); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if !dirExists(filepath.Join(project, ".ankra", "skills", "ankra-cli")) {
+		t.Error("skills should still install when the client takes no hook")
 	}
 }
 
@@ -408,25 +552,21 @@ func TestSkillsInstallNoRulesSkipsRule(t *testing.T) {
 // ~/.claude/CLAUDE.md.
 func TestAgentRuleAndHookPathsPersonalScope(t *testing.T) {
 	home := t.TempDir()
-	cursorTarget := skillsTarget{
-		Scope: "personal", Root: home,
-		Editor: skillsEditor{Name: "Cursor", ConfigurationDirectory: ".cursor", GuardFormat: "cursor"},
-	}
+	t.Setenv("HOME", home)
+
+	cursorTarget := targetFor(t, "", "cursor")
 	if got, want := cursorPluginDir(cursorTarget), filepath.Join(home, ".cursor", "plugins", "local", skills.CursorPluginName); got != want {
 		t.Errorf("cursor plugin dir = %s, want %s", got, want)
 	}
-	if got, want := hookConfigPath(cursorTarget), filepath.Join(home, ".cursor", "hooks.json"); got != want {
+	if got, want := cursorTarget.HooksPath, filepath.Join(home, ".cursor", "hooks.json"); got != want {
 		t.Errorf("cursor hook path = %s, want %s", got, want)
 	}
 
-	claudeTarget := skillsTarget{
-		Scope: "personal", Root: home,
-		Editor: skillsEditor{Name: "Claude Code", ConfigurationDirectory: ".claude", GuardFormat: "claude"},
+	claudeTarget := targetFor(t, "", "claude-code")
+	if got, want := claudeTarget.InstructionsPath, filepath.Join(home, ".claude", "CLAUDE.md"); got != want {
+		t.Errorf("claude instructions path = %s, want %s", got, want)
 	}
-	if got, want := claudeMemoryPath(claudeTarget), filepath.Join(home, ".claude", "CLAUDE.md"); got != want {
-		t.Errorf("claude memory path = %s, want %s", got, want)
-	}
-	if got, want := hookConfigPath(claudeTarget), filepath.Join(home, ".claude", "settings.json"); got != want {
+	if got, want := claudeTarget.HooksPath, filepath.Join(home, ".claude", "settings.json"); got != want {
 		t.Errorf("claude hook path = %s, want %s", got, want)
 	}
 

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -547,6 +547,30 @@ func TestSkillsInstallWithHooksSkipsClientsWithoutHooks(t *testing.T) {
 	}
 }
 
+// Several assistants share the client-neutral library. Installing for all of
+// them in one run must not report the second one's skills as "already
+// present, use --force" - they were written seconds earlier by this run.
+func TestSkillsInstallSharesOneLibraryAcrossClients(t *testing.T) {
+	project := t.TempDir()
+	c := skillsTestCmdFor(t, newSkillsInstallTestCmd(), project, "codex,zed")
+	var err error
+	output := captureStdout(t, func() {
+		err = skillsInstallCmd.RunE(c, nil)
+	})
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if strings.Contains(output, "use --force to overwrite") {
+		t.Errorf("a directory this run just wrote must not be reported as a skip:\n%s", output)
+	}
+	if !strings.Contains(output, "already written here for Codex CLI") {
+		t.Errorf("expected the shared-library line:\n%s", output)
+	}
+	if !dirExists(filepath.Join(project, ".ankra", "skills", "ankra-cli")) {
+		t.Error("the shared library was not populated")
+	}
+}
+
 // Personal scope routes the Cursor rule into a local plugin (there is no
 // supported user-level rules directory) and the Claude rule into
 // ~/.claude/CLAUDE.md.

--- a/internal/skills/bundle.go
+++ b/internal/skills/bundle.go
@@ -1,0 +1,101 @@
+package skills
+
+import (
+	"archive/zip"
+	"bytes"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// The Claude app cannot read the machine it is talking to, so a directory of
+// SKILL.md files is not a delivery mechanism for it. What it does take is an
+// uploaded skill bundle: one zip whose single top-level directory holds the
+// SKILL.md and anything it references. Packaging writes those bundles to disk
+// so the upload is a file picker away.
+
+// PackageBundles writes one .zip per selected skill into destDir, each
+// containing the skill directory at its root. Existing bundles are replaced
+// unless force is false and the file already exists, matching Install's
+// skip-unless-forced behaviour. Returns the bundles written and skipped.
+func PackageBundles(fsys fs.FS, destDir string, names []string, force bool) (written, skipped []string, err error) {
+	available, err := Names(fsys)
+	if err != nil {
+		return nil, nil, err
+	}
+	selected, err := selectNames(available, names)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return nil, nil, err
+	}
+	for _, name := range selected {
+		destination := filepath.Join(destDir, name+".zip")
+		if _, statError := os.Stat(destination); statError == nil && !force {
+			skipped = append(skipped, name)
+			continue
+		}
+		archive, buildError := buildBundle(fsys, name)
+		if buildError != nil {
+			return written, skipped, buildError
+		}
+		if writeError := os.WriteFile(destination, archive, 0o644); writeError != nil {
+			return written, skipped, writeError
+		}
+		written = append(written, name)
+	}
+	return written, skipped, nil
+}
+
+// RemoveBundles deletes the .zip bundles for the named skills from destDir,
+// returning how many existed.
+func RemoveBundles(destDir string, names []string) (int, error) {
+	removed := 0
+	for _, name := range names {
+		destination := filepath.Join(destDir, name+".zip")
+		if _, err := os.Stat(destination); err != nil {
+			continue
+		}
+		if err := os.Remove(destination); err != nil {
+			return removed, err
+		}
+		removed++
+	}
+	return removed, nil
+}
+
+// buildBundle zips one skill directory, keeping the skill name as the
+// archive's single top-level directory.
+func buildBundle(fsys fs.FS, name string) ([]byte, error) {
+	buffer := &bytes.Buffer{}
+	archive := zip.NewWriter(buffer)
+	walkError := fs.WalkDir(fsys, name, func(entryPath string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		data, readError := fs.ReadFile(fsys, entryPath)
+		if readError != nil {
+			return readError
+		}
+		relative := strings.TrimPrefix(strings.TrimPrefix(entryPath, name), "/")
+		file, createError := archive.Create(path.Join(name, relative))
+		if createError != nil {
+			return createError
+		}
+		_, writeError := file.Write(data)
+		return writeError
+	})
+	if walkError != nil {
+		return nil, walkError
+	}
+	if err := archive.Close(); err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
+}

--- a/internal/skills/clients.go
+++ b/internal/skills/clients.go
@@ -1,0 +1,511 @@
+package skills
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Agent clients disagree about almost everything except markdown: where
+// skills live, which file is always in context, whether slash commands
+// exist, and whether the process can read the local filesystem at all. A
+// Client captures those differences as data so install/uninstall stay one
+// code path, and adding the next assistant is a table entry rather than a
+// new branch.
+
+// Layout is where one client keeps its artefacts, relative to the scope root
+// (the home directory for a personal install, the project directory for a
+// project install). An empty field means the client has no such artefact and
+// install silently skips it.
+type Layout struct {
+	// Skills is the directory the skill folders are copied into.
+	Skills string
+	// Instructions is the always-loaded markdown file that carries the
+	// managed Ankra block: the routing rule plus the index of installed
+	// skills. Clients that steer with a rule mechanism instead (Cursor)
+	// leave it empty.
+	Instructions string
+	// Commands is the directory that holds the workflow command files
+	// (slash commands / prompt files / workflows).
+	Commands string
+	// Hooks is the config file the 'ankra skills guard' hook is merged into.
+	Hooks string
+}
+
+// Client is one assistant the skills can be installed for.
+type Client struct {
+	// ID is the canonical --client value.
+	ID string
+	// Aliases are the other spellings accepted for ID.
+	Aliases []string
+	// DisplayName is how the client is named in output.
+	DisplayName string
+	// Personal is the layout for a home-directory install.
+	Personal Layout
+	// Project is the layout for a repository-scoped install.
+	Project Layout
+	// RuleFormat selects how the always-applied routing rule is written:
+	// "cursor" for Cursor's plugin/.mdc mechanism, "block" for a managed
+	// block inside Layout.Instructions, "" for clients that take neither.
+	RuleFormat string
+	// CommandFormat selects the workflow command file format: "markdown",
+	// "copilot" (.prompt.md with a mode header), "toml" (Gemini CLI), or ""
+	// when the client has no command mechanism.
+	CommandFormat string
+	// HookFormat selects the hook event dialect: "cursor", "claude", or ""
+	// when the client exposes no shell hook.
+	HookFormat string
+	// LoadsSkillsNatively is true when the client discovers SKILL.md files
+	// in Layout.Skills by itself. When false the managed index in
+	// Layout.Instructions is what points the agent at them.
+	LoadsSkillsNatively bool
+	// Packaged is true for clients that cannot read the local filesystem, so
+	// install writes uploadable .zip bundles instead of loose directories.
+	Packaged bool
+	// Detect are paths (relative to the scope root) whose presence means the
+	// client is in use here; used by --client auto.
+	DetectPersonal []string
+	DetectProject  []string
+	// Note is printed after a successful install when the client needs one
+	// more manual step than "restart the app".
+	Note string
+}
+
+// ankraLibrary is the client-neutral home for skill bodies. Assistants that
+// have no skills directory of their own still read files, so the skills go
+// somewhere stable and the managed index points at them by path.
+const ankraLibrary = ".ankra/skills"
+
+// clientRegistry is the full set of supported clients, in the order they are
+// listed and installed.
+var clientRegistry = []Client{
+	{
+		ID:          "claude-code",
+		Aliases:     []string{"claude", "claudecode", "cc"},
+		DisplayName: "Claude Code",
+		Personal: Layout{
+			Skills:       ".claude/skills",
+			Instructions: ".claude/CLAUDE.md",
+			Commands:     ".claude/commands",
+			Hooks:        ".claude/settings.json",
+		},
+		Project: Layout{
+			Skills:       ".claude/skills",
+			Instructions: "CLAUDE.md",
+			Commands:     ".claude/commands",
+			Hooks:        ".claude/settings.json",
+		},
+		RuleFormat:          "block",
+		CommandFormat:       "markdown",
+		HookFormat:          "claude",
+		LoadsSkillsNatively: true,
+		DetectPersonal:      []string{".claude"},
+		DetectProject:       []string{".claude", "CLAUDE.md"},
+	},
+	{
+		ID:          "claude-app",
+		Aliases:     []string{"claude-desktop", "claude-ai", "claudeai", "desktop"},
+		DisplayName: "Claude app (claude.ai / desktop)",
+		Personal:    Layout{Skills: ".ankra/claude-app"},
+		Project:     Layout{Skills: ".ankra/claude-app"},
+		Packaged:    true,
+		DetectPersonal: []string{
+			"Library/Application Support/Claude",
+			".config/Claude",
+			"AppData/Roaming/Claude",
+		},
+		Note: "Upload each .zip at claude.ai → Settings → Capabilities → Skills → Upload skill " +
+			"(the Claude app cannot read your filesystem, so the bundles are the delivery).",
+	},
+	{
+		ID:          "cursor",
+		Aliases:     []string{"cursor-ide"},
+		DisplayName: "Cursor",
+		Personal: Layout{
+			Skills:   ".cursor/skills",
+			Commands: ".cursor/commands",
+			Hooks:    ".cursor/hooks.json",
+		},
+		Project: Layout{
+			Skills:   ".cursor/skills",
+			Commands: ".cursor/commands",
+			Hooks:    ".cursor/hooks.json",
+		},
+		RuleFormat:          "cursor",
+		CommandFormat:       "markdown",
+		HookFormat:          "cursor",
+		LoadsSkillsNatively: true,
+		DetectPersonal:      []string{".cursor"},
+		DetectProject:       []string{".cursor"},
+	},
+	{
+		ID:          "codex",
+		Aliases:     []string{"openai-codex", "codex-cli"},
+		DisplayName: "Codex CLI",
+		Personal: Layout{
+			Skills:       ".codex/skills",
+			Instructions: ".codex/AGENTS.md",
+			Commands:     ".codex/prompts",
+		},
+		Project: Layout{
+			Skills:       ankraLibrary,
+			Instructions: "AGENTS.md",
+		},
+		RuleFormat:     "block",
+		CommandFormat:  "markdown",
+		DetectPersonal: []string{".codex"},
+		DetectProject:  []string{"AGENTS.md"},
+	},
+	{
+		ID:          "copilot",
+		Aliases:     []string{"github-copilot", "vscode"},
+		DisplayName: "GitHub Copilot",
+		Personal: Layout{
+			Skills:       ankraLibrary,
+			Instructions: ".ankra/AGENTS.md",
+		},
+		Project: Layout{
+			Skills:       ankraLibrary,
+			Instructions: ".github/copilot-instructions.md",
+			Commands:     ".github/prompts",
+		},
+		RuleFormat:     "block",
+		CommandFormat:  "copilot",
+		DetectPersonal: []string{".vscode", "Library/Application Support/Code/User", ".config/Code/User"},
+		DetectProject:  []string{".github"},
+		Note: "Copilot reads .github/copilot-instructions.md per repository — install with " +
+			"--project <repo> for it to take effect, and commit the result.",
+	},
+	{
+		ID:          "windsurf",
+		Aliases:     []string{"codeium"},
+		DisplayName: "Windsurf",
+		Personal: Layout{
+			Skills:       ankraLibrary,
+			Instructions: ".codeium/windsurf/memories/global_rules.md",
+		},
+		Project: Layout{
+			Skills:       ankraLibrary,
+			Instructions: ".windsurf/rules/ankra.md",
+			Commands:     ".windsurf/workflows",
+		},
+		RuleFormat:     "block",
+		CommandFormat:  "markdown",
+		DetectPersonal: []string{".codeium/windsurf"},
+		DetectProject:  []string{".windsurf"},
+	},
+	{
+		ID:          "gemini",
+		Aliases:     []string{"gemini-cli", "google"},
+		DisplayName: "Gemini CLI",
+		Personal: Layout{
+			Skills:       ".gemini/skills",
+			Instructions: ".gemini/GEMINI.md",
+			Commands:     ".gemini/commands/ankra",
+		},
+		Project: Layout{
+			Skills:       ankraLibrary,
+			Instructions: "GEMINI.md",
+			Commands:     ".gemini/commands/ankra",
+		},
+		RuleFormat:     "block",
+		CommandFormat:  "toml",
+		DetectPersonal: []string{".gemini"},
+		DetectProject:  []string{".gemini", "GEMINI.md"},
+	},
+	{
+		ID:          "opencode",
+		Aliases:     []string{"open-code", "sst"},
+		DisplayName: "OpenCode",
+		Personal: Layout{
+			Skills:       ".config/opencode/skills",
+			Instructions: ".config/opencode/AGENTS.md",
+			Commands:     ".config/opencode/command",
+		},
+		Project: Layout{
+			Skills:       ankraLibrary,
+			Instructions: "AGENTS.md",
+			Commands:     ".opencode/command",
+		},
+		RuleFormat:     "block",
+		CommandFormat:  "markdown",
+		DetectPersonal: []string{".config/opencode"},
+		DetectProject:  []string{".opencode"},
+	},
+	{
+		ID:          "cline",
+		Aliases:     []string{"roo", "roo-code"},
+		DisplayName: "Cline",
+		Personal: Layout{
+			Skills:       ankraLibrary,
+			Instructions: "Documents/Cline/Rules/ankra.md",
+		},
+		Project: Layout{
+			Skills:       ankraLibrary,
+			Instructions: ".clinerules/ankra.md",
+			Commands:     ".clinerules/workflows",
+		},
+		RuleFormat:     "block",
+		CommandFormat:  "markdown",
+		DetectPersonal: []string{"Documents/Cline"},
+		DetectProject:  []string{".clinerules"},
+	},
+	{
+		ID:          "zed",
+		Aliases:     []string{"zed-editor"},
+		DisplayName: "Zed",
+		Personal: Layout{
+			Skills:       ankraLibrary,
+			Instructions: ".config/zed/AGENTS.md",
+		},
+		Project: Layout{
+			Skills:       ankraLibrary,
+			Instructions: "AGENTS.md",
+		},
+		RuleFormat:     "block",
+		DetectPersonal: []string{".config/zed"},
+		DetectProject:  []string{".rules"},
+	},
+	{
+		ID:          "openclaw",
+		Aliases:     []string{"claw"},
+		DisplayName: "OpenClaw",
+		Personal: Layout{
+			Skills:       ".openclaw/skills",
+			Instructions: ".openclaw/AGENTS.md",
+		},
+		Project: Layout{
+			Skills:       ankraLibrary,
+			Instructions: "AGENTS.md",
+		},
+		RuleFormat:          "block",
+		LoadsSkillsNatively: true,
+		DetectPersonal:      []string{".openclaw"},
+	},
+	{
+		ID:          "agents",
+		Aliases:     []string{"agents-md", "agentsmd", "generic", "amp", "aider", "other"},
+		DisplayName: "AGENTS.md (any other assistant)",
+		Personal: Layout{
+			Skills:       ankraLibrary,
+			Instructions: ".ankra/AGENTS.md",
+		},
+		Project: Layout{
+			Skills:       ankraLibrary,
+			Instructions: "AGENTS.md",
+		},
+		RuleFormat: "block",
+		Note: "AGENTS.md is read by Amp, Jules, Aider, Factory and most newer agents. " +
+			"Point any other assistant at the skills directory named above.",
+	},
+}
+
+// Clients returns every supported client, in registry order.
+func Clients() []Client {
+	out := make([]Client, len(clientRegistry))
+	copy(out, clientRegistry)
+	return out
+}
+
+// ClientIDs returns the canonical --client values, in registry order.
+func ClientIDs() []string {
+	ids := make([]string, 0, len(clientRegistry))
+	for _, client := range clientRegistry {
+		ids = append(ids, client.ID)
+	}
+	return ids
+}
+
+// LookupClient resolves an ID or alias, case- and space-insensitively.
+func LookupClient(name string) (Client, error) {
+	wanted := strings.ToLower(strings.TrimSpace(name))
+	if wanted == "" {
+		return Client{}, fmt.Errorf("no client given")
+	}
+	for _, client := range clientRegistry {
+		if client.ID == wanted {
+			return client, nil
+		}
+		for _, alias := range client.Aliases {
+			if alias == wanted {
+				return client, nil
+			}
+		}
+	}
+	return Client{}, fmt.Errorf("unsupported client %q (known: %s, plus \"all\" and \"auto\")",
+		name, strings.Join(ClientIDs(), ", "))
+}
+
+// ResolveClients expands the --client values into a de-duplicated client
+// list, in registry order. "all" selects every client; "auto" selects the
+// clients whose configuration is present under root. An empty request
+// defaults to auto, falling back to Claude Code and Cursor when nothing is
+// detected, so a first run on a bare machine still installs something useful.
+func ResolveClients(requested []string, root string, scope string) ([]Client, error) {
+	if len(requested) == 0 {
+		requested = []string{"auto"}
+	}
+	selected := make(map[string]bool)
+	for _, name := range requested {
+		for _, part := range strings.Split(name, ",") {
+			part = strings.ToLower(strings.TrimSpace(part))
+			switch part {
+			case "":
+				continue
+			case "all":
+				for _, client := range clientRegistry {
+					selected[client.ID] = true
+				}
+			case "auto", "detect":
+				for _, client := range DetectClients(root, scope) {
+					selected[client.ID] = true
+				}
+			default:
+				client, err := LookupClient(part)
+				if err != nil {
+					return nil, err
+				}
+				selected[client.ID] = true
+			}
+		}
+	}
+	if len(selected) == 0 {
+		selected["claude-code"] = true
+		selected["cursor"] = true
+	}
+	out := make([]Client, 0, len(selected))
+	for _, client := range clientRegistry {
+		if selected[client.ID] {
+			out = append(out, client)
+		}
+	}
+	return out, nil
+}
+
+// DetectClients reports which clients are configured under root for the given
+// scope, judged by the presence of their own configuration paths.
+func DetectClients(root string, scope string) []Client {
+	found := make([]Client, 0, len(clientRegistry))
+	for _, client := range clientRegistry {
+		markers := client.DetectPersonal
+		if scope == ScopeProject {
+			markers = client.DetectProject
+		}
+		for _, marker := range markers {
+			if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(marker))); err == nil {
+				found = append(found, client)
+				break
+			}
+		}
+	}
+	return found
+}
+
+// Scope names for a personal (home directory) or project install.
+const (
+	ScopePersonal = "personal"
+	ScopeProject  = "project"
+)
+
+// Layout returns the client's layout for a scope.
+func (c Client) Layout(scope string) Layout {
+	if scope == ScopeProject {
+		return c.Project
+	}
+	return c.Personal
+}
+
+// Target is one resolved installation: a client, a scope, and the absolute
+// paths everything is written to.
+type Target struct {
+	Client Client
+	Scope  string
+	// Root is the scope root: the home directory or the project directory.
+	Root string
+	// SkillsDirectory is where the skill folders (or .zip bundles) land.
+	SkillsDirectory string
+	// InstructionsPath is the markdown file carrying the managed block; empty
+	// when the client uses a rule mechanism instead.
+	InstructionsPath string
+	// CommandsDirectory is where workflow command files land; empty when the
+	// client has no command mechanism.
+	CommandsDirectory string
+	// HooksPath is the hook config file; empty when the client has no hooks.
+	HooksPath string
+}
+
+// ResolveTarget turns a client and scope into absolute paths under root.
+func ResolveTarget(client Client, scope, root string) (Target, error) {
+	if root == "" {
+		return Target{}, fmt.Errorf("no root directory for a %s install", scope)
+	}
+	absoluteRoot, err := filepath.Abs(root)
+	if err != nil {
+		return Target{}, err
+	}
+	layout := client.Layout(scope)
+	if layout.Skills == "" {
+		return Target{}, fmt.Errorf("%s has no %s install location", client.DisplayName, scope)
+	}
+	join := func(relative string) string {
+		if relative == "" {
+			return ""
+		}
+		return filepath.Join(absoluteRoot, filepath.FromSlash(relative))
+	}
+	return Target{
+		Client:            client,
+		Scope:             scope,
+		Root:              absoluteRoot,
+		SkillsDirectory:   join(layout.Skills),
+		InstructionsPath:  join(layout.Instructions),
+		CommandsDirectory: join(layout.Commands),
+		HooksPath:         join(layout.Hooks),
+	}, nil
+}
+
+// LoadsNatively reports whether this target's client discovers the SKILL.md
+// files at SkillsDirectory by itself. A client that does so for its own
+// directory still needs the index when the scope puts the skills in the
+// client-neutral library instead.
+func (t Target) LoadsNatively() bool {
+	return t.Client.LoadsSkillsNatively &&
+		t.Client.Layout(t.Scope).Skills != ankraLibrary
+}
+
+// SupportsHooks reports whether the guard hook can be installed for a target.
+func (t Target) SupportsHooks() bool {
+	return t.Client.HookFormat != "" && t.HooksPath != ""
+}
+
+// SupportsCommands reports whether workflow command files can be written.
+func (t Target) SupportsCommands() bool {
+	return t.Client.CommandFormat != "" && t.CommandsDirectory != ""
+}
+
+// DisplayPath shortens an absolute path for output, collapsing the user's
+// home directory to ~ so install output stays readable.
+func DisplayPath(path string) string {
+	if path == "" {
+		return ""
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return path
+	}
+	if path == home {
+		return "~"
+	}
+	if strings.HasPrefix(path, home+string(os.PathSeparator)) {
+		return "~" + string(os.PathSeparator) + path[len(home)+1:]
+	}
+	return path
+}
+
+// SortClientsByID orders clients alphabetically; used where output should not
+// depend on registry order.
+func SortClientsByID(clients []Client) {
+	sort.Slice(clients, func(i, j int) bool { return clients[i].ID < clients[j].ID })
+}

--- a/internal/skills/clients_test.go
+++ b/internal/skills/clients_test.go
@@ -1,0 +1,382 @@
+package skills
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestClientRegistryIsWellFormed(t *testing.T) {
+	seen := make(map[string]string)
+	for _, client := range Clients() {
+		if client.ID == "" || client.DisplayName == "" {
+			t.Fatalf("client with empty id or display name: %+v", client)
+		}
+		for _, name := range append([]string{client.ID}, client.Aliases...) {
+			if owner, taken := seen[name]; taken {
+				t.Errorf("%q is claimed by both %s and %s", name, owner, client.ID)
+			}
+			seen[name] = client.ID
+		}
+		if client.Personal.Skills == "" || client.Project.Skills == "" {
+			t.Errorf("%s has no skills directory for one of the scopes", client.ID)
+		}
+		if client.RuleFormat == "block" && client.Personal.Instructions == "" && client.Project.Instructions == "" {
+			t.Errorf("%s takes a managed block but names no instructions file", client.ID)
+		}
+		if client.CommandFormat != "" && client.Personal.Commands == "" && client.Project.Commands == "" {
+			t.Errorf("%s declares a command format but no commands directory", client.ID)
+		}
+		if client.HookFormat != "" && client.Personal.Hooks == "" {
+			t.Errorf("%s declares a hook format but no hook config path", client.ID)
+		}
+	}
+	for _, required := range []string{"claude-code", "claude-app", "cursor", "codex", "copilot", "agents"} {
+		if _, taken := seen[required]; !taken {
+			t.Errorf("the registry is missing %s", required)
+		}
+	}
+}
+
+func TestLookupClientAcceptsAliases(t *testing.T) {
+	for alias, want := range map[string]string{
+		"claude":         "claude-code",
+		"CLAUDE-CODE":    "claude-code",
+		" cursor ":       "cursor",
+		"github-copilot": "copilot",
+		"claude-desktop": "claude-app",
+		"generic":        "agents",
+	} {
+		client, err := LookupClient(alias)
+		if err != nil {
+			t.Fatalf("LookupClient(%q): %v", alias, err)
+		}
+		if client.ID != want {
+			t.Errorf("LookupClient(%q) = %s, want %s", alias, client.ID, want)
+		}
+	}
+	if _, err := LookupClient("notepad"); err == nil {
+		t.Error("expected an error for an unknown client")
+	}
+}
+
+func TestResolveClientsExpandsAllAndCommaLists(t *testing.T) {
+	root := t.TempDir()
+
+	all, err := ResolveClients([]string{"all"}, root, ScopePersonal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != len(Clients()) {
+		t.Errorf("\"all\" resolved %d of %d clients", len(all), len(Clients()))
+	}
+
+	pair, err := ResolveClients([]string{"cursor,claude-code", "cursor"}, root, ScopePersonal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make([]string, 0, len(pair))
+	for _, client := range pair {
+		got = append(got, client.ID)
+	}
+	if strings.Join(got, ",") != "claude-code,cursor" {
+		t.Errorf("expected de-duplicated registry order, got %v", got)
+	}
+}
+
+func TestResolveClientsAutoDetectsAndFallsBack(t *testing.T) {
+	root := t.TempDir()
+	fallback, err := ResolveClients(nil, root, ScopePersonal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fallback) != 2 {
+		t.Fatalf("expected the two-client fallback, got %d", len(fallback))
+	}
+
+	if err := os.MkdirAll(filepath.Join(root, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	detected, err := ResolveClients(nil, root, ScopePersonal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(detected) != 1 || detected[0].ID != "codex" {
+		t.Fatalf("expected codex to be detected alone, got %+v", detected)
+	}
+}
+
+func TestResolveTargetJoinsLayoutOntoRoot(t *testing.T) {
+	root := t.TempDir()
+	client, err := LookupClient("claude-code")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := ResolveTarget(client, ScopeProject, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target.SkillsDirectory != filepath.Join(root, ".claude", "skills") {
+		t.Errorf("skills directory = %s", target.SkillsDirectory)
+	}
+	if target.InstructionsPath != filepath.Join(root, "CLAUDE.md") {
+		t.Errorf("instructions path = %s", target.InstructionsPath)
+	}
+	if !target.SupportsHooks() || !target.SupportsCommands() {
+		t.Error("claude-code should support both hooks and commands")
+	}
+
+	codex, err := LookupClient("codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	codexTarget, err := ResolveTarget(codex, ScopeProject, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if codexTarget.SupportsHooks() {
+		t.Error("codex has no hook mechanism")
+	}
+	if codexTarget.SupportsCommands() {
+		t.Error("codex has no project-scoped commands directory")
+	}
+}
+
+func TestInstructionsBlockIndexesSkillsForIndexedClients(t *testing.T) {
+	root := t.TempDir()
+	client, err := LookupClient("codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := ResolveTarget(client, ScopeProject, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block := InstructionsBlock(target, []Skill{
+		{Name: "ankra-cli", Description: "Drive the Ankra CLI. Use when the user mentions the ankra CLI."},
+	})
+	for _, want := range []string{
+		"Ankra skills installed here",
+		"**`ankra-cli`** — Drive the Ankra CLI",
+		".ankra/skills",
+		"ankra-platform-principles",
+	} {
+		if !strings.Contains(block, want) {
+			t.Errorf("block missing %q:\n%s", want, block)
+		}
+	}
+	if strings.Contains(block, "Use when the user mentions") {
+		t.Error("the index should drop the trigger clause from the description")
+	}
+}
+
+func TestSkillIndexPathIsRelativeForAProjectInstall(t *testing.T) {
+	root := t.TempDir()
+	client, err := LookupClient("copilot")
+	if err != nil {
+		t.Fatal(err)
+	}
+	project, err := ResolveTarget(client, ScopeProject, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block := InstructionsBlock(project, []Skill{{Name: "ankra-cli", Description: "Drive the Ankra CLI."}})
+	if strings.Contains(block, root) {
+		t.Errorf("a committed project index must not carry an absolute path:\n%s", block)
+	}
+	if !strings.Contains(block, "`"+ankraLibrary+"`") {
+		t.Errorf("expected the repository-relative directory:\n%s", block)
+	}
+
+	personal, err := ResolveTarget(client, ScopePersonal, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	personalBlock := InstructionsBlock(personal, []Skill{{Name: "ankra-cli", Description: "Drive the Ankra CLI."}})
+	if !strings.Contains(personalBlock, personal.SkillsDirectory) {
+		t.Errorf("a personal index should name the absolute directory:\n%s", personalBlock)
+	}
+}
+
+func TestHeadlineKeepsOneLinePerSkill(t *testing.T) {
+	for description, want := range map[string]string{
+		"Take source code to production - registering, building, deploying. Use when the user deploys code.": "Take source code to production",
+		"Compose Ankra Stacks from Helm addons. Use whenever editing a stack.":                               "Compose Ankra Stacks from Helm addons",
+		"Structure a GitOps repository": "Structure a GitOps repository",
+	} {
+		if got := headline(description); got != want {
+			t.Errorf("headline(%q) = %q, want %q", description, got, want)
+		}
+	}
+}
+
+func TestInstructionsBlockForNativeClientPointsAtTheDirectory(t *testing.T) {
+	root := t.TempDir()
+	client, err := LookupClient("cursor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := ResolveTarget(client, ScopeProject, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block := InstructionsBlock(target, []Skill{{Name: "ankra-cli", Description: "Drive the Ankra CLI."}})
+	if !strings.Contains(block, "loads these from") {
+		t.Errorf("expected the native wording:\n%s", block)
+	}
+}
+
+func TestUpsertAndRemoveManagedBlockPreserveUserContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "AGENTS.md")
+	if err := os.WriteFile(path, []byte("# House rules\n\nUse tabs.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := UpsertManagedBlock(path, "<!-- BEGIN ANKRA MANAGED BLOCK (ankra skills install) -->\nfirst\n<!-- END ANKRA MANAGED BLOCK -->"); err != nil {
+		t.Fatal(err)
+	}
+	if err := UpsertManagedBlock(path, "<!-- BEGIN ANKRA MANAGED BLOCK (ankra skills install) -->\nsecond\n<!-- END ANKRA MANAGED BLOCK -->"); err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(content), "BEGIN ANKRA MANAGED BLOCK") != 1 {
+		t.Errorf("upsert duplicated the block:\n%s", content)
+	}
+	if !strings.Contains(string(content), "second") || strings.Contains(string(content), "first") {
+		t.Errorf("upsert did not replace the block body:\n%s", content)
+	}
+	if !strings.Contains(string(content), "Use tabs.") {
+		t.Errorf("user content lost:\n%s", content)
+	}
+
+	found, err := RemoveManagedBlock(path)
+	if err != nil || !found {
+		t.Fatalf("RemoveManagedBlock found=%v err=%v", found, err)
+	}
+	content, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("file with user content should survive: %v", err)
+	}
+	if strings.Contains(string(content), "ANKRA MANAGED BLOCK") {
+		t.Errorf("block not removed:\n%s", content)
+	}
+}
+
+func TestWriteAndRemoveWorkflowsPerFormat(t *testing.T) {
+	for _, testCase := range []struct {
+		client   string
+		file     string
+		contains string
+	}{
+		{"claude-code", "ankra-ship-service.md", "---\ndescription: "},
+		{"copilot", "ankra-ship-service.prompt.md", "---\nmode: agent\n"},
+		{"gemini", "ship-service.toml", "prompt = \"\"\""},
+	} {
+		t.Run(testCase.client, func(t *testing.T) {
+			root := t.TempDir()
+			client, err := LookupClient(testCase.client)
+			if err != nil {
+				t.Fatal(err)
+			}
+			target, err := ResolveTarget(client, ScopeProject, root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			written, err := WriteWorkflows(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(written) != len(Workflows()) {
+				t.Fatalf("wrote %d of %d workflows", len(written), len(Workflows()))
+			}
+			path := filepath.Join(target.CommandsDirectory, testCase.file)
+			content, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("expected %s: %v", path, err)
+			}
+			if !strings.Contains(string(content), testCase.contains) {
+				t.Errorf("%s missing %q:\n%s", testCase.file, testCase.contains, content)
+			}
+
+			removed, err := RemoveWorkflows(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if removed != len(Workflows()) {
+				t.Errorf("removed %d of %d workflows", removed, len(Workflows()))
+			}
+		})
+	}
+}
+
+func TestWriteWorkflowsIsANoOpWithoutACommandsDirectory(t *testing.T) {
+	root := t.TempDir()
+	client, err := LookupClient("zed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := ResolveTarget(client, ScopeProject, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	written, err := WriteWorkflows(target)
+	if err != nil || len(written) != 0 {
+		t.Fatalf("expected a no-op, wrote %d (err %v)", len(written), err)
+	}
+}
+
+func TestPackageBundlesProducesUploadableZips(t *testing.T) {
+	fsys, err := EmbeddedFS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	destination := t.TempDir()
+	written, skipped, err := PackageBundles(fsys, destination, []string{"ankra-cli"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(written) != 1 || len(skipped) != 0 {
+		t.Fatalf("written=%v skipped=%v", written, skipped)
+	}
+	data, err := os.ReadFile(filepath.Join(destination, "ankra-cli.zip"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	archive, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, file := range archive.File {
+		if file.Name == "ankra-cli/SKILL.md" {
+			found = true
+		}
+		if strings.HasPrefix(file.Name, "/") || strings.Contains(file.Name, "..") {
+			t.Errorf("unsafe archive entry %q", file.Name)
+		}
+	}
+	if !found {
+		t.Error("bundle does not carry ankra-cli/SKILL.md")
+	}
+
+	_, skipped, err = PackageBundles(fsys, destination, []string{"ankra-cli"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skipped) != 1 {
+		t.Error("an existing bundle should be skipped without --force")
+	}
+
+	removed, err := RemoveBundles(destination, []string{"ankra-cli", "never-installed"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != 1 {
+		t.Errorf("removed %d bundles, want 1", removed)
+	}
+}

--- a/internal/skills/embedded/skills/ankra-ai-agents/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-ai-agents/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: ankra-ai-agents
+description: Run and govern Ankra's AI agents - choosing the model provider and catalogue (Ankra, Anthropic, OpenRouter, or an OpenAI-compatible endpoint such as LiteLLM or vLLM), registering MCP tool servers and granting individual tools to organisation roles, dispatching and supervising agent runs and their transcripts, working the AI board of tickets, and confirming or rejecting the writes an agent proposes. Use when the user mentions Ankra AI, AI agents, sub-agents, agent runs, MCP servers or tools, the AI board or tickets, the model catalogue, or configuring which model Ankra uses.
+---
+
+# Ankra AI agents
+
+Ankra runs AI agents against your organisation: they investigate incidents, answer questions about
+clusters, propose changes, and open pull requests. This skill is the **operator's** view — which
+model they use, which tools they may call, what they are allowed to do without asking, and how to
+supervise a run in flight.
+
+Four surfaces, and they are independent:
+
+| Surface | Question it answers | Commands |
+|---------|---------------------|----------|
+| **Provider & catalogue** | Which model, whose key | `ankra ai ...` |
+| **Tools (MCP)** | What the agent can call | `ankra org mcp-servers ...` |
+| **Runs** | What an agent is doing right now | `ankra agents ...` |
+| **Board** | What the agents are working on, and what needs a human | `ankra tickets ...` |
+
+Safety mode (Ask vs Agent) is the fifth, and it lives in `ankra-ai-gateway`.
+
+## 1. Provider and model catalogue
+
+```bash
+ankra ai status                       # active provider and which credentials are configured
+ankra ai provider ankra               # Ankra-managed Claude models (the default)
+ankra ai provider anthropic
+ankra ai provider openrouter
+ankra ai provider openai_compatible
+```
+
+Set the credential **before** switching — switching is blocked without a valid one:
+
+```bash
+ankra ai anthropic set                # your own Anthropic key (sk-ant-...)
+ankra ai openrouter set
+ankra ai endpoints create --name litellm --base-url https://llm.example.com/v1 --api-key <key>
+ankra ai endpoints discover litellm   # the model ids the endpoint advertises
+ankra ai endpoints list
+ankra ai endpoints update litellm --base-url ...
+ankra ai endpoints delete litellm
+```
+
+`endpoints` is the multi-endpoint surface (LiteLLM, vLLM, TGI, Ollama, OpenRouter, Together — any
+OpenAI v1 API); `ankra ai openai` is the older single-endpoint form. Ankra probes
+`GET <base-url>/models` on save, so a bad URL fails immediately — but a **wrong model id only
+surfaces at the first AI call**, which is what `endpoints discover` is for.
+
+The catalogue is what the chat model picker offers:
+
+```bash
+ankra ai models list
+ankra ai models create --name <model-id> ...
+ankra ai models update <model-id> ...
+ankra ai models delete <model-id>
+ankra ai models reset                 # back to the built-in defaults
+```
+
+In OpenAI-compatible mode, tool-using paths (the agentic assistant, AI insights, CI/CD file
+generation, deploy analysis) fall back to the Ankra platform provider; stack descriptions and
+summaries run natively against your endpoint. The **What runs where** matrix on the settings page
+is authoritative — check it before promising an air-gapped setup.
+
+## 2. Tools: MCP servers
+
+An agent can only call tools it has been given. MCP servers are how you extend that set beyond
+Ankra's own — a ticket tracker, an error tracker, an internal API.
+
+```bash
+ankra org mcp-servers catalog                 # curated adapters, their headers and tool lists
+ankra org mcp-servers add sentry --adapter sentry \
+  --url https://mcp.sentry.dev/mcp --secret-header Authorization
+ankra org mcp-servers add internal-tools --url https://mcp.example.internal/sse \
+  --transport sse --tier read_write --allowed-tools search_docs,create_ticket
+ankra org mcp-servers add staging-only --url https://mcp.example.com/mcp \
+  --cluster <cluster-uuid> --disabled
+ankra org mcp-servers list
+ankra org mcp-servers get <name>
+ankra org mcp-servers tools <name>            # what it actually exposes
+ankra org mcp-servers health <name>           # is it reachable
+ankra org mcp-servers update <name> ...
+ankra org mcp-servers enable <name> / disable <name> / remove <name>
+```
+
+Credentials, and why the flag choice matters:
+
+- **`--secret-header Authorization`** (name only) prompts with hidden input, or reads one header
+  per line from piped stdin, and stores the value in an organisation secret slot. The server record
+  keeps only a `${SECRET_SLOT:<id>}` sentinel, so the secret never lands in it.
+- **`--secret-header Key=Value`** works but leaves the secret in shell history and in process
+  listings. Avoid it.
+- **`--header`** is plaintext, for non-secret values only; the backend refuses plaintext under
+  sensitive-looking names.
+- If a later registration step fails, slots already created are removed, so no secret material is
+  orphaned.
+- `--url` is required for **every** transport. With `--transport stdio` it is stored as the
+  server's identifier and never dialled — use a placeholder such as `cmd://<binary-name>`.
+- With `--adapter` and no `--allowed-tools`, the allow-list is seeded from the adapter's
+  recommendation. Trim it: an allow-list is a capability grant.
+
+### Granting tools to roles
+
+```bash
+ankra org mcp-servers grants <name>                     # current per-tool role grants
+ankra org mcp-servers grant sentry get_issue            # defaults to the member role
+ankra org mcp-servers grant sentry create_ticket --role admin
+ankra org mcp-servers revoke-grant sentry create_ticket --role admin
+```
+
+A tool is callable from agent runs started by members holding the granted role. Grants are
+additive. Read tools can sit at `member`; **anything that writes belongs to the narrowest role that
+needs it**, not to `member`.
+
+Two-layer defence: `--tier read_only` on the server, and a tight `--allowed-tools`. Use `--cluster`
+(repeatable) when a server should only serve some clusters' runs.
+
+## 3. Supervising runs
+
+Every dispatch — a board ticket, a schedule, an alert, or run-now — records a run with a linked
+session.
+
+```bash
+ankra agents runs                                  # newest first
+ankra agents runs --status running --status awaiting_user
+ankra agents runs --status failed --limit 50
+ankra agents runs --task <agent-task-uuid>
+ankra agents run <run-id>                          # one run in full
+ankra agents transcript <run-id> --limit 500       # the session transcript
+ankra agents transcript <run-id> --since <sequence-number>
+ankra agents cancel <run-id>                       # interrupts the in-flight turn in seconds
+```
+
+Statuses: `pending`, `running`, `awaiting_user`, `completed`, `failed`, `cancelled`, `expired`,
+`skipped`. `awaiting_user` means it is blocked on a person — that is the queue to watch.
+
+`agents transcript` is the audit trail: it shows what the agent read, which tools it called, and
+what it concluded. Read it before accepting a conclusion, and always before approving a write.
+
+## 4. The AI board
+
+Tickets are how agents track incidents, insights and requests, and how they ask a human for a
+decision.
+
+```bash
+ankra tickets list
+ankra tickets list --needs-human                   # only tickets waiting on a person
+ankra tickets list --status blocked --status awaiting_approval
+ankra tickets list --search ingress --include-closed --limit 100
+ankra tickets get T-8                              # includes the decision it is waiting on
+ankra tickets events T-8                           # the timeline, oldest first
+ankra tickets comment T-8 --body "Checked the ingress; it is the cert, not the route."
+ankra tickets transition T-8 --status investigating --note "Reassigned to the platform lane"
+```
+
+A ticket is referenced by number (`8`, `T-8`, `#8`) or UUID. Statuses: `triage`, `investigating`,
+`planning`, `awaiting_review`, `awaiting_approval`, `executing`, `verifying`, `blocked`, `done`,
+`cancelled`.
+
+### Answering a decision
+
+A `blocked` ticket is waiting on a choice the agent offered:
+
+```bash
+ankra tickets get T-8                              # read the offered options and their keys
+ankra tickets decide T-8 --option rollback
+ankra tickets decide T-8 --answer "Neither - drain the node first, then retry."
+ankra tickets decide T-8 --option rollback --answer "Roll back, then open a follow-up ticket."
+```
+
+`--option` picks one of the offered keys; `--answer` is the "something else" path in your own
+words; both together record the option with your note beside it. The answer lands on the timeline
+as a `Decision:` comment and the agent resumes from it. `decide` only applies to a ticket that is
+actually `blocked` on a decision — otherwise use `tickets comment` to talk to the agent.
+
+**Commenting on a ticket re-admits it** and re-dispatches the agent, but only once any running turn
+has terminated. That is the supported way to steer an agent that is already working.
+
+## 5. Chat, and approving what it proposes
+
+```bash
+ankra chat --mode ask "why is the payments pod crashlooping in prod?"
+ankra chat --mode agent "open a PR fixing the failing lint job"
+ankra chat health                                  # AI-analysed cluster health
+ankra chat history ; ankra chat show <conversation-id> ; ankra chat delete <id>
+
+ankra chat actions list <conversation-id>          # writes awaiting confirmation
+ankra chat actions confirm <action-id>
+ankra chat actions reject <action-id>
+```
+
+Agent-mode chat **halts before every write** and proposes it as a pending action. Pending actions
+expire, so confirm promptly. If the cluster changed since the action was proposed, confirming
+answers a drift conflict — `--force` applies it against the changed state anyway, which you should
+only do after re-reading what changed.
+
+Opening a pull request is the exception: in Agent mode it happens automatically, because the PR is
+itself the review gate. Nothing is merged and nothing is force-pushed.
+
+## 6. Where ephemeral AI work runs
+
+Workspace pods and PR demos run on one **staging cluster** nominated per organisation, configured
+in **Organisation settings → AI → Environment** along with the workspace and demo TTLs and the
+default gateway mode. Without it, the safe-creation tools answer "configure a staging cluster
+first". `ankra org ai-environment` shows and changes where PR demos are published; see
+`ankra-ai-gateway`.
+
+Per-application AI behaviour:
+
+```bash
+ankra application ai-config <application-id>       # read, set, or reset the app's AI lane config
+```
+
+## Rules
+
+- **Set the credential, then switch the provider.** A switch with no valid credential is refused.
+- **`endpoints discover` before trusting a model id.** A wrong id fails at the first real call.
+- **Secret headers go in secret slots** (`--secret-header Key` alone), never inline, never
+  `--header`.
+- **`read_only` tier and a trimmed allow-list by default.** Widen deliberately, per tool, per role.
+- **Read the transcript before approving a write.** `agents transcript` is the evidence.
+- **Watch `awaiting_user` and `--needs-human`.** An unanswered decision is a stalled agent.
+- **Cancel rather than let a wrong run finish** — `agents cancel` interrupts within seconds.
+- **Never paste a provider API key or a secret header value** into a ticket, a transcript, a PR or
+  chat.
+
+## Related skills
+
+- `ankra-ai-gateway` — Ask/Agent modes per Slack/Teams/SCM binding, workspaces and PR demos.
+- `ankra-security` — token scopes, roles, and how tool grants widen with role.
+- `ankra-app-integrations` — pointing an application (rather than Ankra) at an LLM gateway.
+- `ankra-troubleshooting` — verifying what an agent claims it found.
+- `ankra-alerts-webhooks` — routing agent findings to Slack, Teams or PagerDuty.

--- a/internal/skills/embedded/skills/ankra-alerts-webhooks/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-alerts-webhooks/SKILL.md
@@ -1,38 +1,138 @@
 ---
 name: ankra-alerts-webhooks
-description: Configure Ankra alerts and outbound webhooks to notify Slack, Microsoft Teams, Discord, PagerDuty, Opsgenie, Datadog, or custom endpoints, with automatic AI incident analysis attached to alerts. Use when the user wants alerting, notifications, incident routing, on-call integration, or webhook delivery from Ankra.
+description: Route Ankra's platform notifications to Slack, Microsoft Teams, Discord, PagerDuty or a custom webhook - creating destinations (webhook URLs or bot channels), routing rules that filter by kind, severity and cluster with include/exclude modes and priorities, previewing which destinations a notification would reach, and testing delivery before relying on it. Use when the user wants alerting, notifications, incident routing, on-call integration, webhook delivery from Ankra, or asks why a notification did or did not reach a channel.
 ---
 
-# Ankra Alerts & Webhooks
+# Ankra alerts and webhooks
 
-Ankra raises alerts on cluster conditions and delivers them to external systems via webhooks. Alerts can carry AI incident analysis so responders get context, not just a firing signal.
+Ankra emits **notifications** (a failed execution, a degraded resource, a firing alert trigger, a
+GitOps sync failure, an offline agent, new severe CVEs). **Destinations** are where they can be
+delivered; **routes** decide which notification reaches which destination. Both are managed with
+`ankra alerts`.
 
-## Webhook targets
+```
+notification (kind, severity, cluster) → routes (filters, priority) → destinations (Slack/Teams/PagerDuty/webhook)
+```
 
-- **ChatOps:** Slack, Microsoft Teams, Discord.
-- **On-call / incident:** PagerDuty, Opsgenie.
-- **Observability:** Datadog.
-- **Custom:** any HTTPS endpoint that accepts a JSON POST.
+## Destinations
 
-## Configure
+Two shapes: a **webhook URL**, or a **bot channel** for Slack/Teams workspaces connected to the
+organisation.
 
-1. Create a webhook pointing at the destination (channel webhook URL, PagerDuty/Opsgenie integration key, or custom endpoint). Store the URL/key as a credential, not in plaintext config.
-2. Configure which alerts route to which webhook (severity, cluster, namespace scope).
-3. Send a test event and confirm delivery in the destination.
+```bash
+ankra alerts destinations create --name ops-slack \
+  --url https://hooks.slack.com/services/...
+ankra alerts destinations create --name oncall --type pagerduty \
+  --url https://events.pagerduty.com/...
+ankra alerts destinations channels                    # channel ids the Ankra bot can post to
+ankra alerts destinations channels --provider teams
+ankra alerts destinations create --name ops-teams --type teams \
+  --channel-id 19:abc@thread.tacv2 --teams-tenant-id <tenant>
 
-## AI incident analysis
+ankra alerts destinations list
+ankra alerts destinations get <destination-id>
+ankra alerts destinations update <destination-id> ...
+ankra alerts destinations delete <destination-id>
+```
 
-When an alert fires, Ankra can attach an AI analysis of the likely cause and affected resources. Route high-severity alerts to your on-call tool (PagerDuty/Opsgenie) and informational ones to a ChatOps channel so the AI summary lands where responders look.
+- `--type` (`slack`, `teams`, `discord`, `pagerduty`, `custom`; default `slack`) records the
+  receiver and selects the default payload format; `--template-file` overrides the payload with
+  your own template.
+- A Teams channel destination needs both `--channel-id` and `--teams-tenant-id`.
+- In `channels`, a provider reading **"not connected"** means the workspace/tenant is not linked to
+  the organisation, and **"not available"** means the bot service is not configured on the
+  platform. Neither is an error — connect the integration first (`ankra-ai-gateway`).
+- `--disabled` creates a destination without it receiving anything yet.
+
+**Test before relying on it** — both forms exit non-zero on a failed delivery, so CI can gate on
+them:
+
+```bash
+ankra alerts destinations test <destination-id>
+ankra alerts destinations test-url --url https://example.com/hook --template-file payload.json
+```
+
+`test-url` sends to an ad-hoc URL *without* storing a destination — the right way to validate a
+webhook before it goes anywhere near configuration.
+
+## Routes
+
+Every filter is optional; **a route with no filters matches every notification.**
+
+```bash
+ankra alerts routes create --destination-id <id> --severity critical
+ankra alerts routes create --destination-id <id> --kinds execution_failed,gitops_sync_failed
+ankra alerts routes create --destination-id <id> --cluster-id <cluster-id> --severity warning
+ankra alerts routes create --destination-id <id> --kind agent_offline --mode exclude --stop-on-match
+
+ankra alerts routes list
+ankra alerts routes update <route-id> ...
+ankra alerts routes delete <route-id>
+```
+
+Filters and mechanics:
+
+- **Kinds** include `execution_failed`, `resource_deployment_failed`, `resource_health_degraded`,
+  `alert_trigger_fired`, `gitops_sync_failed`, `agent_offline`, `security_new_severe_cves`, and the
+  other platform notification kinds. `--kind` (one), `--kinds` (list), or `--exclude-kinds`
+  (everything except these).
+- **Severities**: `critical`, `warning`, `info`.
+- **`--mode include`** (default) delivers matches; **`--mode exclude`** withholds them — the way to
+  mute one noisy kind from a destination that otherwise gets everything.
+- **`--priority`** orders evaluation (lowest first, default 100), and **`--stop-on-match`** stops
+  lower-priority routes once this one matches. Together they express "critical goes to on-call and
+  *only* on-call".
+- `--source-id` scopes to one emitting source; `--cluster-id` to one cluster.
+
+## Preview and test routing
+
+`preview` is the answer to "where would this go?" — and to "why did that page fire?":
+
+```bash
+ankra alerts routes preview --kind alert_trigger_fired --severity critical
+ankra alerts routes preview --kind alert_trigger_fired --severity critical --alert-id <alert-id>
+ankra alerts routes preview --kind gitops_sync_failed --severity warning --cluster-id <id> -o json
+ankra alerts routes test <route-id>          # queue a real sample through the route
+```
+
+Nothing is delivered by `preview` and nothing changes — it prints the destinations a hypothetical
+notification would reach and the reason each matched. **Pass `--alert-id` whenever previewing an
+alert firing**: an alert can carry its own destination list, a destination reached by both that
+list and a routing rule is delivered to once, and without the id the preview cannot tell you which
+rule that affects.
+
+`routes test` queues a real sample; delivery is asynchronous, so it returns the delivery id once
+queued, not once the receiver accepted it — `destinations test` is the synchronous check.
+
+## A sane starting layout
+
+```bash
+ankra alerts destinations create --name oncall --type pagerduty --url https://events.pagerduty.com/...
+ankra alerts destinations create --name ops-slack --url https://hooks.slack.com/services/...
+
+ankra alerts routes create --destination-id <oncall> --severity critical --priority 10 --stop-on-match
+ankra alerts routes create --destination-id <ops-slack> --severity warning
+ankra alerts routes create --destination-id <ops-slack> --kinds gitops_sync_failed,agent_offline
+```
+
+Critical pages on-call and stops; warnings and platform events land in chat. Ankra attaches AI
+incident analysis to alerts, so the summary lands where responders actually look.
 
 ## Rules
 
-- **Secrets as credentials.** Webhook URLs and integration keys are secrets — store them in Ankra credentials / the secret store, never commit them.
-- **Scope and severity-route.** Don't fan every alert to every channel; map severity to destination (critical → on-call, warning → chat).
-- **Test delivery** before relying on a route in production.
-- **Avoid alert noise.** Tune thresholds so alerts are actionable; noisy alerts get ignored.
-- **Custom endpoints must be HTTPS** and validate the payload.
+- **`test-url` before storing, `test` after storing, `preview` before trusting a route.**
+- **Severity-route**: critical → on-call, warning → chat. Do not fan everything everywhere — noisy
+  alerts get ignored, which is worse than no alerts.
+- **A filterless route matches everything.** Make that a deliberate choice, not an accident.
+- **Use `--mode exclude` to mute a kind**, not deletion of the broad route.
+- **Webhook URLs and integration keys are secrets.** Pass them to the CLI, never commit them to
+  Git; a custom endpoint must be HTTPS and validate the payload.
+- **`--alert-id` on previews of alert firings**, or the dedup against the alert's own destinations
+  is invisible.
 
 ## Related skills
 
-- `ankra-observability` produces the signals that drive these alerts.
-- `ankra-platform-principles` for the secret-handling stance.
+- `ankra-observability` — the Prometheus/Grafana stack producing the underlying signals.
+- `ankra-troubleshooting` — what to do with the notification once it lands.
+- `ankra-ai-gateway` — connecting the Slack workspace / Teams tenant the bot posts into.
+- `ankra-security` — scoping who can manage destinations and routes.

--- a/internal/skills/embedded/skills/ankra-app-integrations/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-app-integrations/SKILL.md
@@ -23,7 +23,7 @@ a live pod and lost at the next roll.
 ankra cluster stacks list                          # what is deployed, by stack
 ankra cluster addons list                          # the Helm releases
 ankra cluster get services -n <namespace>          # in-cluster DNS name and port
-ankra cluster get ingress -n <namespace>           # the public name, if any
+ankra cluster get ingresses -n <namespace>         # the public name, if any
 ankra cluster addons values <addon>                # how the service itself is configured
 ```
 

--- a/internal/skills/embedded/skills/ankra-app-integrations/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-app-integrations/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: ankra-app-integrations
+description: Connect an application to services and secrets that already exist in an Ankra organisation - an LLM gateway such as LiteLLM or vLLM, a container registry such as Harbor, a database, an object store, or an internal API - by reusing stored credentials rather than minting new ones, and choosing correctly between application env-secrets, SOPS-encrypted manifests, and cluster/organisation variables. Use when the user wants to wire an app to LiteLLM, Harbor, Postgres, Redis, S3 or an internal service, mentions connecting to an existing secret or app, or asks where a configuration value should live.
+---
+
+# Connecting an application to what already runs
+
+Most integration work in an Ankra organisation is not "provision a new thing" — it is "point this
+application at the thing that already runs, with the credential that already exists". Doing that
+wrongly is how admin tokens end up in application environments and how a value gets configured in
+a live pod and lost at the next roll.
+
+## The four questions, in order
+
+1. **Where does the service run?** In this cluster, in another cluster, or outside entirely.
+2. **Which credential already exists?** Reuse or scope down; never copy an admin token.
+3. **Where does the value belong?** Environment secret, encrypted manifest, or plain variable.
+4. **How will you prove it works?** A real call, in the logs — not a green deploy.
+
+## 1. Find the service
+
+```bash
+ankra cluster stacks list                          # what is deployed, by stack
+ankra cluster addons list                          # the Helm releases
+ankra cluster get services -n <namespace>          # in-cluster DNS name and port
+ankra cluster get ingress -n <namespace>           # the public name, if any
+ankra cluster addons values <addon>                # how the service itself is configured
+```
+
+For a consumer in the **same cluster**, use the in-cluster address —
+`http://<service>.<namespace>.svc.cluster.local:<port>` — not the public URL. It skips the
+ingress, stays inside the cluster network, and keeps working when the public name changes.
+
+For a consumer in **another cluster**, you need the public name plus authentication; say so
+explicitly rather than assuming cluster-local DNS will resolve.
+
+## 2. Find the credential
+
+```bash
+ankra credentials list                             # cloud, Git, registry credentials
+ankra credentials get <name>
+ankra credentials repositories <name>              # what a Git credential can actually reach
+ankra helm credentials list                        # Helm registry credentials
+ankra cluster decrypt addon <addon>                # SOPS-encrypted addon values, when you must
+```
+
+Rules that matter more than convenience:
+
+- **Reuse an existing scoped credential, or issue a new scoped one from the service itself.**
+  An application gets its own key with its own permissions.
+- **Never hand an application an admin credential.** Admin credentials exist so Ankra can mint
+  the scoped one (see the Harbor pattern below).
+- **Never print a decrypted secret** into the terminal transcript, a pull request, a commit
+  message, or chat. `decrypt` is for verifying shape, not for copying values around.
+
+## 3. Decide where the value lives
+
+| Kind of value | Where it goes | Command |
+|---------------|---------------|---------|
+| Secret only this application needs | Application environment secret | `ankra application env-secrets set` |
+| Secret a stack deploys (a Secret manifest, an addon value) | SOPS-encrypted in the GitOps repo, with `encrypted_paths` | `ankra cluster encrypt manifest` / `... addon` |
+| Non-secret, differs per cluster (base URLs, sizes, model names) | Cluster variable | `ankra cluster variables set` |
+| Non-secret, same across the organisation | Organisation variable | `ankra org variables set` |
+| Non-secret, differs per stack instance | Stack variable | `ankra cluster stacks variables set` |
+| A value other clusters must supply when they install this | Stack profile parameter | `ankra-stack-profiles` |
+
+```bash
+printf '%s' "$LITELLM_KEY" | ankra application env-secrets set <app-id> LLM_API_KEY
+ankra application env-secrets apply <app-id>
+
+ankra cluster variables set LLM_BASE_URL http://litellm.ai.svc.cluster.local:4000 --cluster prod
+ankra org variables set DEFAULT_MODEL gpt-4o-mini
+```
+
+Getting this split right is the whole skill: a base URL in an encrypted secret is unreviewable,
+and an API key in a plain variable is a leak.
+
+## 4. Wire the consumer by reference
+
+Inject the secret **by reference**, never as a literal in the manifest:
+
+```yaml
+env:
+  - name: LLM_BASE_URL
+    value: "${LLM_BASE_URL}"          # a variable, resolved at deploy
+  - name: LLM_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: payments-llm
+        key: api-key
+```
+
+A Secret the stack deploys must live in the consumer's namespace — a Secret in another namespace
+is invisible to the pod, and this is the most common cause of "the value is set but the app sees
+nothing".
+
+## Pattern: an LLM gateway (LiteLLM, vLLM, Ollama, OpenRouter)
+
+Two different connections are often confused. Be explicit about which one is being asked for.
+
+**A. Your application calls the gateway.**
+
+```bash
+ankra cluster get services -n ai                   # e.g. litellm ClusterIP :4000
+ankra cluster variables set LLM_BASE_URL http://litellm.ai.svc.cluster.local:4000 --cluster prod
+printf '%s' "$VIRTUAL_KEY" | ankra application env-secrets set <app-id> LLM_API_KEY
+ankra application env-secrets apply <app-id>
+```
+
+Issue the application a **virtual key** from the gateway with its own budget and model allow-list,
+rather than sharing the gateway's master key. Pin the model id in a variable so a model change is
+a reviewable commit. Verify with one real request and confirm the gateway logged it:
+
+```bash
+ankra cluster logs -l app=litellm -n ai --follow=false --tail 50
+```
+
+**B. Ankra's own AI calls the gateway** — a different, organisation-level setting:
+
+```bash
+ankra ai status
+ankra ai endpoints create --name litellm --base-url https://llm.example.com/v1 --api-key <key>
+ankra ai endpoints discover litellm                # the model ids it advertises
+ankra ai models create --name <model-id> ...       # what the chat picker offers
+ankra ai provider set openai_compatible
+```
+
+Ankra probes `GET <base-url>/models` on save; a wrong model id only surfaces at the first call.
+See `ankra-ai-agents` for the provider and catalogue surface.
+
+## Pattern: a container registry (Harbor and friends)
+
+An application publishing to a registry you operate needs three distinct things, and they are
+frequently conflated:
+
+1. **A push credential for CI** — the build workflow logs in with it.
+2. **A read credential for Ankra** — so Ankra can verify builds and pull demo images
+   (`--credential`). Without it, builds report as never published.
+3. **A pull secret for the cluster** — a `dockerconfigjson` Secret the generated manifests
+   reference (`--pull-secret`). Without it, deploys land in `ImagePullBackOff`.
+
+```bash
+ankra application registry set <app-id> \
+  --url oci://artifact.example.com/commerce \
+  --credential example-harbor-pull \
+  --admin-credential example-harbor-admin \
+  --pull-secret commerce-registry
+```
+
+Given `--admin-credential` (a credential with **project administrator** rights — for Harbor, a
+Harbor *user* with Project Admin on that project, not a robot), Ankra mints, rotates and revokes a
+per-application push robot and stores it in the repository's Actions secrets. That is the pattern
+to prefer: the admin credential stays with the platform, the application gets a narrow robot.
+
+Declare the registry at `ankra application add` time. Adding it afterwards leaves a build workflow
+that logs in with the wrong registry — see `ankra-applications`.
+
+For **charts** rather than images, the equivalent surface is `ankra helm registries` /
+`ankra helm credentials` — see `ankra-helm-registries`.
+
+## Pattern: a database or cache in the cluster
+
+```bash
+ankra cluster get services -n data                  # the operator's service, often -rw / -ro pairs
+ankra cluster get secrets -n data                   # the operator-generated credential Secret
+```
+
+Database operators (CloudNativePG, the Redis and MySQL operators) already generate a credential
+Secret. Consume **that** Secret rather than copying its value into an application env-secret:
+rotation then happens without you. Point the application at the read-write service for writes and
+the read-only service for reads where the operator provides both.
+
+Cross-namespace: replicate the Secret into the consumer's namespace with a stack manifest (and a
+`parents` edge on the namespace), or deploy the consumer into the data namespace. Do not assume a
+pod can read a Secret from elsewhere.
+
+## Pattern: an internal API or third-party SaaS
+
+- In-cluster: `http://<service>.<namespace>.svc.cluster.local:<port>`, no credential if the API
+  trusts the cluster network, a scoped token if it does not.
+- Outside: the public URL in a variable, the token in an env-secret. Check egress actually works
+  from the cluster before blaming the credential.
+- Webhooks pointing *back* at Ankra belong in `ankra alerts destinations` — see
+  `ankra-alerts-webhooks`.
+
+## Verification checklist
+
+```bash
+ankra cluster operations list                       # the change actually deployed
+ankra cluster get pods -n <ns>                      # the consumer rolled and is Ready
+ankra cluster logs -l app=<name> -n <ns> --follow=false --tail 100
+ankra cluster logs -l app=<provider> -n <ns> --follow=false --tail 50   # the provider saw the call
+```
+
+An integration is done when the **provider's** logs show the consumer's call succeeding. A
+consumer that starts without crashing has proved nothing.
+
+## Rules
+
+- **Reuse, scope down, never copy an admin token into an application.**
+- **In-cluster consumers use in-cluster DNS.** Public URLs are for consumers outside the cluster.
+- **Secrets by reference**, in the consumer's namespace, never a literal in a manifest.
+- **Non-secret configuration is a variable**, so it stays reviewable in a diff.
+- **`env-secrets set` then `env-secrets apply`** — setting alone never reaches a running workload.
+- **Pin what you depend on**: chart version, image tag, model id.
+- **Never echo a decrypted secret** anywhere it will be recorded.
+- **Nothing configured only in a live pod.** If it is not in committed YAML or Ankra's stored
+  state, the next roll loses it.
+
+## Related skills
+
+- `ankra-applications` — registering the application and its registry.
+- `ankra-sops-secrets` — encrypting anything that lands in Git.
+- `ankra-helm-registries` — private chart sources and their credentials.
+- `ankra-ai-agents` — Ankra's own AI provider, model catalogue and MCP tool servers.
+- `ankra-security` — credential scope, tokens, and who can reach what.
+- `ankra-troubleshooting` — when the call fails and you need the evidence.

--- a/internal/skills/embedded/skills/ankra-applications/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-applications/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: ankra-applications
+description: Take source code from a Git repository to a running deployment on one or many Ankra clusters - registering an application, the generated Dockerfile/chart/build workflow, the image registry it publishes to, environment secrets, deployments, auto-deploy, PR demos, and publishing the result as a catalogue add-on. Use when the user wants to deploy their own code with Ankra, mentions `ankra application`, connects a repository, asks how to get a service live, or wants the same service on several clusters.
+---
+
+# Ankra Applications
+
+An **Application** is Ankra's link between a Git repository of source code and the clusters that
+run it. Ankra reads the repository, generates the container build and the Kubernetes packaging,
+publishes the image to a registry, and deploys it — so a service goes from source to production
+without anyone hand-writing a Deployment.
+
+Use this skill for *your own code*. For third-party software (a Helm chart someone else
+maintains) use `ankra-stacks-addons`; the two meet when an application publishes its manifests as
+a catalogue add-on.
+
+## The lifecycle
+
+```
+repository → add → setup PR (Dockerfile, chart, build workflow) → build & push image
+          → env-secrets → deploy to cluster → verify → auto-deploy / promote → many clusters
+```
+
+Every step has a CLI command; all of them are also visible in the portal's Applications tab.
+
+## 1. Register the application
+
+```bash
+ankra application add .                      # detect repo, credential and branch from the checkout
+ankra application add ./services/payments --name payments
+ankra application add . --credential github-acme --branch main
+```
+
+`add` reads the local Git checkout: it detects the GitHub repository from the remote (`--remote`,
+default `origin`), uses the remote's default branch, and picks the GitHub credential when the
+choice is unambiguous.
+
+**Declare a registry you already operate in the same command** — not afterwards:
+
+```bash
+ankra application add . \
+  --registry-url oci://artifact.example.com/commerce \
+  --registry-credential example-harbor \
+  --registry-pull-secret commerce-registry
+```
+
+The setup job generates the build workflow *from the declaration the application is created
+with*. A registry added later leaves a workflow that logs in with the wrong one, and you will be
+debugging a push failure that has nothing to do with the code. With no declaration the
+application publishes into the organisation's own Ankra registry project, which is the right
+default when you do not already run a registry.
+
+Related flags: `--registry-api-url`, `--registry-username-secret`, `--registry-password-secret`
+(the repository Actions secrets the workflow logs in with) and `--registry-manage-actions-secrets`
+to let Ankra write the named credential into those secrets for you. See
+[reference.md](reference.md) for the registry matrix (Harbor, ECR, GAR, ACR, GHCR, Docker Hub).
+
+## 2. Review what Ankra generated
+
+Ankra opens a **setup pull request** carrying the Dockerfile, the Helm chart, and the build
+workflow. Read it — this is the contract for everything that follows.
+
+```bash
+ankra application list
+ankra application get <application-id>
+ankra application branches <application-id>
+ankra application branch-files <application-id>      # what is tracked on the setup branch
+ankra application files <application-id> \
+  --file Dockerfile=./Dockerfile --message "Pin the base image"
+ankra application retry <application-id>             # re-run a failed setup
+```
+
+Things worth checking before merging: the base image and its tag, the exposed port, the health
+probe paths, resource requests, and that nothing secret was baked into the image.
+
+## 3. Supply configuration and secrets
+
+The generated manifests declare which environment values they need. Fill them in — a missing one
+is the single most common reason a first deploy crash-loops.
+
+```bash
+ankra application env-secrets list <application-id>          # keys and their state
+printf '%s' "$DATABASE_URL" | ankra application env-secrets set <application-id> DATABASE_URL
+ankra application env-secrets set <application-id> API_TOKEN  # prompts without echo
+ankra application env-secrets apply <application-id>          # seal into the deployments and roll
+ankra application env-secrets delete <application-id> OLD_KEY
+```
+
+**Never pass `--value` on the command line.** It lands in shell history and, on a shared host, in
+the process table. Pipe on stdin or let it prompt.
+
+Storing a value does nothing until `env-secrets apply` seals it into the running deployments.
+Non-secret configuration (base URLs, model names, feature toggles) belongs in cluster or
+organisation variables instead — see `ankra-app-integrations`.
+
+## 4. Deploy to a cluster
+
+```bash
+ankra cluster list                                    # find the target cluster id
+ankra application deploy <application-id> --cluster <cluster-id> --namespace prod
+ankra application deploy <application-id> --cluster <cluster-id> --mode high_availability --set replicas=3
+ankra application deployments <application-id>        # where it is running
+ankra application installations <application-id>      # installation intents and their state
+ankra application jobs <application-id>               # the platform jobs behind those intents
+```
+
+`--mode quick` is the single-replica default; `--mode high_availability` asks for the resilient
+shape. `--set key=value` binds the deploy inputs the chart declares.
+
+Then verify, before you call it done:
+
+```bash
+ankra cluster operations list --cluster <cluster>     # did the platform execution succeed
+ankra cluster get pods -n prod --cluster <cluster>
+ankra cluster logs -l app=<name> -n prod --follow=false --tail 100
+```
+
+## 5. Continuous delivery
+
+```bash
+ankra application auto-deploy get <application-id>
+ankra application auto-deploy set <application-id> --enabled        # or --enabled=false
+ankra application settings get                        # org-wide CI settings
+ankra application settings set --ci-runner-label self-hosted
+ankra application workflow-runs <application-id>
+ankra application workflow-run-jobs <application-id> <run-id>
+ankra application rerun-workflow <application-id> <run-id>
+```
+
+With auto-deploy on, a build Ankra observes on the tracked branch rolls itself out unattended.
+With it off, a push still builds and waits for an explicit `ankra application deploy`. Choose
+deliberately: auto-deploy is right for dev and staging, and for production only when the branch
+is protected and the pipeline gates on tests.
+
+The organisation's CI runner label decides which GitHub Actions runner the generated pipelines
+request — change it when GitHub-hosted runners are unavailable to you.
+
+## 6. Security scanning
+
+```bash
+ankra application upgrade-workflow <application-id>   # add scanning steps to the build workflow
+ankra application code-security <application-id>      # source findings
+ankra application container-security <application-id> # image CVEs
+ankra application pull-request-reviews <application-id>
+```
+
+Treat an application whose build workflow has no scanning step as unfinished. See
+`ankra-security` for how these findings fit the wider posture review.
+
+## 7. Preview a branch before it merges
+
+```bash
+ankra application demo build <application-id> --branch <branch>   # is there a demo-ready image
+ankra application demo deploy <application-id> --branch <branch> --ttl-hours 8
+ankra application demo deploy <application-id> --pr-number 42
+ankra application demo list <application-id>
+ankra application demo detail <application-id> <demo-id>
+ankra application demo logs <application-id> <demo-id>
+ankra application demo stop <application-id> <demo-id>
+ankra application demo fix <application-id> <demo-id>             # AI pre-setup mission on failure
+ankra application demo fix-build <application-id> --branch <branch>
+ankra application demo config <application-id>                    # saved demo defaults
+```
+
+Demos are ephemeral workspaces on the organisation's AI/staging cluster with their own TTL, and
+they are reaped automatically. They are the reviewable artefact for a pull request — a public
+preview URL, not a port-forward. Configure the staging cluster in **Organisation settings → AI →
+Environment** (`ankra-ai-gateway`).
+
+## 8. One service, many clusters
+
+Do **not** repeat `application deploy` with hand-copied values per cluster. Two supported shapes:
+
+**Publish the manifests as a catalogue add-on** — the application becomes installable software
+other clusters pick up:
+
+```bash
+ankra application publish-addon <application-id> --version 1.2.0 \
+  --display-name "Payments" --category backend --changelog "TLS defaults"
+ankra application published-addon <application-id>
+ankra application chart-versions <application-id>
+ankra application manifest-addon <application-id>            # inspect, install, withdraw
+```
+
+**Or capture the deployed stack as a stack profile** — the right choice when each cluster needs
+different values (domains, sizes, replica counts). Every per-cluster difference becomes a
+parameter instead of a fork. See `ankra-stack-profiles`.
+
+Either way the artefact is built once and promoted, never rebuilt per environment.
+
+## 9. Ankra's own analysis of the application
+
+```bash
+ankra application platform <application-id> --cluster <cluster-id>   # operators already present
+ankra application publish-readiness <application-id>
+ankra application ai-config <application-id>                          # the AI lane configuration
+ankra application reconcile <application-id>                          # request a refresh
+```
+
+`platform` detects which operators (ingress, cert-manager, a database operator) a target cluster
+already runs, so the generated manifests reuse them rather than duplicating them.
+
+## Rules
+
+- **Declare the registry at `add` time.** A late `--registry-url` leaves a wrong build workflow.
+- **Immutable image tags.** Commit SHA or semver; never `latest`. This is what makes promotion and
+  rollback meaningful.
+- **Secrets by stdin or prompt**, never `--value`, and never printed back into a transcript.
+- **`env-secrets set` then `env-secrets apply`.** Setting alone does not reach a running workload.
+- **Verify before promoting.** Operations, pods, logs — in that order. A green `deploy` command is
+  not a working service.
+- **Nothing is finished until it is reproducible.** If a deploy only works because someone edited a
+  live resource, it is not deployed.
+- **`ankra application delete` is destructive**; confirm the application id and what it is running
+  before you run it.
+
+## Related skills
+
+- `ankra-cicd` — the pipeline shape and the GitOps bump that drives deploys.
+- `ankra-app-integrations` — wiring the application to LiteLLM, Harbor, a database, an internal API.
+- `ankra-stack-profiles` — one definition, many clusters, per-cluster parameters.
+- `ankra-troubleshooting` — when the first deploy does not come up.
+- `ankra-security` — tokens, scanning findings, and least-privilege registry credentials.

--- a/internal/skills/embedded/skills/ankra-applications/reference.md
+++ b/internal/skills/embedded/skills/ankra-applications/reference.md
@@ -1,0 +1,224 @@
+# Ankra Applications — reference
+
+Long-form detail for `ankra-applications`: the registry matrix, monorepo components, and a
+complete worked greenfield run from an empty repository to production on several clusters.
+
+## Registry matrix
+
+An application publishes its image either into the organisation's own Ankra registry project (the
+default, nothing to configure) or into a registry you already operate. Declare the second kind at
+`ankra application add` time; changing it later regenerates nothing.
+
+| Registry | `--registry-url` | Credential | Notes |
+|----------|------------------|------------|-------|
+| Ankra registry | *(omit)* | — | Default. Ankra owns the project and the robot. |
+| Harbor | `oci://artifact.example.com/commerce` | Harbor **user** with Project Admin on the project | Ankra can mint a per-application push robot — see below. |
+| Amazon ECR | `oci://<account>.dkr.ecr.<region>.amazonaws.com/commerce` | IAM key or role with `ecr:PutImage` | ECR repositories are not auto-created by default; create the repository first. |
+| Google Artifact Registry | `oci://<region>-docker.pkg.dev/<project>/commerce` | Service account key with Artifact Registry Writer | |
+| Azure Container Registry | `oci://<name>.azurecr.io/commerce` | Service principal or token with `AcrPush` | |
+| GHCR | `oci://ghcr.io/<org>` | PAT with `write:packages` | The repository's own `GITHUB_TOKEN` works for same-org pushes. |
+| Docker Hub | `oci://docker.io/<namespace>` | Access token, not the account password | Rate limits apply to pulls from the cluster. |
+| Nexus / Artifactory / ChartMuseum | `oci://<host>/<repo>` | Deploy user scoped to that repository | See `ankra-helm-registries` for the chart side. |
+
+The scheme is optional: `artifact.example.com/commerce` is accepted and normalised.
+
+### Who mints the push robot
+
+```bash
+ankra application registry set <application-id> \
+  --url oci://artifact.example.com/commerce \
+  --credential example-harbor-pull \
+  --admin-credential example-harbor-admin
+```
+
+- `--credential` is what Ankra uses to **read** the registry (verify builds, pull demo images).
+  Without it Ankra can describe where images live but reports builds as never published.
+- `--admin-credential` is a credential with **project administrator** rights. Given one, Ankra
+  mints, rotates and revokes a per-application push robot and stores it in the repository's
+  Actions secrets. Ankra never mints a robot for a registry it was not handed admin keys to.
+- `--manage-actions-secrets` (without an admin credential) writes the *declared* credential into
+  the repository's Actions secrets instead. Use it when you want to keep control of the robot.
+- `--username-secret` / `--password-secret` name the Actions secrets the build workflow logs in
+  with, when you populate them yourself.
+- `--pull-secret` names the `dockerconfigjson` Secret the generated manifests reference, so the
+  cluster can pull the private image. Without it, a private registry deploys to `ImagePullBackOff`.
+
+### Monorepo components
+
+```bash
+ankra application registry set <application-id> \
+  --url oci://artifact.example.com/commerce \
+  --component-repository crm-api=commerce-api \
+  --component-repository crm-frontend=commerce-web
+ankra application registry set <application-id> --url ... --flat-repositories
+```
+
+By default components publish to `<project>/<app>/<component>`. `--flat-repositories` publishes to
+`<project>/<component>` instead — match whatever your registry's project conventions already are.
+`--component-repository` overrides one component's repository explicitly.
+
+Demos of a monorepo run every recorded component as its own pod:
+
+```bash
+ankra application demo deploy <app-id> --branch main \
+  --component crm-frontend --component crm-api \
+  --component-port crm-api=8090 --component-path crm-api=/api \
+  --entry-component crm-frontend
+```
+
+Selection and overrides ride the same request field, so an override may only name a component
+that `--component` selects. To tune one component of a full launch, list them all.
+
+## Worked run: greenfield service to production on three clusters
+
+The whole path, with the decision at each step called out. Substitute names freely.
+
+### 0. Prerequisites
+
+```bash
+ankra login
+ankra org current
+ankra cluster list                 # note the dev, staging and production cluster ids
+ankra credentials list             # a GitHub credential must exist for the repository
+```
+
+### 1. Make the source deployable
+
+Before registering anything, the repository needs: a container build (a Dockerfile, or a stack
+Ankra can generate one for), one listening port, a health endpoint, and **all configuration read
+from the environment**. A service that reads a config file baked into the image cannot be promoted
+between environments without a rebuild, which defeats every step that follows.
+
+### 2. Register
+
+```bash
+ankra application add . --name payments \
+  --registry-url oci://artifact.example.com/commerce \
+  --registry-credential example-harbor-pull \
+  --registry-pull-secret commerce-registry
+ankra application list             # note the application id
+```
+
+### 3. Review and merge the setup pull request
+
+```bash
+ankra application get <app-id>
+ankra application branch-files <app-id>
+```
+
+Read the generated Dockerfile, chart and workflow in the pull request. Adjust anything wrong and
+push it back:
+
+```bash
+ankra application files <app-id> --file Dockerfile=./Dockerfile --message "Pin the base image"
+```
+
+Merge when the diff is right. If setup itself failed, `ankra application retry <app-id>`.
+
+### 4. Configuration and secrets
+
+```bash
+ankra application env-secrets list <app-id>
+printf '%s' "$DATABASE_URL" | ankra application env-secrets set <app-id> DATABASE_URL
+printf '%s' "$STRIPE_KEY"   | ankra application env-secrets set <app-id> STRIPE_KEY
+ankra application env-secrets apply <app-id>
+```
+
+Non-secret values (the LLM gateway base URL, a feature flag, a bucket name) belong in variables,
+not here:
+
+```bash
+ankra cluster variables set LLM_BASE_URL http://litellm.ai.svc.cluster.local:4000 --cluster dev
+ankra org variables set SUPPORT_EMAIL support@example.com
+```
+
+### 5. Dev first
+
+```bash
+ankra application deploy <app-id> --cluster <dev-cluster-id> --namespace payments
+ankra cluster operations list --cluster dev
+ankra cluster get pods -n payments --cluster dev
+ankra cluster logs -l app=payments -n payments --cluster dev --follow=false --tail 100
+```
+
+If it does not come up, switch to `ankra-troubleshooting` before changing anything.
+
+### 6. Preview every pull request
+
+```bash
+ankra application demo config <app-id>
+ankra application demo deploy <app-id> --pr-number 42 --ttl-hours 8
+ankra application demo detail <app-id> <demo-id>       # the public preview URL
+```
+
+The reviewable artefact for a change is the preview URL, not a screenshot.
+
+### 7. Scanning before staging
+
+```bash
+ankra application upgrade-workflow <app-id>
+ankra application container-security <app-id>
+ankra application code-security <app-id>
+```
+
+Fix or accept every high finding deliberately. An accepted finding should be written down.
+
+### 8. Staging, then production
+
+```bash
+ankra application deploy <app-id> --cluster <staging-cluster-id> --namespace payments
+# verify, then
+ankra application deploy <app-id> --cluster <prod-cluster-id> --namespace payments \
+  --mode high_availability --set replicas=3
+```
+
+The **same image tag** promotes. If the tag differs between staging and production, you did not
+promote — you shipped something that was never tested.
+
+### 9. Continuous delivery
+
+```bash
+ankra application auto-deploy set <app-id> --enabled          # dev / staging
+ankra application auto-deploy get <app-id>
+```
+
+For production, leave auto-deploy off unless the tracked branch is protected and the pipeline
+gates on tests. `ankra-cicd` covers the pipeline that bumps the tag in the GitOps repository.
+
+### 10. The rest of the fleet
+
+Two shapes, and the choice is about whether the clusters need different values.
+
+**Same values everywhere** — publish once, install from the catalogue:
+
+```bash
+ankra application publish-addon <app-id> --version 1.2.0 \
+  --display-name "Payments" --category backend --changelog "Initial catalogue release"
+ankra application published-addon <app-id>
+ankra application manifest-addon <app-id>          # inspect, install per cluster, withdraw
+```
+
+**Different values per cluster** — capture the deployed stack as a parameterised profile:
+
+```bash
+ankra stack-profiles drafts create --name payments \
+  --source-cluster prod --source-stack payments
+# turn every domain / size / replica count into a parameter, then
+ankra stack-profiles drafts publish <draft-id> --changelog "Initial version"
+ankra stack-profiles apply payments --cluster eu-prod --set domain=eu.example.com --dry-run
+```
+
+See `ankra-stack-profiles`. Either way you build once and promote; you never fork the YAML.
+
+## Failure modes worth recognising
+
+| Symptom | Usual cause |
+|---------|-------------|
+| Build pushes to the wrong registry | The registry was declared after `add`; the generated workflow still logs in with the old one. Re-run setup after `registry set`. |
+| `ImagePullBackOff` on a private registry | No `--pull-secret`, or the `dockerconfigjson` Secret is not in the deploying namespace. |
+| Builds report "never published" | A registry with no `--credential`: Ankra cannot read it to verify the push. |
+| First deploy crash-loops immediately | An environment secret is unset, or was set but never `env-secrets apply`-ed. |
+| `env-secrets set` had no effect | Same: `set` stores, `apply` seals into the running deployments and rolls them. |
+| Deploy succeeded, service unreachable | Container port, ingress path, or health probe path does not match what the code serves. |
+| Auto-deploy did not fire | Auto-deploy is off, or the build was not on the tracked branch. Check `auto-deploy get`. |
+| Demo has no image | The branch has no demo-ready build — `ankra application demo build`, then `demo fix-build`. |

--- a/internal/skills/embedded/skills/ankra-cicd/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-cicd/SKILL.md
@@ -50,8 +50,18 @@ For full, copy-pasteable GitHub Actions and GitLab CI examples, see [reference.m
 
 When a pipeline fails, Ankra AI can investigate and fix it for you: it reads the failing run's job logs (GitHub Actions, GitLab pipelines, Bitbucket Pipelines via short-lived minted tokens), clones the repo into an ephemeral workspace pod to reproduce, and proposes the exact file changes. In **Agent** mode it opens the fix as a pull request automatically (the PR is the review gate); in **Ask** mode it stops at the proposed patch. `@ankra`-mention a failing PR from an Agent-mode SCM binding to get a fix PR. See `ankra-ai-gateway` for enabling and scoping this.
 
+## When Ankra generates the pipeline for you
+
+For an application registered with `ankra application add`, Ankra writes the Dockerfile, the chart
+and the build workflow itself, and `ankra application auto-deploy` decides whether a build on the
+tracked branch rolls itself out. Read `ankra-applications` first in that case — this skill is the
+shape to aim for, and the reference below is for pipelines you own by hand.
+
 ## Related skills
 
+- `ankra-applications` for Ankra-generated builds, registries, env-secrets and deploys.
 - `ankra-gitops` for the repo layout CI writes into.
-- `ankra-cli` for optional post-deploy verification (`ankra cluster operations list`).
+- `ankra-cli` for post-deploy verification (`ankra cluster operations list`).
+- `ankra-troubleshooting` when the rollout does not come up.
+- `ankra-security` for scanning findings and least-privilege CI credentials.
 - `ankra-ai-gateway` for AI pipeline-failure investigation and auto-fix PRs, and the Ask/Agent safety modes.

--- a/internal/skills/embedded/skills/ankra-cicd/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-cicd/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ankra-cicd
-description: Build CI/CD pipelines (GitHub Actions or GitLab CI) that build a container image, push it with an immutable tag, and bump that tag in the Ankra GitOps repository so Ankra/ArgoCD syncs the change - rather than running kubectl/helm against the cluster from CI. Use when the user wires CI/CD for an Ankra-managed app, mentions GitHub Actions or GitLab CI with Ankra, or asks how to deploy on push.
+description: Build CI/CD pipelines (GitHub Actions or GitLab CI) that build a container image, push it with an immutable tag, and bump that tag in the Ankra GitOps repository so the Ankra engine syncs the change - rather than running kubectl/helm against the cluster from CI. Use when the user wires CI/CD for an Ankra-managed app, mentions GitHub Actions or GitLab CI with Ankra, or asks how to deploy on push.
 ---
 
 # Ankra CI/CD
 
-The Ankra deploy pattern is **GitOps-driven**: CI builds and pushes an image, then updates the image tag in the GitOps repo. Ankra/ArgoCD detects the commit and reconciles the cluster. CI never applies to the cluster directly.
+The Ankra deploy pattern is **GitOps-driven**: CI builds and pushes an image, then updates the image tag in the GitOps repo. The Ankra engine detects the commit and reconciles the cluster. CI never applies to the cluster directly.
 
 ## Pipeline shape (provider-agnostic)
 
@@ -13,7 +13,7 @@ The Ankra deploy pattern is **GitOps-driven**: CI builds and pushes an image, th
 1. Build the image
 2. Push with an immutable tag (commit SHA or semver, never `latest`)
 3. Bump the tag in the GitOps repo (commit / PR)
-4. Ankra syncs the change to the cluster
+4. The Ankra engine syncs the change to the cluster
 5. (optional) Verify rollout with the Ankra CLI / API
 ```
 

--- a/internal/skills/embedded/skills/ankra-cicd/reference.md
+++ b/internal/skills/embedded/skills/ankra-cicd/reference.md
@@ -1,6 +1,6 @@
 # Ankra CI/CD — pipeline examples
 
-Both examples follow the same pattern: build, push an immutable tag, then commit the new tag into the GitOps repository so Ankra/ArgoCD syncs it. Neither talks to the cluster directly.
+Both examples follow the same pattern: build, push an immutable tag, then commit the new tag into the GitOps repository so the Ankra engine syncs it. Neither talks to the cluster directly.
 
 Assumptions:
 - App source repo and GitOps repo may be the same or different. Below they are separate.

--- a/internal/skills/embedded/skills/ankra-cli/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-cli/SKILL.md
@@ -1,76 +1,158 @@
 ---
 name: ankra-cli
-description: Drive the Ankra CLI to log in, select an organisation and cluster, apply cluster/stack YAML, inspect Kubernetes resources and logs, triage operations, and chat with Ankra AI. Use when the user mentions the `ankra` CLI, `ankra login`, `ankra cluster`, applying an ImportCluster, or managing an Ankra-managed cluster from the terminal.
+description: Drive the Ankra CLI end to end - log in, switch organisation and cluster, apply cluster/stack YAML, manage applications and stack profiles, inspect Kubernetes resources, logs, events and metrics, triage operations, work the AI board, and script it all with `-o json` and stable exit codes. Use when the user mentions the `ankra` CLI, `ankra login`, `ankra cluster`, `ankra application`, `ankra stack-profiles`, `ankra tickets`, applying an ImportCluster, or managing an Ankra-managed cluster from the terminal.
 ---
 
 # Ankra CLI
 
-The `ankra` CLI is the terminal client for the Ankra Platform (an AI-powered Kubernetes platform). Use it to manage organisations, clusters, stacks, addons, manifests, credentials, and to inspect live cluster state.
+`ankra` is the terminal client for the Ankra Platform. Everything the portal does, it does — and
+unlike the portal it is scriptable, which is why agent work should go through it.
 
-## Install
+## Install and verify
 
 ```bash
 bash <(curl -sL https://github.com/ankraio/ankra-cli/releases/latest/download/install.sh)
+ankra --version
+ankra completion install            # once per machine
+ankra upgrade                       # later, to update
 ```
 
-Verify: `ankra --version`. Docs: https://docs.ankra.ai
+Docs: https://docs.ankra.ai
 
-## Core workflow (do this in order)
+## Orient before you act
 
 ```bash
-ankra login                 # browser SSO; stores creds in ~/.ankra.yaml
-ankra org list              # see organisations
-ankra org select            # pick the active organisation
-ankra cluster list          # see clusters in the org
-ankra cluster select        # pick the active cluster (persisted)
-ankra cluster info          # confirm the selected cluster
+ankra login                 # browser SSO; stores credentials in ~/.ankra.yaml
+ankra org list
+ankra org switch <slug|name|id>
+ankra org current
+ankra cluster list
+ankra cluster select <name>         # persisted; omit the name for a picker
+ankra cluster info                  # confirm what you are about to change
 ```
 
-Most `ankra cluster ...` subcommands act on the selected cluster. Override per command with `--cluster <name>`. Override the organisation per command with the global `--org <name|id>`.
+Most `ankra cluster ...` subcommands act on the **selected** cluster. Override per command with
+`--cluster <name|id>`, and the organisation with the global `--org <name|id>`. In a shared script,
+never rely on the selection — pass both explicitly.
 
-## Common commands
+## The command map
 
-| Goal | Command |
-|------|---------|
-| Apply cluster/stack YAML | `ankra cluster apply -f cluster.yaml` |
-| Trigger reconciliation | `ankra cluster reconcile` |
-| List stacks / addons / manifests | `ankra cluster stacks list` / `addons list` / `manifests list` |
-| Inspect workloads | `ankra cluster get pods` (also `deployments`, `services`, `nodes`, `events`, ...) |
-| Stream logs | `ankra cluster logs <pod>` |
-| Triage automation | `ankra cluster operations list`, `... retry`, `... cancel` |
-| Ask the AI (read-only) | `ankra chat --mode ask "why is my ingress pod crashlooping?"` |
-| Let the AI act | `ankra chat --mode agent "open a PR fixing the failing lint job"` |
+| Area | Entry point | Skill |
+|------|-------------|-------|
+| Clusters, stacks, addons, manifests | `ankra cluster ...` | `ankra-import-cluster`, `ankra-stacks-addons` |
+| Your own code, deployed | `ankra application ...` | `ankra-applications` |
+| Reusable parameterised stacks | `ankra stack-profiles ...` | `ankra-stack-profiles` |
+| Cloud clusters Ankra provisions | `ankra cluster hetzner\|ovh\|upcloud\|digitalocean\|proxmox\|scaleway\|morpheus ...` | `ankra-cloud-clusters` |
+| Provider-managed Kubernetes | `ankra cluster managed ...` | `ankra-managed-kubernetes` |
+| Helm chart sources | `ankra helm registries\|credentials ...`, `ankra charts` | `ankra-helm-registries` |
+| Secrets in Git | `ankra cluster encrypt\|decrypt\|sops-config` | `ankra-sops-secrets` |
+| Alerts and routing | `ankra alerts destinations\|routes ...` | `ankra-alerts-webhooks` |
+| Metrics and logs | `ankra cluster metrics\|top\|logs\|events` | `ankra-observability`, `ankra-troubleshooting` |
+| AI provider, tools, runs, board | `ankra ai ...`, `ankra org mcp-servers ...`, `ankra agents ...`, `ankra tickets ...` | `ankra-ai-agents` |
+| Tokens, roles, cluster access | `ankra tokens`, `ankra org members\|roles`, `ankra cluster access` | `ankra-security` |
+| Credentials | `ankra credentials ...` | `ankra-security` |
+| Support | `ankra support ...` | — |
 
-## AI safety modes from the terminal
-
-`ankra chat` takes `--mode ask|agent` (omit it to use the server default):
-
-- `--mode ask` — read-only, plus the curated safe creations (spin up a workspace pod to search an Application's repos, deploy a throwaway PR demo, create a brand-new stack). Never changes existing infrastructure and never opens a PR.
-- `--mode agent` — can act; opening a pull request is automatic, other destructive changes stay confirmation-gated.
-
-This is the same Ask/Agent contract the AI Gateway integrations use (see `ankra-ai-gateway`). Workspace pods and PR demos run on the org's staging cluster configured in **Organisation settings → AI → Environment**.
-
-MCP token scopes mirror the modes: create tokens with `ankra tokens create --scope mcp:read` for the Ask surface (read + safe creations, e.g. for Cursor) or `--scope mcp:write` for the Agent surface (adds mutating tools, including opening fix PRs).
-
-## Authentication for automation
-
-For CI or scripts, skip `ankra login` and pass a token created with `ankra tokens create`:
+## Applying configuration
 
 ```bash
-export ANKRA_API_TOKEN=<token>     # never hardcode in the repo
-ankra cluster info --cluster prod
+ankra cluster validate -f cluster.yaml      # server-side validation, changes nothing
+ankra cluster apply -f cluster.yaml --dry-run
+ankra cluster apply -f cluster.yaml
+ankra cluster draft -f cluster.yaml         # stage every stack as a reviewable draft instead
+ankra cluster reconcile                     # ask Ankra to re-converge
+ankra cluster clone existing.yaml new.yaml --stack monitoring
 ```
 
-Resolution order: explicit `--token`, then the saved login from `ankra login`, then `ANKRA_API_TOKEN`. A saved login token takes precedence over `ANKRA_API_TOKEN` - run `ankra logout` first if you want the env var to win. Use least-privilege tokens and store them in the CI secret store, not in Git.
+`ankra cluster draft` is the safe default on an environment you are not ready to change: the local
+checks run first, then each stack is saved as a resource draft to review, edit and deploy from the
+stack builder. **`apply` replaces a stack's contents declaratively** — what is not in the file is
+removed from that stack.
+
+## Reading a cluster
+
+```bash
+ankra cluster get pods -n <ns>              # also deployments, services, nodes, ingresses,
+                                            # configmaps, secrets, statefulsets, daemonsets,
+                                            # cronjobs, k8s-jobs, namespaces, storageclasses
+ankra cluster get resources <kind> --group <api-group>
+ankra cluster describe <kind> <name> -n <ns>
+ankra cluster events --for pod/<name> -n <ns> --type Warning
+ankra cluster logs <pod> -n <ns> --previous --follow=false
+ankra cluster top pods -n <ns>
+ankra cluster metrics query '<promql>'
+```
+
+`--follow` defaults to true on `logs`; pass `--follow=false` for anything scripted or it will hang.
+
+## Triage
+
+```bash
+ankra cluster operations list
+ankra cluster operations steps <execution-id>
+ankra cluster operations retry <execution-id>
+ankra cluster stacks history <stack>
+ankra cluster agent status
+```
+
+A failed platform execution explains more deploy failures than pod logs do — start there. See
+`ankra-troubleshooting`.
+
+## AI from the terminal
+
+```bash
+ankra chat --mode ask "why is my ingress pod crashlooping?"
+ankra chat --mode agent "open a PR fixing the failing lint job"
+ankra chat health
+ankra chat actions list <conversation-id>   # writes awaiting confirmation
+ankra tickets list --needs-human
+ankra agents runs --status running
+```
+
+- `--mode ask` — read-only, plus curated safe creations (a workspace pod to search an
+  application's repositories, a throwaway PR demo, a brand-new stack). It never changes existing
+  infrastructure and never opens a pull request.
+- `--mode agent` — can act. Opening a pull request is automatic (the PR is the review gate); other
+  destructive changes stay confirmation-gated via `ankra chat actions`.
+
+Omit `--mode` to use the server default. MCP token scopes mirror the modes:
+`ankra tokens create <name> --scopes mcp:read` for the Ask surface, `--scopes mcp:read,mcp:write`
+for the Agent surface. See `ankra-ai-agents` and `ankra-ai-gateway`.
+
+## Scripting
+
+```bash
+export ANKRA_API_TOKEN=<token>              # never hardcode in a repository
+ankra cluster info --cluster prod -o json
+ankra cluster logs -l app=web -n prod --follow=false -o json | jq '.[].message'
+```
+
+- **Structured output**: most read commands take `-o json|yaml`. stdout stays parseable; hints and
+  errors go to stderr.
+- **Token resolution order**: explicit `--token`, then the saved login from `ankra login`, then
+  `ANKRA_API_TOKEN`. A saved login **beats** the environment variable — run `ankra logout` first if
+  you want the variable to win.
+- **Exit codes are a contract**: `0` success, `1` API/runtime, `2` usage, `3` not found,
+  `4` confirmation declined, `5` `--wait`/`--timeout` expiry, `6` auth, `7` RBAC permission denied
+  (the role lacks the permission; re-logging in will not help).
+- **Destructive commands confirm first** (`delete`, `uninstall`, `deprovision`); declining exits 4.
+  In automation, decide deliberately whether to pass the command's non-interactive flag.
 
 ## Conventions to follow
 
-- Select the org and cluster first, or pass `--org` / `--cluster` explicitly. Never assume the active selection in a shared script.
-- Treat mutating commands (`apply`, `reconcile`, `delete`, `provision`, `deprovision`) as deliberate; confirm the target cluster with `ankra cluster info` first.
-- Prefer applying versioned YAML (`ankra cluster apply -f`) over ad-hoc edits so the change is reproducible and reviewable.
-- Enable completions once per machine: `ankra completion install`.
+- **Confirm the target before mutating.** `ankra org current` and `ankra cluster info`, every time.
+- **Prefer versioned YAML** (`ankra cluster apply -f`) over ad-hoc edits, so the change is
+  reproducible and reviewable.
+- **Validate, then draft, then apply.** Each step is cheap; a wrong apply is not.
+- **Do not reach for `kubectl` to change things.** Read-only kubectl through
+  `ankra cluster kubeconfig add --use` is fine; mutations belong in the GitOps repo or
+  `ankra cluster apply`.
+- **Never paste secrets** into a command line — use stdin, a prompt, `--set-file` or `--set-env`.
 
 ## Related skills
 
-- Authoring the YAML you apply: see `ankra-import-cluster` and `ankra-stacks-addons`.
-- Encrypting secrets before commit: see `ankra-sops-secrets`.
+- Authoring the YAML you apply: `ankra-import-cluster`, `ankra-stacks-addons`.
+- Deploying your own code: `ankra-applications`, `ankra-cicd`.
+- Reusing a stack across clusters: `ankra-stack-profiles`.
+- When it breaks: `ankra-troubleshooting`.
+- Everything above, safely: `ankra-security`, `ankra-sops-secrets`, `ankra-platform-principles`.

--- a/internal/skills/embedded/skills/ankra-cli/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-cli/SKILL.md
@@ -15,6 +15,7 @@ bash <(curl -sL https://github.com/ankraio/ankra-cli/releases/latest/download/in
 ankra --version
 ankra completion install            # once per machine
 ankra upgrade                       # later, to update
+ankra config beta enable            # opt in to pre-release builds (disable to leave)
 ```
 
 Docs: https://docs.ankra.ai
@@ -51,7 +52,7 @@ never rely on the selection — pass both explicitly.
 | AI provider, tools, runs, board | `ankra ai ...`, `ankra org mcp-servers ...`, `ankra agents ...`, `ankra tickets ...` | `ankra-ai-agents` |
 | Tokens, roles, cluster access | `ankra tokens`, `ankra org members\|roles`, `ankra cluster access` | `ankra-security` |
 | Credentials | `ankra credentials ...` | `ankra-security` |
-| Support | `ankra support ...` | — |
+| Support requests | `ankra support create\|list\|get\|comment\|attach\|close` | below |
 
 ## Applying configuration
 
@@ -118,6 +119,20 @@ ankra agents runs --status running
 Omit `--mode` to use the server default. MCP token scopes mirror the modes:
 `ankra tokens create <name> --scopes mcp:read` for the Ask surface, `--scopes mcp:read,mcp:write`
 for the Agent surface. See `ankra-ai-agents` and `ankra-ai-gateway`.
+
+## Support requests
+
+```bash
+ankra support create --subject "Nodes NotReady" --description "..." --cluster prod
+ankra support list
+ankra support get <ticket-id>
+ankra support comment <ticket-id> --message "Any update?"
+ankra support attach <ticket-id> ./screenshot.png
+ankra support close <ticket-id>
+```
+
+Every request is reviewed by Ankra AI before it reaches the team; `--force` on `create` submits a
+flagged request anyway. Attach the evidence (operations output, logs) rather than describing it.
 
 ## Scripting
 

--- a/internal/skills/embedded/skills/ankra-cloud-clusters/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-cloud-clusters/SKILL.md
@@ -1,139 +1,253 @@
 ---
 name: ankra-cloud-clusters
-description: Provision and manage Ankra-managed K3s clusters on Hetzner Cloud, OVHcloud, UpCloud, and DigitalOcean - creating clusters, storing provider credentials, and managing node groups, scaling, Kubernetes versions, and upgrades. Use when the user wants Ankra to provision a cluster (rather than import one), or mentions Hetzner, OVH, UpCloud, or DigitalOcean clusters.
+description: Provision and operate clusters Ankra builds on cloud infrastructure - Hetzner, OVHcloud, UpCloud, DigitalOcean, Proxmox VE, HPE Morpheus and Scaleway - choosing the region and the right instance family, picking k3s or kubeadm and the etcd topology, wiring the generated stack straight into a GitOps repository, taking the ingress/DNS/TLS batteries at create time, then scaling, node groups, availability zones, upgrades and teardown. Use when the user wants Ankra to build a cluster rather than import one, asks which server type or region to pick, or mentions Hetzner, OVH, UpCloud, DigitalOcean, Proxmox, Morpheus or Scaleway clusters.
 ---
 
-# Ankra Cloud Clusters
+# Ankra cloud clusters
 
-Besides importing existing clusters, Ankra can provision managed K3s clusters on Hetzner Cloud, OVHcloud, UpCloud, and DigitalOcean. This skill covers the provision-and-manage lifecycle. Provider subcommands share a common shape: `ankra cluster hetzner|ovh|upcloud|digitalocean <verb>`.
+Ankra can build a cluster on infrastructure you own an account with, install the agent, and bring
+up ingress, DNS and TLS in the same pass. `ankra cluster <provider> create` is the entry point;
+after creation almost everything is a **provider-agnostic** verb (`ankra cluster scale`,
+`ankra cluster upgrade`, `ankra cluster node-group ...`) because Ankra detects the provider from
+the cluster.
 
-## 1. Store provider credentials
+Providers: `hetzner`, `ovh`, `upcloud`, `digitalocean`, `proxmox`, `morpheus`. (`scaleway` exists
+for lifecycle verbs but has no `create` — build Scaleway Kubernetes as managed Kapsule instead,
+see `ankra-managed-kubernetes`.)
 
-Provider credentials (and SSH keys) are scoped credentials held by Ankra. Create them first and note the returned credential ID - the create commands take the ID, not the name.
+For a control plane the *provider* runs — DOKS, UKS, GKE, OVH MKS, AKS, EKS, Kapsule — use
+`ankra cluster managed ...` and the `ankra-managed-kubernetes` skill instead. Rule of thumb: this
+skill when you want cluster-admin over the control plane, node-level control, or a provider with no
+managed offering; `managed` when you want the provider to own the control plane's uptime.
+
+## 1. Credentials first
+
+`create` takes credential **IDs**, not names, so store them and read the IDs back.
 
 ```bash
 ankra credentials hetzner create --name hetzner-prod
-ankra credentials hetzner ssh-key create --name ops-key      # SSH key credential
+ankra credentials hetzner ssh-key create --name ops-key
 ankra credentials ovh create --name ovh-prod
 ankra credentials upcloud create --name upcloud-prod
-ankra credentials digitalocean create --name do-prod         # alias: ankra creds do
-ankra credentials list                                       # find the IDs to pass below
-ankra credentials get <name>                                 # resolve a name to its ID
+ankra credentials digitalocean create --name do-prod
+ankra credentials proxmox create --name pve-lab
+ankra credentials morpheus create --name morpheus-prod
+
+ankra credentials list                 # the IDs to pass to create
+ankra credentials get <name>
+ankra credentials validate <name>
 ```
 
-DigitalOcean personal access tokens are prefixed with `dop_v1_`.
+Every provider group has `create`, `list` and `ssh-key`. Scope the token at the provider to the
+project Ankra manages — see `ankra-security`.
 
-## 2. Create a cluster (per provider)
+## 2. Choose the region and the instance family *before* you create
 
-`create` provisions a brand-new cloud cluster. It submits asynchronously by default; add `--wait` (bounded by `--timeout`, default 10m) to block and print the agent install command on first import.
+This is the step people skip and then rebuild. Each provider names its compute differently, and
+each has a discovery command that lists what the credential can actually deploy:
+
+| Provider | Region/location | Instance family | Create flags name it |
+|----------|-----------------|-----------------|----------------------|
+| Hetzner | `ankra cluster hetzner locations` | `ankra cluster hetzner server-types --location <loc> --available-only` | `--worker-server-type`, `--control-plane-server-type` |
+| DigitalOcean | `ankra cluster digitalocean regions` | `ankra cluster digitalocean sizes --region <r> --available-only` | `--worker-size`, `--control-plane-size` |
+| OVH | `ankra cluster ovh regions [--with-zones]` | flavors (`b2-*`, `c2-*`, `r2-*`, `t1/t2-*` GPU) | `--worker-flavor-id`, `--control-plane-flavor-id` |
+| UpCloud | zones (`--zone`) | plans (`2xCPU-4GB`, …) | `--worker-plan`, `--control-plane-plan` |
+| Proxmox VE | `ankra cluster proxmox hosts` | `ankra cluster proxmox sizes` (presets) | see `proxmox create --help` |
+| Morpheus | `ankra cluster morpheus clouds` / `groups` | `ankra cluster morpheus plans`, `layouts` | see `morpheus create --help` |
+
+All discovery commands take `--credential-id`. **A region not enabled on the account fails the
+reconcile late, at private-network setup** — list first rather than guessing from the provider's
+public docs.
+
+Kubernetes versions:
 
 ```bash
-ankra cluster ovh regions --credential-id <id>               # pick a region the project can deploy in
-ankra cluster ovh create \
+ankra cluster k3s-versions          # k3s targets
+ankra cluster kubeadm-versions      # vanilla Kubernetes targets
+```
+
+[reference.md](reference.md) has the per-provider family cheat-sheet — what to pick for a control
+plane, a general worker, a memory-heavy or CPU-heavy workload, and GPU.
+
+## 3. Create
+
+The flag shape is the same everywhere; only the compute flag names change.
+
+```bash
+ankra cluster hetzner create \
   --name prod \
-  --credential-id <ovh_cred_id> \
-  --region GRA9 \
-  --ssh-key-credential-ids <id>,<id> \
-  --wait
+  --credential-id <hetzner_cred_id> \
+  --ssh-key-credential-id <ssh_key_id> \
+  --location nbg1 \
+  --control-plane-count 3 --control-plane-server-type cx33 \
+  --worker-count 3 --worker-server-type cx43 \
+  --distribution k3s \
+  --kubernetes-version <from k3s-versions>
 ```
 
-Hetzner/UpCloud/DigitalOcean `create` take equivalent flags (`--name`, `--credential-id`, location/region, control-plane and worker sizes/counts, `--ssh-key-credential-id[s]`, optional `--kubernetes-version`). Run `ankra cluster <provider> create --help` for the provider-specific server-type/location flags.
+```bash
+ankra cluster digitalocean create \
+  --name prod --credential-id <do_cred_id> --ssh-key-credential-id <ssh_key_id> \
+  --region nyc3 --control-plane-size s-2vcpu-4gb --worker-size s-2vcpu-4gb --worker-count 3
 
-OVH availability zones (3-AZ regions only, currently `EU-WEST-PAR`):
+ankra cluster upcloud create \
+  --name prod --credential-id <uc_cred_id> --ssh-key-credential-id <ssh_key_id> \
+  --zone fi-hel1 --control-plane-plan 2xCPU-4GB --worker-plan 4xCPU-8GB --cni cilium
+
+ankra cluster ovh create \
+  --name prod --credential-id <ovh_cred_id> --ssh-key-credential-id <ssh_key_id> \
+  --region GRA9 --control-plane-flavor-id b2-15 --worker-flavor-id b2-30
+```
+
+`create` submits and returns; it does not take `--wait`. Track it with
+`ankra cluster operations list` and `ankra cluster info`.
+
+### Distribution and etcd topology
+
+`--distribution k3s` (default) or `kubeadm`. For kubeadm, `--etcd-topology stacked` (default) puts
+etcd on the control planes; `external` gives it dedicated VMs (`--etcd-node-count 3|5`,
+`--etcd-server-type` / `--etcd-flavor-id` / `--etcd-plan` / `--etcd-size`).
+
+**`--control-plane-count 3` is what makes a cluster survive losing a node** — one control plane is
+fine for dev and is a single point of failure everywhere else. Count is 1 or 3.
+
+### The batteries — take them at create time
+
+Three flags decide whether the cluster is usable the moment it comes up. All default **on**:
+
+- **`--external-cloud-provider`** — installs the provider's CCM and CSI, so `LoadBalancer`
+  Services get a real load balancer and `PersistentVolumeClaim`s get real disks. Turning it off
+  also disables `--include-networking`.
+- **`--include-networking`** — Traefik + cert-manager for ingress. Requires the CCM (the ingress
+  LoadBalancer is provisioned by it).
+- **`--include-dns`** — gives the cluster its own subdomain under `ankra.cc` (or the
+  organisation's own root domain) and installs external-dns, so an Ingress hostname under that
+  subdomain gets its DNS record **and its TLS certificate** with no manual setup.
+
+Scope worth knowing: the generated external-dns manages **only** the generated subdomain. Ingress
+hosts on your own domains are ignored and their records stay yours to create — declare those with
+`ankra org custom-dns-zones` / `ankra cluster custom-dns-zones`. See `ankra-domains-dns`.
+
+Pass `--include-dns=false` / `--include-networking=false` only when you are bringing your own
+ingress and DNS, and say so in the stack.
+
+### Commit the generated stack to Git at create time
+
+Ankra generates a cloud-provider stack (CCM, CSI, ingress, external-dns) for the new cluster. Point
+`create` at a repository and it lands there as a commit instead of existing only in the platform:
 
 ```bash
-ankra cluster ovh regions --credential-id <id> --with-zones     # only region-3-az regions take zones
+ankra cluster hetzner create ... \
+  --gitops-repository my-org/platform-gitops \
+  --gitops-credential-name github-acme \
+  --gitops-branch main
+```
+
+Do this on the first create rather than wiring GitOps afterwards: it is the difference between a
+cluster whose base layer is reviewable in a pull request and one whose base layer only exists in
+the platform. `ankra cluster gitops status` shows what a cluster syncs from. See `ankra-gitops`.
+
+### OVH availability zones
+
+```bash
+ankra cluster ovh regions --credential-id <id> --with-zones      # only region-3-az regions take zones
 ankra cluster ovh create --name prod --region EU-WEST-PAR \
   --availability-zones eu-west-par-a,eu-west-par-b,eu-west-par-c \
-  --control-plane-count 3                                       # 3 CPs required to spread: etcd quorum
-ankra cluster ovh node-group add <cluster_id> --name db-par-a \
-  --availability-zone eu-west-par-a                              # pin a group to one zone
+  --control-plane-count 3
+ankra cluster node-group add <cluster_id> --name db-par-a \
+  --instance-type b2-15 --availability-zone eu-west-par-b
 ```
 
-Zone names are region-scoped, so read them from `--with-zones` rather than guessing. An instance's zone is fixed at creation: workers can be re-placed by adding a pinned group and draining the old one, a control plane cannot. **Node spread alone is not zone fault tolerance** - OVH block storage is zonal and cannot attach across zones, so a stateful workload also needs one replica and one volume per zone.
+Zone names are region-scoped — read them from `--with-zones`, never guess. Spreading needs
+`--control-plane-count 3` for etcd quorum. An instance's zone is fixed at creation: a worker can be
+re-placed by adding a pinned group and draining the old one, a control plane cannot.
 
-DigitalOcean discovery before create:
+**Node spread alone is not zone fault tolerance.** OVH block storage is zonal and cannot attach
+across zones, so a stateful workload also needs one replica and one volume per zone. And on a
+zone-spread cluster an *unpinned* group's nodes each take the thinnest zone cluster-wide, so a
+one-node group lands wherever the cluster is thinnest — pin the group when it runs zonal storage.
+
+## 4. Operate — mostly provider-agnostic
+
+The provider is detected from the cluster, so these work everywhere:
 
 ```bash
-ankra cluster digitalocean regions --credential-id <id>
-ankra cluster digitalocean sizes --credential-id <id> --region nyc3 --available-only
-ankra cluster digitalocean create \
-  --name prod \
-  --credential-id <do_cred_id> \
-  --ssh-key-credential-id <ssh_key_id> \
-  --region nyc3 \
-  --control-plane-size s-2vcpu-4gb \
-  --worker-size s-2vcpu-4gb \
-  --wait
+ankra cluster scale <cluster_id> 5                    # default worker pool
+ankra cluster upgrade <cluster_id> <target_version>   # k3s or kubeadm; --force to override a blocked drain
+ankra cluster ssh-keys get|set|resync <cluster_id>
+
+ankra cluster node-group list <cluster_id>
+ankra cluster node-group add <cluster_id> --name gpu --instance-type <type> --count 2 --wait
+ankra cluster node-group scale <cluster_id> <group> <count>
+ankra cluster node-group labels <cluster_id> <group> --labels k=v,...
+ankra cluster node-group taints <cluster_id> <group> --taints k=v:NoSchedule,...
+ankra cluster node-group autoscaling get|set <cluster_id> <group>
+ankra cluster node-group upgrade <cluster_id> <group>   # instance type change, IRREVERSIBLE
+ankra cluster node-group delete <cluster_id> <group>
 ```
 
-> `ankra cluster provision` and `ankra cluster deprovision` **start and stop** an already-created managed cluster - they are not how you create one. Creation is always `ankra cluster <provider> create`.
+Upgrades roll one node at a time, control plane first: each node is cordoned, drained respecting
+PodDisruptionBudgets, upgraded, and gated on being Ready at the target version. An etcd snapshot is
+taken before the control plane upgrade. A drain blocked by a PDB aborts the rollout. Downgrades and
+skipping a minor version are not supported.
 
-## 3. Manage the lifecycle
-
-Same verbs exist under `hetzner`, `ovh`, `upcloud`, and `digitalocean`:
+Per-provider reads and power:
 
 ```bash
-ankra cluster ovh k8s-version <cluster_id>                   # current Kubernetes version
-ankra cluster ovh upgrade <cluster_id> ...                   # upgrade Kubernetes
-ankra cluster ovh workers <cluster_id>                       # current worker count
-ankra cluster ovh scale <cluster_id> ...                     # scale workers
-
-ankra cluster ovh control-plane get <cluster_id>
-ankra cluster ovh control-plane set-count <cluster_id> 3     # 1 or 3 controllers
-ankra cluster ovh control-plane set-instance-type <cluster_id> ...
-
-ankra cluster ovh nodes list <cluster_id>
-ankra cluster ovh nodes get <cluster_id> <node>
-
-ankra cluster ovh node-group list <cluster_id>
-ankra cluster ovh node-group add <cluster_id> ...            # async by default; --wait to block
-ankra cluster ovh node-group scale <cluster_id> <group> ...
-ankra cluster ovh node-group upgrade <cluster_id> <group>    # instance/plan change, irreversible
-ankra cluster ovh node-group delete <cluster_id> <group>
+ankra cluster <provider> k8s-version <cluster_id>
+ankra cluster <provider> workers <cluster_id>
+ankra cluster <provider> nodes list|get <cluster_id> [node]
+ankra cluster <provider> control-plane get|set-count|set-instance-type <cluster_id>
+ankra cluster <provider> bastion ...
+ankra cluster <provider> stop <cluster_id>            # power off, keep state
+ankra cluster <provider> start <cluster_id>
+ankra cluster ovh access-info <cluster_id>            # bastion/control-plane IPs, ssh -J commands
+ankra cluster power-schedules ...                     # scheduled stop/start
 ```
 
-### OVH-only extras (parity with the web UI)
+## 5. Teardown — three different things
+
+Do not confuse these; the words are similar and the outcomes are not.
+
+| Command | What it does |
+|---------|--------------|
+| `ankra cluster <provider> stop` / `start` | **Power.** Compute off and on, state kept. Also `ankra cluster power-schedules`. |
+| `ankra cluster deprovision <name>` | **Teardown.** Releases every cloud resource (servers, networks, SSH keys) and uninstalls every stack resource. The cluster *record* is kept. |
+| `ankra cluster provision <name>` | Rebuilds a deprovisioned cluster's infrastructure and redeploys its stacks from the stored definition. Not a power-on. |
+| `ankra delete cluster <name>` | Removes the cluster record itself (`--dry-run` first). |
 
 ```bash
-ankra cluster ovh node-group add <cluster_id> --labels k=v,... --taints k=v:Effect,...
-ankra cluster ovh node-group labels <cluster_id> <group> --labels k=v,...   # empty value clears
-ankra cluster ovh node-group taints <cluster_id> <group> --taints k=v:Effect,...  # effect defaults NoSchedule
-ankra cluster ovh stop <cluster_id>                          # stop compute, keep config
-ankra cluster ovh start <cluster_id> [--scope all|control_plane]
-ankra cluster ovh access-info <cluster_id>                   # bastion/control-plane IPs + ssh -J / port-forward commands
-ankra cluster ovh ssh-keys get <cluster_id>
-ankra cluster ovh ssh-keys set <cluster_id> --ssh-key-credential-ids <id>,...  # applies on next reconcile
+ankra cluster info                                     # confirm the target, every time
+ankra cluster deprovision prod --yes
+ankra cluster deprovision prod --force                 # also clears leftover CSI volumes and LBs
 ```
 
-(Hetzner, UpCloud, and DigitalOcean node groups support `add/list/scale/upgrade/delete`; labels/taints, start/stop, access-info, ssh-keys, and `regions` are OVH-specific today. DigitalOcean adds `regions` and `sizes` discovery commands.)
-
-## Provider-native managed Kubernetes
-
-For managed Kubernetes where the provider runs the control plane - DigitalOcean DOKS, UpCloud UKS, Google GKE, OVHcloud MKS, Azure AKS, or Amazon EKS - use `ankra cluster managed <verb> --provider <doks|uks|gke|mks|aks|eks>` instead of the per-provider K3s commands above, and see the `ankra-managed-kubernetes` skill for the full lifecycle (options, create, discover, import, node pools, upgrades, delete).
-
-## 4. Deprovision / delete (destructive)
-
-```bash
-ankra cluster deprovision <cluster_id>                  # stop; for cloud clusters releases cloud resources
-ankra cluster deprovision <cluster_id> --auto-delete    # stop then delete the cluster record
-ankra cluster <provider> deprovision <cluster_id>       # provider-specific teardown
-ankra delete cluster <name>                             # delete the cluster (supports --dry-run)
-```
-
-Confirm the target with `ankra cluster info` first; deprovisioning releases infrastructure.
+`--force` on UpCloud, Hetzner, OVH and DigitalOcean also deletes leftover CSI storage volumes and
+load balancers — without it, a teardown can leave paid-for orphans behind. After a `provision`,
+verify anything that was patched in place: `ankra cluster addons list`, `ankra cluster manifests list`.
 
 ## Rules
 
-- **Least-privilege provider credentials**, stored in Ankra and validated (`ankra credentials get`) before provisioning. Pass credential IDs, not names, to `create`.
-- **Pick a valid region first** (`ankra cluster ovh regions`, `ankra cluster digitalocean regions`); a region not enabled on the account fails the reconcile at private-network setup.
-- **Confirm the target** before any `deprovision`, `delete`, scale-down, or version/instance upgrade. Node-group `upgrade` is irreversible.
-- **Use `--wait`** when a follow-up step depends on the result; otherwise treat creates and node-group mutations as in-flight and don't re-submit.
-- **Plan node groups** for workload isolation rather than one undifferentiated pool, and right-size them to avoid inflated cost.
-- **Upgrade deliberately** - review the target Kubernetes version and upgrade non-prod first.
+- **Discover, then create.** Region and instance family come from the provider's own listing for
+  that credential, not from memory.
+- **Credential IDs, not names**, on `create`.
+- **`--control-plane-count 3` for anything that must survive a node loss.** 1 or 3, nothing else.
+- **Take the batteries on the first create.** Retrofitting CCM, ingress and external-dns onto a
+  running cluster is strictly more work than asking for them.
+- **Wire GitOps at create time** so the base layer is reviewable from day one.
+- **`create` has no `--wait`.** Follow it with `ankra cluster operations list`; do not re-submit.
+- **Pin the group when it runs zonal storage**, and remember node spread is not fault tolerance.
+- **Node-group `upgrade` is irreversible** — it replaces instances.
+- **Confirm before teardown**, and prefer `--force` on cloud providers so orphaned volumes and load
+  balancers are not left billing.
+- **Upgrade non-production first**, one minor at a time.
 
 ## Related skills
 
-- `ankra-cli` for the broader command surface, auth, and async/`--wait` conventions.
-- `ankra-managed-kubernetes` for provider-native managed Kubernetes (DOKS, UKS, GKE, OVH MKS, AKS, EKS).
-- `ankra-stacks-addons` / `ankra-gitops` to deploy workloads once the cluster exists.
+- `ankra-getting-started` — the whole path from an empty organisation to a first app.
+- `ankra-managed-kubernetes` — DOKS, UKS, GKE, OVH MKS, AKS, EKS, Kapsule.
+- `ankra-import-cluster` — adopting a cluster that already exists.
+- `ankra-domains-dns` — the generated domain, your own zones, and where TLS comes from.
+- `ankra-gitops` — the repository `--gitops-repository` commits into.
+- `ankra-stacks-addons` — deploying onto the cluster once it is up.
+- `ankra-troubleshooting` — when a create or upgrade does not converge.

--- a/internal/skills/embedded/skills/ankra-cloud-clusters/reference.md
+++ b/internal/skills/embedded/skills/ankra-cloud-clusters/reference.md
@@ -1,0 +1,131 @@
+# Cloud clusters — reference
+
+Choosing the instance family, sizing the roles, and the create-flag map per provider.
+
+**The discovery command is always authoritative.** Families and SKU names change, and a credential
+can only deploy what its project is entitled to. Everything below is how to *choose*; run the
+listing to find out what exists:
+
+```bash
+ankra cluster hetzner server-types --credential-id <id> --location <loc> --available-only
+ankra cluster digitalocean sizes   --credential-id <id> --region <r> --available-only
+ankra cluster ovh regions          --credential-id <id> --with-zones
+ankra cluster proxmox sizes                        # px-small, px-medium, ... presets
+ankra cluster morpheus plans       --credential-id <id>
+ankra cluster morpheus layouts     --credential-id <id>
+```
+
+## Instance families, by provider
+
+| Provider | Family prefix | Shape | Reach for it when |
+|----------|---------------|-------|-------------------|
+| **Hetzner** | `cx` | Shared vCPU, Intel | Default workers, control planes, anything not latency-critical |
+| | `cpx` | Shared vCPU, AMD | Same as `cx` with more clock per core |
+| | `cax` | Shared vCPU, Ampere **ARM64** | Cheapest per core — only if every image is multi-arch |
+| | `ccx` | **Dedicated** vCPU | Steady CPU-bound work, databases, CI runners, noisy-neighbour sensitivity |
+| **DigitalOcean** | `s-` | Basic, shared | Dev clusters, small workers |
+| | `g-` / `gd-` | General purpose (dedicated) | Production workers |
+| | `c-` | CPU-optimised | Build farms, encoding, CPU-bound services |
+| | `m-` | Memory-optimised | In-memory caches, JVM heaps, analytics |
+| | `so-` | Storage-optimised | Local-NVMe databases |
+| | GPU sizes | GPU | Inference and training — see the GPU section |
+| **OVH** | `d2-` | Discovery, small | Labs only |
+| | `b2-` / `b3-` | Balanced (general purpose) | Default control planes and workers |
+| | `c2-` / `c3-` | CPU-optimised | CPU-bound services |
+| | `r2-` / `r3-` | RAM-optimised | Memory-heavy workloads |
+| | `t1-` / `t2-` | GPU | Inference and training |
+| **UpCloud** | `<N>xCPU-<M>GB` | General purpose plans | Default; the number pair *is* the shape |
+| | Developer plans | Small, capped | Labs only — too small for a production control plane |
+| | High-CPU / High-Memory plans | Skewed ratios | When the general-purpose ratio wastes one dimension |
+| **Proxmox VE** | `px-small`, `px-medium`, … presets | Your own hardware | Sized by what the host node actually has free |
+| **Morpheus** | service plans + layouts | Whatever the Morpheus admin published | Ask the Morpheus admin which plan is intended for Kubernetes |
+
+ARM (`cax`, and ARM sizes elsewhere) is the single biggest cost lever and the single most common
+way to get a cluster that will not schedule: **every image in every stack** must have an `arm64`
+variant, including the platform add-ons. Verify before committing, or stay on x86.
+
+## Sizing the roles
+
+| Role | Guidance |
+|------|----------|
+| **Control plane** | 2 vCPU / 4 GB is the floor; go to 4 vCPU / 8 GB above ~50 nodes or heavy API traffic. `--control-plane-count 3` for anything that must survive a node loss (1 or 3 only — 2 has no quorum benefit). |
+| **etcd** (`--etcd-topology external`) | Latency-sensitive: prefer dedicated or NVMe-backed instances. `--etcd-node-count 3` (5 only for very large clusters). Stacked etcd is fine up to a few dozen nodes. |
+| **Workers** | Fewer, larger nodes pack better and cost less per usable core; smaller nodes give finer failure granularity and cheaper scale steps. Two or three mid-size beats one huge node — losing it should not lose the cluster. |
+| **Bastion / gateway** | The smallest thing the provider sells. It routes; it does not work. |
+| **GPU** | Its own node group, tainted, with the GPU operator installed. |
+
+Leave headroom: kubelet, the CNI, the CSI, ingress, metrics and logging take real CPU and memory
+before your workload starts. A 2 vCPU worker has appreciably less than 2 vCPU for pods.
+
+## GPU node groups
+
+```bash
+ankra cluster node-group add <cluster_id> --name gpu \
+  --instance-type <gpu-type> --count 1 --wait
+ankra cluster node-group taints <cluster_id> gpu --taints nvidia.com/gpu=true:NoSchedule
+ankra cluster node-group labels <cluster_id> gpu --labels workload=gpu
+```
+
+Then install the GPU operator as an addon so the driver, container runtime hook and device plugin
+are present, and confirm nodes advertise `nvidia.com/gpu` before deploying anything that requests
+one.
+
+Two traps that cost a rebuild:
+
+- **The OS disk.** Provider defaults are often 25 GB. GPU driver layers plus a model-serving image
+  plus downloaded weights overrun that and the node wedges on disk pressure. Size the disk, or mount
+  a volume for the model cache, before the first deploy.
+- **Quota and stock are separate refusals.** Providers commonly check stock *before* quota, so an
+  "out of capacity" error can really be a quota of zero. Check both with the provider before
+  concluding the region is full.
+
+## Create-flag map
+
+Same concepts, different names. `--name`, `--credential-id`, `--ssh-key-credential-id`,
+`--distribution`, `--kubernetes-version`, `--control-plane-count`, `--worker-count`,
+`--external-cloud-provider`, `--include-networking`, `--include-dns`, `--gitops-repository`,
+`--gitops-credential-name` and `--gitops-branch` are common to every provider.
+
+| Concept | Hetzner | DigitalOcean | OVH | UpCloud |
+|---------|---------|--------------|-----|---------|
+| Where | `--location` | `--region` | `--region` | `--zone` |
+| Control plane compute | `--control-plane-server-type` | `--control-plane-size` | `--control-plane-flavor-id` | `--control-plane-plan` |
+| Worker compute | `--worker-server-type` | `--worker-size` | `--worker-flavor-id` | `--worker-plan` |
+| Bastion compute | `--bastion-server-type` | `--bastion-size` | `--gateway-flavor-id` | `--bastion-plan` |
+| External etcd compute | `--etcd-server-type` | `--etcd-size` | `--etcd-flavor-id` | `--etcd-plan` |
+| Private network | `--network-ip-range`, `--subnet-range` | `--network-ip-range` | `--network-vlan-id`, `--subnet-cidr`, `--dhcp-start/--dhcp-end` | `--network-ip-range` (auto-picked if omitted) |
+| Zones | — | — | `--availability-zones` | — |
+| CNI | — | — | — | `--cni flannel\|calico\|cilium` |
+
+Proxmox VE and Morpheus have their own placement flags (host node, storage, template, bridge /
+cloud, group, layout, plan) — run `ankra cluster proxmox create --help` and
+`ankra cluster morpheus create --help`; the discovery commands above list the valid values.
+
+## Cost, without surprises
+
+- **Right-size from measurement, not from the default.** Create, run the real workload, then read
+  `ankra cluster top nodes` and `ankra cluster top pods` and resize.
+- **Scale the pool, not the instance**, for elastic load: `ankra cluster node-group autoscaling set`
+  where the provider supports it.
+- **Stop what is not in use.** `ankra cluster <provider> stop` and `ankra cluster power-schedules`
+  turn a dev cluster off nightly. Note a plain stop can still bill for parked networking and load
+  balancers — check the provider's rules before assuming a stopped cluster is free.
+- **Teardown with `--force`** on UpCloud, Hetzner, OVH and DigitalOcean so leftover CSI volumes and
+  load balancers are released. Orphaned volumes bill indefinitely and belong to no cluster, so
+  nothing surfaces them later.
+- **Dedicated vCPU costs more per core and less per unit of predictability.** Use it where jitter
+  actually hurts, not by default.
+
+## Failure modes worth recognising
+
+| Symptom | Usual cause |
+|---------|-------------|
+| Reconcile fails at private-network setup | The region is not enabled on the account. List regions with the credential first. |
+| `LoadBalancer` Service stays `<pending>` | `--external-cloud-provider=false`, so there is no CCM to provision it. |
+| Ingress resolves nowhere / no certificate | `--include-dns=false`, or the hostname is on your own domain — the generated external-dns only manages the generated subdomain. See `ankra-domains-dns`. |
+| PVCs stay `Pending` | No CSI: same root cause as the LoadBalancer one. |
+| Pods `Pending` after adding a node group | Taints without matching tolerations, or the instance type is smaller than the requests. |
+| Everything `Pending` on an ARM cluster | An image with no `arm64` variant. |
+| A one-node group landed in the wrong zone | Unpinned group on a zone-spread cluster: it takes the thinnest zone. Pin with `--availability-zone`. |
+| Upgrade aborted partway | A drain blocked by a PodDisruptionBudget. Fix the PDB or re-run with `--force`. |
+| Cluster gone but the bill is not | Deprovisioned without `--force`: CSI volumes and load balancers were left behind. |

--- a/internal/skills/embedded/skills/ankra-domains-dns/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-domains-dns/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: ankra-domains-dns
+description: Give Ankra clusters public hostnames with DNS and TLS - the generated per-cluster subdomain under ankra.cc, registering your own root domain delegated to Ankra, publishing records in the organisation's zone, serving zones you hold in your own DNS account with your own credential (org-wide or per cluster), and the separate preview domain PR demos publish under. Use when the user wants a custom domain, asks why an ingress hostname does not resolve or has no certificate, mentions external-dns, DNS records, delegation, or where preview and demo URLs come from.
+---
+
+# Domains, DNS and TLS on Ankra
+
+An Ankra cluster can publish an Ingress hostname, create its DNS record and get a TLS certificate
+with no manual step — but only inside the zone whose credential it holds. Almost every "it does not
+resolve" or "there is no certificate" comes down to a hostname outside that zone.
+
+## The four things people conflate
+
+| Thing | What it is | Set with |
+|-------|-----------|----------|
+| **Organisation root domain** | The root every Ankra-generated hostname nests under. `ankra.cc` by default. | `ankra org domain set` |
+| **Cluster generated domain** | `<cluster_short_id>.<root>` — one subzone per cluster, served by the external-dns Ankra installs on it. | `ankra cluster domain --enable` |
+| **Custom DNS zone** | A zone you hold in **your own** DNS account, served by an extra external-dns using **your** credential. | `ankra org custom-dns-zones add` / `ankra cluster custom-dns-zones add` |
+| **Preview domain** | Where PR demos and on-demand previews publish. Changes nothing else. | `ankra org ai-environment set --demo-base-domain` |
+
+The first two are Ankra's own DNS account. The third is yours. The fourth is a separate setting that
+people reach for the root domain to fix, and should not.
+
+## The default path: nothing to configure
+
+Create a cluster with `--include-dns` (the default) and it gets its own subdomain plus an
+external-dns. An Ingress hostname under that subdomain gets its record and its certificate
+automatically:
+
+```bash
+ankra cluster domain <cluster>                 # the generated domain, and its state
+ankra cluster domain <cluster> --enable        # give a cluster one it does not have (idempotent)
+ankra org dns zones                            # every cluster domain in the organisation
+```
+
+A fresh zone reads `pending` until it is published to the authoritative nameservers, then `active`;
+external-dns is wired to it on the next cloud-provider pass. A cluster with none reports `none`.
+
+**Scope, and this is the whole trap:** that external-dns manages **only** the generated subdomain.
+Its credential is scoped to that zone by the DNS provider, so an Ingress on any other hostname is
+dropped **silently** — no record, no certificate, no error.
+
+## Your own root domain, delegated to Ankra
+
+```bash
+ankra org domain get
+ankra org domain set example.com
+ankra org domain set --default                 # back to ankra.cc
+```
+
+The domain must be **delegated to the Ankra nameservers first**; the write is refused otherwise and
+names the nameservers to point at.
+
+What this actually does: Ankra adopts the domain **as the organisation's zone apex** — it does not
+carve a subzone out of it. Each cluster then gets `<cluster_short_id>.example.com`. The external-dns
+on every cluster holds a token pinned to the whole domain, so an Ingress on **any** hostname under
+it — `app.example.com` included — is published by the cluster serving it, with no credential of
+your own. Records you already publish that no Ingress claims are left alone: each cluster's
+external-dns owns only the records it created.
+
+Two things to know before switching:
+
+- **A switch is refused while cluster zones or DNS records still live under the old root.** The
+  refusal lists exactly what to remove. Inventory with `ankra org dns zones` and `ankra org dns list`;
+  clear with `ankra cluster domain <cluster> --remove` and `ankra org dns delete <record>`. Ankra
+  re-creates the organisation zone under the new root once the switch is accepted.
+- **A switch does not re-stamp anything.** Zone labels derive from the organisation and cluster ids,
+  so a cluster keeps its label, its external-dns `--txt-owner-id`, and any GitOps path built from it.
+
+Reading requires membership; changing requires organisation admin.
+
+## Records in the organisation's zone
+
+```bash
+ankra org dns zone                                          # the delegated zone
+ankra org dns list
+ankra org dns add chat CNAME lb-1234.example-lb.com --ttl 300
+ankra org dns update chat target.example.com
+ankra org dns delete chat
+```
+
+Records reconcile asynchronously: a new or edited record starts `pending` and turns `active` once
+published. Creating, editing and deleting requires organisation admin.
+
+## A zone you hold in your own DNS account
+
+When the domain lives in your provider account and cannot be delegated to Ankra, serve it with your
+own credential instead:
+
+```bash
+ankra org dns credentials create ...                        # the external-dns webhook credential
+ankra org dns credentials list
+
+ankra org custom-dns-zones add --zone example.com --credential <name>
+ankra org custom-dns-zones list
+ankra org custom-dns-zones remove --zone example.com
+
+ankra cluster custom-dns-zones add --zone example.com --credential <name>   # one cluster only
+ankra cluster custom-dns-zones list
+```
+
+Ankra renders and reconciles a **separate** external-dns for each declared zone, pinned to exactly
+that zone with its own record ownership, so it can never fight Ankra's own controller, another
+cluster's, or records you publish yourself.
+
+- **`org custom-dns-zones` covers every cluster** — the ones that exist and the ones created later.
+  That "and later" is the reason to declare org-wide: a cluster created after a per-cluster
+  declaration comes up with your hostnames silently unserved.
+- **A cluster's own declaration wins** over the organisation's on that cluster, which is how one
+  cluster serves the zone with a different credential. `cluster custom-dns-zones list` shows
+  inherited zones with source `organisation`.
+- **Withdrawing removes the controller Ankra rendered.** The zone's records are yours and are left
+  untouched. Clusters that declared the zone themselves keep theirs.
+
+Once a custom zone covers the organisation's preview domain, that becomes the cluster's **public**
+domain — what hostnames publish under and what `${{ ankra.cluster_domain }}` resolves to in stacks
+and stack profiles. `ankra cluster domain <cluster>` reports both the generated and the public one.
+
+## Preview and demo URLs
+
+```bash
+ankra org ai-environment get
+ankra org ai-environment set --demo-base-domain previews.example.com
+ankra org ai-environment set --demo-base-domain ""        # back to the Ankra subzone
+ankra org ai-environment set --demo-cert-issuer letsencrypt-prod
+ankra org ai-environment set --demo-tls-secret <secret>
+```
+
+This decides only where PR demos and on-demand previews publish — demos land at
+`<namespace>.<preview-domain>`. It is **not** `ankra org domain`, and reaching for the root domain
+to change preview URLs is the common mistake. Both fields sit on the same portal screen
+(**AI → Settings → Workspaces**), which is why they get confused.
+
+**On your own preview domain, publishing the DNS is yours.** Ankra mints the hostname but publishes
+records only inside the subzones it delegates, and a cluster's external-dns credential is scoped to
+that cluster's own Ankra subzone and nothing else. In practice you create **one wildcard** pointing
+at the staging cluster's ingress. Without it the demo still deploys and still reports ready, and its
+URL does not load — and the certificate goes the same way, because an HTTP-01 challenge is answered
+over the hostname being certified, so a name that does not resolve never gets one. An unpublished
+preview domain costs you the URL and the TLS together.
+
+`ankra org ai-environment get` relays the platform's verdict, naming the wildcard to create and the
+address to point it at when the domain answers nothing — and says so explicitly when the platform
+reports no verdict at all, rather than letting silence read as an all-clear.
+
+TLS on your own preview domain: each demo hostname is concrete when the ingress is written, so an
+HTTP-01 challenge answers for it and no wildcard certificate is involved. `--demo-tls-secret` serves
+a certificate you already hold and requests nothing; `--demo-cert-issuer` asks a different
+cert-manager `ClusterIssuer`. A staging cluster carrying no ACME HTTP-01 issuer cannot be asked for
+a certificate at all, so its previews stay on plain HTTP — `get` says so when that is the case.
+
+On an Ankra subzone none of this applies: the platform provisions the zone and the in-cluster
+external-dns publishes each preview record itself.
+
+## Where TLS comes from
+
+`--include-networking` (default on) installs Traefik **and cert-manager**. A certificate is issued
+when the ACME challenge can be answered, which needs the DNS record to exist and resolve. So TLS
+failures are usually DNS failures one step earlier:
+
+1. Does the hostname's zone have a controller? (generated subdomain, or a declared custom zone)
+2. Did the record get created? `ankra org dns list`, or query the authoritative nameservers.
+3. Is the record `active` rather than `pending`?
+4. Only then look at cert-manager: `ankra cluster get pods -n cert-manager`,
+   `ankra cluster describe certificate <name> -n <ns>`, `ankra cluster events -n <ns> --type Warning`.
+
+## Diagnosing "it does not resolve"
+
+| Symptom | Cause |
+|---------|-------|
+| Ingress host on your own domain gets no record at all | The generated external-dns only serves the generated subdomain. Declare the zone with `custom-dns-zones`. |
+| Worked on one cluster, not on a newly created one | The zone was declared per cluster. Declare it with `ankra org custom-dns-zones` so later clusters inherit it. |
+| Record exists but does not resolve | Still `pending` — not yet published to the authoritative nameservers. |
+| `ankra org domain set` refused | The domain is not delegated to the Ankra nameservers yet, or zones/records still live under the old root. |
+| Certificate never issues | The DNS record is missing or unresolvable; fix DNS first. |
+| Preview URLs on the wrong domain | `ankra org ai-environment set --demo-base-domain`, not `ankra org domain`. |
+| Demo reports ready, its URL does not load | Your preview domain has no wildcard pointing at the staging cluster's ingress. Ankra publishes nothing there. |
+| Preview stays on plain HTTP | The staging cluster carries no ACME HTTP-01 issuer; `ankra org ai-environment get` reports it. |
+| Cluster reports domain `opted out` | Someone ran `ankra cluster domain --remove`; the removal is held until `--enable`. |
+| Nothing has a domain | The cluster was created with `--include-dns=false`. |
+
+## Rules
+
+- **Know which zone a hostname is in** before debugging anything else. Generated subdomain, your own
+  declared zone, or neither — the third case explains most failures.
+- **Delegate before registering** a root domain; the write is refused otherwise.
+- **Declare org-wide** unless one cluster genuinely needs a different credential — per-cluster
+  declarations leave later clusters unserved.
+- **The preview domain is a separate setting** from the root domain — and on a domain you own,
+  publishing its wildcard record is yours, not Ankra's.
+- **Removing a cluster domain is held** until you `--enable` it again; nothing re-creates it.
+- **Withdrawing a custom zone never touches your records.**
+- **DNS before TLS** when diagnosing a missing certificate.
+
+## Related skills
+
+- `ankra-cloud-clusters` — `--include-dns` / `--include-networking` at create time.
+- `ankra-getting-started` — where domains fit in the onboarding order.
+- `ankra-stacks-addons` — the Ingress manifests that carry these hostnames.
+- `ankra-ai-gateway` — PR demos and the staging cluster they publish from.
+- `ankra-troubleshooting` — reading events and certificate state.

--- a/internal/skills/embedded/skills/ankra-getting-started/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-getting-started/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: ankra-getting-started
+description: Onboard from an empty Ankra organisation to a running application - installing and authenticating the CLI, storing cloud/Git/registry credentials, deciding between importing a cluster and letting Ankra build one, wiring the GitOps repository, choosing the domain and DNS, laying down the base platform stack, and deploying the first app - in the order that avoids rework. Use when the user is new to Ankra, is setting up an organisation or their first cluster, asks "how do I start" or "what do I do first", or needs the end-to-end onboarding path rather than one subsystem.
+---
+
+# Getting started with Ankra
+
+The order below is chosen so nothing has to be redone. Three decisions are cheap now and expensive
+later — the GitOps repository, the batteries on the first cluster, and the domain — so they come
+before anything is deployed.
+
+```
+CLI + login → organisation → credentials → GitOps repo → cluster → domain/DNS
+           → base platform stack → first application → access + hardening
+```
+
+## 0. The five decisions, up front
+
+| Decision | Ask | Default if unsure |
+|----------|-----|-------------------|
+| **Import or build?** | Do you already run Kubernetes? | Import what exists; build new clusters with Ankra |
+| **Managed or self-managed control plane?** | Do you need cluster-admin over the control plane? | Provider-managed (`ankra cluster managed`) |
+| **GitOps repository** | Where should cluster state be reviewable? | One repo, `platform-gitops`, wired at cluster create |
+| **Domain** | Whose DNS holds it? | Start on the generated `ankra.cc` subdomain; move later |
+| **Registry** | Do you already run one? | Ankra's own registry until you do |
+
+Getting the first three right is what separates a cluster you can review and rebuild from one that
+only exists in a dashboard.
+
+## 1. CLI and login
+
+```bash
+bash <(curl -sL https://github.com/ankraio/ankra-cli/releases/latest/download/install.sh)
+ankra --version
+ankra completion install
+
+ankra login                      # browser SSO
+ankra org list
+ankra org switch <slug>          # not "select" - the verb is switch
+ankra org current
+```
+
+Install the skills into whatever assistant you use, so the rest of this is applied automatically:
+
+```bash
+ankra skills install             # every assistant configured on this machine
+ankra skills clients
+```
+
+## 2. Credentials
+
+Store these before creating anything; several later steps take credential **IDs**.
+
+```bash
+ankra credentials list
+ankra credentials hetzner create --name hetzner-prod        # or ovh / upcloud / digitalocean / proxmox / morpheus
+ankra credentials hetzner ssh-key create --name ops-key
+ankra credentials repositories <git-credential>             # what a Git credential can ACTUALLY reach
+ankra helm credentials list                                 # private chart registries
+```
+
+GitHub, GCP, Azure, AWS and Scaleway credentials are added from the portal's **Credentials** page.
+Scope each one to the project, subscription or repositories Ankra manages — a Git credential meant
+for one repository often reaches a whole organisation, and nothing in its name says so.
+
+## 3. Decide the GitOps repository now
+
+Cluster state should live in Git and be reviewable in a pull request. Create the repository (empty
+is fine) before the first cluster, because both `create` paths can wire it in the same command:
+
+```bash
+ankra cluster hetzner create ... \
+  --gitops-repository my-org/platform-gitops \
+  --gitops-credential-name github-acme \
+  --gitops-branch main
+
+ankra cluster managed create ... --gitops-repository my-org/platform-gitops \
+  --gitops-credential-name github-acme
+```
+
+Retrofitting GitOps onto a running cluster is strictly more work. See `ankra-gitops` for the layout.
+
+## 4. The first cluster
+
+**Adopting one that already exists** — write an ImportCluster YAML and apply it
+(`ankra-import-cluster`):
+
+```bash
+ankra cluster validate -f cluster.yaml
+ankra cluster draft    -f cluster.yaml      # stage as reviewable drafts
+ankra cluster apply    -f cluster.yaml
+```
+
+For a *managed* cluster at a provider, Ankra can adopt it without you running anything against it:
+
+```bash
+ankra cluster managed discover --provider eks --credential-id <id>
+ankra cluster managed import   --provider eks --credential-id <id> \
+  --provider-cluster-id <id> --name prod
+```
+
+**Letting Ankra build one** — discover the region and instance family first, then create
+(`ankra-cloud-clusters`, or `ankra-managed-kubernetes` for a provider-run control plane):
+
+```bash
+ankra cluster hetzner locations --credential-id <id>
+ankra cluster hetzner server-types --credential-id <id> --location nbg1 --available-only
+ankra cluster k3s-versions
+
+ankra cluster hetzner create --name prod --credential-id <id> \
+  --ssh-key-credential-id <ssh_id> --location nbg1 \
+  --control-plane-count 3 --worker-count 3 --worker-server-type cx43 \
+  --gitops-repository my-org/platform-gitops --gitops-credential-name github-acme
+```
+
+**Take the batteries.** `--external-cloud-provider`, `--include-networking` and `--include-dns`
+default on and give you load balancers, persistent volumes, ingress, DNS and TLS from the first
+minute. Turn one off only when you are bringing your own, and say so in the stack.
+
+Then:
+
+```bash
+ankra cluster select prod
+ankra cluster info
+ankra cluster agent status              # the agent must be online before anything else works
+ankra cluster operations list           # watch the build converge
+```
+
+## 5. Domain and DNS
+
+Out of the box each cluster gets `<cluster_short_id>.ankra.cc` and publishes Ingress hostnames under
+it with certificates, no configuration. That is enough to get an app on a real HTTPS URL today.
+
+When you want your own domain:
+
+```bash
+ankra cluster domain <cluster>                       # what it has now
+ankra org domain set example.com                     # delegate to Ankra's nameservers FIRST
+# or, for a zone you keep in your own DNS account:
+ankra org dns credentials create ...
+ankra org custom-dns-zones add --zone example.com --credential <name>
+```
+
+The generated external-dns serves **only** the generated subdomain — an Ingress on your own domain
+is dropped silently until the zone is declared. Declare org-wide so clusters created later inherit
+it. See `ankra-domains-dns`.
+
+## 6. The base platform stack
+
+Before any application, lay down the shared layer as a stack (`ankra-stacks-addons`), pinned and
+namespace-ordered:
+
+```bash
+ankra cluster stacks list
+ankra cluster addons available
+ankra cluster addons list
+```
+
+Typical first stack: ingress (if you skipped `--include-networking`), monitoring and logging
+(`ankra-observability`), and any operator your apps need. One concern per stack, exact
+`chart_version`, namespace manifest as the parent of everything in it.
+
+Once it works, capture it so the next cluster is not hand-built:
+
+```bash
+ankra stack-profiles drafts create --name base-platform \
+  --source-cluster prod --source-stack platform
+```
+
+See `ankra-stack-profiles`.
+
+## 7. The first application
+
+```bash
+ankra application add .                              # from the repo checkout
+ankra application get <id>                           # review the setup PR Ankra opened
+ankra application env-secrets list <id>
+printf '%s' "$DATABASE_URL" | ankra application env-secrets set <id> DATABASE_URL
+ankra application env-secrets apply <id>
+ankra application deploy <id> --cluster <cluster-id> --namespace app
+```
+
+Verify before calling it done:
+
+```bash
+ankra cluster operations list
+ankra cluster get pods -n app
+ankra cluster logs -l app=<name> -n app --follow=false --tail 100
+```
+
+If it does not come up, switch to `ankra-troubleshooting` rather than changing things. See
+`ankra-applications` for registries, auto-deploy, PR demos and reaching more clusters.
+
+## 8. Access and hardening
+
+```bash
+ankra org invite <email> --role viewer
+ankra cluster access grant <email> --cluster prod --role view
+ankra tokens create ci-deploy --expires 2026-12-31        # REST-only; add --scopes for MCP
+ankra cluster kubeconfig add --use                        # short-lived credentials, no kubeconfig to leak
+```
+
+`view` is enough to troubleshoot — `ankra cluster logs --previous`, `describe`, `events` and `top`
+all work through the agent with no grant at all. Run `/ankra-harden` or read `ankra-security` once
+more than one person has access.
+
+## 9. Where to go next
+
+| Next | Skill |
+|------|-------|
+| Continuous delivery on push | `ankra-cicd`, `ankra-applications` |
+| Secrets in Git | `ankra-sops-secrets` |
+| Wiring an app to LiteLLM, Harbor, a database | `ankra-app-integrations` |
+| The same stack on many clusters | `ankra-stack-profiles` |
+| Alerting | `ankra-alerts-webhooks` |
+| Ankra's own AI agents | `ankra-ai-agents`, `ankra-ai-gateway` |
+| Managing Ankra itself as code | `ankra-terraform` |
+
+## Rules
+
+- **Credentials and the GitOps repo before the first cluster.** Both are wired at create time.
+- **Discover regions and instance families**; never guess them from provider docs.
+- **Take the batteries on the first create** — CCM, ingress and DNS are painful to retrofit.
+- **`ankra org switch`**, not `select`. **`create` has no `--wait`** — follow with
+  `operations list`.
+- **The agent must be online** before anything else is worth debugging.
+- **Validate → draft → apply**, and prefer a reviewable draft on anything you care about.
+- **Verify at the layer that fails**: operations, then pods, then logs.
+- **Start on the generated domain.** Moving to your own domain later is supported; a half-configured
+  custom domain on day one is the most common way to get stuck.
+
+## Related skills
+
+- `ankra-platform-principles` — the practices behind all of the above.
+- `ankra-cli` — the full command surface and scripting conventions.
+- `ankra-import-cluster` / `ankra-cloud-clusters` / `ankra-managed-kubernetes` — the three cluster paths.
+- `ankra-domains-dns` — domains, DNS and TLS in depth.
+- `ankra-gitops` — the repository layout.

--- a/internal/skills/embedded/skills/ankra-getting-started/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-getting-started/SKILL.md
@@ -82,6 +82,18 @@ Retrofitting GitOps onto a running cluster is strictly more work. See `ankra-git
 
 ## 4. The first cluster
 
+**No cloud account yet? Use the playground.** Every organisation may hold one: a real, writable
+virtual cluster on Ankra's own infrastructure, agent already installed, expiring after inactivity.
+It is the fastest way to try stacks, addons and deploys before any credential exists:
+
+```bash
+ankra cluster playground create
+ankra cluster playground status
+ankra cluster playground destroy
+```
+
+Everything below works against it, except the provider-specific lifecycle commands.
+
 **Adopting one that already exists** — write an ImportCluster YAML and apply it
 (`ankra-import-cluster`):
 

--- a/internal/skills/embedded/skills/ankra-gitops/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-gitops/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ankra-gitops
-description: Structure an Ankra GitOps repository with modular include paths so cluster and stack definitions are stored in Git and synced by Ankra/ArgoCD. Use when the user connects a Git repository to a cluster, organizes a GitOps repo layout, or wants Git to be the source of truth for their Kubernetes configuration.
+description: Structure an Ankra GitOps repository with modular include paths so cluster and stack definitions are stored in Git and synced to the cluster by the Ankra engine. Use when the user connects a Git repository to a cluster, organizes a GitOps repo layout, or wants Git to be the source of truth for their Kubernetes configuration.
 ---
 
 # Ankra GitOps
 
-With GitOps enabled, a cluster's stacks are stored in a Git repository and synced to the cluster (ArgoCD-backed). Git becomes the single source of truth; changes flow through commits and pull requests, not manual edits.
+With GitOps enabled, a cluster's stacks are stored in a Git repository and synced to the cluster by the Ankra engine. Git becomes the single source of truth; changes flow through commits and pull requests, not manual edits.
 
 ## Connect a repo
 
@@ -20,7 +20,17 @@ spec:
     branch: main
 ```
 
-The `credential_name` references a Git credential stored in Ankra (least-privilege deploy token / app install). See `ankra-helm-registries` and the credentials docs for storing credentials.
+The `credential_name` references a Git credential stored in Ankra (least-privilege deploy token /
+app install); `ankra credentials repositories <name>` shows what it can actually reach.
+
+When Ankra *builds* the cluster, skip the retrofit entirely: every provider `create` and
+`ankra cluster managed create` take `--gitops-repository`, `--gitops-credential-name` and
+`--gitops-branch`, and the generated cloud-provider stack lands in the repo as a commit from day
+one (`ankra-cloud-clusters`). Inspect the wiring later with:
+
+```bash
+ankra cluster gitops status        # repository, branch, credential, last synced commit, sync errors
+```
 
 ## Modular layout with include paths
 
@@ -50,8 +60,9 @@ gitops-repo/
 
 1. Branch from `main`, edit the relevant `stack.yaml` / manifests.
 2. Open a pull request; review the diff.
-3. Merge to the synced branch — Ankra/ArgoCD reconciles the change onto the cluster.
-4. Confirm with `ankra cluster operations list` and `ankra cluster info`.
+3. Merge to the synced branch — the Ankra engine reconciles the change onto the cluster.
+4. Confirm with `ankra cluster gitops status` (repository, branch, last synced commit, any sync
+   error) and `ankra cluster operations list`.
 
 ## Rules
 

--- a/internal/skills/embedded/skills/ankra-helm-registries/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-helm-registries/SKILL.md
@@ -28,13 +28,45 @@ addons:
     registry_credential_name: my-ghcr-credential
 ```
 
-Manage registries and their credentials with the CLI:
+## Manage registries with the CLI
 
 ```bash
-ankra helm                      # manage Helm registries and registry credentials
-ankra charts search <term>      # browse the chart catalog
-ankra charts info <chart>       # inspect a chart and its versions
+ankra helm credentials create ...              # store the pull credential first
+ankra helm credentials list
+
+ankra helm registries create --name my-charts --url oci://ghcr.io/acme/charts \
+  --credential-name my-cred
+ankra helm registries create --name my-charts --url https://charts.example.com
+ankra helm registries create -f registry-spec.yaml
+ankra helm registries list
+ankra helm registries get <name>
+ankra helm registries update <name> ...
+ankra helm registries sync <name>              # trigger a manual index sync
+ankra helm registries sync-jobs <name>         # why a chart is missing from the catalog
+ankra helm registries delete <name>
 ```
+
+The registry type is inferred from the URL scheme — `oci://` creates an OCI registry, `http(s)://`
+an HTTP chart repository. A spec file nests the registry under exactly one of `helm_oci_registry`
+or `helm_http_registry` (a flat `{name, url}` file is accepted and nested automatically).
+`--exclude-charts` (repeatable) keeps named charts out of the index.
+
+When a chart you expect is not offered, the sync is the usual reason: `registries sync` forces a
+re-index and `sync-jobs` shows what the last runs did.
+
+## Find the chart before writing the addon
+
+```bash
+ankra charts list
+ankra charts search <term>
+ankra charts info <chart>                      # versions, home, description
+ankra charts values <chart>                    # default values (helm show values)
+ankra charts template <chart>                  # rendered manifests (helm template)
+```
+
+`charts values` is where an addon's `configuration.values` starts: read the defaults, override only
+what you mean to. `charts template` shows what a chart would actually create before anything
+touches a cluster.
 
 ## Rules
 
@@ -47,4 +79,6 @@ ankra charts info <chart>       # inspect a chart and its versions
 ## Related skills
 
 - `ankra-stacks-addons` for the addon fields that consume a registry.
+- `ankra-app-integrations` for the container-image side of Harbor and friends.
 - `ankra-sops-secrets` if a credential must be expressed as an encrypted manifest.
+- `ankra-security` for credential scope and review.

--- a/internal/skills/embedded/skills/ankra-import-cluster/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-import-cluster/SKILL.md
@@ -30,7 +30,8 @@ spec:
           from_file: "manifests/fluent-bit-namespace.yaml"
         - name: configmap-fluent-bit
           parents:
-            - manifest: namespace-fluent-bit
+            - kind: manifest
+              name: namespace-fluent-bit
           from_file: "manifests/fluent-bit-configmap.yaml"
       addons:
         - name: fluent-bit
@@ -39,7 +40,8 @@ spec:
           repository_url: https://fluent.github.io/helm-charts
           namespace: fluent-bit
           parents:
-            - manifest: configmap-fluent-bit
+            - kind: manifest
+              name: configmap-fluent-bit
           configuration:
             values: |-
               service:
@@ -51,10 +53,10 @@ spec:
 - `spec.git_repository` — connect a Git repo so stacks are stored and synced from Git (see `ankra-gitops`). Omit for a non-GitOps import.
 - `spec.stacks[]` — each stack groups related `manifests` and `addons`.
 - `manifests[]` — raw Kubernetes YAML. Use `from_file: "path.yaml"` to reference a file, or `manifest: |-` for inline content.
-- `addons[]` — Helm releases. Required: `chart_name`, `chart_version`, `repository_url`, `namespace`. Configure via `configuration.values: |-` (inline) or `configuration.from_file:`.
+- `addons[]` — Helm releases. Required: `chart_name`, `chart_version`, `namespace`. Name the chart source with `registry_name` + `registry_url` (with `registry_credential_name` for a private registry — see `ankra-helm-registries`); the older `repository_url` is still accepted. Configure via `configuration.values: |-` (inline) or `configuration.from_file:`.
 - `agents_md` / `agents_md_from_file` — optional per-manifest and per-addon AGENTS.md: operational learnings in plain markdown, stored as a sibling file in the GitOps repo (e.g. `agents_md_from_file: "manifests/fluent-bit.AGENTS.md"`). Omitting the field preserves the stored content, an explicit empty string clears it, and editing it never triggers a redeploy. Plaintext only — never put secrets in it. After any non-obvious operation (a values quirk, an upgrade pitfall, a dependency gotcha), record what you learned here so future agents working on the same addon or manifest benefit.
 - `group` — optional per-manifest and per-addon organizational label within the stack (a quoted string, e.g. `group: "platform services"`). Purely organizational: it never triggers a redeploy. Keep whatever the exported file carries — apply prunes what the file no longer declares, so removing the key removes the resource from its group.
-- `parents` — the dependency edges that control deployment order. A resource only deploys after its parents succeed. Reference a parent as `- manifest: <name>` or `- addon: <name>`.
+- `parents` — the dependency edges that control deployment order. A resource only deploys after its parents succeed. Every parent is a `kind` + `name` pair — write both keys (`- kind: manifest` / `name: <name>`, or `kind: addon`). **The shorthand `- manifest: <name>` does not work**: it parses to an empty parent and the edge is silently dropped, while both local and server-side validation still pass. Verify what was stored with `ankra cluster stacks list <stack> -o json`.
 
 ## Workflow
 
@@ -64,9 +66,14 @@ spec:
 4. Validate and apply:
 
 ```bash
-ankra cluster apply -f cluster.yaml --cluster my-cluster
-ankra cluster operations list      # watch the resulting operation
+ankra cluster validate -f cluster.yaml     # server-side checks, changes nothing
+ankra cluster draft -f cluster.yaml        # stage every stack as a reviewable draft instead
+ankra cluster apply -f cluster.yaml
+ankra cluster operations list              # watch the resulting operation
 ```
+
+`apply` is a declarative **replace** per stack: what the file no longer declares is removed from
+that stack. `draft` is the safe route on a cluster you are not ready to change.
 
 ## Rules
 

--- a/internal/skills/embedded/skills/ankra-managed-kubernetes/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-managed-kubernetes/SKILL.md
@@ -1,34 +1,38 @@
 ---
 name: ankra-managed-kubernetes
-description: Provision, import, and operate provider-managed Kubernetes through Ankra - DigitalOcean DOKS, UpCloud UKS, Google GKE, OVHcloud MKS, Azure AKS, and Amazon EKS - with live options and pricing, preflight checks, discovery/import of existing clusters, node pool autoscaling, and version upgrades. Use when the user wants a managed Kubernetes cluster (the provider runs the control plane), mentions DOKS, UKS, GKE, AKS, EKS, or OVH MKS, or wants to import a managed cluster into Ankra.
+description: Provision, import, and operate provider-managed Kubernetes through Ankra - DigitalOcean DOKS, UpCloud UKS, Google GKE, OVHcloud MKS, Azure AKS, Amazon EKS and Scaleway Kapsule - creating a cluster with its first node pool and GitOps wiring, discovering and adopting clusters that already exist, node pools and autoscaling, version upgrades, and deletion. Use when the user wants a managed Kubernetes cluster (the provider runs the control plane), mentions DOKS, UKS, GKE, AKS, EKS, OVH MKS or Kapsule, or wants to import a managed cluster into Ankra.
 ---
 
-# Ankra Managed Kubernetes
+# Ankra managed Kubernetes
 
-Ankra provisions and manages provider-native managed Kubernetes: the cloud provider runs the control plane, Ankra manages node pools, upgrades, addons, stacks, and GitOps on top. This is distinct from `ankra-cloud-clusters` (self-managed k3s/kubeadm on VMs with a bastion).
+The provider runs the control plane; Ankra manages the node pools, upgrades, addons, stacks and
+GitOps on top. This is the counterpart to `ankra-cloud-clusters` (self-managed k3s/kubeadm on VMs).
 
-Providers: `doks` (DigitalOcean), `uks` (UpCloud), `gke` (Google Cloud), `ovh-mks` (OVHcloud), `aks` (Azure), `eks` (AWS). Every `ankra cluster managed` subcommand takes `--provider`.
+Choose **managed** when you want the provider responsible for control-plane uptime and patching, and
+you do not need cluster-admin over it. Choose **cloud clusters** when you need control-plane access,
+a provider with no managed offering, or node-level control the managed API does not expose.
 
-## Prerequisite: one provider credential
+Providers, exactly as `--provider` spells them:
+
+`doks` (DigitalOcean) · `uks` (UpCloud) · `gke` (Google) · `ovh_mks` (OVHcloud) · `aks` (Azure) ·
+`eks` (AWS) · `kapsule` (Scaleway)
+
+**Every `ankra cluster managed` subcommand takes `--provider`.**
+
+## 1. A provider credential
 
 ```bash
 ankra credentials list                       # find an existing credential ID
-ankra credentials digitalocean create ...    # doks
-ankra credentials upcloud create ...         # uks
-ankra credentials ovh create ...             # ovh-mks (needs a Public Cloud project)
+ankra credentials digitalocean create --name do-prod     # doks
+ankra credentials upcloud create --name upcloud-prod     # uks
+ankra credentials ovh create --name ovh-prod             # ovh_mks (needs a Public Cloud project)
 ```
 
-GCP (service account key with `roles/container.admin`), Azure (service principal with Contributor), and AWS credentials are added from the Ankra portal **Credentials** page.
+GCP (service account key with `roles/container.admin`), Azure (service principal with Contributor),
+AWS and Scaleway credentials are added from the portal's **Credentials** page. Scope each to the
+project or subscription Ankra manages — see `ankra-security`.
 
-## Always check live options first
-
-Locations, Kubernetes versions (with support windows), node sizes, and pricing are fetched live from the provider — never guess sizes or regions:
-
-```bash
-ankra cluster managed options --provider gke --credential-id <id>
-```
-
-## Provision
+## 2. Create
 
 ```bash
 ankra cluster managed create \
@@ -38,57 +42,136 @@ ankra cluster managed create \
   --location westeurope \
   --node-pool-name workers \
   --node-pool-size Standard_D2s_v5 \
-  --node-pool-count 2 \
-  --node-pool-autoscaling-min 2 --node-pool-autoscaling-max 5
+  --node-pool-count 2
 ```
 
-- Preflight checks (credential, quota, naming) run automatically and abort on errors; only bypass with `--skip-preflight` when the user explicitly accepts the risk.
-- `--ha` (doks), `--cluster-plan` (uks), and `--kubernetes-version` are optional.
-- Provider naming rules: GKE names are lowercase; AKS node pool names are lowercase alphanumeric, max 12 characters.
+With autoscaling on the first pool instead of a fixed count:
 
-## Discover and import existing clusters
+```bash
+ankra cluster managed create --provider doks --name prod --credential-id <id> \
+  --location fra1 --node-pool-name workers --node-pool-size s-4vcpu-8gb \
+  --autoscaling --autoscaling-min 2 --autoscaling-max 8
+```
+
+`--autoscaling-min` / `--autoscaling-max` require `--autoscaling`. `--kubernetes-version` is
+optional; omitted, the provider's default applies.
+
+Scaleway Kapsule additionally requires the private network:
+
+```bash
+ankra cluster managed create --provider kapsule --name prod --credential-id <id> \
+  --location fr-par-1 --private-network-id <network_id> \
+  --node-pool-name workers --node-pool-size DEV1-M
+```
+
+### Wire GitOps in the same command
+
+```bash
+ankra cluster managed create ... \
+  --gitops-repository my-org/platform-gitops \
+  --gitops-credential-name github-acme \
+  --gitops-branch main
+```
+
+Doing this at create time means the cluster's definition is reviewable in a pull request from the
+start, rather than living only in the platform. `ankra cluster gitops status` shows what a cluster
+syncs from. See `ankra-gitops`.
+
+### Sizes, regions and versions
+
+There is no `managed options` command. Get the valid values from the provider side before you
+create — the provider's own console or CLI, or (for the providers that overlap with the VM lane)
+the Ankra discovery commands:
+
+```bash
+ankra cluster digitalocean regions --credential-id <id>
+ankra cluster digitalocean sizes   --credential-id <id> --region fra1 --available-only
+ankra cluster ovh regions          --credential-id <id>
+```
+
+Naming rules bite here: GKE cluster names must be lowercase; AKS node pool names are lowercase
+alphanumeric, max 12 characters. A rejected name is a provider error, not an Ankra one — fix it
+rather than retrying.
+
+## 3. Adopt a cluster that already exists
 
 ```bash
 ankra cluster managed discover --provider eks --credential-id <id>
-ankra cluster managed import --provider eks --credential-id <id> \
-  --cluster-id <provider_cluster_id> --name imported-prod
+ankra cluster managed import  --provider eks --credential-id <id> \
+  --provider-cluster-id <id-from-discover> --name imported-prod --description "..."
 ```
 
-Discovery marks clusters that are already imported. Import adopts the cluster without modifying it at the provider.
+`discover` lists what the credential can see at the provider and marks the ones already imported.
+`import` fetches the kubeconfig through the provider API and installs the agent itself, so **there
+is nothing to run against the cluster** and nothing at the provider is modified.
 
-## Day-2 operations
+`--name` defaults to the provider-side name. Use `--provider-cluster-id`, not `--cluster-id`.
+
+## 4. Node pools
 
 ```bash
-ankra cluster managed node-pool add <cluster_id> --provider doks --name pool-b --size s-4vcpu-8gb --count 2
-ankra cluster managed node-pool scale <cluster_id> workers --provider doks --count 5
+ankra cluster managed node-pool add <cluster_id> --provider doks \
+  --name pool-b --size s-4vcpu-8gb --count 2
+ankra cluster managed node-pool add <cluster_id> --provider doks \
+  --name burst --size s-4vcpu-8gb --autoscaling --autoscaling-min 0 --autoscaling-max 10
+
+ankra cluster managed node-pool scale  <cluster_id> workers --provider doks --count 5
 ankra cluster managed node-pool update <cluster_id> workers --provider doks \
-  --autoscaling-enabled --autoscaling-min 2 --autoscaling-max 10
-ankra cluster managed node-pool delete <cluster_id> pool-b --provider doks
-
-ankra cluster managed upgrades <cluster_id> --provider aks     # list provider upgrade targets
-ankra cluster managed upgrade <cluster_id> --provider aks --version 1.33.0
+  --autoscaling --autoscaling-min 2 --autoscaling-max 10
+ankra cluster managed node-pool update <cluster_id> workers --provider doks --autoscaling=false
+ankra cluster managed node-pool delete <cluster_id> pool-b --provider doks --yes
 ```
 
-Autoscaling works on every provider except `uks`.
+`update` takes at least one of `--count`, `--autoscaling`, `--autoscaling-min`,
+`--autoscaling-max`; anything unspecified is left unchanged. `--autoscaling` is a boolean —
+`--autoscaling=false` turns it off.
 
-## Delete (destructive)
+To see the pools, read the cluster: `ankra cluster info` and `ankra cluster get nodes`.
+
+## 5. Upgrade
 
 ```bash
-ankra cluster managed delete <cluster_id> --provider aks
+ankra cluster managed upgrade <cluster_id> --provider aks --version 1.33.0 --yes
 ```
 
-Destroys the cluster at the provider — control plane, node pools, and workloads. Confirm the target with `ankra cluster info` first, and clean up provider-created LoadBalancers/volumes.
+One command, singular. Get the valid target versions from the provider — a managed control plane
+only accepts the versions its own support window offers, and skipping a minor is refused by the
+provider, not by Ankra. Upgrade non-production first.
+
+## 6. Power and deletion
+
+```bash
+ankra cluster managed stop  <cluster_id> --provider aks    # AKS only
+ankra cluster managed start <cluster_id> --provider aks    # AKS only
+
+ankra cluster managed delete <cluster_id> --provider aks --yes
+ankra cluster managed delete <cluster_id> --provider aks --force   # cluster in a non-idle state
+```
+
+Stop/start currently works on **AKS only**; every other provider bills a running control plane
+until the cluster is deleted.
+
+`delete` destroys the cluster at the provider — control plane, node pools and workloads. Confirm
+with `ankra cluster info` first, and afterwards check the provider for LoadBalancers and volumes the
+cluster created: those are frequently left behind and keep billing.
 
 ## Rules
 
-- **Fetch options live** (`managed options`) before proposing sizes, regions, or versions — pricing and availability change.
-- **Never skip preflight** unless the user explicitly asks.
-- **Confirm before create, import, upgrade, and delete** — they cost money or are destructive.
-- **Respect provider naming rules** (GKE lowercase, AKS pool-name limits) instead of retrying blindly.
-- **Prefer autoscaling bounds** over large fixed counts when the workload is variable.
+- **Get sizes, regions and versions from the provider before proposing them.** There is no
+  `managed options`; availability and pricing change.
+- **`--provider` on every subcommand**, spelled `ovh_mks` (not `mks` or `ovh-mks`).
+- **`--provider-cluster-id` on import**, from `discover`.
+- **Autoscaling flags are `--autoscaling` / `--autoscaling-min` / `--autoscaling-max`** on
+  `create`, `node-pool add` and `node-pool update`.
+- **Wire GitOps at create time** rather than retrofitting it.
+- **Confirm before create, import, upgrade and delete** — each costs money or is destructive.
+- **Prefer autoscaling bounds** to a large fixed count when the workload varies.
+- **After deleting, check the provider for orphaned LoadBalancers and volumes.**
 
 ## Related skills
 
-- `ankra-cloud-clusters` for self-managed k3s/kubeadm clusters on provider VMs.
-- `ankra-import-cluster` for importing self-managed clusters via an ImportCluster manifest.
-- `ankra-stacks-addons` / `ankra-gitops` to deploy workloads once the cluster exists.
+- `ankra-cloud-clusters` — self-managed k3s/kubeadm on provider VMs, and the instance-family guide.
+- `ankra-getting-started` — the path from an empty organisation to a first running app.
+- `ankra-import-cluster` — adopting a self-managed cluster via an ImportCluster manifest.
+- `ankra-domains-dns` — ingress hostnames, DNS and TLS once the cluster is up.
+- `ankra-stacks-addons` / `ankra-gitops` — deploying onto it.

--- a/internal/skills/embedded/skills/ankra-observability/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-observability/SKILL.md
@@ -25,7 +25,8 @@ stacks:
         repository_url: https://prometheus-community.github.io/helm-charts
         namespace: monitoring
         parents:
-          - manifest: monitoring-ns
+          - kind: manifest
+            name: monitoring-ns
         configuration:
           values: |-
             grafana:
@@ -36,19 +37,38 @@ stacks:
         repository_url: https://grafana.github.io/helm-charts
         namespace: monitoring
         parents:
-          - manifest: monitoring-ns
+          - kind: manifest
+            name: monitoring-ns
       - name: promtail                      # log shipping
         chart_name: promtail
         chart_version: 6.16.4
         repository_url: https://grafana.github.io/helm-charts
         namespace: monitoring
         parents:
-          - addon: loki
+          - kind: addon
+            name: loki
 ```
 
 ## External metrics sources
 
 Instead of (or in addition to) in-cluster Prometheus, connect a Prometheus-compatible source so Ankra reads metrics for dashboards/insights: Grafana Cloud, Amazon Managed Prometheus, Google Cloud Managed Prometheus, Thanos, or VictoriaMetrics. Provide the query endpoint URL and scoped, read-only credentials stored in Ankra.
+
+The source a cluster queries is configured in **Cluster Settings → Metrics**; that is the endpoint
+`ankra cluster metrics` proxies to.
+
+## Reading what you deployed
+
+```bash
+ankra cluster metrics query 'sum by (pod) (rate(container_cpu_usage_seconds_total[5m]))'
+ankra cluster metrics query-range 'up' --range 6h --step 5m
+ankra cluster top nodes                       # metrics-server, works without Prometheus
+ankra cluster top pods -n monitoring
+ankra cluster logs -l app.kubernetes.io/name=grafana -n monitoring --follow=false --tail 50
+```
+
+`top` reads the aggregated metrics API directly and works on clusters where Prometheus was never
+installed; `metrics` is the PromQL surface for trends. Use these to verify the stack itself came up
+before wiring dashboards to it.
 
 ## Rules
 
@@ -62,3 +82,4 @@ Instead of (or in addition to) in-cluster Prometheus, connect a Prometheus-compa
 
 - `ankra-stacks-addons` for stack composition.
 - `ankra-alerts-webhooks` to route alerts from this stack to Slack/Teams/PagerDuty with AI analysis.
+- `ankra-troubleshooting` for the diagnosis workflow these metrics feed.

--- a/internal/skills/embedded/skills/ankra-platform-principles/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-platform-principles/SKILL.md
@@ -1,53 +1,115 @@
 ---
 name: ankra-platform-principles
-description: Cross-cutting best practices for building and operating Kubernetes with Ankra - Git as source of truth, pinned versions, variables over hardcoding, least-privilege credentials, promotion through environments, idempotent operations, and explicit confirmation for destructive actions. Use whenever designing, reviewing, or changing Ankra clusters, stacks, GitOps repos, or CI/CD that touches Ankra.
+description: Cross-cutting best practices for building and operating Kubernetes with Ankra - Git as source of truth, pinned versions, variables over hardcoding, least-privilege credentials, promotion through environments, idempotent operations, explicit confirmation for destructive actions - plus the routing map from a request to the right Ankra skill. Use whenever designing, reviewing, or changing Ankra clusters, stacks, applications, GitOps repos, or CI/CD that touches Ankra, and to decide which other ankra-* skill applies.
 ---
 
 # Ankra Platform Principles
 
-Apply these whenever you design, review, or change anything in an Ankra environment. They are the defaults Ankra follows; deviate only with a stated reason.
+Apply these whenever you design, review, or change anything in an Ankra environment. They are the
+defaults Ankra follows; deviate only with a stated reason.
+
+## Which skill applies
+
+| The request is about | Read |
+|----------------------|------|
+| Driving the CLI, orienting, scripting | `ankra-cli` |
+| Importing or onboarding an existing cluster | `ankra-import-cluster` |
+| Provisioning a cluster Ankra manages | `ankra-cloud-clusters`, `ankra-managed-kubernetes` |
+| Composing stacks, Helm addons, manifests, ordering | `ankra-stacks-addons` |
+| One stack across many clusters, parameterised | `ankra-stack-profiles` |
+| Deploying your own source code | `ankra-applications` |
+| Wiring an app to LiteLLM, Harbor, a database, an API | `ankra-app-integrations` |
+| Pipelines that build and roll out | `ankra-cicd` |
+| The repository layout Ankra syncs | `ankra-gitops` |
+| Secrets in Git | `ankra-sops-secrets` |
+| Private chart sources | `ankra-helm-registries` |
+| Monitoring, dashboards, log stacks, metrics sources | `ankra-observability` |
+| Something is broken right now | `ankra-troubleshooting` |
+| Alerting and notification routing | `ankra-alerts-webhooks` |
+| Permissions, tokens, RBAC, hardening | `ankra-security` |
+| AI models, MCP tools, agent runs, the board | `ankra-ai-agents` |
+| Ask/Agent mode per Slack/Teams/SCM binding | `ankra-ai-gateway` |
+| Managing Ankra itself as code | `ankra-terraform` |
+
+Several usually apply at once. Shipping a new service touches `ankra-applications`,
+`ankra-cicd` and `ankra-stack-profiles`; the principles below apply to all of them.
 
 ## 1. Git is the source of truth
 
-Express cluster state as committed YAML (ImportCluster, stacks, manifests). Change the repo and let Ankra sync it; avoid out-of-band manual mutations. Every running change should be traceable to a commit.
+Express cluster state as committed YAML (ImportCluster, stacks, manifests). Change the repo and let
+Ankra sync it; avoid out-of-band manual mutations. Every running change should be traceable to a
+commit. Nothing that only exists because someone edited a live resource is deployed.
 
 ## 2. Pin everything
 
 - Helm addons: exact `chart_version`, never floating or `latest`.
 - Container images: immutable tags or digests, never `latest`.
+- Models, when an application depends on one: a pinned id.
 
-A commit should fully determine what runs.
+A commit should fully determine what runs. An unpinned artefact means the thing you reviewed is not
+necessarily the thing running, which quietly defeats review, promotion, rollback and scanning.
 
 ## 3. Variables, not hardcoded values
 
-Promote environment-specific values (domains, sizes, replica counts, storage classes) to variables. The same stack definition should work across dev, staging, and prod by changing variables, not by forking the YAML.
+Promote environment-specific values (domains, sizes, replica counts, storage classes) to variables
+or profile parameters. The same definition should work across dev, staging and prod by changing
+values, not by forking the YAML. A copied-and-edited stack is a bug with a delay on it.
 
 ## 4. Small, focused, composable stacks
 
-One concern per stack (ingress, monitoring, logging). Small stacks are easier to order, clone, and reason about than a single mega-stack. Use dependency `parents` to express order explicitly; deploy namespace manifests before anything inside them.
+One concern per stack (ingress, monitoring, logging). Small stacks are easier to order, clone and
+reason about than one mega-stack. Use dependency `parents` to express order explicitly; deploy the
+namespace manifest before anything inside it.
 
 ## 5. Least-privilege credentials and secrets
 
-- Scope Git, registry, and cloud credentials to the minimum needed.
-- Never commit plaintext Secrets; encrypt with SOPS and mark `encrypted_paths`.
-- Keep API tokens in the secret store / environment, never in the repo. Use short-lived, scoped tokens for automation.
+- Scope Git, registry and cloud credentials to the minimum needed; `ankra credentials repositories`
+  shows what a Git credential can actually reach, which is often more than intended.
+- Never commit plaintext Secrets; encrypt with SOPS and declare `encrypted_paths`.
+- Keep API tokens in the secret store or the environment, never in the repo. Short-lived and
+  scoped for automation, with an expiry set.
+- Never print a decrypted secret into a transcript, a pull request, an issue, or chat.
 
 ## 6. Promote through environments
 
-Roll a change out to dev/staging first, verify, then promote the identical definition to production. Production uses the most conservative, pinned configuration.
+Roll a change out to dev/staging first, verify, then promote the **identical artefact** to
+production. If the image tag differs between staging and production, you did not promote — you
+shipped something that was never tested. Production runs the most conservative, pinned
+configuration.
 
 ## 7. Operations are idempotent and retry-safe
 
-Ankra operations can re-run. Design changes so reapplying is safe: declarative manifests, no side effects that break on a second apply, no reliance on one-shot imperative steps.
+Ankra operations re-run. Design changes so re-applying is safe: declarative manifests, no side
+effects that break on a second apply, no reliance on one-shot imperative steps. Retry a transient
+failure; fix a deterministic one rather than retrying it.
 
 ## 8. Confirm destructive actions
 
-Treat `delete`, `deprovision`, `roll-to`, and force operations as deliberate. Confirm the target cluster/org first (`ankra cluster info`) and prefer a reviewed PR over an ad-hoc command for anything irreversible.
+Treat `delete`, `uninstall`, `deprovision`, `revoke`, `roll-to` and force operations as deliberate.
+Confirm the organisation and cluster first (`ankra org current`, `ankra cluster info`) and prefer a
+reviewed pull request over an ad-hoc command for anything irreversible.
 
 ## 9. Review before deploy
 
-Protect synced branches, require pull-request review, and keep diffs small. A merge is a deploy — review it like one.
+Protect synced branches, require pull-request review, keep diffs small. A merge is a deploy —
+review it like one. Where Ankra offers a draft (`ankra cluster draft`, `stack-profiles apply`
+without `--deploy`), take it: a reviewable draft costs nothing and an unreviewed apply can cost a
+lot.
+
+## 10. Verify, then claim
+
+A green command is not a working service. Verify at the layer that would actually fail: the
+platform execution, the pod, the log, and — for an integration — the *provider's* log showing the
+call arrive. Report what you checked.
+
+## 11. Read-only by default
+
+Investigate with reads (`get`, `describe`, `events`, `logs`, `top`, `metrics`, `operations`), and
+propose the change before making it. Do not reconcile or re-apply as a probe: it changes the state
+you are diagnosing.
 
 ## Related skills
 
-These principles are applied concretely in `ankra-import-cluster`, `ankra-stacks-addons`, `ankra-gitops`, `ankra-cicd`, and `ankra-sops-secrets`.
+These principles are applied concretely in `ankra-import-cluster`, `ankra-stacks-addons`,
+`ankra-stack-profiles`, `ankra-applications`, `ankra-gitops`, `ankra-cicd`, `ankra-sops-secrets`,
+`ankra-security` and `ankra-troubleshooting`.

--- a/internal/skills/embedded/skills/ankra-platform-principles/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-platform-principles/SKILL.md
@@ -12,9 +12,12 @@ defaults Ankra follows; deviate only with a stated reason.
 
 | The request is about | Read |
 |----------------------|------|
+| Starting from nothing; "what do I do first" | `ankra-getting-started` |
 | Driving the CLI, orienting, scripting | `ankra-cli` |
 | Importing or onboarding an existing cluster | `ankra-import-cluster` |
-| Provisioning a cluster Ankra manages | `ankra-cloud-clusters`, `ankra-managed-kubernetes` |
+| Building a cluster: provider, region, instance family | `ankra-cloud-clusters` |
+| A control plane the provider runs (DOKS, GKE, AKS, EKS, …) | `ankra-managed-kubernetes` |
+| Custom domain, DNS records, why TLS is missing | `ankra-domains-dns` |
 | Composing stacks, Helm addons, manifests, ordering | `ankra-stacks-addons` |
 | One stack across many clusters, parameterised | `ankra-stack-profiles` |
 | Deploying your own source code | `ankra-applications` |
@@ -32,7 +35,9 @@ defaults Ankra follows; deviate only with a stated reason.
 | Managing Ankra itself as code | `ankra-terraform` |
 
 Several usually apply at once. Shipping a new service touches `ankra-applications`,
-`ankra-cicd` and `ankra-stack-profiles`; the principles below apply to all of them.
+`ankra-cicd` and `ankra-stack-profiles`; standing up a first cluster touches
+`ankra-getting-started`, `ankra-cloud-clusters` and `ankra-domains-dns`. The principles below apply
+to all of them.
 
 ## 1. Git is the source of truth
 
@@ -110,6 +115,7 @@ you are diagnosing.
 
 ## Related skills
 
-These principles are applied concretely in `ankra-import-cluster`, `ankra-stacks-addons`,
-`ankra-stack-profiles`, `ankra-applications`, `ankra-gitops`, `ankra-cicd`, `ankra-sops-secrets`,
-`ankra-security` and `ankra-troubleshooting`.
+These principles are applied concretely in `ankra-getting-started`, `ankra-import-cluster`,
+`ankra-cloud-clusters`, `ankra-stacks-addons`, `ankra-stack-profiles`, `ankra-applications`,
+`ankra-gitops`, `ankra-cicd`, `ankra-sops-secrets`, `ankra-domains-dns`, `ankra-security` and
+`ankra-troubleshooting`.

--- a/internal/skills/embedded/skills/ankra-security/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-security/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: ankra-security
+description: Secure an Ankra organisation end to end - API tokens and their MCP scopes, organisation roles and membership, cluster access grants through the kube gateway, credential scope for Git/registry/cloud, secret handling with SOPS, application code and container scanning findings, and how much autonomy the AI agents and MCP tool servers are given. Use when the user asks about permissions, RBAC, who can access a cluster, token scopes, least privilege, a security review, hardening, or handling secrets safely.
+---
+
+# Ankra security
+
+Ankra has five distinct places where access is granted. Confusing them is how a "read-only" token
+ends up able to open pull requests, and how a developer who needed to read logs ends up
+`cluster-admin`.
+
+| Layer | Grants | Managed with |
+|-------|--------|--------------|
+| **API tokens** | What a script or an MCP client can call | `ankra tokens` |
+| **Organisation roles** | What a member can do in Ankra | `ankra org members`, `ankra org roles` |
+| **Cluster access grants** | Kubernetes API access through the Ankra gateway | `ankra cluster access` |
+| **Credentials** | What Ankra can reach in Git, registries and clouds | `ankra credentials`, `ankra helm credentials` |
+| **Agent autonomy** | What the AI may do without a human | Ask/Agent mode, MCP tool grants |
+
+## 1. API tokens and MCP scopes
+
+```bash
+ankra tokens list
+ankra tokens create ci-payments --expires 2026-12-31
+ankra tokens create cursor-readonly --scopes mcp:read
+ankra tokens create agent-writer   --scopes mcp:read,mcp:write
+ankra tokens revoke <token-id>
+ankra tokens delete <token-id>          # only after it is revoked
+```
+
+- **Omitting `--scopes` creates a REST-only token** — it can drive the CLI and API but exposes no
+  MCP tool surface. That is the right default for CI.
+- **`mcp:read`** is the Ask surface: reads plus the curated safe creations (a workspace pod, a
+  throwaway PR demo, a brand-new stack). Give this to an editor integration.
+- **`mcp:read,mcp:write`** adds the mutating tools, including opening fix pull requests. Give it
+  only where you want the agent to act.
+- **Always set `--expires`.** A token with no expiry is a permanent credential nobody will
+  remember to rotate.
+- Revoke first, delete second — the two-step exists so an accidental delete cannot hide an active
+  credential.
+
+Resolution order in the CLI is `--token`, then the saved login from `ankra login`, then
+`ANKRA_API_TOKEN`. A saved login **beats** the environment variable, so a script that seems to
+ignore `ANKRA_API_TOKEN` usually needs `ankra logout` first.
+
+Store tokens in the CI secret store or the environment — never in the repository, never in a
+committed `.ankra.yaml`.
+
+## 2. Organisation roles and membership
+
+```bash
+ankra org members
+ankra org roles                          # the assignable roles
+ankra org invite <email> --role viewer   # owner, admin, operator, member, viewer, read-only
+ankra org remove <email>
+ankra org current
+```
+
+Invite at the lowest role that works, and review membership when people change teams. Role is also
+what gates MCP tool grants (below), so a wide role quietly widens agent capability too.
+
+## 3. Cluster access through the kube gateway
+
+```bash
+ankra cluster access list --cluster prod
+ankra cluster access grant alice@example.com --cluster prod --role view
+ankra cluster access grant bob@example.com --cluster prod --role edit --namespace payments
+ankra cluster access revoke alice@example.com --cluster prod
+```
+
+Roles map to the standard Kubernetes ClusterRoles: `view`, `edit`, `admin`, `cluster-admin`. Grants
+are **cluster-wide by default** — pass `--namespace` to scope one.
+
+Two rules that carry most of the value here:
+
+- **`view` is enough for troubleshooting.** `ankra cluster logs --previous`, `describe`, `events`
+  and `top` all work through the agent without a grant at all; a grant is only needed for direct
+  `kubectl`. Reaching for `edit` to read a crash log is a common and unnecessary escalation.
+- **`cluster-admin` needs a named reason and a review date.** Treat every existing one as a finding
+  until someone justifies it.
+
+```bash
+ankra cluster kubeconfig add --use     # a kubeconfig context using ankra cluster kube-token
+ankra cluster kubeconfig list
+ankra cluster kubeconfig remove <context>
+```
+
+The kubeconfig credential plugin mints short-lived credentials per call, so there is no long-lived
+kubeconfig to leak. Read-only kubectl through it is fine; mutations belong in the GitOps repo.
+
+## 4. Credentials: scope, and what they can really reach
+
+```bash
+ankra credentials list
+ankra credentials get <name>
+ankra credentials repositories <name>    # what a Git credential can ACTUALLY reach
+ankra credentials validate <name>
+ankra helm credentials list
+```
+
+`credentials repositories` is the one to run in a review: a Git credential that was meant for one
+repository frequently reaches an entire organisation, and nothing in its name says so.
+
+- Scope Git credentials to the repositories Ankra needs, and no more.
+- Registry credentials come in three flavours and should not be shared: a **push** credential for
+  CI, a **read** credential for Ankra, and a **pull secret** for the cluster. Where the registry
+  supports it, hand Ankra an **admin** credential so it mints a narrow per-application robot
+  instead — see `ankra-app-integrations`.
+- Cloud provider credentials should be scoped to the project/subscription Ankra manages.
+
+## 5. Secrets
+
+```bash
+ankra cluster sops-config                          # the public key in use
+ankra cluster encrypt manifest <name> --key password --key username
+ankra cluster encrypt addon <name> --key apiKey
+ankra cluster decrypt manifest <name>              # verify shape, never to copy values
+ankra application env-secrets list <application-id>
+```
+
+- **Nothing sensitive is committed in plaintext.** Encrypt with SOPS and declare `encrypted_paths`
+  so Ankra decrypts the right fields — an encrypted value with no declared path deploys as
+  ciphertext.
+- **Never print a decrypted value** into a terminal transcript, a pull request, a commit message,
+  an issue, or chat. Report the key name and its state.
+- **Rotate and re-encrypt when access changes**, and scope decryption to the clusters that need it.
+- Opening a stack profile builder draft on a published profile **drops `encrypted_paths`** —
+  re-declare them before publishing (see `ankra-stack-profiles`).
+
+## 6. Supply chain
+
+```bash
+ankra application upgrade-workflow <application-id>    # add scanning to the build workflow
+ankra application code-security <application-id>
+ankra application container-security <application-id>
+ankra application pull-request-reviews <application-id>
+```
+
+An application whose build workflow has no scanning step is a finding in itself. So is a floating
+image tag or an unpinned chart version: a mutable tag means the artefact you reviewed is not
+necessarily the artefact that runs, which defeats every other control here.
+
+## 7. Agent autonomy
+
+```bash
+ankra org mcp-servers list
+ankra org mcp-servers get <name>
+ankra org mcp-servers tools <name>
+ankra org mcp-servers grants <name>                    # per-tool role grants
+ankra org mcp-servers grant <name> <tool> --role admin
+ankra org mcp-servers revoke-grant <name> <tool> --role admin
+ankra org mcp-servers disable <name>
+ankra agents runs --status failed
+```
+
+- **Ask is the safe default and the gateway fails closed to it.** A binding with no explicit mode
+  inherits the organisation default, which is `ask` until an admin changes it.
+- **Agent mode auto-opens pull requests** — that is the design; the PR is the review gate. It never
+  merges and never force-pushes.
+- **MCP servers**: prefer `--tier read_only`, keep `--allowed-tools` to what is actually needed,
+  restrict with `--cluster` where a server should only serve some clusters, and store credential
+  headers with `--secret-header` (a secret slot) rather than `--header` (plaintext).
+- Grant mutating tools to the narrowest role that needs them, not to `member`.
+
+See `ankra-ai-agents` for the full surface and `ankra-ai-gateway` for the Ask/Agent contract.
+
+## A review pass, in order
+
+```bash
+ankra tokens list                        # no-expiry tokens, over-scoped mcp:write
+ankra org members ; ankra org roles      # who holds what
+ankra cluster access list --cluster <c>  # cluster-admin, cluster-wide grants
+ankra credentials list                   # then `credentials repositories` on each Git credential
+ankra cluster sops-config                # secrets encrypted, paths declared
+ankra application container-security <a> # per application; and code-security
+ankra org mcp-servers list               # read_write tiers, wide tool grants
+```
+
+Report findings ranked by exposure: what is reachable, by whom, and the one command or change that
+closes it. Do not change anything in a review pass without asking, and never print a secret value.
+
+## Rules
+
+- **Least privilege at every layer**, and the layers are independent — a narrow role does not
+  narrow a token.
+- **Expiry on every token.** Revoke, then delete.
+- **`view` before `edit`, `edit` before `admin`**, namespace-scoped before cluster-wide.
+- **Plaintext secrets never reach Git**, and decrypted values never reach a transcript.
+- **Pin every artefact.** Unpinned images and charts make review meaningless.
+- **Ask mode by default**; promote a binding to Agent deliberately, per binding.
+- **Destructive commands confirm first** (`delete`, `uninstall`, `deprovision`, `revoke`) — check
+  the organisation and cluster with `ankra org current` and `ankra cluster info` before running one.
+
+## Related skills
+
+- `ankra-sops-secrets` — the encryption workflow in detail.
+- `ankra-app-integrations` — credential reuse and the registry credential split.
+- `ankra-ai-agents` — MCP servers, tool grants, and agent runs.
+- `ankra-ai-gateway` — Ask/Agent modes per integration.
+- `ankra-platform-principles` — the least-privilege and confirm-destructive defaults.

--- a/internal/skills/embedded/skills/ankra-sops-secrets/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-sops-secrets/SKILL.md
@@ -1,32 +1,101 @@
 ---
 name: ankra-sops-secrets
-description: Encrypt Kubernetes Secrets and sensitive values stored in an Ankra GitOps repo using SOPS with AGE, and track them with encrypted_paths so Ankra decrypts at deploy time. Use when the user needs to store secrets in Git, mentions SOPS, AGE, encrypted_paths, or `ankra cluster encrypt`/`decrypt`/`sops-config`.
+description: Encrypt Kubernetes Secrets and sensitive addon values with SOPS and AGE so they can live in an Ankra GitOps repo, using `ankra cluster encrypt`/`decrypt` in cluster mode or file mode, glob key patterns that keep covering keys added later, `--all-data` for a whole Secret, and `encrypted_paths` so Ankra decrypts at deploy time. Use when the user needs to store a secret in Git, mentions SOPS, AGE, `encrypted_paths`, `ankra cluster encrypt`/`decrypt`/`sops-config`, or asks how to change a secret value without committing plaintext.
 ---
 
-# Ankra Secrets with SOPS
+# Ankra secrets with SOPS
 
-Never commit plaintext Secrets. Ankra integrates SOPS (with AGE keys) so sensitive manifests and addon values are encrypted in Git and decrypted only at deploy time.
+Never commit a plaintext Secret. Ankra integrates SOPS (with AGE keys) so sensitive manifest and
+addon values are ciphertext in Git and decrypted only at deploy time — while the surrounding YAML
+stays readable, so diffs remain reviewable.
 
 ## Concepts
 
-- **SOPS** encrypts the values of YAML keys, leaving structure readable so diffs stay reviewable.
-- **AGE** is the recommended key type (simple, modern). The public key encrypts; the private key (held by Ankra / the cluster) decrypts.
-- **`encrypted_paths`** — the list, on a manifest or addon, of paths that are SOPS-encrypted, so Ankra knows what to decrypt.
-
-## Workflow with the CLI
+- **SOPS** encrypts the *values* of named YAML keys, leaving structure and key names visible.
+- **AGE** is the key type. The public key encrypts; the private key, held by Ankra, decrypts.
+- **`encrypted_paths`** is the list on a manifest or addon telling Ankra which values are
+  encrypted. **An encrypted value with no declared path deploys as ciphertext** — this is the most
+  common SOPS mistake in Ankra.
 
 ```bash
-# 1. Inspect / set the SOPS configuration for the cluster
-ankra cluster sops-config
-
-# 2. Encrypt a file before committing it
-ankra cluster encrypt -f manifests/db-secret.yaml
-
-# 3. (When needed) decrypt locally to inspect
-ankra cluster decrypt -f manifests/db-secret.yaml
+ankra cluster sops-config          # the organisation's SOPS configuration and public key
 ```
 
-Then reference the encrypted file from your stack and declare its encrypted paths:
+## Two modes, and when to use which
+
+Both `encrypt` and `decrypt` work either against the live cluster or against a local file.
+
+| Mode | What it does | When |
+|------|--------------|------|
+| **Cluster** (default) | Fetch from the live cluster, encrypt, push back via the partial-stack PATCH. The owning stack is resolved automatically. | The stack already exists on a cluster |
+| **File** (`-f cluster.yaml`) | Rewrite the `from_file` the local `cluster.yaml` references, in place, and add the key to `encrypted_paths` in the file | GitOps, where the source of truth is on disk |
+
+## Encrypting
+
+```bash
+ankra cluster encrypt manifest db-secret --key password
+ankra cluster encrypt manifest db-secret --key password --cluster prod
+ankra cluster encrypt manifest db-secret --key password --key api-token
+ankra cluster encrypt manifest db-secret --all-data --cluster prod
+ankra cluster encrypt manifest db-secret --key 'glob:stringData.DB_*' --cluster prod
+ankra cluster encrypt manifest db-secret --key password -f cluster.yaml
+
+ankra cluster encrypt addon my-app --key apiKey
+ankra cluster encrypt addon my-app --key 'glob:*Password' -f cluster.yaml
+```
+
+Key semantics worth knowing before you write a `--key`:
+
+- `--key` takes the **YAML key name**, not a dotted path: for `data.password`, that is `password`.
+  A dotted `--key` is normalised to its last segment. SOPS matches key names anywhere in the
+  document.
+- A key whose own name starts with a dot (`.dockerconfigjson` in a `kubernetes.io/dockerconfigjson`
+  Secret) is kept literally.
+- Repeating `--key` encrypts several keys in one SOPS pass and one write.
+- **`--key 'glob:<pattern>'`** encrypts every key matching the pattern — now *and on every later
+  re-encrypt*, so keys added afterwards are covered automatically. Only `*` is a wildcard;
+  everything else is literal. A pattern matching nothing fails, the same as a misspelled key.
+- **`--all-data`** selects every key under `data` and `stringData` of a Secret manifest, skipping
+  values already encrypted. The manifest must be a Secret; `--all-data` and `--key` are mutually
+  exclusive.
+- After encrypting, the CLI verifies every value really is `ENC[...]` ciphertext and fails if not.
+
+## Changing a secret value without committing plaintext
+
+This is the pattern that matters most, and the obvious route gets it wrong.
+
+```bash
+# Right: the new value and its encryption land in ONE commit
+ankra cluster encrypt manifest db-secret --key password \
+  --set 'data.password=bmV3LXNlY3JldA==' --cluster prod
+```
+
+In cluster mode `--set` applies the value edit **in memory before encrypting**, so the plaintext
+never reaches Git history.
+
+```bash
+# Wrong: this commits the plaintext value first, and it stays in history forever
+ankra cluster manifests upgrade db-secret --set 'data.password=...'
+ankra cluster encrypt manifest db-secret --key password
+```
+
+If plaintext has already been committed, treat the value as compromised: rotate it at the source,
+then encrypt the new one. Rewriting Git history is not a fix.
+
+## Decrypting
+
+```bash
+ankra cluster decrypt manifest db-secret
+ankra cluster decrypt manifest db-secret --cluster prod
+ankra cluster decrypt manifest db-secret -f cluster.yaml
+ankra cluster decrypt addon my-app --cluster prod
+```
+
+Decryption prints to stdout. Use it to **verify shape** — that the right keys are encrypted, that a
+value is present — not to copy values around. Never paste decrypted output into a pull request, a
+commit message, an issue, a chat message, or a CI log.
+
+## Declaring it in the stack
 
 ```yaml
 manifests:
@@ -35,11 +104,13 @@ manifests:
     encrypted_paths:
       - data.password
       - data.username
+      - "glob:stringData.DB_*"
 addons:
   - name: my-app
     chart_name: my-app
     chart_version: 1.4.2
-    repository_url: https://charts.example.com
+    registry_name: example-charts
+    registry_url: https://charts.example.com
     namespace: app
     configuration:
       from_file: "values/my-app.yaml"
@@ -47,15 +118,49 @@ addons:
         - secrets.apiKey
 ```
 
+A glob entry is recorded in `encrypted_paths` **as written** (`glob:stringData.DB_*`), which is the
+form the platform re-expands into the SOPS `encrypted_regex` on every push. `ankra cluster encrypt`
+maintains these entries for you in file mode; if you hand-edit the YAML, keep them in sync.
+
+Verify what the platform actually stored:
+
+```bash
+ankra cluster stacks list <stack> -o json     # echoes each resource's encrypted_paths
+```
+
+## Where a secret should live
+
+SOPS in Git is one of three homes, and picking the wrong one is a common mistake:
+
+| Value | Home |
+|-------|------|
+| A Secret or addon value a stack deploys | SOPS-encrypted in the GitOps repo, `encrypted_paths` declared |
+| A secret only one application needs | `ankra application env-secrets set` (then `apply`) |
+| A non-secret that varies per environment | A cluster / organisation / stack variable |
+
+See `ankra-app-integrations` for the full split.
+
+## Traps
+
+- **`encrypted_paths` lost on a stack profile draft.** Opening a builder draft on a published
+  profile drops them. Re-declare before publishing, or the launch deploys ciphertext.
+- **A key that does not exist yet.** An exact `--key` for a key added later is not covered; use a
+  `glob:` pattern when the key set will grow.
+- **Cross-namespace Secrets.** A Secret is only visible to pods in its own namespace. Encrypting it
+  correctly does not make it reachable from elsewhere.
+- **Rotation.** Re-encrypt when access changes, and scope decryption to the clusters that need it.
+
 ## Rules
 
-- **Plaintext secrets never reach Git.** Encrypt first, commit the encrypted file.
-- **Encrypt values, not whole files where possible** — keep keys/structure visible so reviews are meaningful.
-- **Declare `encrypted_paths`** for every encrypted value so Ankra decrypts the right fields.
-- **Rotate keys** and re-encrypt when access changes; scope decryption to the clusters that need it.
-- **Do not log decrypted output** or paste it into chat, issues, or CI logs.
+- **Plaintext never reaches Git.** Encrypt first, or use `encrypt --set` to do both at once.
+- **Declare `encrypted_paths`** for every encrypted value.
+- **Encrypt values, not whole files**, so reviews stay meaningful.
+- **Never log or paste decrypted output.**
+- **Rotate at the source** when plaintext has leaked; history rewriting is not remediation.
 
 ## Related skills
 
-- `ankra-gitops` for the repo that stores these encrypted files.
-- `ankra-platform-principles` for the broader least-privilege stance.
+- `ankra-gitops` — the repository these encrypted files live in.
+- `ankra-stacks-addons` — the manifests and addon values being encrypted.
+- `ankra-app-integrations` — choosing between env-secrets, SOPS, and variables.
+- `ankra-security` — the wider least-privilege posture and review pass.

--- a/internal/skills/embedded/skills/ankra-stack-profiles/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-stack-profiles/SKILL.md
@@ -102,7 +102,7 @@ Later versions from a deployed stack, without reopening the builder:
 ```bash
 ankra stack-profiles save-version payments --stack payments --cluster staging \
   --changelog "Bump CloudNativePG to 1.30" --channel stable
-ankra stack-profiles set-current-version payments --version 3
+ankra stack-profiles set-current-version payments v3
 ```
 
 `save-version` re-snapshots a source stack and makes the result the current version;
@@ -113,7 +113,7 @@ ankra stack-profiles set-current-version payments --version 3
 ```bash
 ankra stack-profiles list
 ankra stack-profiles get payments                     # versions and the parameters they expect
-ankra stack-profiles version payments --version 3     # one version's contents
+ankra stack-profiles version payments v3              # one version's contents
 
 ankra stack-profiles apply payments --cluster eu-prod --dry-run
 ankra stack-profiles apply payments --cluster eu-prod \

--- a/internal/skills/embedded/skills/ankra-stack-profiles/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-stack-profiles/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: ankra-stack-profiles
+description: Turn a working cluster stack into a reusable, parameterised stack profile and launch it across a fleet - builder drafts, parameters and their annotations, option sets that move several inputs together, secret parameters, publishing versions, applying to a cluster as a reviewable draft, diffing versions, sharing with other organisations, and exporting as ClusterInfrastructureAsCode YAML. Use when the user mentions stack profiles, `ankra stack-profiles`, a profile catalogue, reusing a stack across clusters, or wants one definition to serve many environments.
+---
+
+# Ankra Stack Profiles
+
+A **stack profile** is a published, versioned, parameterised snapshot of a stack. It is how one
+definition serves many clusters: the parts that differ per cluster become **parameters** the
+launcher fills in, and the rest is fixed and pinned.
+
+Reach for a profile the moment a stack would otherwise be copy-pasted to a second cluster and
+edited. The copy is the bug: two stacks that started identical drift silently, and nothing tells
+you which one is right.
+
+## Where a profile comes from
+
+```
+deployed stack → builder draft → parameters + annotations + options → publish → version
+                                                                          ↓
+                                                     apply to cluster (draft → deploy)
+```
+
+Everything below is also available in the portal's stack builder; the CLI is what makes it
+scriptable and reviewable.
+
+## 1. Open a builder draft
+
+```bash
+ankra stack-profiles drafts create --name payments \
+  --source-cluster prod --source-stack payments      # seed from a deployed stack
+ankra stack-profiles drafts create --profile payments  # edit an existing profile (next version)
+ankra stack-profiles drafts create --name blank-profile
+ankra stack-profiles drafts list
+ankra stack-profiles drafts get <draft-id>            # parameters and annotations
+ankra stack-profiles drafts delete <draft-id>
+```
+
+Seeding from a deployed stack is the normal route: build it once on a real cluster, verify it,
+then capture it.
+
+> **Opening a draft on a published profile drops `encrypted_paths`.** Re-declare them before
+> publishing, or the next launch deploys a secret Ankra will not decrypt.
+
+## 2. Turn cluster-specific values into parameters
+
+Every domain, size, replica count, storage class, node selector and credential that came from the
+source cluster must become a parameter. Anything you leave as a literal is the source cluster's
+value silently baked into everyone else's launch.
+
+```bash
+ankra stack-profiles drafts annotate <draft-id> --parameter domain \
+  --title "Public domain" \
+  --description "The host the ingress serves, e.g. payments.example.com" \
+  --required
+ankra stack-profiles drafts annotate <draft-id> --parameter replicas \
+  --type number --default 2
+ankra stack-profiles drafts annotate <draft-id> --parameter storage_class \
+  --type enum --enum "gp3,standard,local-path" --default gp3
+```
+
+The `--description` is the guidance the launch form shows under the field. Write it for someone
+who has never seen this stack — that is the whole point of publishing it.
+
+`--add` declares an input the draft does not have, which you need for a choice input that no
+manifest references (see below).
+
+## 3. Group the choices that move together
+
+Where one decision drives several values, declare it once as an **option set**. A single "Model
+size" input can move the model id, the context length and the volume size together, so whoever
+launches the profile picks one thing instead of keeping four consistent.
+
+```bash
+ankra stack-profiles drafts annotate <draft-id> --parameter model_size --add --type enum
+ankra stack-profiles drafts options set <draft-id> --parameter model_size \
+  --value 8b --title "8B (single GPU)" \
+  --set model_id=meta-llama/Llama-3.1-8B-Instruct --set context_length=8192 --set volume_size=40Gi
+ankra stack-profiles drafts options set <draft-id> --parameter model_size \
+  --value 32b --title "32B (two GPUs)" \
+  --set model_id=Qwen/Qwen2.5-32B-Instruct --set context_length=32768 --set volume_size=120Gi
+ankra stack-profiles drafts options remove <draft-id> --parameter model_size --value 8b
+```
+
+Resolution order at apply time is fixed: **an explicit `--set` wins, then what the selected choice
+sets, then the input's own default.** A choice may set any non-secret input that does not offer
+choices of its own.
+
+## 4. Validate and publish
+
+```bash
+ankra stack-profiles drafts validate <draft-id>       # publish checks, without publishing
+ankra stack-profiles drafts publish <draft-id> --changelog "Initial version"
+ankra stack-profiles drafts rebase <draft-id>         # move a stale draft onto the latest version
+```
+
+Validate first. It catches the omissions that only bite the person launching it: an unannotated
+required input, a secret parameter with a default, a dangling reference.
+
+Later versions from a deployed stack, without reopening the builder:
+
+```bash
+ankra stack-profiles save-version payments --stack payments --cluster staging \
+  --changelog "Bump CloudNativePG to 1.30" --channel stable
+ankra stack-profiles set-current-version payments --version 3
+```
+
+`save-version` re-snapshots a source stack and makes the result the current version;
+`--include-addon-configurations` (default true) carries the source add-ons' values with it.
+
+## 5. Launch it on a cluster
+
+```bash
+ankra stack-profiles list
+ankra stack-profiles get payments                     # versions and the parameters they expect
+ankra stack-profiles version payments --version 3     # one version's contents
+
+ankra stack-profiles apply payments --cluster eu-prod --dry-run
+ankra stack-profiles apply payments --cluster eu-prod \
+  --set domain=payments.eu.example.com --set replicas=3 \
+  --set-file tls_key=./tls.key --set-env api_token=PAYMENTS_TOKEN \
+  --stack-name payments-eu
+ankra stack-profiles apply payments --cluster eu-prod --deploy
+```
+
+- **`--dry-run` shows the value every input would deploy with** — your `--set`, the selected
+  choice, or the default. Run it before every production apply; it is the only place the
+  three-way resolution is visible.
+- **Without `--deploy` you get a reviewable stack draft**, not a deployment. That is the default
+  and it is the right one: review in the stack builder, then deploy.
+- **Secret parameters take `--set-file` or `--set-env`**, never `--set`. A `--set` secret lands in
+  shell history and the process table.
+
+## 6. Operate the fleet
+
+```bash
+ankra stack-profiles deployments payments             # every stack deployed from this profile
+ankra stack-profiles diff payments --from 2 --to 3    # what changed between versions
+ankra stack-profiles update payments --description ... --category ...
+ankra stack-profiles logo set payments ./logo.svg      # also: logo get / logo clear
+ankra stack-profiles delete payments
+```
+
+`deployments` is the fleet view: which clusters are on which version. Upgrade by publishing a
+version and re-applying per cluster — one cluster, verified, then the rest.
+
+## 7. Share and move profiles between organisations
+
+```bash
+ankra stack-profiles share add payments <organisation-slug>
+ankra stack-profiles share list payments
+ankra stack-profiles share remove payments <organisation-slug>
+
+ankra stack-profiles export-iac payments --version 3 -o payments.yaml
+ankra stack-profiles import payments.yaml --name payments --category general
+
+ankra stack-profiles suggestions list payments        # suggestions from other organisations
+ankra stack-profiles suggestions get payments <suggestion-id>
+ankra stack-profiles suggestions approve payments <suggestion-id>   # publishes it as the next version
+ankra stack-profiles suggestions reject payments <suggestion-id> --note "..."
+ankra stack-profiles drafts submit-suggestion <draft-id>            # propose to another org's profile
+```
+
+Shared organisations can view and deploy every version but cannot change the profile. Keep the
+exported `ClusterInfrastructureAsCode` YAML in Git so the definition has a home outside the
+platform.
+
+## 8. Throwaway launches
+
+```bash
+ankra stack-profiles demo launch payments      # on the org's staging cluster, no cluster of your own
+ankra stack-profiles demo list payments
+ankra stack-profiles demo detail payments <demo-id>
+ankra stack-profiles demo logs payments <demo-id>
+ankra stack-profiles demo stop payments <demo-id>
+```
+
+The fastest way to prove a profile launches clean from nothing — run it before publishing a
+version anyone else will depend on.
+
+## Rules
+
+- **No cluster-specific literals.** If it came from the source cluster and differs elsewhere, it is
+  a parameter.
+- **Annotate every parameter.** An input with no description is a support ticket.
+- **Secrets are secret parameters**, bound with `--set-file`/`--set-env`, and their
+  `encrypted_paths` are re-declared after any draft reopen.
+- **`--dry-run` before a production apply.** It is the only view of the resolution order.
+- **Draft, review, deploy.** `--deploy` is for environments you are willing to change unreviewed.
+- **Pin chart and image versions inside the profile.** A profile with a floating tag makes every
+  launch a different stack.
+- **Version, do not fork.** Publish a new version rather than a second profile that differs
+  slightly.
+- **One concern per profile**, matching the one-concern-per-stack rule in `ankra-stacks-addons`.
+
+## Related skills
+
+- `ankra-stacks-addons` — the stack a profile is captured from, and dependency ordering.
+- `ankra-applications` — publishing your own code as an add-on rather than a profile.
+- `ankra-import-cluster` — the ImportCluster document and `ankra cluster draft`.
+- `ankra-sops-secrets` — `encrypted_paths` and what happens when they are lost.
+- `ankra-platform-principles` — promotion, pinning, and variables over hardcoding.

--- a/internal/skills/embedded/skills/ankra-stacks-addons/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-stacks-addons/SKILL.md
@@ -68,8 +68,18 @@ ankra cluster addons upgrade <addon>       # change version/values/parents
 ankra cluster manifests upgrade <name>
 ```
 
+## One stack, many clusters
+
+The moment a stack would be copy-pasted to a second cluster and edited, stop and capture it as a
+stack profile instead: every per-cluster difference becomes a parameter, and the two clusters
+cannot drift apart silently. `ankra cluster stacks clone <stack> --to <cluster>` is the one-off
+route (it lands as a draft on the target and strips encrypted values, which must be reconfigured
+there); a profile is the durable one. See `ankra-stack-profiles`.
+
 ## Related skills
 
 - `ankra-import-cluster` for the surrounding ImportCluster document.
+- `ankra-stack-profiles` for reusing a stack across a fleet, with parameters.
 - `ankra-helm-registries` for private chart sources.
 - `ankra-gitops` for storing stacks in Git.
+- `ankra-troubleshooting` when a resource deploys before its dependency.

--- a/internal/skills/embedded/skills/ankra-troubleshooting/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-troubleshooting/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: ankra-troubleshooting
+description: Diagnose a failing workload, deployment or Ankra operation on a managed cluster - reading logs (including the previous container of a CrashLoopBackOff), events scoped to one object, describe output, live CPU/memory from the metrics API, PromQL against the cluster's Prometheus, and the platform execution history that explains most deploy failures. Use when something is broken, a pod is crashlooping or Pending, a deploy failed, a stack will not come up, or the user asks to check logs, events, metrics or operations.
+---
+
+# Troubleshooting an Ankra cluster
+
+Diagnose read-only first, propose the fix second, apply it only when asked. Almost everything here
+is a bounded read that needs no cluster credentials of your own — the Ankra agent proxies it.
+
+## Order of investigation
+
+The order matters more than the commands. Working bottom-up from pod logs wastes time on failures
+whose cause is one layer up.
+
+```
+1. operations   did the platform execution succeed?      ankra cluster operations list
+2. object       what does the object itself say?         ankra cluster describe <kind> <name>
+3. events       what happened to it?                     ankra cluster events --for <kind>/<name>
+4. logs         what did the process say?                ankra cluster logs ... --previous
+5. resources    was it starved or evicted?               ankra cluster top pods / metrics query
+6. dependency   is the thing it calls actually up?       get services / logs of the provider
+```
+
+## 1. Platform executions
+
+A stack, addon or application change that "did not happen" almost always has a failed execution
+behind it, and its step output names the cause directly.
+
+```bash
+ankra cluster info                                   # confirm which cluster you are on
+ankra cluster operations list
+ankra cluster operations list <execution-id>         # detail for one execution
+ankra cluster operations steps <execution-id>        # per-step status and output
+ankra cluster operations retry <execution-id>        # terminal (failed/cancelled/timeout) only
+ankra cluster operations cancel <execution-id>
+ankra cluster operations cancel-step <execution-id> <step-id>
+```
+
+Retry is the right move for a transient failure (a registry timeout, a node that came back). It is
+the wrong move for a bad manifest: fix the definition, then re-apply.
+
+## 2. The object itself
+
+```bash
+ankra cluster get pods -n <namespace>
+ankra cluster get pods --all-namespaces
+ankra cluster describe pod <name> -n <namespace>
+ankra cluster describe deployment <name> -n <namespace>
+ankra cluster describe node <name>
+ankra cluster describe pvc <name> -n <namespace> -o json
+```
+
+`describe` answers "why is it not ready?" in one call: conditions, per-container state (probe
+failures, image-pull errors, OOMKills, exit codes) and the events whose `involvedObject` is this
+resource. Kinds outside the built-in set need `--group` (and sometimes `--api-version`), the same
+as `ankra cluster get resources`.
+
+## 3. Events, scoped
+
+```bash
+ankra cluster events -n <namespace>
+ankra cluster events --for pod/<name> -n <namespace>
+ankra cluster events --for deployment/<name> -n <namespace> --type Warning
+ankra cluster events --all-namespaces --type Warning -o json
+```
+
+`--for` is a server-side field selector on `involvedObject`, not a substring match — it is what
+turns "the pod is Pending" into "no node matches the nodeSelector". Prefer it over reading a
+namespace-wide list by eye.
+
+## 4. Logs
+
+```bash
+ankra cluster logs <pod> -n <namespace> --tail 200 --follow=false
+ankra cluster logs <pod> -n <namespace> --previous            # the CrashLoopBackOff log
+ankra cluster logs <pod> -n <namespace> -c <container>
+ankra cluster logs -l app=web -n <namespace> --follow=false --tail 50
+ankra cluster logs <pod> -n <namespace> --all-containers --previous
+ankra cluster logs -l app=web -n <namespace> --follow=false -o json
+```
+
+- `--namespace` is required.
+- **`--previous` is the only log with the failure in it** for a pod in CrashLoopBackOff: the
+  running container is the *next* attempt, which has not failed yet. A previous log is closed, so
+  this is always a bounded read.
+- `--follow` defaults to true. Pass `--follow=false` for anything you are piping into `grep`, or a
+  script will hang.
+- `-l/--selector` reads every matching pod; `--all-containers` expands each pod to all of its
+  containers, init and ephemeral included. With more than one target, lines are prefixed with
+  `[pod]` or `[pod/container]` so interleaved output stays attributable.
+
+## 5. Resources
+
+```bash
+ankra cluster top pods -n <namespace>
+ankra cluster top nodes
+ankra cluster metrics query 'sum by (pod) (rate(container_cpu_usage_seconds_total[5m]))'
+ankra cluster metrics query-range 'rate(node_cpu_seconds_total[5m])' --range 6h --step 5m
+```
+
+`top` reads the aggregated metrics API directly, so it works on clusters where Prometheus was
+never installed — it is the "which container just got OOMKilled" view. `metrics` proxies PromQL to
+the Prometheus source configured in **Cluster Settings → Metrics**, and is the view for trends over
+time. See `ankra-observability` for installing and wiring those sources.
+
+## 6. Cluster and agent health
+
+```bash
+ankra cluster list
+ankra cluster info
+ankra cluster agent status                            # an offline agent explains "nothing works"
+ankra cluster get nodes
+ankra cluster reconcile                               # ask Ankra to re-converge
+ankra cluster helm releases                           # what Helm thinks is installed
+ankra cluster stacks history <stack>                  # what changed on this stack, and when
+```
+
+An offline agent is the first thing to rule out when every command is failing rather than one
+workload. `ankra cluster stacks history` is the cheapest way to answer "what changed?" when
+something that worked yesterday does not today.
+
+## 7. Ask Ankra AI
+
+```bash
+ankra chat health                                     # AI-analysed cluster health
+ankra chat --mode ask "why is the payments pod crashlooping in prod?"
+ankra tickets list --needs-human                      # incidents the agents have filed
+```
+
+Ask mode is read-only. It is a good first pass on an unfamiliar cluster, and it will tell you what
+it looked at — verify the evidence rather than acting on the conclusion alone. See
+`ankra-ai-agents`.
+
+## Classifying what you found
+
+| Evidence | Class | Where the fix belongs |
+|----------|-------|-----------------------|
+| `CreateContainerConfigError`, missing key | Configuration / secret | Application env-secrets, or the Secret the stack deploys |
+| `ImagePullBackOff` | Registry / pull secret | `--pull-secret`, credential scope, image tag exists |
+| `CrashLoopBackOff` with a stack trace | Application code | The repository, as a pull request |
+| `CrashLoopBackOff` immediately, no output | Config read at startup, or the wrong command | Chart values / Dockerfile |
+| Pending, `no nodes available` | Scheduling / capacity | Node group size, requests, tolerations |
+| OOMKilled | Limits | Chart values; check `top pods` first |
+| Ready but unreachable | Port, ingress path, probe path | Chart values / ingress manifest |
+| Deployed too early, dependency missing | Stack ordering | `parents` edges — see `ankra-stacks-addons` |
+| Execution failed before any pod existed | Platform / manifest | The stack or addon definition |
+
+## Rules
+
+- **Read before you write.** Diagnose fully, then propose. Do not re-apply or reconcile as a
+  probe — it changes the state you are diagnosing.
+- **`--follow=false` for anything scripted.** The default streams forever.
+- **`--previous` for CrashLoopBackOff**, every time.
+- **Name the layer.** "Platform" and "application code" have different owners and different fixes;
+  say which one it is.
+- **Never paste secret values** from `get secrets` or `cluster decrypt` into an issue, a PR, or
+  chat. Report the key name and its state.
+- **Retry a transient failure, fix a deterministic one.** Repeatedly retrying a bad manifest just
+  moves the failure later.
+- **Do not reach for `kubectl` to mutate.** Read-only kubectl against a context from
+  `ankra cluster kubeconfig add --use` is fine; mutations belong in the GitOps repo or
+  `ankra cluster apply`.
+
+## Related skills
+
+- `ankra-observability` — installing Prometheus/Grafana/Loki and wiring external metrics sources.
+- `ankra-alerts-webhooks` — routing what you just found to Slack, Teams, or PagerDuty.
+- `ankra-stacks-addons` — dependency ordering, the cause behind most "deployed too early" failures.
+- `ankra-applications` — application deploys, env-secrets, and their failure modes.
+- `ankra-ai-agents` — Ankra AI's own investigation, agent runs, and the incident board.

--- a/internal/skills/index.go
+++ b/internal/skills/index.go
@@ -1,0 +1,135 @@
+package skills
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// A skill is only offered to an agent whose runtime knows how to discover it.
+// Claude Code and Cursor read a skills directory; Codex, Copilot, Gemini,
+// Windsurf and everything behind AGENTS.md do not. For those, the managed
+// block written into the always-loaded instructions file is the discovery
+// mechanism: it names each installed skill, what it covers, and the path to
+// open. The same block carries the routing rule, so one upsert configures
+// both.
+
+// InstructionsBlock renders the managed block for a target: the Ankra routing
+// rule, then the index of the skills installed for that client. Clients that
+// load skills natively get a shorter index, since their runtime already
+// surfaces the descriptions.
+func InstructionsBlock(target Target, installed []Skill) string {
+	var builder strings.Builder
+	builder.WriteString(managedBlockBegin)
+	builder.WriteString("\n\n")
+	builder.WriteString(ruleBody)
+	builder.WriteString("\n")
+	builder.WriteString(skillIndex(target, installed))
+	builder.WriteString(managedBlockEnd)
+	return builder.String()
+}
+
+// skillIndex renders the "## Ankra skills" section listing what is installed
+// and where to read it.
+func skillIndex(target Target, installed []Skill) string {
+	if len(installed) == 0 {
+		return ""
+	}
+	directory := indexDirectory(target)
+	var builder strings.Builder
+	builder.WriteString("## Ankra skills installed here\n\n")
+	if target.LoadsNatively() {
+		fmt.Fprintf(&builder,
+			"%s loads these from `%s` automatically. Read the matching one before acting; "+
+				"`ankra-platform-principles` applies to all Ankra work.\n\n",
+			target.Client.DisplayName, directory)
+	} else {
+		fmt.Fprintf(&builder,
+			"Each skill is a markdown file under `%s`. Before doing Ankra work, open the "+
+				"`SKILL.md` of the entry that matches the request (several may apply) and follow it; "+
+				"`ankra-platform-principles/SKILL.md` applies to all Ankra work. Some skills carry a "+
+				"`reference.md` alongside with the long-form detail.\n\n",
+			directory)
+	}
+	for _, skill := range installed {
+		fmt.Fprintf(&builder, "- **`%s`** — %s\n", skill.Name, headline(skill.Description))
+	}
+	builder.WriteString("\n")
+	return builder.String()
+}
+
+// indexDirectory renders the path the index points at. A project install is
+// committed and read on other machines, so it names the repository-relative
+// directory; a personal install names the absolute path with the home
+// directory collapsed.
+func indexDirectory(target Target) string {
+	if target.Scope == ScopeProject {
+		return target.Client.Layout(target.Scope).Skills
+	}
+	return DisplayPath(target.SkillsDirectory)
+}
+
+// headline trims a skill description down to its leading claim, dropping both
+// the enumeration after the dash and the "Use when ..." trigger clause that
+// only the runtime matcher needs. The index sits in an always-loaded file, so
+// one line per skill is the budget.
+func headline(description string) string {
+	trimmed := strings.TrimSpace(description)
+	for _, separator := range []string{" - ", " — ", ". Use when ", " Use when ", " Use whenever "} {
+		if marker := strings.Index(trimmed, separator); marker > 0 {
+			trimmed = trimmed[:marker]
+		}
+	}
+	return strings.TrimRight(trimmed, ". ")
+}
+
+// UpsertManagedBlock inserts or refreshes the Ankra managed block in the
+// markdown file at path, creating it (and its directory) when absent. Content
+// outside the markers is preserved byte for byte, so a CLAUDE.md or AGENTS.md
+// the user also maintains survives a reinstall.
+func UpsertManagedBlock(path, block string) error {
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	content := string(existing)
+
+	if begin, end, ok := findManagedBlock(content); ok {
+		content = content[:begin] + block + content[end:]
+	} else if trimmed := strings.TrimRight(content, "\n"); trimmed != "" {
+		content = trimmed + "\n\n" + block + "\n"
+	} else {
+		content = block + "\n"
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+// RemoveManagedBlock strips the Ankra managed block from the file at path,
+// deleting the file when nothing else was in it. Reports whether a block was
+// found.
+func RemoveManagedBlock(path string) (bool, error) {
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	content := string(existing)
+	begin, end, ok := findManagedBlock(content)
+	if !ok {
+		return false, nil
+	}
+	remainder := strings.TrimRight(content[:begin], "\n") + content[end:]
+	if strings.TrimSpace(remainder) == "" {
+		return true, os.Remove(path)
+	}
+	if !strings.HasSuffix(remainder, "\n") {
+		remainder += "\n"
+	}
+	return true, os.WriteFile(path, []byte(remainder), 0o644)
+}

--- a/internal/skills/rules.go
+++ b/internal/skills/rules.go
@@ -114,52 +114,14 @@ func RemoveCursorPlugin(pluginDir string) (bool, error) {
 // path, creating the file if needed. Content outside the markers is preserved
 // byte for byte.
 func UpsertClaudeRule(path string) error {
-	existing, err := os.ReadFile(path)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	content := string(existing)
-	block := ClaudeManagedBlock()
-
-	if begin, end, ok := findManagedBlock(content); ok {
-		content = content[:begin] + block + content[end:]
-	} else {
-		if trimmed := strings.TrimRight(content, "\n"); trimmed != "" {
-			content = trimmed + "\n\n" + block + "\n"
-		} else {
-			content = block + "\n"
-		}
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	return os.WriteFile(path, []byte(content), 0o644)
+	return UpsertManagedBlock(path, ClaudeManagedBlock())
 }
 
 // RemoveClaudeRule strips the managed block from the CLAUDE.md at path. When
 // nothing but the block was in the file, the file itself is removed. Reports
 // whether a block was found.
 func RemoveClaudeRule(path string) (bool, error) {
-	existing, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	content := string(existing)
-	begin, end, ok := findManagedBlock(content)
-	if !ok {
-		return false, nil
-	}
-	remainder := strings.TrimRight(content[:begin], "\n") + content[end:]
-	if strings.TrimSpace(remainder) == "" {
-		return true, os.Remove(path)
-	}
-	if !strings.HasSuffix(remainder, "\n") {
-		remainder += "\n"
-	}
-	return true, os.WriteFile(path, []byte(remainder), 0o644)
+	return RemoveManagedBlock(path)
 }
 
 // findManagedBlock locates the managed block including its markers and

--- a/internal/skills/workflows.go
+++ b/internal/skills/workflows.go
@@ -1,0 +1,316 @@
+package skills
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Skills are matched against what the user happens to say. A workflow is the
+// other direction: a named entry point the user invokes deliberately for a
+// job that spans several skills and a fixed order of steps — ship a new
+// service, wire an app to a platform service, triage a broken rollout. Each
+// client spells them differently (Claude Code and Cursor commands, Codex
+// prompts, Copilot prompt files, Gemini TOML, Windsurf workflows), so the
+// body is authored once and rendered per format.
+
+// Workflow is one named, multi-step entry point.
+type Workflow struct {
+	// Name is the file stem and, for most clients, the slash command.
+	Name string
+	// Description is the one-line summary the client lists.
+	Description string
+	// Body is the markdown instruction the client feeds the agent.
+	Body string
+}
+
+// workflowFilePrefix is stripped from the file name when the commands
+// directory is already namespaced (Gemini's .gemini/commands/ankra), so the
+// invocation stays /ankra:ship-service rather than /ankra:ankra-ship-service.
+const workflowFilePrefix = "ankra-"
+
+var workflowRegistry = []Workflow{
+	{
+		Name:        "ankra-ship-service",
+		Description: "Take source code from a repository to a production deployment on one or many Ankra clusters",
+		Body: `Take the service in the current repository (or the path the user names) from source
+to a running production deployment on Ankra. Read the ` + "`ankra-applications`" + ` skill first,
+then ` + "`ankra-cicd`" + `, ` + "`ankra-stacks-addons`" + ` and ` + "`ankra-platform-principles`" + `.
+
+Work in this order and confirm the target with the user before anything mutating:
+
+1. **Orient.** ` + "`ankra org current`" + `, ` + "`ankra cluster list`" + `. Establish which organisation, which
+   clusters are the dev/staging/production targets, and whether the repo is already an
+   application (` + "`ankra application list`" + `).
+2. **Check the source is deployable.** A Dockerfile (or the language default Ankra can
+   generate one for), a listening port, health endpoints, and configuration read from the
+   environment — not baked-in files. Fix what is missing before registering.
+3. **Register the application.** ` + "`ankra application add . --name <name>`" + `. If the organisation
+   publishes images to a registry it already operates (Harbor, ECR, GAR, ACR), declare it in
+   the same command with ` + "`--registry-url oci://<host>/<project>`" + ` and ` + "`--registry-credential <name>`" + `:
+   a registry added afterwards leaves a build workflow that logs in with the wrong one.
+4. **Review the generated setup.** ` + "`ankra application get <id>`" + `, ` + "`ankra application branch-files <id>`" + `.
+   Ankra opens a setup pull request with the Dockerfile, chart and build workflow. Read the
+   diff, adjust, and use ` + "`ankra application files`" + ` to commit changes back to that branch.
+5. **Supply configuration and secrets.** ` + "`ankra application env-secrets list <id>`" + ` shows what the
+   manifests expect. Set each with ` + "`ankra application env-secrets set`" + ` (pipe the value on stdin —
+   never ` + "`--value`" + ` on the command line), then ` + "`ankra application env-secrets apply <id>`" + `.
+6. **Deploy to the first cluster.** ` + "`ankra application deploy <id> --cluster <cluster-id> --namespace <ns>`" + `.
+   Watch it land with ` + "`ankra cluster operations list`" + ` and ` + "`ankra cluster get pods -n <ns>`" + `.
+7. **Verify.** Logs (` + "`ankra cluster logs -l app=<name> -n <ns> --follow=false`" + `), events, and the
+   application's own health endpoint. Do not proceed to production on an unverified rollout.
+8. **Wire continuous delivery.** Decide with the user between ` + "`ankra application auto-deploy set on`" + `
+   (a build on the tracked branch rolls itself out) and an explicit gate. Add scanning with
+   ` + "`ankra application upgrade-workflow`" + `, and read the findings with ` + "`ankra application code-security`" + `
+   and ` + "`ankra application container-security`" + `.
+9. **Reach the rest of the fleet.** For many clusters, publish the manifests once with
+   ` + "`ankra application publish-addon <id> --version <semver>`" + ` and install that add-on per cluster, or
+   capture the deployed stack as a stack profile (see the ` + "`ankra-stack-profiles`" + ` skill) and apply it
+   per cluster with the cluster-specific values bound as parameters. Do not copy-paste YAML per
+   cluster.
+
+Report back: the application id, the registry it publishes to, which clusters it is live on,
+the URL(s), and what is still manual.`,
+	},
+	{
+		Name:        "ankra-connect-app",
+		Description: "Connect an application to an existing platform service and its secrets (LiteLLM, Harbor, a database, an internal API)",
+		Body: `Connect the application the user names to a service that already runs in this
+organisation — an LLM gateway (LiteLLM), a container registry (Harbor), a database, an
+internal API — using the credentials that already exist rather than minting new ones by hand.
+Read the ` + "`ankra-app-integrations`" + ` skill first, then ` + "`ankra-sops-secrets`" + ` and ` + "`ankra-security`" + `.
+
+1. **Find the service.** ` + "`ankra cluster stacks list`" + ` and ` + "`ankra cluster addons list`" + ` show what is
+   deployed. ` + "`ankra cluster get services -n <namespace>`" + ` gives the in-cluster DNS name and port —
+   that, not a public URL, is what a same-cluster consumer should use.
+2. **Find the credential that already exists.** ` + "`ankra cluster addons values <addon>`" + ` (and
+   ` + "`ankra cluster decrypt addon`" + ` where values are SOPS-encrypted) shows how the service itself is
+   configured; ` + "`ankra credentials list`" + ` and ` + "`ankra helm credentials list`" + ` show the stored ones.
+   Reuse an existing key or issue a scoped one from the service — never copy an admin token
+   into an application.
+3. **Decide where the value lives.** Application environment secrets
+   (` + "`ankra application env-secrets set`" + `) for values only that application needs; a SOPS-encrypted
+   manifest in the GitOps repo with ` + "`encrypted_paths`" + ` declared for anything a stack deploys; a
+   cluster or organisation variable (` + "`ankra cluster variables set`" + ` / ` + "`ankra org variables set`" + `) for
+   non-secret values such as base URLs and model names.
+4. **Wire the consumer.** Point the application at the in-cluster endpoint, inject the secret by
+   reference (a Secret ` + "`envFrom`" + `/` + "`valueFrom`" + `, not a literal), and pin any model, chart or image
+   version it depends on.
+5. **Prove it end to end.** Roll the consumer, then read its logs for a successful call. For an
+   LLM gateway, make one real request and confirm the gateway logged it. For a registry, confirm
+   a pull with the generated ` + "`dockerconfigjson`" + ` pull secret actually succeeds.
+6. **Leave it reproducible.** Every change lands in committed YAML or in Ankra's stored state —
+   nothing configured only by hand in a live pod.
+
+Never print a decrypted secret into the terminal transcript, a pull request, or chat.`,
+	},
+	{
+		Name:        "ankra-triage",
+		Description: "Investigate a failing workload, deployment, or Ankra operation and propose the fix",
+		Body: `Triage what is broken on the Ankra-managed cluster the user names. Read the
+` + "`ankra-troubleshooting`" + ` skill first. Work read-only until you have a diagnosis; propose the
+change, do not apply it unasked.
+
+1. **Scope it.** ` + "`ankra cluster info`" + ` to confirm the cluster, then
+   ` + "`ankra cluster operations list`" + ` — a failed platform execution explains far more failures than
+   the pod logs do. ` + "`ankra cluster operations steps <id>`" + ` for the failing step.
+2. **Look at the object.** ` + "`ankra cluster get pods -n <ns>`" + `, then
+   ` + "`ankra cluster describe pod <name> -n <ns>`" + ` for conditions and its own events, and
+   ` + "`ankra cluster events -n <ns>`" + ` for the namespace timeline.
+3. **Read the log that has the failure in it.** For CrashLoopBackOff that is the previous
+   container: ` + "`ankra cluster logs <pod> -n <ns> --previous`" + `. For a set of replicas use
+   ` + "`ankra cluster logs -l <selector> -n <ns> --follow=false --tail 200`" + `, and ` + "`--all-containers`" + ` when an
+   init container is the suspect.
+4. **Check resources before blaming the code.** ` + "`ankra cluster top pods -n <ns>`" + ` and
+   ` + "`ankra cluster top nodes`" + ` read the metrics API directly; ` + "`ankra cluster metrics query '<promql>'`" + `
+   for trends where Prometheus is installed.
+5. **Classify.** Configuration or secret missing, image or chart version, scheduling and capacity,
+   dependency ordering (a stack resource whose ` + "`parents`" + ` are wrong deploys too early), an
+   external dependency, or genuine application code.
+6. **Propose the smallest correct fix**, at the right layer: stack/addon values and ordering for
+   platform problems, the application repository and a pull request for code problems. Say which
+   one it is. For a terminal execution that failed on a transient cause, ` + "`ankra cluster operations retry <id>`" + `
+   is the right move — say so rather than re-applying everything.
+
+Finish with: what is broken, the evidence, the fix, and the blast radius of applying it.`,
+	},
+	{
+		Name:        "ankra-promote",
+		Description: "Promote a verified change from dev or staging to production across one or many clusters",
+		Body: `Promote a change that is already verified in a lower environment to the next one,
+without rebuilding it. Read ` + "`ankra-platform-principles`" + `, ` + "`ankra-stack-profiles`" + ` and ` + "`ankra-gitops`" + `.
+
+1. **Establish what is verified.** The exact image tag or digest, the chart version, and the
+   cluster it is verified on. If nothing is pinned, stop: promote a pinned artefact or nothing.
+2. **Diff the environments.** ` + "`ankra cluster stacks list <stack> -o json`" + ` on both clusters, or
+   ` + "`ankra stack-profiles diff <profile> --from <v> --to <v>`" + ` for a profile. Name every difference that
+   is deliberate (sizes, replicas, domains) and every one that is drift.
+3. **Promote the same artefact.** Commit the verified tag to the production path in the GitOps
+   repository, or ` + "`ankra stack-profiles apply <profile> --cluster <prod> --version <v>`" + ` binding the
+   production values with ` + "`--set`" + ` / ` + "`--set-file`" + ` / ` + "`--set-env`" + `. Never rebuild for production.
+4. **Land it as a reviewable draft first.** ` + "`ankra stack-profiles apply`" + ` without ` + "`--deploy`" + `, or
+   ` + "`ankra cluster draft -f cluster.yaml`" + `, stages the change for review instead of deploying it.
+   Use ` + "`--dry-run`" + ` to show exactly which value every input resolves to.
+5. **Roll out, then verify** with operations, pods, and logs before touching the next cluster.
+   For a fleet, do one cluster, verify, then the rest — never all at once.
+6. **Know the rollback.** ` + "`git revert`" + ` for a GitOps change, ` + "`ankra cluster roll-to`" + ` for a resource
+   version, ` + "`ankra stack-profiles set-current-version`" + ` for a profile. State it before you deploy.`,
+	},
+	{
+		Name:        "ankra-harden",
+		Description: "Run a security pass over an Ankra organisation: tokens, access grants, secrets, and image findings",
+		Body: `Review the security posture of the Ankra organisation the user names and report
+findings ranked by exposure. Read the ` + "`ankra-security`" + ` and ` + "`ankra-sops-secrets`" + ` skills first.
+This is a read-and-report pass: change nothing without asking.
+
+1. **Identity and tokens.** ` + "`ankra tokens list`" + ` — flag tokens with no expiry, tokens holding
+   ` + "`mcp:write`" + ` that only need ` + "`mcp:read`" + `, and anything unused. ` + "`ankra org members`" + ` and
+   ` + "`ankra org roles`" + ` for who holds what.
+2. **Cluster access.** ` + "`ankra cluster access list`" + ` per cluster — flag every ` + "`cluster-admin`" + ` and every
+   cluster-wide grant that could be namespace-scoped.
+3. **Secrets.** Confirm nothing sensitive is committed in plaintext: every SOPS-encrypted value has
+   its ` + "`encrypted_paths`" + ` declared (` + "`ankra cluster stacks list <stack> -o json`" + `), and
+   ` + "`ankra cluster sops-config`" + ` shows the key in use. Check application environment secrets are set
+   rather than defaulted (` + "`ankra application env-secrets list`" + `).
+4. **Supply chain.** ` + "`ankra application container-security <id>`" + ` and ` + "`ankra application code-security <id>`" + `
+   per application; flag any application whose build workflow has no scanning step
+   (` + "`ankra application upgrade-workflow`" + ` adds it). Flag floating image tags and unpinned chart
+   versions — a mutable tag defeats every other control here.
+5. **Agent autonomy.** ` + "`ankra org mcp-servers list`" + ` and ` + "`ankra org mcp-servers grants <server>`" + ` — flag
+   read_write tiers and tool grants wider than the role needs. Check which integrations run in
+   Agent rather than Ask mode.
+6. **Registry and credential scope.** ` + "`ankra credentials list`" + `, ` + "`ankra helm credentials list`" + ` — flag
+   any credential that is broader than the repositories it is used for
+   (` + "`ankra credentials repositories <name>`" + ` shows what it can actually reach).
+
+Report a ranked list: what is exposed, how it could be used, and the one command or change that
+closes it. Do not print secret values.`,
+	},
+	{
+		Name:        "ankra-profile",
+		Description: "Capture a working cluster stack as a reusable, parameterised stack profile for the fleet",
+		Body: `Turn a stack that works on one cluster into a reusable stack profile other clusters
+and organisations can launch. Read the ` + "`ankra-stack-profiles`" + ` skill first, then ` + "`ankra-stacks-addons`" + `.
+
+1. **Pick the source.** ` + "`ankra cluster stacks list`" + ` on the cluster where it works. The source stack
+   should be one concern, pinned, and already verified.
+2. **Open a builder draft from it.**
+   ` + "`ankra stack-profiles drafts create --name <profile> --source-cluster <cluster> --source-stack <stack>`" + `.
+3. **Turn the cluster-specific values into parameters.** ` + "`ankra stack-profiles drafts get <draft>`" + ` lists
+   what was detected. Every domain, size, replica count, storage class and credential must be a
+   parameter, not a literal carried over from the source cluster. Annotate each one with
+   ` + "`ankra stack-profiles drafts annotate`" + ` so the launch form explains itself.
+4. **Group the choices that move together.** Where one decision drives several inputs (a "model
+   size" that sets the model id, the context length and the volume), declare it with
+   ` + "`ankra stack-profiles drafts options set`" + ` so whoever launches it picks one thing instead of keeping
+   four consistent.
+5. **Mark the secrets.** Secret parameters must be declared as such, and any encrypted value needs
+   its ` + "`encrypted_paths`" + `. Opening a draft on a published profile drops encrypted paths — re-declare
+   them before publishing.
+6. **Validate, then publish.** ` + "`ankra stack-profiles drafts validate <draft>`" + `, then
+   ` + "`ankra stack-profiles drafts publish <draft> --changelog \"...\"`" + `.
+7. **Prove it launches clean.** ` + "`ankra stack-profiles apply <profile> --cluster <other> --dry-run`" + ` shows
+   the value every input resolves to; then apply for real as a draft and review before deploying.
+8. **Distribute.** ` + "`ankra stack-profiles share add`" + ` for named organisations,
+   ` + "`ankra stack-profiles export-iac`" + ` to keep the definition in Git.`,
+	},
+}
+
+// Workflows returns the workflow entry points, in registry order.
+func Workflows() []Workflow {
+	out := make([]Workflow, len(workflowRegistry))
+	copy(out, workflowRegistry)
+	return out
+}
+
+// WriteWorkflows renders every workflow into the target's commands directory
+// in that client's format, returning the paths written. It is a no-op for
+// clients with no command mechanism.
+func WriteWorkflows(target Target) ([]string, error) {
+	if !target.SupportsCommands() {
+		return nil, nil
+	}
+	if err := os.MkdirAll(target.CommandsDirectory, 0o755); err != nil {
+		return nil, err
+	}
+	written := make([]string, 0, len(workflowRegistry))
+	for _, workflow := range workflowRegistry {
+		path := workflowPath(target, workflow)
+		content, err := renderWorkflow(target.Client.CommandFormat, workflow)
+		if err != nil {
+			return written, err
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			return written, err
+		}
+		written = append(written, path)
+	}
+	return written, nil
+}
+
+// RemoveWorkflows deletes the workflow files install wrote for a target,
+// returning how many existed. Files the CLI did not write are left alone.
+func RemoveWorkflows(target Target) (int, error) {
+	if !target.SupportsCommands() {
+		return 0, nil
+	}
+	removed := 0
+	for _, workflow := range workflowRegistry {
+		path := workflowPath(target, workflow)
+		if _, err := os.Stat(path); err != nil {
+			continue
+		}
+		if err := os.Remove(path); err != nil {
+			return removed, err
+		}
+		removed++
+	}
+	return removed, nil
+}
+
+// workflowPath resolves one workflow's file name for a target, dropping the
+// "ankra-" stem when the commands directory is already the ankra namespace.
+func workflowPath(target Target, workflow Workflow) string {
+	name := workflow.Name
+	if filepath.Base(target.CommandsDirectory) == "ankra" {
+		name = strings.TrimPrefix(name, workflowFilePrefix)
+	}
+	return filepath.Join(target.CommandsDirectory, name+workflowExtension(target.Client.CommandFormat))
+}
+
+func workflowExtension(format string) string {
+	switch format {
+	case "copilot":
+		return ".prompt.md"
+	case "toml":
+		return ".toml"
+	default:
+		return ".md"
+	}
+}
+
+// renderWorkflow renders one workflow in a client's command file format.
+func renderWorkflow(format string, workflow Workflow) (string, error) {
+	switch format {
+	case "markdown":
+		return fmt.Sprintf("---\ndescription: %s\n---\n\n%s\n", workflow.Description, workflow.Body), nil
+	case "copilot":
+		return fmt.Sprintf("---\nmode: agent\ndescription: %s\n---\n\n%s\n", workflow.Description, workflow.Body), nil
+	case "toml":
+		return fmt.Sprintf("description = %s\nprompt = \"\"\"\n%s\n\"\"\"\n",
+			tomlString(workflow.Description), escapeTOMLBlock(workflow.Body)), nil
+	default:
+		return "", fmt.Errorf("unsupported command format %q", format)
+	}
+}
+
+func tomlString(value string) string {
+	return `"` + strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(value) + `"`
+}
+
+// escapeTOMLBlock protects a multi-line basic string: backslashes must not
+// start an escape and a literal triple quote would close the block early.
+func escapeTOMLBlock(value string) string {
+	return strings.NewReplacer(`\`, `\\`, `"""`, `\"\"\"`).Replace(value)
+}

--- a/internal/skills/workflows.go
+++ b/internal/skills/workflows.go
@@ -74,6 +74,49 @@ Report back: the application id, the registry it publishes to, which clusters it
 the URL(s), and what is still manual.`,
 	},
 	{
+		Name:        "ankra-new-cluster",
+		Description: "Stand up a new Ankra cluster: provider, region, instance family, GitOps, ingress, DNS and TLS",
+		Body: `Stand up a cluster on Ankra for the user, from the provider choice through to a
+hostname that resolves with TLS. Read the ` + "`ankra-getting-started`" + ` skill first, then
+` + "`ankra-cloud-clusters`" + ` (or ` + "`ankra-managed-kubernetes`" + `) and ` + "`ankra-domains-dns`" + `.
+
+Settle these five before creating anything - creating first and retrofitting is the expensive path:
+
+1. **Import or build?** If Kubernetes already runs, adopt it (` + "`ankra-import-cluster`" + `, or
+   ` + "`ankra cluster managed discover`" + ` / ` + "`import`" + ` for a managed cluster) instead of building a second one.
+2. **Who runs the control plane?** ` + "`ankra cluster managed create`" + ` when the provider should own its
+   uptime and you do not need cluster-admin over it; ` + "`ankra cluster <provider> create`" + ` when you need
+   control-plane access, node-level control, or a provider with no managed offering.
+3. **Region and instance family.** Never guess these. List them for the actual credential:
+   ` + "`ankra cluster hetzner locations|server-types`" + `, ` + "`ankra cluster digitalocean regions|sizes`" + `,
+   ` + "`ankra cluster ovh regions --with-zones`" + `, ` + "`ankra cluster proxmox sizes|hosts`" + `,
+   ` + "`ankra cluster morpheus plans|layouts`" + `. A region the account cannot deploy in fails late, at
+   private-network setup. Size the control plane and workers per the table in
+   ` + "`ankra-cloud-clusters/reference.md`" + `, and use ` + "`--control-plane-count 3`" + ` for anything that must
+   survive losing a node.
+4. **The GitOps repository.** Pass ` + "`--gitops-repository`" + `, ` + "`--gitops-credential-name`" + ` and
+   ` + "`--gitops-branch`" + ` on the create command itself, so the generated cloud-provider stack lands as a
+   reviewable commit rather than existing only in the platform.
+5. **The domain.** The generated ` + "`<cluster>.ankra.cc`" + ` subdomain needs nothing and gives you HTTPS
+   today. Your own domain either delegates to Ankra (` + "`ankra org domain set`" + `) or stays in your DNS
+   account and is declared with ` + "`ankra org custom-dns-zones add`" + `. Declare org-wide, or clusters
+   created later come up with your hostnames silently unserved.
+
+Then:
+
+- **Store the credentials first** (` + "`ankra credentials <provider> create`" + `, plus an SSH key credential);
+  ` + "`create`" + ` takes credential **IDs**, which ` + "`ankra credentials list`" + ` gives you.
+- **Take the batteries.** ` + "`--external-cloud-provider`" + `, ` + "`--include-networking`" + ` and ` + "`--include-dns`" + `
+  default on and give load balancers, volumes, ingress, DNS and TLS from the first minute.
+- **Create, then watch.** ` + "`create`" + ` has no ` + "`--wait`" + `: follow with ` + "`ankra cluster operations list`" + ` and
+  ` + "`ankra cluster agent status`" + `. Do not re-submit.
+- **Verify before handing it over:** the agent is online, nodes are Ready, a test Ingress on the
+  cluster domain resolves and serves a valid certificate.
+
+Report the cluster id, its domain, what was installed, what it costs per month at this size, and
+the one command to tear it down.`,
+	},
+	{
 		Name:        "ankra-connect-app",
 		Description: "Connect an application to an existing platform service and its secrets (LiteLLM, Harbor, a database, an internal API)",
 		Body: `Connect the application the user names to a service that already runs in this


### PR DESCRIPTION
## What & why

Two things: `ankra skills install` now reaches every AI assistant instead of two, and the skill
catalogue grew from 14 to 22 — including fixes to skills that were teaching commands the CLI does
not have.

### 1. Install covers every assistant

`--editor cursor|claude-code` reached two of the tools a team actually has open. Everyone on Codex,
GitHub Copilot, Windsurf, Gemini CLI, OpenCode, Cline, Zed, OpenClaw or the Claude app either went
without the skills or hand-copied them somewhere their assistant never reads.

`--client` replaces `--editor` (kept as a deprecated alias) and takes a repeatable, comma-separated
list, `all`, or `auto`. With no `--client`, install detects what is configured on the machine and
does them together, falling back to Claude Code and Cursor when it finds none.
`ankra skills clients` lists what is supported, what was detected, and where each one's skills land.

**Assistants with no skills mechanism now get an index instead of nothing.** Claude Code and Cursor
discover `SKILL.md` themselves. The rest get the skills in a client-neutral library plus an index —
each skill, what it covers, the path to open — inside the same managed block that already carried
the Ankra routing rule. A project-scoped index names the *repository-relative* directory, so a
committed `AGENTS.md` or `.github/copilot-instructions.md` works on a teammate's machine. The Claude
app cannot read a filesystem at all, so `--client claude-app` writes one uploadable `.zip` per skill.

**Workflows.** Skills are matched against whatever the user happens to say; a workflow is a named
entry point for a job that spans several of them. `/ankra-new-cluster`, `/ankra-ship-service`,
`/ankra-connect-app`, `/ankra-triage`, `/ankra-promote`, `/ankra-harden` and `/ankra-profile` are
written in each assistant's own command format (Claude Code and Cursor commands, Codex prompts,
Copilot `.prompt.md`, Gemini TOML, Windsurf and Cline workflows).

Adding the next assistant is a row in `internal/skills/clients.go` — paths per scope, rule/command/
hook format — not a new branch.

### 2. Skills: eight new, and real bugs fixed in five

A pass that checked **every `ankra ...` invocation in every skill against the real command tree**
found two skills teaching commands the CLI does not have. An agent following them emits something
that fails:

| Documented | Reality |
|---|---|
| `ankra org select` | the verb is `ankra org switch` |
| `ankra cluster encrypt -f <file>` | `encrypt` names keys with `--key`; cluster mode or file mode |
| `ankra cluster ovh node-group\|upgrade\|scale\|ssh-keys` | removed — the verbs are provider-agnostic now |
| `ankra cluster <provider> create --wait` | never existed |
| `ankra cluster deprovision --auto-delete` | removed |
| `ankra cluster managed options` | does not exist |
| `ankra cluster managed upgrades` | it is `upgrade`, with `--version` |
| `--provider mks` | it is `ovh_mks` (and `kapsule` was missing) |
| `managed import --cluster-id` | it is `--provider-cluster-id` |
| `--node-pool-autoscaling-min/max`, `--autoscaling-enabled` | `--autoscaling`, `--autoscaling-min`, `--autoscaling-max` |
| `managed create --skip-preflight`, `--ha`, `--cluster-plan` | none exist |

`ankra-cloud-clusters` also described `provision`/`deprovision` as a power-off. They are not:
deprovision releases every cloud resource and uninstalls every stack; stop/start is the power pair.
Someone reaching for deprovision to pause a cluster loses it.

**New skills:**

| Skill | Covers |
|---|---|
| `ankra-getting-started` | Empty organisation → credentials → GitOps repo → cluster → domain → first app, in the order that avoids rework |
| `ankra-applications` | Source → running on one or many clusters: registry declaration, setup PR, env-secrets, deploy, auto-deploy, PR demos, publishing as an add-on (+ `reference.md`) |
| `ankra-app-integrations` | Wiring an app to LiteLLM, Harbor, a database, an internal API with credentials that already exist |
| `ankra-stack-profiles` | Builder drafts, parameters, option sets, publishing, fleet launches |
| `ankra-domains-dns` | Generated subdomain, your own delegated root, custom DNS zones, preview domain, where TLS comes from |
| `ankra-troubleshooting` | Operations → describe → scoped events → `--previous` logs → `top`/PromQL, and what each symptom classifies as |
| `ankra-security` | The five independent grant layers: tokens/MCP scopes, roles, cluster access, credential scope, agent autonomy |
| `ankra-ai-agents` | Provider and model catalogue, MCP tool servers + per-tool role grants, agent runs, the AI board |

**`ankra-cloud-clusters` rewritten and expanded** to actually cover cluster creation: all seven
providers, the discovery commands that list the regions and instance families a credential can
really deploy (guessing a region fails late, at private-network setup), k3s vs kubeadm and etcd
topology, the `--external-cloud-provider` / `--include-networking` / `--include-dns` batteries,
committing the generated stack to a GitOps repo with `--gitops-repository` **on the create command
itself**, OVH availability zones and why node spread is not zone fault tolerance, and the difference
between power, teardown and delete. A new `reference.md` carries the per-provider instance-family
guide, role sizing, GPU node groups, the create-flag map and the cost traps.

## Test plan

- `go test -race -count=1 ./...` — green. `golangci-lint run` — 0 issues.
- New unit coverage: client registry well-formedness and alias uniqueness, `all`/`auto`/comma
  resolution and the no-detection fallback, per-scope target paths, managed-block upsert/remove
  preserving user content, the index for native vs indexed clients, repository-relative index paths
  for a project install, headline trimming, workflow rendering per format (markdown / `.prompt.md` /
  TOML), and bundle packaging (skill directory at the archive root, skip-unless-forced, removal).
- Command coverage rewritten for `--client`: project paths per client, unknown client exits 2, the
  deprecated `--editor` alias still resolves, Cursor and Claude Code full install/uninstall cycles,
  indexed-client `AGENTS.md` index written and removed, Copilot instructions + `.prompt.md`, Claude
  app bundles, `--no-rules`/`--no-workflows`, `--with-hooks` skipping a hook-less client, and the
  shared-library dedupe.
- **Skill commands verified against the binary**: a script walks `--help` recursively to build the
  real command tree and flag sets, extracts all 674 `ankra ...` invocations from the 22 skills, and
  reports chains or flags that do not exist. Everything it flags now is extractor noise
  (`...` placeholders, `a|b` table alternations, `ankra --version`, Terraform HCL).
- Manual round-trip with a built binary: `skills install --client all --project <tmp> --with-hooks`
  writes every client's rule, commands, hook and payload at the documented paths, then
  `skills uninstall --client all` removes every file and leaves a pre-existing `AGENTS.md` byte-for-byte.

## Docs checklist

- [x] Command/flag changes — the CLI reference regenerates automatically on release
  (`tools/gendocs`); `Short`/`Long`/`Example` on `skills`, `skills clients`, `skills install` and
  `skills uninstall` are written for docs readers.
- [ ] No user-facing command/flag changes — no docs needed
- [ ] Broader behaviour changes — docs updated in ankra-docs

`--editor` and `--personal` are recorded in `DEPRECATIONS.md` for removal in v0.15.0.

Bead: ankra-f7ddh
