### PR TITLE
fix(systemtest): skip the scheduled lifecycle run when the repository has no systemtest credentials (ankra-nof9y)

### DIFF
--- a/.github/workflows/systemtest.yml
+++ b/.github/workflows/systemtest.yml
@@ -53,7 +53,30 @@ jobs:
       GITOPS_REPOSITORY: ${{ vars.SYSTEMTEST_GITOPS_REPOSITORY }}
       TMPDIR: ${{ github.workspace }}/systemtest-artifacts
     steps:
+      # Every SYSTEMTEST_* value above is a repository secret or variable, and a
+      # repository without them cannot run this suite at all: the preflight in
+      # lifecycle_systemtest.sh dies on the first empty credential seconds in.
+      # On a schedule that reads as a broken build every Monday, Wednesday and
+      # Friday, which is what the 30 consecutive red runs since 2026-06-22
+      # actually were - nobody had created the secrets. Skip with a notice
+      # instead, the way the cluster repo's nightly skips its live-model eval
+      # tier when ANTHROPIC_API_KEY is absent.
+      #
+      # Only the API token is gated on. A repository that has the token but is
+      # missing a provider credential IS misconfigured, and the preflight has
+      # to keep failing loudly for it.
+      - name: Check systemtest configuration
+        id: configuration
+        run: |
+          if [ -n "$ANKRA_API_TOKEN" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::SYSTEMTEST_ANKRA_API_TOKEN is not configured in this repository, so the cloud lifecycle system test is skipped. Each run provisions real billable cloud infrastructure, so these credentials are deliberately not defaulted."
+          fi
+
       - name: Checkout code
+        if: steps.configuration.outputs.configured == 'true'
         uses: actions/checkout@v6
 
       # TMPDIR (set job-wide above) lives inside the workspace so the test's
@@ -61,17 +84,21 @@ jobs:
       # clean workspace. It must exist before anything invokes Go: setup-go
       # runs `go env`, and Go refuses to start with a missing TMPDIR.
       - name: Create TMPDIR
+        if: steps.configuration.outputs.configured == 'true'
         run: mkdir -p "$TMPDIR"
 
       - name: Set up Go
+        if: steps.configuration.outputs.configured == 'true'
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Build ankra binary
+        if: steps.configuration.outputs.configured == 'true'
         run: go build -o bin/ankra .
 
       - name: Run lifecycle system test
+        if: steps.configuration.outputs.configured == 'true'
         run: |
           # "none" lets a dispatch skip a whole family (an empty input would
           # fall back to the default matrix instead).
@@ -82,7 +109,7 @@ jobs:
       # Debug aid only — an org storage-quota block on artifact uploads
       # must not redden a run whose cloud lifecycle actually passed.
       - name: Upload run logs
-        if: always()
+        if: always() && steps.configuration.outputs.configured == 'true'
         continue-on-error: true
         uses: actions/upload-artifact@v4
         with:

--- a/systemtest/README.md
+++ b/systemtest/README.md
@@ -158,6 +158,25 @@ Per-target logs and result files are written under a `mktemp -d` work directory
 printed at the start of the run; output on the console is line-tagged
 `[provider-distribution]` (cloud-managed targets use `[provider-managed]`).
 
+## Scheduled runs in CI
+
+`.github/workflows/systemtest.yml` runs this suite at 03:00 UTC every Monday,
+Wednesday and Friday, and on manual dispatch. Every value in its `env:` block
+comes from a repository secret or variable named `SYSTEMTEST_*` — the same
+names as the environment variables above, prefixed:
+
+| Kind | Names |
+|---|---|
+| Secrets | `SYSTEMTEST_ANKRA_API_TOKEN`, `SYSTEMTEST_SSH_KEY_CREDENTIAL_ID`, `SYSTEMTEST_HETZNER_CREDENTIAL_ID`, `SYSTEMTEST_OVH_CREDENTIAL_ID`, `SYSTEMTEST_UPCLOUD_CREDENTIAL_ID`, `SYSTEMTEST_DIGITALOCEAN_CREDENTIAL_ID`, `SYSTEMTEST_GKE_CREDENTIAL_ID`, `SYSTEMTEST_AKS_CREDENTIAL_ID`, `SYSTEMTEST_EKS_CREDENTIAL_ID` |
+| Variables | `SYSTEMTEST_ANKRA_BASE_URL`, `SYSTEMTEST_ANKRA_ORG`, `SYSTEMTEST_GITOPS_CREDENTIAL_NAME`, `SYSTEMTEST_GITOPS_REPOSITORY` |
+
+None of them are defaulted, because a run provisions real, billable
+infrastructure and the target org must be a deliberate choice. A repository
+without `SYSTEMTEST_ANKRA_API_TOKEN` therefore skips the job with a notice
+rather than failing: an unconfigured repository is not a broken build. If the
+token is present but a provider credential is missing, the preflight still
+fails loudly — that repository *is* misconfigured.
+
 ## Output
 
 The script prints a per-step `PASS`/`FAIL`/`SKIP` (tagged with the target in


### PR DESCRIPTION
Bead: ankra-nof9y

The "Lifecycle system test" workflow has failed **30 out of 30 runs since 2026-06-22** — it has never once succeeded. The cause is not the test: `ankraio/ankra-cli` has zero repository variables and only two secrets (`DOCS_REPO_TOKEN`, `HOMEBREW_TAP_DEPLOY_KEY`), so every `SYSTEMTEST_*` reference in the job's `env:` resolves to an empty string and `lifecycle_systemtest.sh` dies in its preflight ~15s in with `SSH_KEY_CREDENTIAL_ID is required for Ankra-managed providers`.

An unconfigured repository is not a broken build, but on a Mon/Wed/Fri schedule it reads as one, three times a week, for two months.

This gates the job on `SYSTEMTEST_ANKRA_API_TOKEN` and skips with a `::notice::` when it is absent — the same shape the cluster repo's nightly uses for its live-model eval tier when `ANTHROPIC_API_KEY` is missing. Only the API token is gated: a repository that *has* the token but is missing a provider credential genuinely is misconfigured, and the preflight keeps failing loudly for it.

`systemtest/README.md` gains a "Scheduled runs in CI" section naming every secret and variable the schedule reads, so the human half — deciding whether this suite should run at all, and against which org — is discoverable. Worth an explicit decision rather than a default: each run provisions **real billable cloud infrastructure** across hetzner/ovh/upcloud/digitalocean plus six managed providers.

Verified: `go build ./...` clean, `bash -n systemtest/lifecycle_systemtest.sh` clean, workflow parses and every step gates on the new output (checked with a YAML load), and the gate shell was exercised both ways — empty token emits the notice and sets `configured=false`, a set token sets `configured=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RU7SQqa328gPSqmt3CvJQV
