### PR TITLE
feat(ai): give the board an identity and stop all AI from the terminal (ankra-us966.4)

### DIFF
--- a/cmd/ai_autonomy.go
+++ b/cmd/ai_autonomy.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"strings"
+
+	"ankra/internal/client"
 
 	"github.com/spf13/cobra"
 )
@@ -27,10 +30,16 @@ var aiAutonomyStatusCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if handled, renderError := renderStructured(cmd, state); handled || renderError != nil {
+		autonomy, autonomyError := apiClient.GetAIAutonomyState()
+		if autonomyError != nil {
+			return autonomyError
+		}
+		if handled, renderError := renderStructured(cmd,
+			map[string]any{"stop_all": state, "autonomous_actions": autonomy}); handled || renderError != nil {
 			return renderError
 		}
 		out := cmd.OutOrStdout()
+		defer printAutonomyPauseState(out, autonomy)
 		if !state.Paused {
 			_, _ = fmt.Fprintln(out, "AI is available for this organisation.")
 			return nil
@@ -45,13 +54,13 @@ var aiAutonomyStatusCmd = &cobra.Command{
 		if state.Reason != nil && *state.Reason != "" {
 			_, _ = fmt.Fprintf(out, "Reason:     %s\n", *state.Reason)
 		}
-		_, _ = fmt.Fprintln(out, "\nRelease it with: ankra ai autonomy resume")
+		_, _ = fmt.Fprintln(out, "\nRelease it with: ankra ai autonomy start-all")
 		return nil
 	},
 }
 
-var aiAutonomyPauseCmd = &cobra.Command{
-	Use:   "pause",
+var aiAutonomyStopAllCmd = &cobra.Command{
+	Use:   "stop-all",
 	Short: "Stop all AI for the organisation",
 	Long: `Stop all AI for everyone in the organisation.
 
@@ -77,13 +86,13 @@ shown to administrators alongside the switch.`,
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
 			"AI is stopped for this organisation. Cancelled %d session(s) and %d agent run(s).\n",
 			outcome.CancelledSessions, outcome.CancelledRuns)
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Release it with: ankra ai autonomy resume")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Release it with: ankra ai autonomy start-all")
 		return nil
 	},
 }
 
