### PR TITLE
feat(backup): add 'ankra backup vaults' to manage organisation backup vaults (ankra-0xsdd.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Ankra CLI Changelog
 
+## Unreleased
+
+### Added
+
+- **`ankra backup vaults` manages the organisation's backup vaults from the
+  terminal.** A vault is an S3-compatible bucket cluster backups are written
+  to: `create` registers one (the access keys are prompted for when not
+  passed as flags, the secret hidden, so they stay out of your shell
+  history) and reports the platform's immediate credential check - a vault
+  that fails verification exits non-zero with the failure excerpt instead
+  of a green create. `list` shows every vault with its status and when it
+  last verified, `get` describes one - including the failure excerpt when
+  the last check failed - `verify` re-runs the check after rotating or
+  fixing keys, and `delete` confirms first (or takes `--yes`). `get` and
+  `list` take a vault name as well as an id and support `-o json|yaml`.
+
 ## v0.13.0 — 2026-08-25
 
 Promotes v0.13.0-rc0 through rc4 — the kubectl-shaped read surface

--- a/cmd/backup_vaults.go
+++ b/cmd/backup_vaults.go
@@ -1,0 +1,338 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/manifoldco/promptui"
+	"github.com/spf13/cobra"
+)
+
+// backupCmd is the parent command for backup operations.
+var backupCmd = &cobra.Command{
+	Use:   "backup",
+	Short: "Backup operations",
+	Long:  "Commands for managing the organisation's backup infrastructure.",
+}
+
+var backupVaultsCmd = &cobra.Command{
+	Use:     "vaults",
+	Aliases: []string{"vault"},
+	Short:   "Manage backup vaults",
+	Long: "Manage the organisation's backup vaults: S3-compatible object-storage " +
+		"targets that cluster backups are written to. The platform verifies each " +
+		"vault's credentials against its bucket and reports the outcome as the " +
+		"vault's status.",
+}
+
+// backupVaultIDPattern matches the canonical UUID form the API expects for a
+// vault id. Anything else is treated as a vault name to resolve.
+var backupVaultIDPattern = regexp.MustCompile(
+	`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// resolveBackupVaultID accepts either a vault id or a vault name. `backup
+// vaults list` prints a NAME column, so a name is the obvious thing to pass
+// to the next command; resolving it here spares the user a raw server-side
+// uuid-parsing error.
+func resolveBackupVaultID(vaults APIClient, reference string) (string, error) {
+	if backupVaultIDPattern.MatchString(reference) {
+		return reference, nil
+	}
+	listing, listError := vaults.ListBackupVaults()
+	if listError != nil {
+		// The lookup is a convenience, not the operation. If listing is
+		// unavailable, hand the reference to the API unchanged and let the
+		// real call decide.
+		return reference, nil
+	}
+	matched := []client.BackupVault{}
+	for _, vault := range listing.Items {
+		if vault.Name == reference {
+			matched = append(matched, vault)
+		}
+	}
+	switch len(matched) {
+	case 1:
+		return matched[0].ID, nil
+	case 0:
+		return "", fmt.Errorf(
+			"no backup vault named %q - run 'ankra backup vaults list' to see the available vaults", reference)
+	default:
+		identifiers := make([]string, 0, len(matched))
+		for _, vault := range matched {
+			identifiers = append(identifiers, vault.ID)
+		}
+		return "", fmt.Errorf("%d backup vaults are named %q - pass the id instead (%s)",
+			len(matched), reference, strings.Join(identifiers, ", "))
+	}
+}
+
+// backupVaultVerifyHint tells the user what to do after a failed credential
+// check: the stored keys are replaced by recreating them server-side, so the
+// actionable next step is fixing the keys at the provider and re-verifying.
+func backupVaultVerifyHint(vaultName string) string {
+	return fmt.Sprintf("fix the access keys, then run 'ankra backup vaults verify %s'", vaultName)
+}
+
+// backupVaultStatusError turns a vault whose verification failed into a
+// non-zero exit carrying the failure excerpt, so scripts see the broken
+// vault instead of a green create.
+func backupVaultStatusError(vault *client.BackupVault) error {
+	message := fmt.Sprintf("backup vault %q failed verification", vault.Name)
+	if vault.ErrorExcerpt != nil && *vault.ErrorExcerpt != "" {
+		message += ": " + *vault.ErrorExcerpt
+	}
+	return fmt.Errorf("%s - %s", message, backupVaultVerifyHint(vault.Name))
+}
+
+func printBackupVault(vault *client.BackupVault) {
+	fmt.Println("Backup Vault:")
+	fmt.Printf("  Name:          %s\n", vault.Name)
+	fmt.Printf("  ID:            %s\n", vault.ID)
+	fmt.Printf("  Provider:      %s\n", vault.Provider)
+	fmt.Printf("  Endpoint:      %s\n", vault.Endpoint)
+	region := vault.Region
+	if region == "" {
+		region = "-"
+	}
+	fmt.Printf("  Region:        %s\n", region)
+	fmt.Printf("  Bucket:        %s\n", vault.Bucket)
+	pathStyle := "no"
+	if vault.PathStyle {
+		pathStyle = "yes"
+	}
+	fmt.Printf("  Path style:    %s\n", pathStyle)
+	fmt.Printf("  Status:        %s\n", vault.Status)
+	lastVerified := "-"
+	if vault.LastVerifiedAt != nil && *vault.LastVerifiedAt != "" {
+		lastVerified = formatTimeAgo(*vault.LastVerifiedAt)
+	}
+	fmt.Printf("  Last verified: %s\n", lastVerified)
+	fmt.Printf("  Created:       %s\n", formatTimeAgo(vault.CreatedAt))
+	if vault.Status == "error" {
+		fmt.Println("\nLast verification error:")
+		if vault.ErrorExcerpt != nil && *vault.ErrorExcerpt != "" {
+			fmt.Printf("  %s\n", *vault.ErrorExcerpt)
+		} else {
+			fmt.Println("  (no error detail recorded)")
+		}
+		fmt.Printf("\nTo recover: %s\n", backupVaultVerifyHint(vault.Name))
+	}
+}
+
+var backupVaultsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List the organisation's backup vaults",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		listing, listError := apiClient.ListBackupVaults()
+		if listError != nil {
+			return fmt.Errorf("listing backup vaults: %w", listError)
+		}
+		if rendered, renderError := renderStructured(cmd, listing); rendered || renderError != nil {
+			return renderError
+		}
+		if len(listing.Items) == 0 {
+			fmt.Println("No backup vaults found. Create one with 'ankra backup vaults create <name> --endpoint <url> --bucket <bucket>'.")
+			return nil
+		}
+
+		writer := table.NewWriter()
+		writer.SetOutputMirror(os.Stdout)
+		writer.SetStyle(table.StyleRounded)
+		writer.AppendHeader(table.Row{"Name", "Provider", "Bucket", "Endpoint", "Status", "Last Verified"})
+		for _, vault := range listing.Items {
+			lastVerified := "-"
+			if vault.LastVerifiedAt != nil && *vault.LastVerifiedAt != "" {
+				lastVerified = formatTimeAgo(*vault.LastVerifiedAt)
+			}
+			writer.AppendRow(table.Row{
+				vault.Name,
+				vault.Provider,
+				vault.Bucket,
+				vault.Endpoint,
+				vault.Status,
+				lastVerified,
+			})
+		}
+		writer.Render()
+		return nil
+	},
+}
+
+var backupVaultsGetCmd = &cobra.Command{
+	Use:   "get [vault-name|vault-id]",
+	Short: "Show a backup vault's details and verification status",
+	Long: "Describe a backup vault: its endpoint, bucket, verification status, " +
+		"and - when the last credential check failed - the failure excerpt.",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		vaultID, resolveError := resolveBackupVaultID(apiClient, args[0])
+		if resolveError != nil {
+			return resolveError
+		}
+		vault, getError := apiClient.GetBackupVault(vaultID)
+		if getError != nil {
+			return fmt.Errorf("getting backup vault: %w", getError)
+		}
+		if rendered, renderError := renderStructured(cmd, vault); rendered || renderError != nil {
+			return renderError
+		}
+		printBackupVault(vault)
+		return nil
+	},
+}
+
+var backupVaultsCreateCmd = &cobra.Command{
+	Use:   "create <name>",
+	Short: "Create a backup vault backed by an S3-compatible bucket",
+	Long: `Create a backup vault: an S3-compatible bucket cluster backups are written to.
+
+The access keys are prompted for interactively when not passed as flags, so
+they never have to appear in your shell history. The platform verifies the
+keys against the bucket immediately and the command reports the outcome.
+
+Example:
+  ankra backup vaults create offsite --endpoint https://s3.example.com --bucket cluster-backups`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		endpoint, _ := cmd.Flags().GetString("endpoint")
+		bucket, _ := cmd.Flags().GetString("bucket")
+		provider, _ := cmd.Flags().GetString("provider")
+		region, _ := cmd.Flags().GetString("region")
+		pathStyle, _ := cmd.Flags().GetBool("path-style")
+		accessKeyID, _ := cmd.Flags().GetString("access-key-id")
+		secretAccessKey, _ := cmd.Flags().GetString("secret-access-key")
+
+		if accessKeyID == "" {
+			prompt := promptui.Prompt{
+				Label: "Access key ID",
+				Validate: func(input string) error {
+					if len(input) == 0 {
+						return fmt.Errorf("access key ID cannot be empty")
+					}
+					return nil
+				},
+			}
+			promptedValue, promptError := prompt.Run()
+			if promptError != nil {
+				return errors.New("prompt cancelled")
+			}
+			accessKeyID = promptedValue
+		}
+		if secretAccessKey == "" {
+			prompt := promptui.Prompt{
+				Label: "Secret access key",
+				Mask:  '*',
+				Validate: func(input string) error {
+					if len(input) == 0 {
+						return fmt.Errorf("secret access key cannot be empty")
+					}
+					return nil
+				},
+			}
+			promptedValue, promptError := prompt.Run()
+			if promptError != nil {
+				return errors.New("prompt cancelled")
+			}
+			secretAccessKey = promptedValue
+		}
+
+		vault, createError := apiClient.CreateBackupVault(client.CreateBackupVaultRequest{
+			Name:            name,
+			Provider:        provider,
+			Endpoint:        endpoint,
+			Region:          region,
+			Bucket:          bucket,
+			PathStyle:       pathStyle,
+			AccessKeyID:     accessKeyID,
+			SecretAccessKey: secretAccessKey,
+		})
+		if createError != nil {
+			return fmt.Errorf("creating backup vault: %w", createError)
+		}
+
+		printBackupVault(vault)
+		if vault.Status == "error" {
+			return backupVaultStatusError(vault)
+		}
+		fmt.Printf("\nBackup vault '%s' created (status: %s).\n", vault.Name, vault.Status)
+		return nil
+	},
+}
+
+var backupVaultsVerifyCmd = &cobra.Command{
+	Use:   "verify [vault-name|vault-id]",
+	Short: "Re-check a backup vault's credentials against its bucket",
+	Long: "Re-run the platform's credential check against the vault's bucket and " +
+		"report the new status. Use this after rotating or fixing the access keys.",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		vaultID, resolveError := resolveBackupVaultID(apiClient, args[0])
+		if resolveError != nil {
+			return resolveError
+		}
+		vault, verifyError := apiClient.VerifyBackupVault(vaultID)
+		if verifyError != nil {
+			return fmt.Errorf("verifying backup vault: %w", verifyError)
+		}
+		if vault.Status == "error" {
+			return backupVaultStatusError(vault)
+		}
+		fmt.Printf("Backup vault '%s' verified (status: %s).\n", vault.Name, vault.Status)
+		return nil
+	},
+}
+
+var backupVaultsDeleteCmd = &cobra.Command{
+	Use:   "delete [vault-name|vault-id]",
+	Short: "Delete a backup vault",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		yes, _ := cmd.Flags().GetBool("yes")
+		vaultID, resolveError := resolveBackupVaultID(apiClient, args[0])
+		if resolveError != nil {
+			return resolveError
+		}
+		if confirmError := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Delete backup vault %q? [y/N]: ", args[0]), yes); confirmError != nil {
+			return confirmError
+		}
+		if deleteError := apiClient.DeleteBackupVault(vaultID); deleteError != nil {
+			return fmt.Errorf("deleting backup vault: %w", deleteError)
+		}
+		fmt.Printf("Backup vault '%s' deleted.\n", args[0])
+		return nil
+	},
+}
+
+func init() {
+	backupVaultsCreateCmd.Flags().String("endpoint", "", "S3-compatible endpoint URL (required)")
+	backupVaultsCreateCmd.Flags().String("bucket", "", "Bucket the backups are written to (required)")
+	backupVaultsCreateCmd.Flags().String("provider", "other", "Object-storage provider")
+	backupVaultsCreateCmd.Flags().String("region", "", "Bucket region (leave empty when the endpoint implies it)")
+	backupVaultsCreateCmd.Flags().Bool("path-style", true, "Address the bucket path-style (https://endpoint/bucket) instead of virtual-hosted-style")
+	backupVaultsCreateCmd.Flags().String("access-key-id", "", "Access key ID (prompted for when omitted)")
+	backupVaultsCreateCmd.Flags().String("secret-access-key", "", "Secret access key (prompted for hidden when omitted; prefer the prompt so the key stays out of your shell history)")
+	_ = backupVaultsCreateCmd.MarkFlagRequired("endpoint")
+	_ = backupVaultsCreateCmd.MarkFlagRequired("bucket")
+
+	backupVaultsDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
+
+	registerStructuredOutputFlags(backupVaultsListCmd, backupVaultsGetCmd)
+
+	backupVaultsCmd.AddCommand(backupVaultsListCmd)
+	backupVaultsCmd.AddCommand(backupVaultsGetCmd)
+	backupVaultsCmd.AddCommand(backupVaultsCreateCmd)
+	backupVaultsCmd.AddCommand(backupVaultsVerifyCmd)
+	backupVaultsCmd.AddCommand(backupVaultsDeleteCmd)
+
+	backupCmd.AddCommand(backupVaultsCmd)
+	rootCmd.AddCommand(backupCmd)
+}

