### PR TITLE
fix(packaging): keep the version out of the formula's prose so a release renders the tap byte for byte (ankra-srw9q)

### DIFF
--- a/packaging/homebrew/ankra.rb.tmpl
+++ b/packaging/homebrew/ankra.rb.tmpl
@@ -5,7 +5,7 @@
 # There is deliberately no `version` stanza: `brew audit` fails a tap whose
 # declared version it can already scan from the stable URL (redundant_version),
 # and every release URL below carries the tag. That is why the URLs interpolate
-# nothing - the release workflow substitutes __VERSION__ into them directly.
+# nothing - the release workflow substitutes the version into them directly.
 class Ankra < Formula
   desc "Command-line interface for the Ankra Kubernetes platform"
   homepage "https://ankra.io"


### PR DESCRIPTION
Bead: ankra-srw9q

Follow-up to #166. The explanatory comment that PR added contains the literal `__VERSION__`, and the release workflow's `sed` substitutes **every** occurrence — including the one in prose. So the next release would render:

```
# nothing - the release workflow substitutes 0.14.0 into them directly.
```

which reads wrong and, more usefully, differs from the comment now sitting in `ankraio/homebrew-tap` (#1 landed the reworded line there). That would show up as a spurious diff on the next release commit, in the one file where an unexplained diff is worth a second look.

One word: `__VERSION__` → `the version`.

Verified mechanically rather than by eye — rendering this template with the version and all four checksums taken from the tap's live `Formula/ankra.rb` now reproduces that file **byte for byte**, so the next release is a no-op diff apart from the version and checksums it is meant to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RU7SQqa328gPSqmt3CvJQV