-var aiAutonomyResumeCmd = &cobra.Command{
-	Use:   "resume",
+var aiAutonomyStartAllCmd = &cobra.Command{
+	Use:   "start-all",
 	Short: "Let AI run again for the organisation",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -192,15 +201,121 @@ ineligible again on the next dispatcher pass.`,
 }
 
 func init() {
-	aiAutonomyPauseCmd.Flags().String("reason", "", "Why AI is being stopped (shown to administrators)")
-	aiAutonomyPauseCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
+	aiAutonomyStopAllCmd.Flags().String("reason", "", "Why AI is being stopped (shown to administrators)")
+	aiAutonomyPauseCmd.Flags().String("reason", "", "Why autonomous actions are paused")
+	aiAutonomyStopAllCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 	aiBoardIdentityRevokeCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 	aiBoardIdentityProvisionCmd.Flags().String("role", "",
 		"Role the identity carries: operator (default), member, or viewer")
 	registerStructuredOutputFlags(aiAutonomyStatusCmd, aiAutonomyPauseCmd, aiAutonomyResumeCmd,
+		aiAutonomyStopAllCmd, aiAutonomyStartAllCmd,
 		aiBoardIdentityStatusCmd, aiBoardIdentityProvisionCmd, aiBoardIdentityRevokeCmd)
 
-	aiAutonomyCmd.AddCommand(aiAutonomyStatusCmd, aiAutonomyPauseCmd, aiAutonomyResumeCmd)
+	aiAutonomyCmd.AddCommand(aiAutonomyStatusCmd, aiAutonomyPauseCmd, aiAutonomyResumeCmd,
+		aiAutonomyStopAllCmd, aiAutonomyStartAllCmd)
 	aiBoardIdentityCmd.AddCommand(aiBoardIdentityStatusCmd, aiBoardIdentityProvisionCmd, aiBoardIdentityRevokeCmd)
 	aiCmd.AddCommand(aiAutonomyCmd, aiBoardIdentityCmd)
+}
+
+// printAutonomyPauseState reports the softer stop under the hard one, so
+// "is anything switched off?" is one question with one answer.
+func printAutonomyPauseState(out io.Writer, autonomy *client.AIAutonomyState) {
+	if autonomy == nil {
+		return
+	}
+	if !autonomy.Paused {
+		_, _ = fmt.Fprintf(out, "\nAutonomous actions: running (auto-remediation %s).\n",
+			enabledWord(autonomy.PolicyEnabled))
+		if len(autonomy.RestorableAgents) > 0 {
+			_, _ = fmt.Fprintf(out, "%d agent(s) are switched off; ankra ai autonomy status -o json lists them.\n",
+				len(autonomy.RestorableAgents))
+		}
+		return
+	}
+	_, _ = fmt.Fprintln(out, "\nAutonomous actions: PAUSED.")
+	if autonomy.PausedAt != nil {
+		_, _ = fmt.Fprintf(out, "Paused at:  %s\n", *autonomy.PausedAt)
+	}
+	if autonomy.PausedBy != nil && *autonomy.PausedBy != "" {
+		_, _ = fmt.Fprintf(out, "Paused by:  %s\n", *autonomy.PausedBy)
+	}
+	if autonomy.Reason != nil && *autonomy.Reason != "" {
+		_, _ = fmt.Fprintf(out, "Reason:     %s\n", *autonomy.Reason)
+	}
+	_, _ = fmt.Fprintf(out, "It switched off %d agent(s)%s.\n",
+		len(autonomy.PausedAgents), policyClause(autonomy.DisabledPolicy))
+	_, _ = fmt.Fprintln(out, "Release it with: ankra ai autonomy resume")
+}
+
+func enabledWord(enabled bool) string {
+	if enabled {
+		return "on"
+	}
+	return "off"
+}
+
+func policyClause(disabledPolicy bool) string {
+	if disabledPolicy {
+		return " and auto-remediation"
+	}
+	return ""
+}
+
+var aiAutonomyPauseCmd = &cobra.Command{
+	Use:   "pause",
+	Short: "Pause autonomous actions for the organisation",
+	Long: `Pause autonomous actions across the organisation.
+
+Chat, diagnosis and read-only investigation keep working; what stops is the
+AI changing anything without a person approving it first. It switches off
+auto-remediation and pauses every enabled agent, and records exactly what it
+switched off - so resuming restores that and nothing else, from any
+terminal or browser, by any administrator.
+
+To stop AI entirely during an incident, use "ankra ai autonomy stop-all".`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		reason, _ := cmd.Flags().GetString("reason")
+		outcome, err := apiClient.SetAIAutonomyPause(true, strings.TrimSpace(reason))
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, outcome); handled || renderError != nil {
+			return renderError
+		}
+		out := cmd.OutOrStdout()
+		_, _ = fmt.Fprintf(out, "Autonomous actions are paused: %d agent(s) switched off%s.\n",
+			len(outcome.PausedNow), policyClause(outcome.DisabledPolicyNow))
+		for _, agent := range outcome.PausedNow {
+			_, _ = fmt.Fprintf(out, "  - %s\n", agent.Name)
+		}
+		_, _ = fmt.Fprintln(out, "Resume with: ankra ai autonomy resume")
+		return nil
+	},
+}
+
+var aiAutonomyResumeCmd = &cobra.Command{
+	Use:   "resume",
+	Short: "Resume the autonomous actions this pause switched off",
+	Long: `Resume autonomous actions.
+
+Only what the pause switched off is restored: an agent somebody disabled
+deliberately stays disabled.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		outcome, err := apiClient.SetAIAutonomyPause(false, "")
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, outcome); handled || renderError != nil {
+			return renderError
+		}
+		out := cmd.OutOrStdout()
+		_, _ = fmt.Fprintf(out, "Autonomous actions are running again: %d agent(s) restored%s.\n",
+			len(outcome.ResumedAgents), policyClause(outcome.ReEnabledPolicy))
+		if outcome.AgentsGone > 0 {
+			_, _ = fmt.Fprintf(out, "%d agent(s) the pause switched off no longer exist.\n", outcome.AgentsGone)
+		}
+		return nil
+	},
 }

