### PR TITLE
docs(skills): ankra-cicd routes application repositories to the generator first (ankra-ryfuy.8)

### DIFF
--- a/internal/skills/embedded/skills/ankra-cicd/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-cicd/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: ankra-cicd
-description: Build CI/CD pipelines (GitHub Actions or GitLab CI) that build a container image, push it with an immutable tag, and bump that tag in the Ankra GitOps repository so the Ankra engine syncs the change - rather than running kubectl/helm against the cluster from CI. Use when the user wires CI/CD for an Ankra-managed app, mentions GitHub Actions or GitLab CI with Ankra, or asks how to deploy on push.
+description: Build CI/CD pipelines (GitHub Actions or GitLab CI) that build a container image, push it with an immutable tag, and bump that tag in the Ankra GitOps repository so the Ankra engine syncs the change - rather than running kubectl/helm against the cluster from CI. For an application repository, reach for `ankra application add` FIRST - it generates this whole pipeline (build, security scans, immutable sha- tags, managed registry login) plus the deploy contract, with push-to-deploy built in; use the manual pattern here when the repository is not an Ankra application or the pipeline must stay hand-rolled. Use when the user wires CI/CD for an Ankra-managed app, mentions GitHub Actions or GitLab CI with Ankra, or asks how to deploy on push.
 ---
 
 # Ankra CI/CD
 
 The Ankra deploy pattern is **GitOps-driven**: CI builds and pushes an image, then updates the image tag in the GitOps repo. The Ankra engine detects the commit and reconciles the cluster. CI never applies to the cluster directly.
+
+For an application repository, `ankra application add .` generates this whole pipeline - security gates, immutable `sha-` tags, managed registry login and the deploy contract, with push-to-deploy built in. Read "When Ankra generates the pipeline for you" below and the `ankra-applications` skill before hand-rolling anything here.
 
 ## Pipeline shape (provider-agnostic)
 

--- a/internal/skills/embedded/skills/ankra-cicd/reference.md
+++ b/internal/skills/embedded/skills/ankra-cicd/reference.md
@@ -1,5 +1,7 @@
 # Ankra CI/CD — pipeline examples
 
+Before copying either example: for an application repository, `ankra application add` generates this entire pipeline (with security gates and managed registry credentials) and the deploy contract in one setup PR - see SKILL.md. The examples below are the manual pattern for everything else.
+
 Both examples follow the same pattern: build, push an immutable tag, then commit the new tag into the GitOps repository so the Ankra engine syncs it. Neither talks to the cluster directly.
 
 Assumptions:


### PR DESCRIPTION
## What

The ankra-cicd skill's description now names `ankra application add` as the first stop for an application repository, and a pointer directly under the intro sends the reader to the existing "When Ankra generates the pipeline for you" section and the `ankra-applications` skill before the manual pipeline shapes. reference.md carries the same pointer above its copy-paste examples.

Previously the description routed agents straight into hand-rolling what the platform generates, and the generates-for-you section sat below every manual example - an agent reading top-down had built the pipeline before learning it never needed to.

Complements the skills overhaul that shipped with v0.13.0 (the ankra-applications skill itself); this is only the routing residue.

## Validation

`go build ./...` and `go test ./internal/skills/` green.

Bead: ankra-ryfuy.8