--- a/cmd/backup_vaults_test.go
+++ b/cmd/backup_vaults_test.go
@@ -1,0 +1,389 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+// backupVaultsMock answers the backup vault surface and records what the
+// commands sent, so the tests can assert the wire-facing behaviour without
+// a server.
+type backupVaultsMock struct {
+	baseMock
+	vaults        []client.BackupVault
+	listError     error
+	listCalls     int
+	vault         *client.BackupVault
+	created       *client.CreateBackupVaultRequest
+	createdVault  *client.BackupVault
+	verifiedVault *client.BackupVault
+	deletedID     string
+	deleteCalls   int
+}
+
+func (mock *backupVaultsMock) ListBackupVaults() (*client.BackupVaultListResult, error) {
+	mock.listCalls++
+	if mock.listError != nil {
+		return nil, mock.listError
+	}
+	return &client.BackupVaultListResult{Items: mock.vaults}, nil
+}
+
+func (mock *backupVaultsMock) GetBackupVault(vaultID string) (*client.BackupVault, error) {
+	if mock.vault == nil || mock.vault.ID != vaultID {
+		return nil, errors.New("Backup vault not found.")
+	}
+	return mock.vault, nil
+}
+
+func (mock *backupVaultsMock) CreateBackupVault(request client.CreateBackupVaultRequest) (*client.BackupVault, error) {
+	mock.created = &request
+	return mock.createdVault, nil
+}
+
+func (mock *backupVaultsMock) VerifyBackupVault(vaultID string) (*client.BackupVault, error) {
+	if mock.verifiedVault == nil {
+		return nil, errors.New("Backup vault not found.")
+	}
+	return mock.verifiedVault, nil
+}
+
+func (mock *backupVaultsMock) DeleteBackupVault(vaultID string) error {
+	mock.deleteCalls++
+	mock.deletedID = vaultID
+	return nil
+}
+
+// resetBackupVaultsFlags restores the backup vault commands' flag values and
+// Changed markers before and after each test: the cobra tree is shared across
+// the test binary, so an earlier invocation's flags would otherwise leak.
+func resetBackupVaultsFlags(t *testing.T) {
+	t.Helper()
+	reset := func() {
+		createFlags := backupVaultsCreateCmd.Flags()
+		for name, value := range map[string]string{
+			"endpoint":          "",
+			"bucket":            "",
+			"provider":          "other",
+			"region":            "",
+			"path-style":        "true",
+			"access-key-id":     "",
+			"secret-access-key": "",
+		} {
+			_ = createFlags.Set(name, value)
+			createFlags.Lookup(name).Changed = false
+		}
+		_ = backupVaultsDeleteCmd.Flags().Set("yes", "false")
+		backupVaultsDeleteCmd.Flags().Lookup("yes").Changed = false
+		_ = backupVaultsListCmd.Flags().Set("output", "")
+		backupVaultsListCmd.Flags().Lookup("output").Changed = false
+		_ = backupVaultsGetCmd.Flags().Set("output", "")
+		backupVaultsGetCmd.Flags().Lookup("output").Changed = false
+	}
+	reset()
+	t.Cleanup(reset)
+}
+
+const backupVaultTestID = "0d9c1f9e-5f2a-4c53-9d3e-6a1f2b3c4d5e"
+
+func TestResolveBackupVaultIDPassesAUUIDStraightThrough(t *testing.T) {
+	mock := &backupVaultsMock{listError: errors.New("listing must not be called for a uuid")}
+
+	resolved, resolveError := resolveBackupVaultID(mock, backupVaultTestID)
+
+	if resolveError != nil {
+		t.Fatalf("a uuid must resolve to itself: %v", resolveError)
+	}
+	if resolved != backupVaultTestID {
+		t.Fatalf("expected %q, got %q", backupVaultTestID, resolved)
+	}
+	if mock.listCalls != 0 {
+		t.Fatal("resolving a uuid must not cost a listing round-trip")
+	}
+}
+
+func TestResolveBackupVaultIDResolvesAName(t *testing.T) {
+	mock := &backupVaultsMock{vaults: []client.BackupVault{
+		{ID: "aaaaaaaa-1111-4111-8111-111111111111", Name: "minio-lab"},
+		{ID: backupVaultTestID, Name: "offsite"},
+	}}
+
+	resolved, resolveError := resolveBackupVaultID(mock, "offsite")
+
+	if resolveError != nil {
+		t.Fatalf("resolving a name printed by `list`: %v", resolveError)
+	}
+	if resolved != backupVaultTestID {
+		t.Fatalf("resolved to the wrong vault: %q", resolved)
+	}
+}
+
+func TestResolveBackupVaultIDExplainsAnUnknownName(t *testing.T) {
+	mock := &backupVaultsMock{vaults: []client.BackupVault{{ID: "id-1", Name: "offsite"}}}
+
+	_, resolveError := resolveBackupVaultID(mock, "offsit")
+
+	if resolveError == nil {
+		t.Fatal("an unknown name must be reported, not passed to the API as a bogus uuid")
+	}
+	if !strings.Contains(resolveError.Error(), "backup vaults list") {
+		t.Fatalf("the error must point at how to find the right name, got: %v", resolveError)
+	}
+}
+
+func TestResolveBackupVaultIDReportsDuplicateNames(t *testing.T) {
+	mock := &backupVaultsMock{vaults: []client.BackupVault{
+		{ID: "aaaaaaaa-1111-4111-8111-111111111111", Name: "offsite"},
+		{ID: "bbbbbbbb-2222-4222-8222-222222222222", Name: "offsite"},
+	}}
+
+	_, resolveError := resolveBackupVaultID(mock, "offsite")
+
+	if resolveError == nil {
+		t.Fatal("duplicate names must be reported so the user passes an id")
+	}
+	if !strings.Contains(resolveError.Error(), "aaaaaaaa-1111-4111-8111-111111111111") ||
+		!strings.Contains(resolveError.Error(), "bbbbbbbb-2222-4222-8222-222222222222") {
+		t.Fatalf("the error must list the candidate ids, got: %v", resolveError)
+	}
+}
+
+func TestResolveBackupVaultIDFallsBackWhenLookupIsUnavailable(t *testing.T) {
+	mock := &backupVaultsMock{listError: errors.New("listing unavailable")}
+
+	resolved, resolveError := resolveBackupVaultID(mock, "offsite")
+
+	if resolveError != nil {
+		t.Fatalf("a failed lookup must not fail the command: %v", resolveError)
+	}
+	if resolved != "offsite" {
+		t.Fatalf("the reference must pass through unchanged, got %q", resolved)
+	}
+}
+
+func TestBackupVaultsListRendersEveryColumn(t *testing.T) {
+	lastVerifiedAt := "2026-08-25T09:00:00Z"
+	mock := &backupVaultsMock{vaults: []client.BackupVault{
+		{ID: backupVaultTestID, Name: "offsite", Provider: "other",
+			Endpoint: "https://s3.example.com", Bucket: "cluster-backups",
+			Status: "ready", LastVerifiedAt: &lastVerifiedAt},
+	}}
+	setMockClient(t, mock)
+	resetBackupVaultsFlags(t)
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("backup", "vaults", "list")
+	})
+
+	for _, expected := range []string{
+		"NAME", "PROVIDER", "BUCKET", "ENDPOINT", "STATUS", "LAST VERIFIED",
+		"offsite", "other", "cluster-backups", "https://s3.example.com", "ready",
+	} {
+		if !strings.Contains(stripANSICodes(stdoutOutput), expected) {
+			t.Errorf("expected output to contain %q, got: %s", expected, stdoutOutput)
+		}
+	}
+}
+
+func TestBackupVaultsListEmptySuggestsCreate(t *testing.T) {
+	mock := &backupVaultsMock{}
+	setMockClient(t, mock)
+	resetBackupVaultsFlags(t)
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("backup", "vaults", "list")
+	})
+
+	if !strings.Contains(stdoutOutput, "No backup vaults found") ||
+		!strings.Contains(stdoutOutput, "ankra backup vaults create") {
+		t.Fatalf("an empty listing must point at create, got: %s", stdoutOutput)
+	}
+}
+
+func TestBackupVaultsGetPrintsErrorExcerptAndRecoveryHint(t *testing.T) {
+	excerpt := "SignatureDoesNotMatch: the request signature we calculated does not match"
+	mock := &backupVaultsMock{vault: &client.BackupVault{
+		ID: backupVaultTestID, Name: "offsite", Provider: "other",
+		Endpoint: "https://s3.example.com", Bucket: "cluster-backups",
+		Status: "error", ErrorExcerpt: &excerpt,
+	}}
+	setMockClient(t, mock)
+	resetBackupVaultsFlags(t)
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("backup", "vaults", "get", backupVaultTestID)
+	})
+
+	if !strings.Contains(stdoutOutput, "SignatureDoesNotMatch") {
+		t.Errorf("expected the error excerpt in the output, got: %s", stdoutOutput)
+	}
+	if !strings.Contains(stdoutOutput, "ankra backup vaults verify offsite") {
+		t.Errorf("expected the verify recovery hint, got: %s", stdoutOutput)
+	}
+}
+
+func TestBackupVaultsGetResolvesAName(t *testing.T) {
+	mock := &backupVaultsMock{
+		vaults: []client.BackupVault{{ID: backupVaultTestID, Name: "offsite"}},
+		vault: &client.BackupVault{
+			ID: backupVaultTestID, Name: "offsite", Provider: "other", Status: "ready"},
+	}
+	setMockClient(t, mock)
+	resetBackupVaultsFlags(t)
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("backup", "vaults", "get", "offsite")
+	})
+
+	if !strings.Contains(stdoutOutput, backupVaultTestID) {
+		t.Fatalf("expected the vault resolved by name to be printed, got: %s", stdoutOutput)
+	}
+}
+
+func TestBackupVaultsCreateSendsFlagsWithoutPrompting(t *testing.T) {
+	mock := &backupVaultsMock{createdVault: &client.BackupVault{
+		ID: backupVaultTestID, Name: "offsite", Provider: "other", Status: "ready"}}
+	setMockClient(t, mock)
+	resetBackupVaultsFlags(t)
+
+	var executeError error
+	stdoutOutput := captureStdout(t, func() {
+		_, executeError = executeCommand("backup", "vaults", "create", "offsite",
+			"--endpoint", "https://s3.example.com",
+			"--bucket", "cluster-backups",
+			"--region", "eu-north-1",
+			"--path-style=false",
+			"--access-key-id", "AKIA123",
+			"--secret-access-key", "shhh")
+	})
+
+	if executeError != nil {
+		t.Fatalf("create with a ready outcome must succeed: %v", executeError)
+	}
+	if mock.created == nil {
+		t.Fatal("the create request never reached the client")
+	}
+	expected := client.CreateBackupVaultRequest{
+		Name: "offsite", Provider: "other", Endpoint: "https://s3.example.com",
+		Region: "eu-north-1", Bucket: "cluster-backups", PathStyle: false,
+		AccessKeyID: "AKIA123", SecretAccessKey: "shhh",
+	}
+	if *mock.created != expected {
+		t.Fatalf("request = %+v, want %+v", *mock.created, expected)
+	}
+	if !strings.Contains(stdoutOutput, "created") || !strings.Contains(stdoutOutput, "ready") {
+		t.Errorf("expected a creation confirmation with the status, got: %s", stdoutOutput)
+	}
+}
+
+func TestBackupVaultsCreateFailedVerificationExitsNonZero(t *testing.T) {
+	excerpt := "AccessDenied: access denied"
+	mock := &backupVaultsMock{createdVault: &client.BackupVault{
+		ID: backupVaultTestID, Name: "offsite", Status: "error", ErrorExcerpt: &excerpt}}
+	setMockClient(t, mock)
+	resetBackupVaultsFlags(t)
+
+	var executeError error
+	captureStdout(t, func() {
+		_, executeError = executeCommand("backup", "vaults", "create", "offsite",
+			"--endpoint", "https://s3.example.com",
+			"--bucket", "cluster-backups",
+			"--access-key-id", "AKIA123",
+			"--secret-access-key", "wrong")
+	})
+
+	if executeError == nil {
+		t.Fatal("a vault created in status error must exit non-zero")
+	}
+	if !strings.Contains(executeError.Error(), "AccessDenied") {
+		t.Errorf("the error must carry the excerpt, got: %v", executeError)
+	}
+	if !strings.Contains(executeError.Error(), "ankra backup vaults verify offsite") {
+		t.Errorf("the error must point at verify after fixing the keys, got: %v", executeError)
+	}
+}
+
+func TestBackupVaultsVerifyPrintsTheNewStatus(t *testing.T) {
+	mock := &backupVaultsMock{verifiedVault: &client.BackupVault{
+		ID: backupVaultTestID, Name: "offsite", Status: "ready"}}
+	setMockClient(t, mock)
+	resetBackupVaultsFlags(t)
+
+	var executeError error
+	stdoutOutput := captureStdout(t, func() {
+		_, executeError = executeCommand("backup", "vaults", "verify", backupVaultTestID)
+	})
+
+	if executeError != nil {
+		t.Fatalf("verify with a ready outcome must succeed: %v", executeError)
+	}
+	if !strings.Contains(stdoutOutput, "ready") {
+		t.Errorf("expected the refreshed status, got: %s", stdoutOutput)
+	}
+}
+
+func TestBackupVaultsVerifyFailureExitsNonZero(t *testing.T) {
+	excerpt := "connection refused"
+	mock := &backupVaultsMock{verifiedVault: &client.BackupVault{
+		ID: backupVaultTestID, Name: "offsite", Status: "error", ErrorExcerpt: &excerpt}}
+	setMockClient(t, mock)
+	resetBackupVaultsFlags(t)
+
+	var executeError error
+	captureStdout(t, func() {
+		_, executeError = executeCommand("backup", "vaults", "verify", backupVaultTestID)
+	})
+
+	if executeError == nil {
+		t.Fatal("a verification that leaves the vault in error must exit non-zero")
+	}
+	if !strings.Contains(executeError.Error(), "connection refused") {
+		t.Errorf("the error must carry the excerpt, got: %v", executeError)
+	}
+}
+
+func TestBackupVaultsDeleteDeclinedLeavesTheVault(t *testing.T) {
+	mock := &backupVaultsMock{vaults: []client.BackupVault{
+		{ID: backupVaultTestID, Name: "offsite"}}}
+	setMockClient(t, mock)
+	resetBackupVaultsFlags(t)
+	rootCmd.SetIn(strings.NewReader("n\n"))
+	t.Cleanup(func() { rootCmd.SetIn(nil) })
+
+	_, executeError := executeCommand("backup", "vaults", "delete", "offsite")
+
+	if executeError == nil {
+		t.Fatal("declining the confirmation must not succeed silently")
+	}
+	if got := exitCodeFor(executeError); got != exitCancelled {
+		t.Errorf("declined confirmation should exit %d, got %d", exitCancelled, got)
+	}
+	if mock.deleteCalls != 0 {
+		t.Errorf("expected no delete call after a declined confirmation, got %d", mock.deleteCalls)
+	}
+}
+
+func TestBackupVaultsDeleteYesSkipsThePrompt(t *testing.T) {
+	mock := &backupVaultsMock{vaults: []client.BackupVault{
+		{ID: backupVaultTestID, Name: "offsite"}}}
+	setMockClient(t, mock)
+	resetBackupVaultsFlags(t)
+
+	var executeError error
+	stdoutOutput := captureStdout(t, func() {
+		_, executeError = executeCommand("backup", "vaults", "delete", "offsite", "--yes")
+	})
+
+	if executeError != nil {
+		t.Fatalf("delete --yes must not prompt: %v", executeError)
+	}
+	if mock.deletedID != backupVaultTestID {
+		t.Errorf("expected the resolved vault id to be deleted, got %q", mock.deletedID)
+	}
+	if !strings.Contains(stdoutOutput, "deleted") {
+		t.Errorf("expected a deletion confirmation, got: %s", stdoutOutput)
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -491,6 +491,26 @@ func (m baseMock) DeletePowerSchedule(clusterID, scheduleID string) (*client.Del
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) ListBackupVaults() (*client.BackupVaultListResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetBackupVault(vaultID string) (*client.BackupVault, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) CreateBackupVault(request client.CreateBackupVaultRequest) (*client.BackupVault, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) VerifyBackupVault(vaultID string) (*client.BackupVault, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) DeleteBackupVault(vaultID string) error {
+	return errors.New("not implemented")
+}
+
 func (m baseMock) ListExecutions(opts client.ListExecutionsOptions) (client.ExecutionListResponse, error) {
 	return client.ExecutionListResponse{}, errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -42,6 +42,12 @@ type APIClient interface {
 	UpdatePowerSchedule(clusterID, scheduleID string, request client.PowerScheduleRequest) (*client.PowerScheduleListResult, error)
 	DeletePowerSchedule(clusterID, scheduleID string) (*client.DeletePowerScheduleResult, error)
 
+	ListBackupVaults() (*client.BackupVaultListResult, error)
+	GetBackupVault(vaultID string) (*client.BackupVault, error)
+	CreateBackupVault(request client.CreateBackupVaultRequest) (*client.BackupVault, error)
+	VerifyBackupVault(vaultID string) (*client.BackupVault, error)
+	DeleteBackupVault(vaultID string) error
+
 	ListExecutions(opts client.ListExecutionsOptions) (client.ExecutionListResponse, error)
 	GetExecution(executionID string) (client.ExecutionDetail, error)
 	GetExecutionResult(executionID string) (client.ExecutionResultResponse, error)

--- a/internal/client/backup_vaults.go
+++ b/internal/client/backup_vaults.go
@@ -1,0 +1,100 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+	neturl "net/url"
+)
+
+// BackupVault is one organisation-level object-storage backup target. Status
+// is "provisioning" while the platform has not yet checked the credentials,
+// "ready" once a verification succeeded, and "error" when the last check
+// failed - ErrorExcerpt then carries the failure's first lines. Credential
+// material is never returned.
+type BackupVault struct {
+	ID             string  `json:"id"`
+	Name           string  `json:"name"`
+	Kind           string  `json:"kind"`
+	Provider       string  `json:"provider"`
+	Endpoint       string  `json:"endpoint"`
+	Region         string  `json:"region"`
+	Bucket         string  `json:"bucket"`
+	PathStyle      bool    `json:"path_style"`
+	Status         string  `json:"status"`
+	ErrorExcerpt   *string `json:"error_excerpt,omitempty"`
+	LastVerifiedAt *string `json:"last_verified_at,omitempty"`
+	CreatedAt      string  `json:"created_at"`
+	UpdatedAt      string  `json:"updated_at"`
+}
+
+// BackupVaultListResult wraps the organisation's backup vault listing.
+type BackupVaultListResult struct {
+	Items []BackupVault `json:"items"`
+}
+
+// CreateBackupVaultRequest is the body for creating a backup vault. The
+// platform verifies the credentials against the bucket synchronously, so the
+// returned vault already carries the verification outcome in Status.
+type CreateBackupVaultRequest struct {
+	Name            string `json:"name"`
+	Provider        string `json:"provider"`
+	Endpoint        string `json:"endpoint"`
+	Region          string `json:"region"`
+	Bucket          string `json:"bucket"`
+	PathStyle       bool   `json:"path_style"`
+	AccessKeyID     string `json:"access_key_id"`
+	SecretAccessKey string `json:"secret_access_key"`
+}
+
+// ListBackupVaults returns the organisation's backup vaults.
+// GET /api/v1/org/backup-vaults
+func (c *Client) ListBackupVaults() (*BackupVaultListResult, error) {
+	url := fmt.Sprintf("%s/api/v1/org/backup-vaults", c.BaseURL)
+	var result BackupVaultListResult
+	if requestError := c.sendJSON(http.MethodGet, url, nil, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// GetBackupVault returns one backup vault by id.
+// GET /api/v1/org/backup-vaults/{vault_id}
+func (c *Client) GetBackupVault(vaultID string) (*BackupVault, error) {
+	url := fmt.Sprintf("%s/api/v1/org/backup-vaults/%s", c.BaseURL, neturl.PathEscape(vaultID))
+	var result BackupVault
+	if requestError := c.sendJSON(http.MethodGet, url, nil, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// CreateBackupVault creates a backup vault and returns it with the outcome
+// of the platform's synchronous credential verification.
+// POST /api/v1/org/backup-vaults
+func (c *Client) CreateBackupVault(request CreateBackupVaultRequest) (*BackupVault, error) {
+	url := fmt.Sprintf("%s/api/v1/org/backup-vaults", c.BaseURL)
+	var result BackupVault
+	if requestError := c.sendJSON(http.MethodPost, url, request, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// VerifyBackupVault re-runs the credential check against the vault's bucket
+// and returns the vault with its refreshed status.
+// POST /api/v1/org/backup-vaults/{vault_id}/verify
+func (c *Client) VerifyBackupVault(vaultID string) (*BackupVault, error) {
+	url := fmt.Sprintf("%s/api/v1/org/backup-vaults/%s/verify", c.BaseURL, neturl.PathEscape(vaultID))
+	var result BackupVault
+	if requestError := c.sendJSON(http.MethodPost, url, nil, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// DeleteBackupVault deletes one backup vault.
+// DELETE /api/v1/org/backup-vaults/{vault_id}
+func (c *Client) DeleteBackupVault(vaultID string) error {
+	url := fmt.Sprintf("%s/api/v1/org/backup-vaults/%s", c.BaseURL, neturl.PathEscape(vaultID))
+	return c.sendJSON(http.MethodDelete, url, nil, nil)
+}

--- a/internal/client/backup_vaults_test.go
+++ b/internal/client/backup_vaults_test.go
@@ -1,0 +1,208 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestListBackupVaults_Success(t *testing.T) {
+	lastVerifiedAt := "2026-08-25T09:00:00Z"
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/org/backup-vaults" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+testToken {
+			t.Errorf("Authorization = %q", got)
+		}
+		jsonResponse(t, w, http.StatusOK, BackupVaultListResult{Items: []BackupVault{
+			{ID: "vault-1", Name: "offsite", Provider: "other", Endpoint: "https://s3.example.com",
+				Bucket: "cluster-backups", PathStyle: true, Status: "ready", LastVerifiedAt: &lastVerifiedAt},
+		}})
+	}
+	testClient := newTestClient(t, handler)
+	result, listError := testClient.ListBackupVaults()
+	if listError != nil {
+		t.Fatalf("ListBackupVaults: %v", listError)
+	}
+	if len(result.Items) != 1 || result.Items[0].Name != "offsite" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if result.Items[0].LastVerifiedAt == nil || *result.Items[0].LastVerifiedAt != lastVerifiedAt {
+		t.Errorf("LastVerifiedAt = %v, want %s", result.Items[0].LastVerifiedAt, lastVerifiedAt)
+	}
+}
+
+func TestListBackupVaults_Empty(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(t, w, http.StatusOK, BackupVaultListResult{Items: []BackupVault{}})
+	}
+	testClient := newTestClient(t, handler)
+	result, listError := testClient.ListBackupVaults()
+	if listError != nil {
+		t.Fatalf("ListBackupVaults: %v", listError)
+	}
+	if len(result.Items) != 0 {
+		t.Fatalf("expected an empty listing, got: %+v", result)
+	}
+}
+
+func TestCreateBackupVault_SendsBodyAndDecodesVault(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/org/backup-vaults" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		var body map[string]any
+		if decodeError := json.NewDecoder(r.Body).Decode(&body); decodeError != nil {
+			t.Fatalf("decoding body: %v", decodeError)
+		}
+		if body["name"] != "offsite" || body["provider"] != "other" ||
+			body["endpoint"] != "https://s3.example.com" || body["region"] != "" ||
+			body["bucket"] != "cluster-backups" || body["path_style"] != true ||
+			body["access_key_id"] != "AKIA123" || body["secret_access_key"] != "shhh" {
+			t.Errorf("unexpected body: %+v", body)
+		}
+		jsonResponse(t, w, http.StatusOK, BackupVault{
+			ID: "vault-new", Name: "offsite", Provider: "other", Status: "ready"})
+	}
+	testClient := newTestClient(t, handler)
+	vault, createError := testClient.CreateBackupVault(CreateBackupVaultRequest{
+		Name: "offsite", Provider: "other", Endpoint: "https://s3.example.com",
+		Bucket: "cluster-backups", PathStyle: true,
+		AccessKeyID: "AKIA123", SecretAccessKey: "shhh",
+	})
+	if createError != nil {
+		t.Fatalf("CreateBackupVault: %v", createError)
+	}
+	if vault.ID != "vault-new" || vault.Status != "ready" {
+		t.Fatalf("unexpected result: %+v", vault)
+	}
+}
+
+func TestCreateBackupVault_ValidationDetailSurfaces(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(t, w, http.StatusBadRequest, map[string]string{
+			"detail": "A backup vault named 'offsite' already exists."})
+	}
+	testClient := newTestClient(t, handler)
+	_, createError := testClient.CreateBackupVault(CreateBackupVaultRequest{Name: "offsite"})
+	if createError == nil || !strings.Contains(createError.Error(), "already exists") {
+		t.Fatalf("expected the backend detail to surface, got %v", createError)
+	}
+	var unexpected *UnexpectedResponseError
+	if !errors.As(createError, &unexpected) || unexpected.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected an UnexpectedResponseError carrying 400, got %v", createError)
+	}
+}
+
+func TestCreateBackupVault_PermissionDeniedMapsToTypedError(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(t, w, http.StatusForbidden, map[string]string{
+			"detail": "permission_denied", "permission": "backups.manage"})
+	}
+	testClient := newTestClient(t, handler)
+	_, createError := testClient.CreateBackupVault(CreateBackupVaultRequest{Name: "offsite"})
+	var denied *PermissionDeniedError
+	if !errors.As(createError, &denied) {
+		t.Fatalf("expected a PermissionDeniedError, got %v", createError)
+	}
+	if denied.Permission != "backups.manage" {
+		t.Errorf("Permission = %q, want backups.manage", denied.Permission)
+	}
+}
+
+func TestGetBackupVault_ReturnsErrorExcerpt(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/org/backup-vaults/vault-1" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		jsonResponse(t, w, http.StatusOK, BackupVault{
+			ID: "vault-1", Name: "offsite", Status: "error",
+			ErrorExcerpt: strPtr("SignatureDoesNotMatch: the request signature we calculated does not match")})
+	}
+	testClient := newTestClient(t, handler)
+	vault, getError := testClient.GetBackupVault("vault-1")
+	if getError != nil {
+		t.Fatalf("GetBackupVault: %v", getError)
+	}
+	if vault.Status != "error" || vault.ErrorExcerpt == nil ||
+		!strings.Contains(*vault.ErrorExcerpt, "SignatureDoesNotMatch") {
+		t.Fatalf("unexpected result: %+v", vault)
+	}
+}
+
+func TestGetBackupVault_NotFoundCarries404(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(t, w, http.StatusNotFound, map[string]string{
+			"detail": "Backup vault not found."})
+	}
+	testClient := newTestClient(t, handler)
+	_, getError := testClient.GetBackupVault("vault-missing")
+	if getError == nil || !strings.Contains(getError.Error(), "Backup vault not found.") {
+		t.Fatalf("expected the backend detail to surface, got %v", getError)
+	}
+	var unexpected *UnexpectedResponseError
+	if !errors.As(getError, &unexpected) || unexpected.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected an UnexpectedResponseError carrying 404, got %v", getError)
+	}
+}
+
+func TestVerifyBackupVault_PostsAndDecodesRefreshedStatus(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/org/backup-vaults/vault-1/verify" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		jsonResponse(t, w, http.StatusOK, BackupVault{ID: "vault-1", Name: "offsite", Status: "ready"})
+	}
+	testClient := newTestClient(t, handler)
+	vault, verifyError := testClient.VerifyBackupVault("vault-1")
+	if verifyError != nil {
+		t.Fatalf("VerifyBackupVault: %v", verifyError)
+	}
+	if vault.Status != "ready" {
+		t.Fatalf("unexpected result: %+v", vault)
+	}
+}
+
+func TestDeleteBackupVault_AcceptsNoContent(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("method = %s, want DELETE", r.Method)
+		}
+		if r.URL.Path != "/api/v1/org/backup-vaults/vault-1" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+	testClient := newTestClient(t, handler)
+	if deleteError := testClient.DeleteBackupVault("vault-1"); deleteError != nil {
+		t.Fatalf("DeleteBackupVault: %v", deleteError)
+	}
+}
+
+func TestDeleteBackupVault_NotFoundCarries404(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(t, w, http.StatusNotFound, map[string]string{
+			"detail": "Backup vault not found."})
+	}
+	testClient := newTestClient(t, handler)
+	deleteError := testClient.DeleteBackupVault("vault-missing")
+	var unexpected *UnexpectedResponseError
+	if !errors.As(deleteError, &unexpected) || unexpected.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected an UnexpectedResponseError carrying 404, got %v", deleteError)
+	}
+}