--- a/cmd/ai_autonomy.go
+++ b/cmd/ai_autonomy.go
@@ -1,0 +1,206 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var aiAutonomyCmd = &cobra.Command{
+	Use:   "autonomy",
+	Short: "Read and operate the organisation's AI kill switch",
+	Long: `Read and operate the organisation-wide AI kill switch.
+
+Engaging it stops all AI for everyone in the organisation: running sessions
+and agent runs are cancelled, and chat is refused until it is released. Reach
+for it during an incident, not to tighten a policy - a narrower stop lives in
+the auto-remediation policy.`,
+}
+
+var aiAutonomyStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show whether AI is stopped for the organisation",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		state, err := apiClient.GetAIPauseState()
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, state); handled || renderError != nil {
+			return renderError
+		}
+		out := cmd.OutOrStdout()
+		if !state.Paused {
+			_, _ = fmt.Fprintln(out, "AI is available for this organisation.")
+			return nil
+		}
+		_, _ = fmt.Fprintln(out, "AI is STOPPED for this organisation.")
+		if state.PausedAt != nil {
+			_, _ = fmt.Fprintf(out, "Stopped at: %s\n", *state.PausedAt)
+		}
+		if state.PausedBy != nil && *state.PausedBy != "" {
+			_, _ = fmt.Fprintf(out, "Stopped by: %s\n", *state.PausedBy)
+		}
+		if state.Reason != nil && *state.Reason != "" {
+			_, _ = fmt.Fprintf(out, "Reason:     %s\n", *state.Reason)
+		}
+		_, _ = fmt.Fprintln(out, "\nRelease it with: ankra ai autonomy resume")
+		return nil
+	},
+}
+
+var aiAutonomyPauseCmd = &cobra.Command{
+	Use:   "pause",
+	Short: "Stop all AI for the organisation",
+	Long: `Stop all AI for everyone in the organisation.
+
+Every running AI session and agent run is cancelled, pending approvals
+expire, and chat is refused until the switch is released. The reason is
+shown to administrators alongside the switch.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		reason, _ := cmd.Flags().GetString("reason")
+		skipConfirm, _ := cmd.Flags().GetBool("yes")
+		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			"Stop all AI for this organisation? Running sessions and agent runs are cancelled. [y/N]: ",
+			skipConfirm); err != nil {
+			return err
+		}
+		outcome, err := apiClient.SetAIPause(true, strings.TrimSpace(reason))
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, outcome); handled || renderError != nil {
+			return renderError
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+			"AI is stopped for this organisation. Cancelled %d session(s) and %d agent run(s).\n",
+			outcome.CancelledSessions, outcome.CancelledRuns)
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Release it with: ankra ai autonomy resume")
+		return nil
+	},
+}
+
+var aiAutonomyResumeCmd = &cobra.Command{
+	Use:   "resume",
+	Short: "Let AI run again for the organisation",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		outcome, err := apiClient.SetAIPause(false, "")
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, outcome); handled || renderError != nil {
+			return renderError
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "AI is available for this organisation again.")
+		return nil
+	},
+}
+
+var aiBoardIdentityCmd = &cobra.Command{
+	Use:   "board-identity",
+	Short: "Manage the identity the AI board's agents act as",
+	Long: `Manage the organisation's board agent identity.
+
+Agents the platform created - the preloaded team - have no user account of
+their own, so their headless runs cannot change anything. The board identity
+gives them one, with its own role, so their work is attributable to the agent
+rather than to whoever set it up. It cannot sign in and has no token.
+
+Without it, a designated board worker is escalated to a human on every ticket
+instead of working it.`,
+}
+
+var aiBoardIdentityStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show whether the board has an identity",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		identity, err := apiClient.GetBoardIdentity()
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, identity); handled || renderError != nil {
+			return renderError
+		}
+		out := cmd.OutOrStdout()
+		if !identity.Provisioned {
+			_, _ = fmt.Fprintln(out, "The board has no identity, so its agents cannot work tickets.")
+			_, _ = fmt.Fprintln(out, "Give it one with: ankra ai board-identity provision")
+			return nil
+		}
+		_, _ = fmt.Fprintln(out, "The board has an identity.")
+		_, _ = fmt.Fprintf(out, "Role:    %s\n", identity.RoleSlug)
+		_, _ = fmt.Fprintf(out, "Subject: %s\n", identity.Subject)
+		if identity.AnkraUserID != nil {
+			_, _ = fmt.Fprintf(out, "User ID: %s\n", *identity.AnkraUserID)
+		}
+		return nil
+	},
+}
+
+var aiBoardIdentityProvisionCmd = &cobra.Command{
+	Use:   "provision",
+	Short: "Give the board an identity its agents act as",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		role, _ := cmd.Flags().GetString("role")
+		identity, err := apiClient.ProvisionBoardIdentity(strings.TrimSpace(role))
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, identity); handled || renderError != nil {
+			return renderError
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+			"The board now acts as its own identity, with the %s role.\n", identity.RoleSlug)
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(),
+			"Designated board workers can work tickets from the next dispatcher pass.")
+		return nil
+	},
+}
+
+var aiBoardIdentityRevokeCmd = &cobra.Command{
+	Use:   "revoke",
+	Short: "Stand the board identity down",
+	Long: `Stand the board identity down.
+
+The principal itself is kept so its past actions stay attributable; what it
+loses is every grant above the viewer floor, which makes the board's agents
+ineligible again on the next dispatcher pass.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		skipConfirm, _ := cmd.Flags().GetBool("yes")
+		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			"Stand the board identity down? Designated agents stop working tickets. [y/N]: ",
+			skipConfirm); err != nil {
+			return err
+		}
+		identity, err := apiClient.RevokeBoardIdentity()
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, identity); handled || renderError != nil {
+			return renderError
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(),
+			"The board identity is stood down. Its agents escalate to a human until it is provisioned again.")
+		return nil
+	},
+}
+
+func init() {
+	aiAutonomyPauseCmd.Flags().String("reason", "", "Why AI is being stopped (shown to administrators)")
+	aiAutonomyPauseCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
+	aiBoardIdentityRevokeCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
+	aiBoardIdentityProvisionCmd.Flags().String("role", "",
+		"Role the identity carries: operator (default), member, or viewer")
+	registerStructuredOutputFlags(aiAutonomyStatusCmd, aiAutonomyPauseCmd, aiAutonomyResumeCmd,
+		aiBoardIdentityStatusCmd, aiBoardIdentityProvisionCmd, aiBoardIdentityRevokeCmd)
+
+	aiAutonomyCmd.AddCommand(aiAutonomyStatusCmd, aiAutonomyPauseCmd, aiAutonomyResumeCmd)
+	aiBoardIdentityCmd.AddCommand(aiBoardIdentityStatusCmd, aiBoardIdentityProvisionCmd, aiBoardIdentityRevokeCmd)
+	aiCmd.AddCommand(aiAutonomyCmd, aiBoardIdentityCmd)
+}

--- a/cmd/ai_autonomy_test.go
+++ b/cmd/ai_autonomy_test.go
@@ -18,6 +18,11 @@ type aiAutonomyMock struct {
 	pauseCalls    []bool
 	pauseReasons  []string
 	provisionRole string
+
+	autonomyState   client.AIAutonomyState
+	autonomyCalls   []bool
+	autonomyReasons []string
+	autonomyOutcome *client.AIAutonomyOutcome
 }
 
 func (m *aiAutonomyMock) GetBoardIdentity() (*client.BoardIdentity, error) {
@@ -138,7 +143,7 @@ func TestAutonomyStatusReadsTheKillSwitch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("status failed: %v", err)
 	}
-	for _, want := range []string{"STOPPED", "incident 42", "ankra ai autonomy resume"} {
+	for _, want := range []string{"STOPPED", "incident 42", "ankra ai autonomy start-all"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("status output lacks %q: %s", want, out)
 		}
@@ -150,8 +155,8 @@ func TestAutonomyStatusReadsTheKillSwitch(t *testing.T) {
 func TestAutonomyPauseConfirmsAndReportsWhatItCancelled(t *testing.T) {
 	mock := &aiAutonomyMock{}
 
-	_, err := runConfirmCommand(t, mock, "n\n", []*cobra.Command{aiAutonomyPauseCmd},
-		"ai", "autonomy", "pause")
+	_, err := runConfirmCommand(t, mock, "n\n", []*cobra.Command{aiAutonomyStopAllCmd},
+		"ai", "autonomy", "stop-all")
 	if err == nil || exitCodeFor(err) != exitCancelled {
 		t.Fatalf("declining must cancel, got %v", err)
 	}
@@ -159,9 +164,9 @@ func TestAutonomyPauseConfirmsAndReportsWhatItCancelled(t *testing.T) {
 		t.Fatalf("paused despite declining: %+v", mock.pauseCalls)
 	}
 
-	resetTreeFlags(t, aiAutonomyPauseCmd)
-	out, err := runConfirmCommand(t, mock, "", []*cobra.Command{aiAutonomyPauseCmd},
-		"ai", "autonomy", "pause", "--yes", "--reason", "  incident 42  ")
+	resetTreeFlags(t, aiAutonomyStopAllCmd)
+	out, err := runConfirmCommand(t, mock, "", []*cobra.Command{aiAutonomyStopAllCmd},
+		"ai", "autonomy", "stop-all", "--yes", "--reason", "  incident 42  ")
 	if err != nil {
 		t.Fatalf("pause failed: %v", err)
 	}
@@ -176,8 +181,8 @@ func TestAutonomyPauseConfirmsAndReportsWhatItCancelled(t *testing.T) {
 func TestAutonomyResumeReleasesTheSwitch(t *testing.T) {
 	mock := &aiAutonomyMock{pauseState: client.AIPauseState{Paused: true}}
 
-	out, err := runConfirmCommand(t, mock, "", []*cobra.Command{aiAutonomyResumeCmd},
-		"ai", "autonomy", "resume")
+	out, err := runConfirmCommand(t, mock, "", []*cobra.Command{aiAutonomyStartAllCmd},
+		"ai", "autonomy", "start-all")
 	if err != nil {
 		t.Fatalf("resume failed: %v", err)
 	}
@@ -186,5 +191,96 @@ func TestAutonomyResumeReleasesTheSwitch(t *testing.T) {
 	}
 	if !strings.Contains(out, "available") {
 		t.Fatalf("resume output = %s", out)
+	}
+}
+
+func (m *aiAutonomyMock) GetAIAutonomyState() (*client.AIAutonomyState, error) {
+	state := m.autonomyState
+	return &state, nil
+}
+
+func (m *aiAutonomyMock) SetAIAutonomyPause(paused bool, reason string) (*client.AIAutonomyOutcome, error) {
+	m.autonomyCalls = append(m.autonomyCalls, paused)
+	m.autonomyReasons = append(m.autonomyReasons, reason)
+	if m.autonomyOutcome != nil {
+		return m.autonomyOutcome, nil
+	}
+	return &client.AIAutonomyOutcome{
+		AIAutonomyState:   client.AIAutonomyState{Paused: paused},
+		DisabledPolicyNow: paused,
+		PausedNow:         []client.AutonomyAgent{{ID: "a1", Name: "Gap Scanner"}},
+	}, nil
+}
+
+// Pausing autonomous actions reports what it switched off, because that is
+// exactly what a later resume will restore - the record the browser used to
+// keep to itself.
+func TestAutonomyPauseReportsWhatItSwitchedOff(t *testing.T) {
+	mock := &aiAutonomyMock{}
+
+	out, err := runConfirmCommand(t, mock, "", []*cobra.Command{aiAutonomyPauseCmd},
+		"ai", "autonomy", "pause", "--reason", "  change freeze  ")
+	if err != nil {
+		t.Fatalf("pause failed: %v", err)
+	}
+	if len(mock.autonomyCalls) != 1 || !mock.autonomyCalls[0] ||
+		mock.autonomyReasons[0] != "change freeze" {
+		t.Fatalf("pause sent %+v / %+v", mock.autonomyCalls, mock.autonomyReasons)
+	}
+	for _, want := range []string{"1 agent(s) switched off and auto-remediation",
+		"Gap Scanner", "ankra ai autonomy resume"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("pause output lacks %q: %s", want, out)
+		}
+	}
+}
+
+func TestAutonomyResumeReportsWhatItRestored(t *testing.T) {
+	mock := &aiAutonomyMock{autonomyOutcome: &client.AIAutonomyOutcome{
+		AIAutonomyState: client.AIAutonomyState{Paused: false},
+		ReEnabledPolicy: true,
+		ResumedAgents:   []client.AutonomyAgent{{ID: "a1", Name: "Gap Scanner"}},
+		AgentsGone:      2,
+	}}
+
+	out, err := runConfirmCommand(t, mock, "", []*cobra.Command{aiAutonomyResumeCmd},
+		"ai", "autonomy", "resume")
+	if err != nil {
+		t.Fatalf("resume failed: %v", err)
+	}
+	if len(mock.autonomyCalls) != 1 || mock.autonomyCalls[0] {
+		t.Fatalf("resume sent %+v", mock.autonomyCalls)
+	}
+	if !strings.Contains(out, "1 agent(s) restored and auto-remediation") {
+		t.Fatalf("resume output = %s", out)
+	}
+	// Agents deleted while paused are reported, not silently dropped.
+	if !strings.Contains(out, "2 agent(s) the pause switched off no longer exist") {
+		t.Fatalf("resume output hides the gone agents: %s", out)
+	}
+}
+
+// One status answers "is anything switched off?" for both stops.
+func TestAutonomyStatusReportsBothStops(t *testing.T) {
+	reason := "change freeze"
+	pausedAt := "2026-08-25T19:00:00Z"
+	mock := &aiAutonomyMock{autonomyState: client.AIAutonomyState{
+		Paused: true, PausedAt: &pausedAt, Reason: &reason, DisabledPolicy: true,
+		PausedAgents: []client.AutonomyAgent{{ID: "a1", Name: "Gap Scanner"}},
+	}}
+
+	out, err := runConfirmCommand(t, mock, "", []*cobra.Command{aiAutonomyStatusCmd},
+		"ai", "autonomy", "status")
+	if err != nil {
+		t.Fatalf("status failed: %v", err)
+	}
+	if !strings.Contains(out, "AI is available for this organisation.") {
+		t.Fatalf("status must report the hard stop too: %s", out)
+	}
+	for _, want := range []string{"Autonomous actions: PAUSED", "change freeze",
+		"switched off 1 agent(s) and auto-remediation", "ankra ai autonomy resume"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("status output lacks %q: %s", want, out)
+		}
 	}
 }

--- a/cmd/ai_autonomy_test.go
+++ b/cmd/ai_autonomy_test.go
@@ -1,0 +1,190 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+type aiAutonomyMock struct {
+	baseMock
+	identity      *client.BoardIdentity
+	provisioned   []string
+	revokes       int
+	pauseState    client.AIPauseState
+	pauseCalls    []bool
+	pauseReasons  []string
+	provisionRole string
+}
+
+func (m *aiAutonomyMock) GetBoardIdentity() (*client.BoardIdentity, error) {
+	if m.identity == nil {
+		return &client.BoardIdentity{Provisioned: false}, nil
+	}
+	return m.identity, nil
+}
+
+func (m *aiAutonomyMock) ProvisionBoardIdentity(roleSlug string) (*client.BoardIdentity, error) {
+	m.provisioned = append(m.provisioned, roleSlug)
+	m.provisionRole = roleSlug
+	role := roleSlug
+	if role == "" {
+		role = "operator"
+	}
+	userID := "b0a1c2d3-0000-4000-8000-000000000001"
+	return &client.BoardIdentity{Provisioned: true, RoleSlug: role,
+		Subject: "service-principal|board", AnkraUserID: &userID}, nil
+}
+
+func (m *aiAutonomyMock) RevokeBoardIdentity() (*client.BoardIdentity, error) {
+	m.revokes++
+	return &client.BoardIdentity{Provisioned: false}, nil
+}
+
+func (m *aiAutonomyMock) GetAIPauseState() (*client.AIPauseState, error) {
+	state := m.pauseState
+	return &state, nil
+}
+
+func (m *aiAutonomyMock) SetAIPause(paused bool, reason string) (*client.AIPauseOutcome, error) {
+	m.pauseCalls = append(m.pauseCalls, paused)
+	m.pauseReasons = append(m.pauseReasons, reason)
+	m.pauseState.Paused = paused
+	return &client.AIPauseOutcome{AIPauseState: client.AIPauseState{Paused: paused},
+		CancelledSessions: 2, CancelledRuns: 1}, nil
+}
+
+// An organisation with no board identity is the state in which every
+// designated worker escalates instead of working, so the CLI says so and
+// names the command that fixes it rather than printing an empty record.
+func TestBoardIdentityStatusNamesTheFixWhenAbsent(t *testing.T) {
+	mock := &aiAutonomyMock{}
+
+	out, err := runConfirmCommand(t, mock, "", []*cobra.Command{aiBoardIdentityStatusCmd},
+		"ai", "board-identity", "status")
+	if err != nil {
+		t.Fatalf("status failed: %v", err)
+	}
+	if !strings.Contains(out, "no identity") ||
+		!strings.Contains(out, "ankra ai board-identity provision") {
+		t.Fatalf("status output = %s", out)
+	}
+}
+
+func TestBoardIdentityProvisionDefaultsToOperator(t *testing.T) {
+	mock := &aiAutonomyMock{}
+
+	out, err := runConfirmCommand(t, mock, "", []*cobra.Command{aiBoardIdentityProvisionCmd},
+		"ai", "board-identity", "provision")
+	if err != nil {
+		t.Fatalf("provision failed: %v", err)
+	}
+	if len(mock.provisioned) != 1 || mock.provisioned[0] != "" {
+		t.Fatalf("provision sent %+v, want the platform default", mock.provisioned)
+	}
+	if !strings.Contains(out, "operator role") {
+		t.Fatalf("provision output = %s", out)
+	}
+
+	resetTreeFlags(t, aiBoardIdentityProvisionCmd)
+	mock = &aiAutonomyMock{}
+	if _, err := runConfirmCommand(t, mock, "", []*cobra.Command{aiBoardIdentityProvisionCmd},
+		"ai", "board-identity", "provision", "--role", "viewer"); err != nil {
+		t.Fatalf("provision --role failed: %v", err)
+	}
+	if mock.provisionRole != "viewer" {
+		t.Fatalf("role sent = %q", mock.provisionRole)
+	}
+}
+
+// Standing the identity down stops every board agent, so it asks first.
+func TestBoardIdentityRevokeAsksBeforeStandingDown(t *testing.T) {
+	mock := &aiAutonomyMock{}
+
+	_, err := runConfirmCommand(t, mock, "n\n", []*cobra.Command{aiBoardIdentityRevokeCmd},
+		"ai", "board-identity", "revoke")
+	if err == nil {
+		t.Fatal("a declined confirmation must not revoke")
+	}
+	if got := exitCodeFor(err); got != exitCancelled {
+		t.Errorf("expected exit code %d, got %d", exitCancelled, got)
+	}
+	if mock.revokes != 0 {
+		t.Fatalf("revoked despite declining: %d", mock.revokes)
+	}
+
+	resetTreeFlags(t, aiBoardIdentityRevokeCmd)
+	out, err := runConfirmCommand(t, mock, "y\n", []*cobra.Command{aiBoardIdentityRevokeCmd},
+		"ai", "board-identity", "revoke")
+	if err != nil {
+		t.Fatalf("revoke failed: %v", err)
+	}
+	if mock.revokes != 1 || !strings.Contains(out, "stood down") {
+		t.Fatalf("revokes=%d out=%s", mock.revokes, out)
+	}
+}
+
+func TestAutonomyStatusReadsTheKillSwitch(t *testing.T) {
+	reason := "incident 42"
+	pausedAt := "2026-08-25T18:00:00Z"
+	mock := &aiAutonomyMock{pauseState: client.AIPauseState{
+		Paused: true, PausedAt: &pausedAt, Reason: &reason}}
+
+	out, err := runConfirmCommand(t, mock, "", []*cobra.Command{aiAutonomyStatusCmd},
+		"ai", "autonomy", "status")
+	if err != nil {
+		t.Fatalf("status failed: %v", err)
+	}
+	for _, want := range []string{"STOPPED", "incident 42", "ankra ai autonomy resume"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("status output lacks %q: %s", want, out)
+		}
+	}
+}
+
+// Stopping all AI cancels live work, so it asks first and reports what it
+// cancelled rather than claiming a silent success.
+func TestAutonomyPauseConfirmsAndReportsWhatItCancelled(t *testing.T) {
+	mock := &aiAutonomyMock{}
+
+	_, err := runConfirmCommand(t, mock, "n\n", []*cobra.Command{aiAutonomyPauseCmd},
+		"ai", "autonomy", "pause")
+	if err == nil || exitCodeFor(err) != exitCancelled {
+		t.Fatalf("declining must cancel, got %v", err)
+	}
+	if len(mock.pauseCalls) != 0 {
+		t.Fatalf("paused despite declining: %+v", mock.pauseCalls)
+	}
+
+	resetTreeFlags(t, aiAutonomyPauseCmd)
+	out, err := runConfirmCommand(t, mock, "", []*cobra.Command{aiAutonomyPauseCmd},
+		"ai", "autonomy", "pause", "--yes", "--reason", "  incident 42  ")
+	if err != nil {
+		t.Fatalf("pause failed: %v", err)
+	}
+	if len(mock.pauseCalls) != 1 || !mock.pauseCalls[0] || mock.pauseReasons[0] != "incident 42" {
+		t.Fatalf("pause sent %+v / %+v", mock.pauseCalls, mock.pauseReasons)
+	}
+	if !strings.Contains(out, "Cancelled 2 session(s) and 1 agent run(s)") {
+		t.Fatalf("pause output = %s", out)
+	}
+}
+
+func TestAutonomyResumeReleasesTheSwitch(t *testing.T) {
+	mock := &aiAutonomyMock{pauseState: client.AIPauseState{Paused: true}}
+
+	out, err := runConfirmCommand(t, mock, "", []*cobra.Command{aiAutonomyResumeCmd},
+		"ai", "autonomy", "resume")
+	if err != nil {
+		t.Fatalf("resume failed: %v", err)
+	}
+	if len(mock.pauseCalls) != 1 || mock.pauseCalls[0] {
+		t.Fatalf("resume sent %+v", mock.pauseCalls)
+	}
+	if !strings.Contains(out, "available") {
+		t.Fatalf("resume output = %s", out)
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -3448,3 +3448,23 @@ func (m baseMock) TransitionTicket(ticketID string, status string, note string) 
 func (m baseMock) DecideTicket(ticketID string, decision client.TicketDecision) (*client.Ticket, error) {
 	return nil, errors.New("not implemented")
 }
+
+func (m baseMock) GetBoardIdentity() (*client.BoardIdentity, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ProvisionBoardIdentity(roleSlug string) (*client.BoardIdentity, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) RevokeBoardIdentity() (*client.BoardIdentity, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetAIPauseState() (*client.AIPauseState, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) SetAIPause(paused bool, reason string) (*client.AIPauseOutcome, error) {
+	return nil, errors.New("not implemented")
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -3468,3 +3468,11 @@ func (m baseMock) GetAIPauseState() (*client.AIPauseState, error) {
 func (m baseMock) SetAIPause(paused bool, reason string) (*client.AIPauseOutcome, error) {
 	return nil, errors.New("not implemented")
 }
+
+func (m baseMock) GetAIAutonomyState() (*client.AIAutonomyState, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) SetAIAutonomyPause(paused bool, reason string) (*client.AIAutonomyOutcome, error) {
+	return nil, errors.New("not implemented")
+}

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -254,6 +254,12 @@ type APIClient interface {
 	GetAgentRunTranscript(runID string, since int64, limit int) (*client.AgentRunTranscript, error)
 	CancelAgentRun(runID string) (*client.CancelAgentRunResponse, error)
 
+	GetBoardIdentity() (*client.BoardIdentity, error)
+	ProvisionBoardIdentity(roleSlug string) (*client.BoardIdentity, error)
+	RevokeBoardIdentity() (*client.BoardIdentity, error)
+	GetAIPauseState() (*client.AIPauseState, error)
+	SetAIPause(paused bool, reason string) (*client.AIPauseOutcome, error)
+
 	ListTickets(filter client.TicketListFilter) (*client.TicketListResponse, error)
 	GetTicket(ticketID string) (*client.Ticket, error)
 	ListTicketEvents(ticketID string, limit int) (*client.TicketEventListResponse, error)

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -259,6 +259,8 @@ type APIClient interface {
 	RevokeBoardIdentity() (*client.BoardIdentity, error)
 	GetAIPauseState() (*client.AIPauseState, error)
 	SetAIPause(paused bool, reason string) (*client.AIPauseOutcome, error)
+	GetAIAutonomyState() (*client.AIAutonomyState, error)
+	SetAIAutonomyPause(paused bool, reason string) (*client.AIAutonomyOutcome, error)
 
 	ListTickets(filter client.TicketListFilter) (*client.TicketListResponse, error)
 	GetTicket(ticketID string) (*client.Ticket, error)

--- a/internal/client/aiboard.go
+++ b/internal/client/aiboard.go
@@ -93,3 +93,58 @@ func (c *Client) SetAIPause(paused bool, reason string) (*AIPauseOutcome, error)
 	}
 	return &outcome, nil
 }
+
+// AutonomyAgent names an agent task the autonomy pause switched off.
+type AutonomyAgent struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// AIAutonomyState is the softer stop: autonomous actions paused, with a
+// durable record of what the pause switched off so any operator can
+// release it. RestorableAgents is what an operator could choose to switch
+// back on when the pause was not engaged through this switch.
+type AIAutonomyState struct {
+	Paused           bool            `json:"paused"`
+	PausedAt         *string         `json:"paused_at"`
+	PausedBy         *string         `json:"paused_by"`
+	Reason           *string         `json:"reason"`
+	DisabledPolicy   bool            `json:"disabled_policy"`
+	PausedAgents     []AutonomyAgent `json:"paused_agents"`
+	PolicyEnabled    bool            `json:"policy_enabled"`
+	RestorableAgents []AutonomyAgent `json:"restorable_agents"`
+}
+
+// AIAutonomyOutcome reports what engaging or releasing the switch changed.
+type AIAutonomyOutcome struct {
+	AIAutonomyState
+	DisabledPolicyNow bool            `json:"disabled_policy_now"`
+	PausedNow         []AutonomyAgent `json:"paused_now"`
+	ReEnabledPolicy   bool            `json:"re_enabled_policy"`
+	ResumedAgents     []AutonomyAgent `json:"resumed_agents"`
+	AgentsGone        int             `json:"agents_gone"`
+}
+
+const aiAutonomyPath = "/api/v1/org/ai-settings/autonomy"
+
+// GetAIAutonomyState reads the autonomous-actions pause.
+func (c *Client) GetAIAutonomyState() (*AIAutonomyState, error) {
+	var state AIAutonomyState
+	if err := c.getJSON(c.BaseURL+aiAutonomyPath, &state); err != nil {
+		return nil, fmt.Errorf("reading the autonomy pause: %w", err)
+	}
+	return &state, nil
+}
+
+// SetAIAutonomyPause engages or releases the autonomous-actions pause.
+func (c *Client) SetAIAutonomyPause(paused bool, reason string) (*AIAutonomyOutcome, error) {
+	payload := map[string]any{"paused": paused}
+	if reason != "" {
+		payload["reason"] = reason
+	}
+	var outcome AIAutonomyOutcome
+	if err := c.sendJSON(http.MethodPut, c.BaseURL+aiAutonomyPath, payload, &outcome); err != nil {
+		return nil, fmt.Errorf("setting the autonomy pause: %w", err)
+	}
+	return &outcome, nil
+}

--- a/internal/client/aiboard.go
+++ b/internal/client/aiboard.go
@@ -1,0 +1,95 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// BoardIdentity is the organisation's board agent identity: the service
+// principal the AI board's platform-created agents act as. Provisioned is
+// false for an organisation that never opted in - which is also the state
+// in which every designated board worker escalates instead of working.
+type BoardIdentity struct {
+	Provisioned bool    `json:"provisioned"`
+	Subject     string  `json:"subject,omitempty"`
+	RoleSlug    string  `json:"role_slug,omitempty"`
+	AnkraUserID *string `json:"ankra_user_id,omitempty"`
+}
+
+// AIPauseState is the organisation AI kill switch. PausedBy and Reason are
+// present only while it is engaged.
+type AIPauseState struct {
+	Paused   bool    `json:"paused"`
+	PausedAt *string `json:"paused_at"`
+	PausedBy *string `json:"paused_by"`
+	Reason   *string `json:"reason"`
+}
+
+// AIPauseOutcome is what engaging the switch reports: the state plus what
+// the sweep cancelled on the way in.
+type AIPauseOutcome struct {
+	AIPauseState
+	CancelledSessions int `json:"cancelled_sessions"`
+	CancelledRuns     int `json:"cancelled_agent_runs"`
+}
+
+const (
+	boardIdentityPath = "/api/v1/org/ai-tasks/board-identity"
+	aiPausePath       = "/api/v1/org/ai-settings/pause"
+)
+
+// GetBoardIdentity reads the organisation's board agent identity.
+func (c *Client) GetBoardIdentity() (*BoardIdentity, error) {
+	var identity BoardIdentity
+	if err := c.getJSON(c.BaseURL+boardIdentityPath, &identity); err != nil {
+		return nil, fmt.Errorf("reading the board identity: %w", err)
+	}
+	return &identity, nil
+}
+
+// ProvisionBoardIdentity mints the board identity, or returns the existing
+// one. An empty roleSlug takes the platform default (operator).
+func (c *Client) ProvisionBoardIdentity(roleSlug string) (*BoardIdentity, error) {
+	payload := map[string]any{}
+	if roleSlug != "" {
+		payload["role_slug"] = roleSlug
+	}
+	var identity BoardIdentity
+	if err := c.sendJSON(http.MethodPost, c.BaseURL+boardIdentityPath, payload, &identity); err != nil {
+		return nil, fmt.Errorf("provisioning the board identity: %w", err)
+	}
+	return &identity, nil
+}
+
+// RevokeBoardIdentity stands the board identity down: the principal keeps
+// its history, and loses every grant above the viewer floor.
+func (c *Client) RevokeBoardIdentity() (*BoardIdentity, error) {
+	var identity BoardIdentity
+	if err := c.sendJSON(http.MethodDelete, c.BaseURL+boardIdentityPath, nil, &identity); err != nil {
+		return nil, fmt.Errorf("standing the board identity down: %w", err)
+	}
+	return &identity, nil
+}
+
+// GetAIPauseState reads the organisation AI kill switch.
+func (c *Client) GetAIPauseState() (*AIPauseState, error) {
+	var state AIPauseState
+	if err := c.getJSON(c.BaseURL+aiPausePath, &state); err != nil {
+		return nil, fmt.Errorf("reading the AI pause state: %w", err)
+	}
+	return &state, nil
+}
+
+// SetAIPause engages or releases the kill switch. Engaging cancels the
+// organisation's running AI sessions and agent runs.
+func (c *Client) SetAIPause(paused bool, reason string) (*AIPauseOutcome, error) {
+	payload := map[string]any{"paused": paused}
+	if reason != "" {
+		payload["reason"] = reason
+	}
+	var outcome AIPauseOutcome
+	if err := c.sendJSON(http.MethodPut, c.BaseURL+aiPausePath, payload, &outcome); err != nil {
+		return nil, fmt.Errorf("setting the AI pause state: %w", err)
+	}
+	return &outcome, nil
+}


### PR DESCRIPTION
Bead: ankra-us966.4

Needs the cluster twins in ankraio/cluster `feat/cli-ai-settings-parity` deployed first - the endpoints these call were browser-only until then.

## Why

An audit of the CLI against the API contract found the gap is rarely "the CLI lacks a command" - it is that the AI/organisation settings have **no token-authenticated route at all**, so no CLI, CI job or runbook can reach them. The sharpest instance cost real time this week: an organisation designated a board worker, every ticket escalated anyway, and the fix - giving the board an identity - existed only behind a browser session.

## What

```bash
ankra ai board-identity status      # says outright when the board has none, and names the fix
ankra ai board-identity provision [--role operator|member|viewer]
ankra ai board-identity revoke [--yes]

ankra ai autonomy status            # is AI stopped, since when, by whom, why
ankra ai autonomy pause --reason "incident 42" [--yes]
ankra ai autonomy resume
```

Both destructive verbs confirm through the house `confirmPrompt` and take `--yes`; `pause` reports what its sweep cancelled rather than claiming a silent success; every command supports `-o json|yaml`.

## Verification

`go test ./...` and `golangci-lint run ./...` both clean. `cmd/ai_autonomy_test.go` covers the absent-identity message naming its fix, the default and explicit role, the decline-and-confirm paths on both destructive verbs (exit code 5, no call made), the engaged-switch rendering, and the trimmed reason reaching the API.