### PR DESCRIPTION
## What & why

Adds the `ankra backup vaults` command group so organisation backup vaults — S3-compatible buckets cluster backups are written to — can be managed from the terminal. The server surface merged CI-green as ankraio/cluster#1937.

- `ankra backup vaults list` — table of NAME, PROVIDER, BUCKET, ENDPOINT, STATUS, LAST VERIFIED; an empty listing points at `create`.
- `ankra backup vaults get <name-or-id>` — details including the failure excerpt and a recovery hint when the last credential check failed.
- `ankra backup vaults create <name> --endpoint --bucket [--provider|--region|--path-style|--access-key-id|--secret-access-key]` — missing keys are prompted for interactively (secret hidden, following the existing credential-prompt pattern); the platform's synchronous verification outcome is reported, and a vault created in status `error` exits non-zero with the excerpt and a hint to fix the keys then run `verify`.
- `ankra backup vaults verify <name-or-id>` — re-runs the check and prints the new status (non-zero when it fails).
- `ankra backup vaults delete <name-or-id> [--yes]` — confirms first; declining exits 4.

`get`/`verify`/`delete` accept a vault name as well as a UUID (the house name-or-UUID resolution pattern), and `list`/`get` support `-o json|yaml`. The client rides the shared `sendJSON` helper, so backend `detail` strings surface, RBAC 403 (`backups.manage`) maps to exit 7, and 404 maps to exit 3.

Bead: ankra-0xsdd.1

## Test plan

- `go build ./...`, `go vet ./...`, `go test -race -count=1 ./...` — green locally (pre-commit hook re-ran tests + golangci-lint, 0 issues).
- New httptest client tests: list happy/empty, create body round-trip, 400 detail surfacing, 403 `permission_denied` → typed error, 404 carrying the status, verify, delete 204.
- New command tests: name/UUID resolution (passthrough, unknown-name guidance, duplicate names, lookup fallback), list columns + empty-state hint, get error-excerpt rendering, create flag wiring without prompting + non-zero exit on failed verification, verify status output + failure exit, delete confirm-declined (exit 4, no API call) and `--yes`.

## Docs checklist

- [x] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); `Short`/`Long`/`Example` on the new commands are written for docs readers
- [ ] No user-facing command/flag changes — no docs needed
- [ ] Broader behaviour changes — docs updated in [ankra-docs](https://github.com/ankraio/ankra-docs) (link the PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQdNseeg1R1zPKXkGWuZFt
