### PR TITLE
fix(kubeconfig): resolve a cluster across your organisations instead of a misleading 404 (ankra-btmyn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,26 @@
   fixing keys, and `delete` confirms first (or takes `--yes`). `get` and
   `list` take a vault name as well as an id and support `-o json|yaml`.
 
+### Fixed
+
+- **`kubectl` against an Ankra context no longer fails with "Cluster not
+  found" when your selected organisation is not the one that owns the
+  cluster.** The platform resolves a cluster reference inside the
+  organisation the request is scoped to, so a cluster you have a grant on,
+  whose id is right there in the kubeconfig server URL, came back as a bare
+  404 that blamed the cluster - sending you to check access grants and RBAC
+  for what was an organisation-selection problem. A cluster id the selected
+  organisation does not have is now looked up across the organisations you
+  belong to and the request runs against the one that owns it, so contexts
+  written before `--org` was pinned into the exec args keep working across
+  an `ankra org switch`. `ankra cluster kubeconfig add <id>` and
+  `ankra cluster access` do the same lookup, so an id from another
+  organisation writes a context pinned to the real owner instead of a
+  context that 404s on first use. Your selected organisation is never
+  changed, and `ANKRA_ORG=<org> kubectl ...` still short-circuits the
+  lookup. When the cluster genuinely is nowhere, the error now names the
+  organisation the request was scoped to and the ones that were searched.
+
 ## v0.13.0 — 2026-08-25
 
 Promotes v0.13.0-rc0 through rc4 — the kubectl-shaped read surface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,10 @@
   an `ankra org switch`. `ankra cluster kubeconfig add <id>` and
   `ankra cluster access` do the same lookup, so an id from another
   organisation writes a context pinned to the real owner instead of a
-  context that 404s on first use. Your selected organisation is never
+  context that 404s on first use. The cluster from `ankra cluster select`
+  gets the same treatment, since that selection outlives the organisation
+  chosen alongside it: omitting `--cluster` no longer fails where passing
+  that very same id succeeds. Your selected organisation is never
   changed, and neither is an organisation you pinned yourself: `--org` and
   `ANKRA_ORG` are honoured as given, so a cluster that is not in the one you
   named is reported rather than quietly fetched from somewhere else. When

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,13 @@
   `ankra cluster access` do the same lookup, so an id from another
   organisation writes a context pinned to the real owner instead of a
   context that 404s on first use. Your selected organisation is never
-  changed, and `ANKRA_ORG=<org> kubectl ...` still short-circuits the
-  lookup. When the cluster genuinely is nowhere, the error now names the
-  organisation the request was scoped to and the ones that were searched.
+  changed, and neither is an organisation you pinned yourself: `--org` and
+  `ANKRA_ORG` are honoured as given, so a cluster that is not in the one you
+  named is reported rather than quietly fetched from somewhere else. When
+  the cluster genuinely is nowhere, the error names the organisation the
+  request was scoped to and the ones that were searched - and only the ones
+  that actually answered, so a lookup that failed is never reported as an
+  absence.
 
 ## v0.13.0 — 2026-08-25
 

--- a/cmd/cluster_access.go
+++ b/cmd/cluster_access.go
@@ -44,7 +44,7 @@ var clusterAccessListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List access grants for a cluster",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID, err := resolveGatewayClusterID(accessClusterFlag, os.Stderr)
+		clusterID, _, err := resolveGatewayClusterID(accessClusterFlag, os.Stderr)
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ admin, cluster-admin.`,
 		if err := validateAccessRole(accessRoleFlag); err != nil {
 			return err
 		}
-		clusterID, err := resolveGatewayClusterID(accessClusterFlag, os.Stderr)
+		clusterID, _, err := resolveGatewayClusterID(accessClusterFlag, os.Stderr)
 		if err != nil {
 			return err
 		}
@@ -128,7 +128,7 @@ or an email address to revoke every grant that member has on the cluster.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		target := args[0]
-		clusterID, err := resolveGatewayClusterID(accessClusterFlag, os.Stderr)
+		clusterID, _, err := resolveGatewayClusterID(accessClusterFlag, os.Stderr)
 		if err != nil {
 			return err
 		}

--- a/cmd/cluster_access.go
+++ b/cmd/cluster_access.go
@@ -44,7 +44,7 @@ var clusterAccessListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List access grants for a cluster",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID, err := resolveKubeTokenClusterID(accessClusterFlag)
+		clusterID, err := resolveGatewayClusterID(accessClusterFlag, os.Stderr)
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ admin, cluster-admin.`,
 		if err := validateAccessRole(accessRoleFlag); err != nil {
 			return err
 		}
-		clusterID, err := resolveKubeTokenClusterID(accessClusterFlag)
+		clusterID, err := resolveGatewayClusterID(accessClusterFlag, os.Stderr)
 		if err != nil {
 			return err
 		}
@@ -128,7 +128,7 @@ or an email address to revoke every grant that member has on the cluster.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		target := args[0]
-		clusterID, err := resolveKubeTokenClusterID(accessClusterFlag)
+		clusterID, err := resolveGatewayClusterID(accessClusterFlag, os.Stderr)
 		if err != nil {
 			return err
 		}

--- a/cmd/cluster_kube_token.go
+++ b/cmd/cluster_kube_token.go
@@ -172,13 +172,7 @@ func resolveGatewayClusterID(clusterFlag string, notify io.Writer) (string, bool
 			return cluster.ID, true, nil
 		}
 		if isLikelyClusterID(clusterFlag) {
-			resolution := resolveClusterOrganisation(clusterFlag, notify)
-			if resolution.absent {
-				return "", false, withExitCode(exitNotFound, notInScopedOrganisationError(resolution.search, clusterFlag, nil))
-			}
-			// Settled or unknown: either way the backend gets the ID, but
-			// only "unknown" leaves an organisation question to explain.
-			return clusterFlag, resolution.settled(), nil
+			return resolveGatewayClusterByID(clusterFlag, notify)
 		}
 		return "", false, fmt.Errorf("cluster %q not found; pass a cluster name or ID (not the kubeconfig context name): %w", clusterFlag, err)
 	}
@@ -186,9 +180,26 @@ func resolveGatewayClusterID(clusterFlag string, notify io.Writer) (string, bool
 	if err != nil {
 		return "", false, fmt.Errorf("no cluster specified and no active cluster selected; pass --cluster <name|id>")
 	}
-	// The selection is a local file and can name a cluster in an organisation
-	// this invocation is not scoped to, so nothing is settled here.
+	// The selection is a local file written by 'ankra cluster select', so it
+	// long outlives the organisation that was selected alongside it. Give it
+	// the same treatment as an ID typed at the prompt rather than trusting it:
+	// omitting --cluster must not fail where passing the very same ID
+	// succeeds.
+	if isLikelyClusterID(cluster.ID) {
+		return resolveGatewayClusterByID(cluster.ID, notify)
+	}
 	return cluster.ID, false, nil
+}
+
+// resolveGatewayClusterByID settles the organisation for a cluster ID and
+// reports whether the owner ended up known. Absent is the only outcome that
+// fails: unknown leaves the ID to the backend, as before the lookup existed.
+func resolveGatewayClusterByID(clusterID string, notify io.Writer) (string, bool, error) {
+	resolution := resolveClusterOrganisation(clusterID, notify)
+	if resolution.absent {
+		return "", false, withExitCode(exitNotFound, notInScopedOrganisationError(resolution.search, clusterID, nil))
+	}
+	return clusterID, resolution.settled(), nil
 }
 
 func normalizeExpirationTimestamp(expiresAt string) string {

--- a/cmd/cluster_kube_token.go
+++ b/cmd/cluster_kube_token.go
@@ -179,7 +179,7 @@ func resolveGatewayClusterByID(clusterID string, notify io.Writer) (string, erro
 	if cluster, err := apiClient.GetClusterByID(clusterID); err == nil && cluster.ID == clusterID {
 		return clusterID, nil
 	}
-	search, adopted := adoptOwningOrganisation(clusterID, notify)
+	search, adopted := resolveOwningOrganisation(clusterID, notify)
 	if adopted || search.err != nil {
 		return clusterID, nil
 	}

--- a/cmd/cluster_kube_token.go
+++ b/cmd/cluster_kube_token.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -43,7 +44,10 @@ for example in a kubeconfig:
 
 Pinning --org to the cluster's organisation ID keeps the entry working when
 your selected organisation differs from the cluster's ('ankra cluster
-kubeconfig add' writes it automatically).
+kubeconfig add' writes it automatically). An entry written without --org still
+works: a cluster ID the selected organisation does not have is looked up
+across the organisations you belong to, and the token is minted against the
+one that owns it. Your selected organisation is not changed.
 
 It prints JSON to stdout and never prompts; run 'ankra login' first.`,
 	Annotations: map[string]string{"group": "kubernetes"},
@@ -56,7 +60,7 @@ It prints JSON to stdout and never prompts; run 'ankra login' first.`,
 
 		kubeToken, err := apiClient.GetClusterKubeToken(context.Background(), clusterID)
 		if err != nil {
-			return suggestAccessOnKubeTokenDenied(err, kubeTokenClusterReference(clusterFlag, clusterID))
+			return decorateKubeTokenError(err, kubeTokenClusterReference(clusterFlag, clusterID), clusterID)
 		}
 
 		credential := execCredential{
@@ -74,6 +78,34 @@ It prints JSON to stdout and never prompts; run 'ankra login' first.`,
 		fmt.Println(string(output))
 		return nil
 	},
+}
+
+// decorateKubeTokenError turns the two kube-token mint failures that look like
+// a cluster problem but are not into errors that name the real cause. Both
+// decorations keep the original error in the chain, so exit-code
+// classification is unchanged; every other failure passes through untouched.
+func decorateKubeTokenError(err error, clusterRef, clusterID string) error {
+	var unexpected *client.UnexpectedResponseError
+	if errors.As(err, &unexpected) && unexpected.StatusCode == http.StatusNotFound {
+		return explainKubeTokenNotFound(err, clusterRef, clusterID)
+	}
+	return suggestAccessOnKubeTokenDenied(err, clusterRef)
+}
+
+// explainKubeTokenNotFound decorates a 404 from the token mint. The gateway
+// resolves the cluster inside the organisation the request is scoped to, so
+// "Cluster not found" is also the answer for a cluster that exists, that you
+// hold a grant on, and whose ID is right there in the kubeconfig server URL —
+// it just belongs to another organisation. Name the organisations instead, so
+// nobody goes hunting through access grants and RBAC for an organisation
+// selection problem.
+func explainKubeTokenNotFound(err error, clusterRef, clusterID string) error {
+	search := findClusterInOtherOrganisations(clusterID)
+	explained := notInScopedOrganisationError(search, clusterRef, err)
+	if !search.found {
+		return explained
+	}
+	return fmt.Errorf("%w\nOr re-add the context so it pins the organisation itself and survives 'ankra org switch':\n  ankra cluster kubeconfig add %s", explained, clusterID)
 }
 
 // suggestAccessOnKubeTokenDenied decorates a kube-token mint failure. A 403
@@ -104,14 +136,30 @@ func kubeTokenClusterReference(clusterFlag, clusterID string) string {
 	return clusterID
 }
 
+// resolveKubeTokenClusterID resolves the cluster reference the kube-gateway
+// commands were given (kube-token, cluster access) to a cluster ID. It is the
+// quiet variant: kubectl re-runs the credential plugin on every command, so
+// nothing here may write to stderr.
 func resolveKubeTokenClusterID(clusterFlag string) (string, error) {
+	return resolveGatewayClusterID(clusterFlag, nil)
+}
+
+// resolveGatewayClusterID resolves the cluster reference and, for an ID the
+// organisation in scope does not have, re-scopes this invocation to the
+// organisation that owns it. Without that the ID is forwarded as-is and
+// resolved inside the selected organisation, which answers 404 for a cluster
+// that plainly exists.
+//
+// notify, when non-nil, receives a note whenever the organisation was
+// re-scoped.
+func resolveGatewayClusterID(clusterFlag string, notify io.Writer) (string, error) {
 	if clusterFlag != "" {
 		cluster, err := apiClient.GetCluster(clusterFlag)
 		if err == nil {
 			return cluster.ID, nil
 		}
 		if isLikelyClusterID(clusterFlag) {
-			return clusterFlag, nil
+			return resolveGatewayClusterByID(clusterFlag, notify)
 		}
 		return "", fmt.Errorf("cluster %q not found; pass a cluster name or ID (not the kubeconfig context name): %w", clusterFlag, err)
 	}
@@ -120,6 +168,29 @@ func resolveKubeTokenClusterID(clusterFlag string) (string, error) {
 		return "", fmt.Errorf("no cluster specified and no active cluster selected; pass --cluster <name|id>")
 	}
 	return cluster.ID, nil
+}
+
+// resolveGatewayClusterByID confirms a cluster UUID in the organisation this
+// invocation is scoped to, and failing that adopts the organisation that owns
+// it. A search that could not run leaves the ID untouched for the backend to
+// answer for, which is the behaviour that predates the cross-organisation
+// lookup: an unreachable organisation list is not evidence about a cluster.
+func resolveGatewayClusterByID(clusterID string, notify io.Writer) (string, error) {
+	if cluster, err := apiClient.GetClusterByID(clusterID); err == nil && cluster.ID == clusterID {
+		return clusterID, nil
+	}
+	search, adopted := adoptOwningOrganisation(clusterID, notify)
+	if adopted || search.err != nil {
+		return clusterID, nil
+	}
+	// The first lookup can also fail for a reason that says nothing about the
+	// cluster. The search has just proved the API is reachable, so ask the
+	// scoped organisation once more rather than turning one bad response into
+	// "this cluster does not exist".
+	if cluster, err := apiClient.GetClusterByID(clusterID); err == nil && cluster.ID == clusterID {
+		return clusterID, nil
+	}
+	return "", withExitCode(exitNotFound, notInScopedOrganisationError(search, clusterID, nil))
 }
 
 func normalizeExpirationTimestamp(expiresAt string) string {

--- a/cmd/cluster_kube_token.go
+++ b/cmd/cluster_kube_token.go
@@ -53,14 +53,14 @@ It prints JSON to stdout and never prompts; run 'ankra login' first.`,
 	Annotations: map[string]string{"group": "kubernetes"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterFlag, _ := cmd.Flags().GetString("cluster")
-		clusterID, err := resolveKubeTokenClusterID(clusterFlag)
+		clusterID, organisationKnown, err := resolveGatewayClusterID(clusterFlag, nil)
 		if err != nil {
 			return err
 		}
 
 		kubeToken, err := apiClient.GetClusterKubeToken(context.Background(), clusterID)
 		if err != nil {
-			return decorateKubeTokenError(err, kubeTokenClusterReference(clusterFlag, clusterID), clusterID)
+			return decorateKubeTokenError(err, kubeTokenClusterReference(clusterFlag, clusterID), clusterID, organisationKnown)
 		}
 
 		credential := execCredential{
@@ -84,9 +84,15 @@ It prints JSON to stdout and never prompts; run 'ankra login' first.`,
 // a cluster problem but are not into errors that name the real cause. Both
 // decorations keep the original error in the chain, so exit-code
 // classification is unchanged; every other failure passes through untouched.
-func decorateKubeTokenError(err error, clusterRef, clusterID string) error {
+//
+// organisationKnown says the caller already established which organisation has
+// this cluster. The cross-organisation sweep then cannot change the answer, so
+// it is skipped: on the kubectl credential-plugin path, which reruns on every
+// command, it would be an organisation list plus a lookup per organisation on
+// an already-failing invocation.
+func decorateKubeTokenError(err error, clusterRef, clusterID string, organisationKnown bool) error {
 	var unexpected *client.UnexpectedResponseError
-	if errors.As(err, &unexpected) && unexpected.StatusCode == http.StatusNotFound {
+	if !organisationKnown && errors.As(err, &unexpected) && unexpected.StatusCode == http.StatusNotFound {
 		return explainKubeTokenNotFound(err, clusterRef, clusterID)
 	}
 	return suggestAccessOnKubeTokenDenied(err, clusterRef)
@@ -141,7 +147,8 @@ func kubeTokenClusterReference(clusterFlag, clusterID string) string {
 // quiet variant: kubectl re-runs the credential plugin on every command, so
 // nothing here may write to stderr.
 func resolveKubeTokenClusterID(clusterFlag string) (string, error) {
-	return resolveGatewayClusterID(clusterFlag, nil)
+	clusterID, _, err := resolveGatewayClusterID(clusterFlag, nil)
+	return clusterID, err
 }
 
 // resolveGatewayClusterID resolves the cluster reference and, for an ID the
@@ -150,47 +157,38 @@ func resolveKubeTokenClusterID(clusterFlag string) (string, error) {
 // resolved inside the selected organisation, which answers 404 for a cluster
 // that plainly exists.
 //
+// The second return value reports whether the owning organisation ended up
+// known. A mint that fails afterwards is then not an organisation-scoping
+// problem, so the error path can skip the cross-organisation sweep.
+//
 // notify, when non-nil, receives a note whenever the organisation was
 // re-scoped.
-func resolveGatewayClusterID(clusterFlag string, notify io.Writer) (string, error) {
+func resolveGatewayClusterID(clusterFlag string, notify io.Writer) (string, bool, error) {
 	if clusterFlag != "" {
 		cluster, err := apiClient.GetCluster(clusterFlag)
 		if err == nil {
-			return cluster.ID, nil
+			// A name only resolves inside the organisation in scope, so a hit
+			// here settles the organisation question by construction.
+			return cluster.ID, true, nil
 		}
 		if isLikelyClusterID(clusterFlag) {
-			return resolveGatewayClusterByID(clusterFlag, notify)
+			resolution := resolveClusterOrganisation(clusterFlag, notify)
+			if resolution.absent {
+				return "", false, withExitCode(exitNotFound, notInScopedOrganisationError(resolution.search, clusterFlag, nil))
+			}
+			// Settled or unknown: either way the backend gets the ID, but
+			// only "unknown" leaves an organisation question to explain.
+			return clusterFlag, resolution.settled(), nil
 		}
-		return "", fmt.Errorf("cluster %q not found; pass a cluster name or ID (not the kubeconfig context name): %w", clusterFlag, err)
+		return "", false, fmt.Errorf("cluster %q not found; pass a cluster name or ID (not the kubeconfig context name): %w", clusterFlag, err)
 	}
 	cluster, err := loadSelectedCluster()
 	if err != nil {
-		return "", fmt.Errorf("no cluster specified and no active cluster selected; pass --cluster <name|id>")
+		return "", false, fmt.Errorf("no cluster specified and no active cluster selected; pass --cluster <name|id>")
 	}
-	return cluster.ID, nil
-}
-
-// resolveGatewayClusterByID confirms a cluster UUID in the organisation this
-// invocation is scoped to, and failing that adopts the organisation that owns
-// it. A search that could not run leaves the ID untouched for the backend to
-// answer for, which is the behaviour that predates the cross-organisation
-// lookup: an unreachable organisation list is not evidence about a cluster.
-func resolveGatewayClusterByID(clusterID string, notify io.Writer) (string, error) {
-	if cluster, err := apiClient.GetClusterByID(clusterID); err == nil && cluster.ID == clusterID {
-		return clusterID, nil
-	}
-	search, adopted := resolveOwningOrganisation(clusterID, notify)
-	if adopted || search.err != nil {
-		return clusterID, nil
-	}
-	// The first lookup can also fail for a reason that says nothing about the
-	// cluster. The search has just proved the API is reachable, so ask the
-	// scoped organisation once more rather than turning one bad response into
-	// "this cluster does not exist".
-	if cluster, err := apiClient.GetClusterByID(clusterID); err == nil && cluster.ID == clusterID {
-		return clusterID, nil
-	}
-	return "", withExitCode(exitNotFound, notInScopedOrganisationError(search, clusterID, nil))
+	// The selection is a local file and can name a cluster in an organisation
+	// this invocation is not scoped to, so nothing is settled here.
+	return cluster.ID, false, nil
 }
 
 func normalizeExpirationTimestamp(expiresAt string) string {

--- a/cmd/cluster_kube_token.go
+++ b/cmd/cluster_kube_token.go
@@ -142,15 +142,6 @@ func kubeTokenClusterReference(clusterFlag, clusterID string) string {
 	return clusterID
 }
 
-// resolveKubeTokenClusterID resolves the cluster reference the kube-gateway
-// commands were given (kube-token, cluster access) to a cluster ID. It is the
-// quiet variant: kubectl re-runs the credential plugin on every command, so
-// nothing here may write to stderr.
-func resolveKubeTokenClusterID(clusterFlag string) (string, error) {
-	clusterID, _, err := resolveGatewayClusterID(clusterFlag, nil)
-	return clusterID, err
-}
-
 // resolveGatewayClusterID resolves the cluster reference and, for an ID the
 // organisation in scope does not have, re-scopes this invocation to the
 // organisation that owns it. Without that the ID is forwarded as-is and

--- a/cmd/cluster_kubeconfig.go
+++ b/cmd/cluster_kubeconfig.go
@@ -302,7 +302,7 @@ func buildManagedEntries(targets []kubeTarget, names []string) ([]kubeconfig.Ent
 		for index, target := range targets {
 			token, err := apiClient.GetClusterKubeToken(context.Background(), target.id)
 			if err != nil {
-				return nil, suggestAccessOnKubeTokenDenied(fmt.Errorf("mint token for %s: %w", target.name, err), target.name)
+				return nil, decorateKubeTokenError(fmt.Errorf("mint token for %s: %w", target.name, err), target.name, target.id)
 			}
 			entry, buildErr := kubeconfig.BuildTokenEntry(names[index], token.Server, token.Token, kubeconfigNamespace, kubeconfigInsecure)
 			if buildErr != nil {
@@ -322,6 +322,10 @@ func buildManagedEntries(targets []kubeTarget, names []string) ([]kubeconfig.Ent
 		server := base + proxyServerPath(target.id)
 		orgID := target.orgID
 		if orgID == "" {
+			// The backend lookup supplied no owner (a raw cluster-ID
+			// passthrough). The token mint only succeeds inside the owning
+			// organisation, so whatever this invocation is scoped to is that
+			// organisation.
 			if fallbackOrgID == "" {
 				fallbackOrgID = effectiveOrganisationID()
 			}
@@ -340,23 +344,6 @@ func buildManagedEntries(targets []kubeTarget, names []string) ([]kubeconfig.Ent
 	return entries, nil
 }
 
-// effectiveOrganisationID returns the organisation ID this invocation is
-// scoped to: the resolved --org/ANKRA_ORG override when one was applied,
-// otherwise the persistently selected organisation. Used as the fallback for
-// targets whose owning organisation the backend lookup did not supply (a raw
-// cluster-ID passthrough): the token mint during add only succeeds within the
-// owning organisation, so the effective scope is that organisation. Returns
-// "" when no organisation can be determined.
-func effectiveOrganisationID() string {
-	if override := apiClient.OrganisationOverride(); override != "" {
-		return override
-	}
-	if orgID, err := resolveOrganisationID(); err == nil {
-		return orgID
-	}
-	return ""
-}
-
 func proxyServerPath(clusterID string) string {
 	return "/api/v1/clusters/" + clusterID + "/k8s"
 }
@@ -368,7 +355,7 @@ func proxyServerPath(clusterID string) string {
 func resolveProxyBaseURL(sample kubeTarget) (string, error) {
 	token, err := apiClient.GetClusterKubeToken(context.Background(), sample.id)
 	if err != nil {
-		return "", suggestAccessOnKubeTokenDenied(fmt.Errorf("resolve kube proxy URL for %s: %w", sample.name, err), sample.name)
+		return "", decorateKubeTokenError(fmt.Errorf("resolve kube proxy URL for %s: %w", sample.name, err), sample.name, sample.id)
 	}
 	suffix := proxyServerPath(sample.id)
 	if !strings.HasSuffix(token.Server, suffix) {
@@ -393,6 +380,13 @@ func resolveKubeconfigTargets() ([]kubeTarget, error) {
 			// kubeconfig whenever the selection has diverged from the owner.
 			if byID, idErr := apiClient.GetClusterByID(kubeconfigClusterFlag); idErr == nil {
 				return []kubeTarget{{id: byID.ID, name: byID.Name, orgID: byID.OrganisationID}}, nil
+			}
+			// Not in the organisation in scope. Adding a context for a
+			// cluster you were handed the ID of is exactly when the selection
+			// is wrong, so find the owner rather than writing a context that
+			// pins the wrong organisation and 404s on first use.
+			if search, adopted := adoptOwningOrganisation(kubeconfigClusterFlag, os.Stderr); adopted {
+				return []kubeTarget{{id: search.cluster.ID, name: search.cluster.Name, orgID: search.owner.OrganisationID}}, nil
 			}
 			return []kubeTarget{{id: kubeconfigClusterFlag, name: kubeconfigClusterFlag}}, nil
 		}

--- a/cmd/cluster_kubeconfig.go
+++ b/cmd/cluster_kubeconfig.go
@@ -302,7 +302,7 @@ func buildManagedEntries(targets []kubeTarget, names []string) ([]kubeconfig.Ent
 		for index, target := range targets {
 			token, err := apiClient.GetClusterKubeToken(context.Background(), target.id)
 			if err != nil {
-				return nil, decorateKubeTokenError(fmt.Errorf("mint token for %s: %w", target.name, err), target.name, target.id)
+				return nil, decorateKubeTokenError(fmt.Errorf("mint token for %s: %w", target.name, err), target.name, target.id, target.orgID != "")
 			}
 			entry, buildErr := kubeconfig.BuildTokenEntry(names[index], token.Server, token.Token, kubeconfigNamespace, kubeconfigInsecure)
 			if buildErr != nil {
@@ -355,7 +355,7 @@ func proxyServerPath(clusterID string) string {
 func resolveProxyBaseURL(sample kubeTarget) (string, error) {
 	token, err := apiClient.GetClusterKubeToken(context.Background(), sample.id)
 	if err != nil {
-		return "", decorateKubeTokenError(fmt.Errorf("resolve kube proxy URL for %s: %w", sample.name, err), sample.name, sample.id)
+		return "", decorateKubeTokenError(fmt.Errorf("resolve kube proxy URL for %s: %w", sample.name, err), sample.name, sample.id, sample.orgID != "")
 	}
 	suffix := proxyServerPath(sample.id)
 	if !strings.HasSuffix(token.Server, suffix) {
@@ -378,25 +378,18 @@ func resolveKubeconfigTargets() ([]kubeTarget, error) {
 			// the ID properly to learn the owning organisation — pinning the
 			// locally selected org instead would bake a wrong --org into the
 			// kubeconfig whenever the selection has diverged from the owner.
-			if byID, idErr := apiClient.GetClusterByID(kubeconfigClusterFlag); idErr == nil {
-				return []kubeTarget{{id: byID.ID, name: byID.Name, orgID: byID.OrganisationID}}, nil
+			// Adding a context for a cluster you were handed the ID of is
+			// exactly when the selection is wrong.
+			resolution := resolveClusterOrganisation(kubeconfigClusterFlag, os.Stderr)
+			switch {
+			case resolution.settled():
+				return []kubeTarget{{id: resolution.cluster.ID, name: resolution.cluster.Name, orgID: resolution.organisationID}}, nil
+			case resolution.absent:
+				// Writing a raw-ID context now would pin whatever organisation
+				// is in scope and produce a context that fails on first use.
+				return nil, withExitCode(exitNotFound, notInScopedOrganisationError(resolution.search, kubeconfigClusterFlag, nil))
 			}
-			// Not in the organisation in scope. Adding a context for a
-			// cluster you were handed the ID of is exactly when the selection
-			// is wrong, so find the owner rather than writing a context that
-			// pins the wrong organisation and 404s on first use.
-			search, adopted := resolveOwningOrganisation(kubeconfigClusterFlag, os.Stderr)
-			if adopted {
-				return []kubeTarget{{id: search.cluster.ID, name: search.cluster.Name, orgID: search.owner.OrganisationID}}, nil
-			}
-			if search.err == nil {
-				// The search settled the question: the cluster is either
-				// somewhere the caller pinned away from, or nowhere. Writing
-				// a raw-ID context now would pin the wrong organisation and
-				// produce a context that fails on first use.
-				return nil, withExitCode(exitNotFound, notInScopedOrganisationError(search, kubeconfigClusterFlag, nil))
-			}
-			// Inconclusive: leave the ID to the backend, as before.
+			// Unknown: leave the ID to the backend, as before the lookup existed.
 			return []kubeTarget{{id: kubeconfigClusterFlag, name: kubeconfigClusterFlag}}, nil
 		}
 		return nil, fmt.Errorf("cluster %q not found; pass a cluster name or ID: %w", kubeconfigClusterFlag, err)

--- a/cmd/cluster_kubeconfig.go
+++ b/cmd/cluster_kubeconfig.go
@@ -385,9 +385,18 @@ func resolveKubeconfigTargets() ([]kubeTarget, error) {
 			// cluster you were handed the ID of is exactly when the selection
 			// is wrong, so find the owner rather than writing a context that
 			// pins the wrong organisation and 404s on first use.
-			if search, adopted := adoptOwningOrganisation(kubeconfigClusterFlag, os.Stderr); adopted {
+			search, adopted := resolveOwningOrganisation(kubeconfigClusterFlag, os.Stderr)
+			if adopted {
 				return []kubeTarget{{id: search.cluster.ID, name: search.cluster.Name, orgID: search.owner.OrganisationID}}, nil
 			}
+			if search.err == nil {
+				// The search settled the question: the cluster is either
+				// somewhere the caller pinned away from, or nowhere. Writing
+				// a raw-ID context now would pin the wrong organisation and
+				// produce a context that fails on first use.
+				return nil, withExitCode(exitNotFound, notInScopedOrganisationError(search, kubeconfigClusterFlag, nil))
+			}
+			// Inconclusive: leave the ID to the backend, as before.
 			return []kubeTarget{{id: kubeconfigClusterFlag, name: kubeconfigClusterFlag}}, nil
 		}
 		return nil, fmt.Errorf("cluster %q not found; pass a cluster name or ID: %w", kubeconfigClusterFlag, err)

--- a/cmd/cluster_kubeconfig_test.go
+++ b/cmd/cluster_kubeconfig_test.go
@@ -575,20 +575,20 @@ func TestKubeconfigAddDeniedSuggestsAccessGrant(t *testing.T) {
 	}
 }
 
-func TestResolveKubeTokenClusterID(t *testing.T) {
+func TestResolveGatewayClusterIDAcceptsNamesAndIDs(t *testing.T) {
 	withKubeconfigMock(t, kubeconfigMock{cluster: client.ClusterListItem{ID: "id-1", Name: "demo"}})
 
-	if id, err := resolveKubeTokenClusterID("demo"); err != nil || id != "id-1" {
+	if id, _, err := resolveGatewayClusterID("demo", nil); err != nil || id != "id-1" {
 		t.Fatalf("name resolves to id: got %q err=%v", id, err)
 	}
 
 	const clusterUUID = "11111111-1111-1111-1111-111111111111"
-	if id, err := resolveKubeTokenClusterID(clusterUUID); err != nil || id != clusterUUID {
+	if id, _, err := resolveGatewayClusterID(clusterUUID, nil); err != nil || id != clusterUUID {
 		t.Fatalf("uuid passes through: got %q err=%v", id, err)
 	}
 
 	// The exact failure case: passing the kubeconfig context name.
-	if _, err := resolveKubeTokenClusterID("ankra-hetzner-kube"); err == nil {
+	if _, _, err := resolveGatewayClusterID("ankra-hetzner-kube", nil); err == nil {
 		t.Fatal("expected error for unknown non-uuid value")
 	} else if !strings.Contains(err.Error(), "not found") {
 		t.Errorf("error = %v, want 'not found'", err)

--- a/cmd/cluster_org_scope.go
+++ b/cmd/cluster_org_scope.go
@@ -78,20 +78,34 @@ func findClusterInOtherOrganisations(clusterID string) organisationScopeSearch {
 
 	restore := apiClient.OrganisationOverride()
 	defer apiClient.SetOrganisationOverride(restore)
+
+	// A lookup that failed is not a miss. Counting one as a miss would put
+	// the organisation in searchedLabels and let the caller report "searched
+	// everywhere, found nothing" about an organisation that never answered —
+	// the same unknown-as-absence reading this whole file exists to prevent.
+	var firstFailure error
 	for _, organisation := range organisations {
 		if organisation.OrganisationID == "" || organisation.OrganisationID == scopedID {
 			continue
 		}
-		search.searchedLabels = append(search.searchedLabels, organisationLabel(organisation))
 		apiClient.SetOrganisationOverride(organisation.OrganisationID)
 		cluster, lookupErr := apiClient.GetClusterByID(clusterID)
-		if lookupErr != nil || cluster.ID != clusterID {
-			continue
+		switch {
+		case lookupErr == nil && cluster.ID == clusterID:
+			search.cluster = cluster
+			search.owner = organisation
+			search.found = true
+			return search
+		case lookupErr != nil && !errors.Is(lookupErr, client.ErrClusterNotFound):
+			if firstFailure == nil {
+				firstFailure = fmt.Errorf("%s: %w", organisationLabel(organisation), lookupErr)
+			}
+		default:
+			search.searchedLabels = append(search.searchedLabels, organisationLabel(organisation))
 		}
-		search.cluster = cluster
-		search.owner = organisation
-		search.found = true
-		break
+	}
+	if firstFailure != nil {
+		search.err = firstFailure
 	}
 	return search
 }
@@ -117,9 +131,21 @@ func adoptOwningOrganisation(clusterID string, notify io.Writer) (organisationSc
 	apiClient.SetOrganisationOverride(search.owner.OrganisationID)
 	if notify != nil {
 		_, _ = fmt.Fprintf(notify, "Note: cluster %s is in organisation %s, not %s; running against the owning organisation.\n",
-			clusterID, organisationLabel(search.owner), search.scopedLabel)
+			clusterID, organisationLabel(search.owner), scopedOrganisationPhrase(search.scopedLabel))
 	}
 	return search, true
+}
+
+// resolveOwningOrganisation is the entry point the gateway commands use: it
+// adopts the organisation that owns clusterID, except when the caller pinned
+// one explicitly with --org or ANKRA_ORG. An explicit pin is a statement about
+// which organisation to use, so it is never silently replaced; the search
+// still runs, but only so the error can name the owner and the exact retry.
+func resolveOwningOrganisation(clusterID string, notify io.Writer) (organisationScopeSearch, bool) {
+	if apiClient.OrganisationOverride() != "" {
+		return findClusterInOtherOrganisations(clusterID), false
+	}
+	return adoptOwningOrganisation(clusterID, notify)
 }
 
 // notInScopedOrganisationError explains a cluster the scoped organisation
@@ -128,7 +154,7 @@ func adoptOwningOrganisation(clusterID string, notify io.Writer) (organisationSc
 // chain so exit-code classification still sees the original response.
 func notInScopedOrganisationError(search organisationScopeSearch, reference string, cause error) error {
 	var message strings.Builder
-	fmt.Fprintf(&message, "cluster %s is not in organisation %s", reference, search.scopedLabel)
+	fmt.Fprintf(&message, "cluster %s is not in %s", reference, scopedOrganisationPhrase(search.scopedLabel))
 	switch {
 	case search.found:
 		fmt.Fprintf(&message, "; it belongs to %s.\nRetry scoped to the owning organisation:\n  ankra --org %s <command>   (or ANKRA_ORG=%s)",
@@ -163,7 +189,7 @@ func effectiveOrganisationID() string {
 
 // scopedOrganisationLabel names the organisation this invocation runs
 // against, without an API call — error messages must not depend on a second
-// request succeeding.
+// request succeeding. Returns "" when nothing local identifies it.
 func scopedOrganisationLabel() string {
 	if override := apiClient.OrganisationOverride(); override != "" {
 		return override
@@ -174,7 +200,17 @@ func scopedOrganisationLabel() string {
 		}
 		return selected.OrganisationID
 	}
-	return "the selected organisation"
+	return ""
+}
+
+// scopedOrganisationPhrase renders a scope label for prose, so an
+// unidentifiable scope reads as a sentence instead of naming an organisation
+// called "the selected organisation".
+func scopedOrganisationPhrase(label string) string {
+	if label == "" {
+		return "the organisation this command is scoped to"
+	}
+	return "organisation " + label
 }
 
 // organisationLabel renders an organisation as name-and-ID, falling back to

--- a/cmd/cluster_org_scope.go
+++ b/cmd/cluster_org_scope.go
@@ -24,6 +24,52 @@ import (
 // request to the owner, and — when the cluster really is nowhere — say which
 // organisations were searched instead of repeating the bare 404.
 
+// clusterLookup is the answer to "does the organisation in scope have this
+// cluster?". It has three states, not two, and that is the point: this bug
+// was written three separate times (the search loop, the in-scope retry, and
+// the kubeconfig target lookup) because a (cluster, error) pair spells "the
+// backend said no" and "the backend said nothing" identically, and `err !=
+// nil` reads naturally as absence at every one of those call sites.
+type clusterLookup struct {
+	cluster client.ClusterListItem
+
+	// present is true only when the backend answered and the cluster was in
+	// the answer.
+	present bool
+
+	// unanswered holds the reason the lookup could not be completed. While it
+	// is non-nil, present being false means nothing at all.
+	unanswered error
+}
+
+// found reports that the cluster is definitely in the scoped organisation.
+func (l clusterLookup) found() bool { return l.present }
+
+// absent reports that the backend answered and the cluster was not in the
+// answer. It is deliberately not the negation of found: a lookup that never
+// completed is neither.
+func (l clusterLookup) absent() bool { return !l.present && l.unanswered == nil }
+
+// lookUpClusterInScope asks the organisation in scope for a cluster ID.
+//
+// This is the only place in the gateway flow permitted to turn a
+// (cluster, error) pair into a judgement about existence. Everything else
+// reads found()/absent(), so "we did not get an answer" cannot be spelled the
+// same way as "there is no such cluster" — which is the whole failure mode
+// this file exists to remove, and which kept reappearing while each call site
+// classified the error itself.
+func lookUpClusterInScope(clusterID string) clusterLookup {
+	cluster, err := apiClient.GetClusterByID(clusterID)
+	switch {
+	case err == nil && cluster.ID == clusterID:
+		return clusterLookup{cluster: cluster, present: true}
+	case err == nil, errors.Is(err, client.ErrClusterNotFound):
+		return clusterLookup{}
+	default:
+		return clusterLookup{unanswered: err}
+	}
+}
+
 // organisationScopeSearch is the outcome of looking for a cluster ID outside
 // the organisation this invocation is scoped to.
 type organisationScopeSearch struct {
@@ -79,29 +125,27 @@ func findClusterInOtherOrganisations(clusterID string) organisationScopeSearch {
 	restore := apiClient.OrganisationOverride()
 	defer apiClient.SetOrganisationOverride(restore)
 
-	// A lookup that failed is not a miss. Counting one as a miss would put
-	// the organisation in searchedLabels and let the caller report "searched
-	// everywhere, found nothing" about an organisation that never answered —
-	// the same unknown-as-absence reading this whole file exists to prevent.
+	// A lookup that failed is not a miss. Counting one as a miss would put the
+	// organisation in searchedLabels and let the caller report "searched
+	// everywhere, found nothing" about an organisation that never answered.
 	var firstFailure error
 	for _, organisation := range organisations {
 		if organisation.OrganisationID == "" || organisation.OrganisationID == scopedID {
 			continue
 		}
 		apiClient.SetOrganisationOverride(organisation.OrganisationID)
-		cluster, lookupErr := apiClient.GetClusterByID(clusterID)
-		switch {
-		case lookupErr == nil && cluster.ID == clusterID:
-			search.cluster = cluster
+		switch answer := lookUpClusterInScope(clusterID); {
+		case answer.found():
+			search.cluster = answer.cluster
 			search.owner = organisation
 			search.found = true
 			return search
-		case lookupErr != nil && !errors.Is(lookupErr, client.ErrClusterNotFound):
-			if firstFailure == nil {
-				firstFailure = fmt.Errorf("%s: %w", organisationLabel(organisation), lookupErr)
-			}
-		default:
+		case answer.absent():
 			search.searchedLabels = append(search.searchedLabels, organisationLabel(organisation))
+		default:
+			if firstFailure == nil {
+				firstFailure = fmt.Errorf("%s: %w", organisationLabel(organisation), answer.unanswered)
+			}
 		}
 	}
 	if firstFailure != nil {
@@ -146,6 +190,80 @@ func resolveOwningOrganisation(clusterID string, notify io.Writer) (organisation
 		return findClusterInOtherOrganisations(clusterID), false
 	}
 	return adoptOwningOrganisation(clusterID, notify)
+}
+
+// clusterOrganisationResolution settles which organisation a cluster ID
+// should be requested in. It carries the same three-state discipline as
+// clusterLookup, one level up: settled() and absent() are separate questions,
+// and neither is the negation of the other.
+type clusterOrganisationResolution struct {
+	// cluster and organisationID are populated when settled() is true.
+	cluster        client.ClusterListItem
+	organisationID string
+
+	// inScope: the organisation already in scope has the cluster.
+	inScope bool
+	// adopted: another organisation owns it and the client was re-scoped.
+	adopted bool
+	// absent: every organisation answered, and none has it.
+	absent bool
+
+	search organisationScopeSearch
+}
+
+// settled reports that the owning organisation is known, either because it
+// was already in scope or because the client was re-scoped to it. A mint that
+// fails after this is not an organisation-scoping problem.
+func (r clusterOrganisationResolution) settled() bool { return r.inScope || r.adopted }
+
+// resolveClusterOrganisation is the single door the gateway commands use to
+// decide which organisation a cluster ID belongs to.
+//
+// Exactly one of three things is true when it returns, and a caller that
+// handles only two has the bug this file is about:
+//   - settled():   the owner is known (in scope, or adopted).
+//   - absent:      every organisation answered and none has the cluster.
+//   - neither:     nothing answered usefully. Unknown is not absence, so the
+//     caller must fall back to letting the backend answer for the ID, which
+//     is the behaviour that predates the cross-organisation lookup.
+func resolveClusterOrganisation(clusterID string, notify io.Writer) clusterOrganisationResolution {
+	if answer := lookUpClusterInScope(clusterID); answer.found() {
+		return clusterOrganisationResolution{
+			cluster:        answer.cluster,
+			organisationID: answer.cluster.OrganisationID,
+			inScope:        true,
+		}
+	}
+	search, adopted := resolveOwningOrganisation(clusterID, notify)
+	if adopted {
+		return clusterOrganisationResolution{
+			cluster:        search.cluster,
+			organisationID: search.owner.OrganisationID,
+			adopted:        true,
+			search:         search,
+		}
+	}
+	if search.err != nil {
+		return clusterOrganisationResolution{search: search}
+	}
+	// The first lookup may have failed for a reason that says nothing about
+	// the cluster. The search has just proved the API is reachable, so ask the
+	// organisation in scope once more before settling on absent.
+	switch retry := lookUpClusterInScope(clusterID); {
+	case retry.found():
+		return clusterOrganisationResolution{
+			cluster:        retry.cluster,
+			organisationID: retry.cluster.OrganisationID,
+			inScope:        true,
+			search:         search,
+		}
+	case retry.absent():
+		return clusterOrganisationResolution{absent: true, search: search}
+	default:
+		// The organisation in scope still has not answered, so its silence is
+		// not an absence either.
+		return clusterOrganisationResolution{search: search}
+	}
 }
 
 // notInScopedOrganisationError explains a cluster the scoped organisation

--- a/cmd/cluster_org_scope.go
+++ b/cmd/cluster_org_scope.go
@@ -1,0 +1,200 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"ankra/internal/client"
+)
+
+// The platform resolves a cluster reference inside the organisation the
+// request is scoped to, so a perfectly real cluster owned by another
+// organisation is indistinguishable from a typo: the backend answers 404
+// "Cluster not found". That message blames the cluster, which sends people
+// looking at access grants and RBAC when the actual problem is which
+// organisation the CLI is selected on — a genuine trap on a machine that
+// works across organisations, and the one that bites hardest through the
+// kubeconfig exec credential plugin, where nobody typed an organisation at
+// all.
+//
+// The kube-gateway commands (kube-token, kubeconfig, access) therefore look a
+// cluster ID up across every organisation the caller belongs to, re-scope the
+// request to the owner, and — when the cluster really is nowhere — say which
+// organisations were searched instead of repeating the bare 404.
+
+// organisationScopeSearch is the outcome of looking for a cluster ID outside
+// the organisation this invocation is scoped to.
+type organisationScopeSearch struct {
+	// cluster and owner are only meaningful when found is true.
+	cluster client.ClusterListItem
+	owner   client.OrganisationSummary
+	found   bool
+
+	// scopedLabel names the organisation the invocation was scoped to.
+	scopedLabel string
+
+	// searchedLabels names the other organisations that were searched, in
+	// listing order.
+	searchedLabels []string
+
+	// err records why the search could not be completed. A search that could
+	// not run proves nothing about the cluster, so callers must fall back to
+	// their previous behaviour rather than declaring the cluster non-existent.
+	err error
+}
+
+// findClusterInOtherOrganisations looks for clusterID in every organisation
+// the caller belongs to except the one already in scope (which the caller has
+// just tried without success).
+//
+// Only IDs are searched. Cluster names are unique only within an
+// organisation, so resolving one across organisations would mean guessing
+// which of several same-named clusters was meant.
+//
+// The client's organisation scope is restored before returning, so a match
+// never silently re-targets later calls; adoptOwningOrganisation is what
+// commits to the owning organisation.
+func findClusterInOtherOrganisations(clusterID string) organisationScopeSearch {
+	search := organisationScopeSearch{scopedLabel: scopedOrganisationLabel()}
+	if !isLikelyClusterID(clusterID) {
+		search.err = fmt.Errorf("%q is not a cluster ID", clusterID)
+		return search
+	}
+	organisations, err := apiClient.ListOrganisations()
+	if err != nil {
+		search.err = err
+		return search
+	}
+
+	scopedID := effectiveOrganisationID()
+	for _, organisation := range organisations {
+		if organisation.OrganisationID != "" && organisation.OrganisationID == scopedID {
+			search.scopedLabel = organisationLabel(organisation)
+			break
+		}
+	}
+
+	restore := apiClient.OrganisationOverride()
+	defer apiClient.SetOrganisationOverride(restore)
+	for _, organisation := range organisations {
+		if organisation.OrganisationID == "" || organisation.OrganisationID == scopedID {
+			continue
+		}
+		search.searchedLabels = append(search.searchedLabels, organisationLabel(organisation))
+		apiClient.SetOrganisationOverride(organisation.OrganisationID)
+		cluster, lookupErr := apiClient.GetClusterByID(clusterID)
+		if lookupErr != nil || cluster.ID != clusterID {
+			continue
+		}
+		search.cluster = cluster
+		search.owner = organisation
+		search.found = true
+		break
+	}
+	return search
+}
+
+// adoptOwningOrganisation re-scopes this invocation to the organisation that
+// owns clusterID when the organisation in scope does not have it. The caller
+// named one specific cluster by ID and holds a grant on it, so the only scope
+// in which that request means anything is the owning organisation.
+//
+// This is what keeps a kubeconfig context working across an 'ankra org
+// switch' even when the exec args predate the pinned --org. It changes only
+// this process's scope: the persistently selected organisation, which other
+// terminals and sessions share, is never touched.
+//
+// notify, when non-nil, receives a one-line note about the re-scoping. The
+// kube-token credential plugin passes nil: kubectl runs it on every command,
+// so a note there would be per-invocation noise on stderr.
+func adoptOwningOrganisation(clusterID string, notify io.Writer) (organisationScopeSearch, bool) {
+	search := findClusterInOtherOrganisations(clusterID)
+	if !search.found {
+		return search, false
+	}
+	apiClient.SetOrganisationOverride(search.owner.OrganisationID)
+	if notify != nil {
+		_, _ = fmt.Fprintf(notify, "Note: cluster %s is in organisation %s, not %s; running against the owning organisation.\n",
+			clusterID, organisationLabel(search.owner), search.scopedLabel)
+	}
+	return search, true
+}
+
+// notInScopedOrganisationError explains a cluster the scoped organisation
+// does not have, naming the organisations involved instead of repeating the
+// backend's bare "Cluster not found". cause, when non-nil, stays in the error
+// chain so exit-code classification still sees the original response.
+func notInScopedOrganisationError(search organisationScopeSearch, reference string, cause error) error {
+	var message strings.Builder
+	fmt.Fprintf(&message, "cluster %s is not in organisation %s", reference, search.scopedLabel)
+	switch {
+	case search.found:
+		fmt.Fprintf(&message, "; it belongs to %s.\nRetry scoped to the owning organisation:\n  ankra --org %s <command>   (or ANKRA_ORG=%s)",
+			organisationLabel(search.owner), search.owner.OrganisationID, search.owner.OrganisationID)
+	case search.err != nil:
+		fmt.Fprintf(&message, " (the other organisations you belong to could not be checked: %v)", search.err)
+	case len(search.searchedLabels) > 0:
+		fmt.Fprintf(&message, ", and it was not found in the %d other organisation(s) you belong to: %s",
+			len(search.searchedLabels), strings.Join(search.searchedLabels, ", "))
+	default:
+		message.WriteString(", the only organisation you belong to")
+	}
+	if cause != nil {
+		return fmt.Errorf("%w\n%s", cause, message.String())
+	}
+	return errors.New(message.String())
+}
+
+// effectiveOrganisationID returns the organisation ID this invocation is
+// scoped to: the resolved --org/ANKRA_ORG override when one was applied,
+// otherwise the persistently selected organisation. Returns "" when no
+// organisation can be determined.
+func effectiveOrganisationID() string {
+	if override := apiClient.OrganisationOverride(); override != "" {
+		return override
+	}
+	if orgID, err := resolveOrganisationID(); err == nil {
+		return orgID
+	}
+	return ""
+}
+
+// scopedOrganisationLabel names the organisation this invocation runs
+// against, without an API call — error messages must not depend on a second
+// request succeeding.
+func scopedOrganisationLabel() string {
+	if override := apiClient.OrganisationOverride(); override != "" {
+		return override
+	}
+	if selected, err := loadSelectedOrganisation(); err == nil && selected.OrganisationID != "" {
+		if name := trimmedOptional(selected.Name); name != "" {
+			return fmt.Sprintf("%q (%s)", name, selected.OrganisationID)
+		}
+		return selected.OrganisationID
+	}
+	return "the selected organisation"
+}
+
+// organisationLabel renders an organisation as name-and-ID, falling back to
+// the slug and then the bare ID. The ID is always present because it is what
+// the user has to paste into --org.
+func organisationLabel(organisation client.OrganisationSummary) string {
+	if name := trimmedOptional(organisation.Name); name != "" {
+		return fmt.Sprintf("%q (%s)", name, organisation.OrganisationID)
+	}
+	if slug := trimmedOptional(organisation.Slug); slug != "" {
+		return fmt.Sprintf("%q (%s)", slug, organisation.OrganisationID)
+	}
+	return organisation.OrganisationID
+}
+
+// trimmedOptional dereferences a nullable API string, yielding "" for both a
+// nil pointer and a whitespace-only value so callers can test one thing.
+func trimmedOptional(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
+}

--- a/cmd/cluster_org_scope_test.go
+++ b/cmd/cluster_org_scope_test.go
@@ -170,13 +170,14 @@ func writeSelectedCluster(t *testing.T, clusterID, name string) {
 	}
 }
 
-func TestResolveKubeTokenClusterIDAdoptsTheOwningOrganisation(t *testing.T) {
+func TestKubeTokenPathAdoptsTheOwningOrganisation(t *testing.T) {
 	// The bug: the exec credential plugin passes no organisation, so a
 	// cluster ID from another organisation used to be forwarded verbatim and
 	// 404'd. It must resolve against the organisation that owns it instead.
+	// kube-token resolves with notify=nil, which is what this exercises.
 	mock := withOrgScopeMock(t, crossOrgMock())
 
-	clusterID, err := resolveKubeTokenClusterID(otherOrgClusterID)
+	clusterID, _, err := resolveGatewayClusterID(otherOrgClusterID, nil)
 	if err != nil {
 		t.Fatalf("resolve failed: %v", err)
 	}
@@ -211,9 +212,9 @@ func TestResolveGatewayClusterIDNotifiesWhenAdopting(t *testing.T) {
 	}
 }
 
-func TestResolveKubeTokenClusterIDStaysQuiet(t *testing.T) {
-	// kubectl re-runs the credential plugin on every command, so the quiet
-	// variant must not write a per-invocation note anywhere.
+func TestKubeTokenPathStaysQuiet(t *testing.T) {
+	// kubectl re-runs the credential plugin on every command, so resolving
+	// with notify=nil must not write a per-invocation note anywhere.
 	mock := withOrgScopeMock(t, crossOrgMock())
 	stderr := os.Stderr
 	read, write, err := os.Pipe()
@@ -221,7 +222,7 @@ func TestResolveKubeTokenClusterIDStaysQuiet(t *testing.T) {
 		t.Fatal(err)
 	}
 	os.Stderr = write
-	_, resolveErr := resolveKubeTokenClusterID(otherOrgClusterID)
+	_, _, resolveErr := resolveGatewayClusterID(otherOrgClusterID, nil)
 	os.Stderr = stderr
 	if err := write.Close(); err != nil {
 		t.Fatal(err)

--- a/cmd/cluster_org_scope_test.go
+++ b/cmd/cluster_org_scope_test.go
@@ -1,0 +1,403 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+	"ankra/internal/kubeconfig"
+)
+
+const (
+	otherOrgClusterID = "11111111-1111-1111-1111-111111111111"
+	selectedOrgID     = "org-depict"
+	owningOrgID       = "org-ankra"
+)
+
+// orgScopeMock models the one behaviour that makes the bug possible: the
+// backend resolves every cluster reference *inside* the organisation the
+// request is scoped to, and answers 404 for anything outside it.
+type orgScopeMock struct {
+	baseMock
+	override      string
+	selected      string
+	organisations []client.OrganisationSummary
+	// clustersByOrg maps an organisation ID to the clusters it owns.
+	clustersByOrg map[string][]client.ClusterListItem
+
+	listOrganisationsErr   error
+	listOrganisationsCalls int
+	byIDScopes             []string
+	tokenScopes            []string
+
+	// failByIDCalls makes the first n by-ID lookups fail for a reason that
+	// says nothing about the cluster, modelling a single bad response.
+	failByIDCalls int
+}
+
+// scope is the organisation the current request resolves against: the
+// per-invocation override when set, else the selected organisation.
+func (m *orgScopeMock) scope() string {
+	if m.override != "" {
+		return m.override
+	}
+	return m.selected
+}
+
+func (m *orgScopeMock) SetOrganisationOverride(orgID string) { m.override = orgID }
+
+func (m *orgScopeMock) OrganisationOverride() string { return m.override }
+
+func (m *orgScopeMock) ListOrganisations() ([]client.OrganisationSummary, error) {
+	m.listOrganisationsCalls++
+	if m.listOrganisationsErr != nil {
+		return nil, m.listOrganisationsErr
+	}
+	return m.organisations, nil
+}
+
+func (m *orgScopeMock) GetCluster(name string) (client.ClusterListItem, error) {
+	for _, cluster := range m.clustersByOrg[m.scope()] {
+		if cluster.Name == name {
+			return cluster, nil
+		}
+	}
+	return client.ClusterListItem{}, errors.New("no cluster found for name " + name)
+}
+
+func (m *orgScopeMock) GetClusterByID(clusterID string) (client.ClusterListItem, error) {
+	m.byIDScopes = append(m.byIDScopes, m.scope())
+	if m.failByIDCalls > 0 {
+		m.failByIDCalls--
+		return client.ClusterListItem{}, errors.New("request failed: unexpected EOF")
+	}
+	for _, cluster := range m.clustersByOrg[m.scope()] {
+		if cluster.ID == clusterID {
+			return cluster, nil
+		}
+	}
+	return client.ClusterListItem{}, errors.New("no cluster found for id " + clusterID)
+}
+
+func (m *orgScopeMock) GetClusterKubeToken(_ context.Context, clusterID string) (*client.KubeToken, error) {
+	m.tokenScopes = append(m.tokenScopes, m.scope())
+	for _, cluster := range m.clustersByOrg[m.scope()] {
+		if cluster.ID == clusterID {
+			return &client.KubeToken{
+				Token:  "kube-token",
+				Server: "https://api.platform.ankra.dev/api/v1/clusters/" + clusterID + "/k8s",
+			}, nil
+		}
+	}
+	return nil, client.NewUnexpectedResponseError(404, `kube token request failed: status 404, body: {"detail":"Cluster not found"}`)
+}
+
+func organisationName(name string) *string { return &name }
+
+// crossOrgMock is the bead's exact situation: the CLI is selected on one
+// organisation while the cluster lives in another one the user also belongs
+// to, and holds a grant in.
+func crossOrgMock() *orgScopeMock {
+	return &orgScopeMock{
+		selected: selectedOrgID,
+		organisations: []client.OrganisationSummary{
+			{OrganisationID: selectedOrgID, Name: organisationName("Depict"), UserCurrent: true},
+			{OrganisationID: "org-acme", Name: organisationName("Acme")},
+			{OrganisationID: owningOrgID, Name: organisationName("Ankra AB")},
+		},
+		clustersByOrg: map[string][]client.ClusterListItem{
+			selectedOrgID: {{ID: "22222222-2222-2222-2222-222222222222", Name: "depict-prod", OrganisationID: selectedOrgID}},
+			owningOrgID:   {{ID: otherOrgClusterID, Name: "ankra-prod", OrganisationID: owningOrgID}},
+		},
+	}
+}
+
+// withOrgScopeMock installs the mock and an isolated HOME carrying the
+// persistently selected organisation, so nothing reads the developer's real
+// ~/.ankra state.
+func withOrgScopeMock(t *testing.T, mock *orgScopeMock) *orgScopeMock {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if mock.selected != "" {
+		selectionDir := filepath.Join(home, ".ankra")
+		if err := os.MkdirAll(selectionDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		selection := `{"organisation_id":"` + mock.selected + `","name":"Depict","role":"admin"}`
+		if err := os.WriteFile(filepath.Join(selectionDir, "organisation.json"), []byte(selection), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	originalClient := apiClient
+	originalBaseURL := baseURL
+	apiClient = mock
+	baseURL = "https://test.ankra.app"
+	t.Cleanup(func() {
+		apiClient = originalClient
+		baseURL = originalBaseURL
+	})
+	return mock
+}
+
+func TestResolveKubeTokenClusterIDAdoptsTheOwningOrganisation(t *testing.T) {
+	// The bug: the exec credential plugin passes no organisation, so a
+	// cluster ID from another organisation used to be forwarded verbatim and
+	// 404'd. It must resolve against the organisation that owns it instead.
+	mock := withOrgScopeMock(t, crossOrgMock())
+
+	clusterID, err := resolveKubeTokenClusterID(otherOrgClusterID)
+	if err != nil {
+		t.Fatalf("resolve failed: %v", err)
+	}
+	if clusterID != otherOrgClusterID {
+		t.Fatalf("cluster id = %q, want %q", clusterID, otherOrgClusterID)
+	}
+	if mock.override != owningOrgID {
+		t.Fatalf("organisation scope = %q, want the owning organisation %q", mock.override, owningOrgID)
+	}
+
+	// The mint that follows now runs in the owning organisation and succeeds.
+	if _, err := apiClient.GetClusterKubeToken(context.Background(), clusterID); err != nil {
+		t.Fatalf("token mint after adoption failed: %v", err)
+	}
+	if got := mock.tokenScopes; len(got) != 1 || got[0] != owningOrgID {
+		t.Errorf("token minted in scopes %v, want [%s]", got, owningOrgID)
+	}
+}
+
+func TestResolveGatewayClusterIDNotifiesWhenAdopting(t *testing.T) {
+	withOrgScopeMock(t, crossOrgMock())
+
+	var notes bytes.Buffer
+	if _, err := resolveGatewayClusterID(otherOrgClusterID, &notes); err != nil {
+		t.Fatalf("resolve failed: %v", err)
+	}
+	note := notes.String()
+	for _, fragment := range []string{otherOrgClusterID, `"Ankra AB" (` + owningOrgID + `)`, `"Depict" (` + selectedOrgID + `)`} {
+		if !strings.Contains(note, fragment) {
+			t.Errorf("note %q is missing %q", note, fragment)
+		}
+	}
+}
+
+func TestResolveKubeTokenClusterIDStaysQuiet(t *testing.T) {
+	// kubectl re-runs the credential plugin on every command, so the quiet
+	// variant must not write a per-invocation note anywhere.
+	mock := withOrgScopeMock(t, crossOrgMock())
+	stderr := os.Stderr
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = write
+	_, resolveErr := resolveKubeTokenClusterID(otherOrgClusterID)
+	os.Stderr = stderr
+	if err := write.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if resolveErr != nil {
+		t.Fatalf("resolve failed: %v", resolveErr)
+	}
+	var captured bytes.Buffer
+	if _, err := captured.ReadFrom(read); err != nil {
+		t.Fatal(err)
+	}
+	if captured.Len() != 0 {
+		t.Errorf("kube-token wrote %q to stderr; the credential plugin must stay silent", captured.String())
+	}
+	if mock.override != owningOrgID {
+		t.Errorf("organisation scope = %q, want %q", mock.override, owningOrgID)
+	}
+}
+
+func TestResolveGatewayClusterIDLeavesScopeAloneWhenTheClusterIsInScope(t *testing.T) {
+	// The common case must not pay for the cross-organisation search, and
+	// must not touch the organisation scope.
+	mock := withOrgScopeMock(t, crossOrgMock())
+
+	const inScope = "22222222-2222-2222-2222-222222222222"
+	if _, err := resolveGatewayClusterID(inScope, nil); err != nil {
+		t.Fatalf("resolve failed: %v", err)
+	}
+	if mock.override != "" {
+		t.Errorf("organisation scope = %q, want it untouched", mock.override)
+	}
+	if mock.listOrganisationsCalls != 0 {
+		t.Errorf("organisations listed %d times, want 0", mock.listOrganisationsCalls)
+	}
+	if len(mock.byIDScopes) != 1 {
+		t.Errorf("by-id lookups = %v, want exactly one", mock.byIDScopes)
+	}
+}
+
+func TestResolveGatewayClusterIDHonoursAnExplicitOrganisationOverride(t *testing.T) {
+	// ANKRA_ORG=<org> kubectl ... is the documented workaround: root resolves
+	// it into the client's override before the command runs. That path must
+	// still resolve in one lookup, with no search and no re-scoping.
+	mock := withOrgScopeMock(t, crossOrgMock())
+	mock.override = owningOrgID
+
+	if _, err := resolveGatewayClusterID(otherOrgClusterID, nil); err != nil {
+		t.Fatalf("resolve failed: %v", err)
+	}
+	if mock.override != owningOrgID {
+		t.Errorf("organisation scope = %q, want the override %q to survive", mock.override, owningOrgID)
+	}
+	if mock.listOrganisationsCalls != 0 {
+		t.Errorf("organisations listed %d times, want 0", mock.listOrganisationsCalls)
+	}
+}
+
+func TestResolveGatewayClusterIDNamesTheOrganisationsSearched(t *testing.T) {
+	// A cluster ID that exists nowhere must say which organisations were
+	// looked in, not "Cluster not found".
+	mock := withOrgScopeMock(t, crossOrgMock())
+	const unknown = "99999999-9999-9999-9999-999999999999"
+
+	_, err := resolveGatewayClusterID(unknown, nil)
+	if err == nil {
+		t.Fatal("expected an error for a cluster no organisation has")
+	}
+	for _, fragment := range []string{
+		`cluster ` + unknown + ` is not in organisation "Depict" (` + selectedOrgID + `)`,
+		"not found in the 2 other organisation(s) you belong to",
+		`"Acme" (org-acme)`,
+		`"Ankra AB" (` + owningOrgID + `)`,
+	} {
+		if !strings.Contains(err.Error(), fragment) {
+			t.Errorf("error %q is missing %q", err, fragment)
+		}
+	}
+	if code := exitCodeFor(err); code != exitNotFound {
+		t.Errorf("exit code = %d, want %d", code, exitNotFound)
+	}
+	if mock.override != "" {
+		t.Errorf("a failed search left the organisation scope at %q; it must be restored", mock.override)
+	}
+}
+
+func TestResolveGatewayClusterIDPassesThroughWhenTheSearchCannotRun(t *testing.T) {
+	// An unreachable organisation list is not evidence about a cluster, so
+	// the ID goes to the backend exactly as it did before the search existed.
+	mock := withOrgScopeMock(t, crossOrgMock())
+	mock.listOrganisationsErr = errors.New("dial tcp: connection refused")
+
+	clusterID, err := resolveGatewayClusterID(otherOrgClusterID, nil)
+	if err != nil {
+		t.Fatalf("an inconclusive search must not fail the command: %v", err)
+	}
+	if clusterID != otherOrgClusterID {
+		t.Errorf("cluster id = %q, want the input passed through", clusterID)
+	}
+}
+
+func TestResolveGatewayClusterIDSurvivesOneBadLookup(t *testing.T) {
+	// A single failed response must not be promoted into "this cluster does
+	// not exist": the cluster is in the scoped organisation all along, and
+	// the command has to keep working.
+	mock := withOrgScopeMock(t, crossOrgMock())
+	mock.failByIDCalls = 1
+	const inScope = "22222222-2222-2222-2222-222222222222"
+
+	clusterID, err := resolveGatewayClusterID(inScope, nil)
+	if err != nil {
+		t.Fatalf("one bad lookup failed the command: %v", err)
+	}
+	if clusterID != inScope {
+		t.Errorf("cluster id = %q, want %q", clusterID, inScope)
+	}
+	if mock.override != "" {
+		t.Errorf("organisation scope = %q, want it untouched", mock.override)
+	}
+}
+
+func TestExplainKubeTokenNotFoundNamesTheOwningOrganisation(t *testing.T) {
+	// Defence in depth for the mint itself: a 404 must never be reported as
+	// a missing cluster while an organisation the caller belongs to has it.
+	withOrgScopeMock(t, crossOrgMock())
+	original := client.NewUnexpectedResponseError(404, `kube token request failed: status 404, body: {"detail":"Cluster not found"}`)
+
+	err := decorateKubeTokenError(original, otherOrgClusterID, otherOrgClusterID)
+	for _, fragment := range []string{
+		`is not in organisation "Depict" (` + selectedOrgID + `)`,
+		`it belongs to "Ankra AB" (` + owningOrgID + `)`,
+		"ankra --org " + owningOrgID,
+		"ANKRA_ORG=" + owningOrgID,
+		"ankra cluster kubeconfig add " + otherOrgClusterID,
+	} {
+		if !strings.Contains(err.Error(), fragment) {
+			t.Errorf("error %q is missing %q", err, fragment)
+		}
+	}
+	// The original response stays in the chain, so the exit code is unchanged.
+	var unexpected *client.UnexpectedResponseError
+	if !errors.As(err, &unexpected) || unexpected.StatusCode != 404 {
+		t.Fatalf("expected the 404 to stay wrapped, got: %v", err)
+	}
+	if code := exitCodeFor(err); code != exitNotFound {
+		t.Errorf("exit code = %d, want %d", code, exitNotFound)
+	}
+}
+
+func TestDecorateKubeTokenErrorLeavesOtherStatusesToTheAccessSuggestion(t *testing.T) {
+	withOrgScopeMock(t, crossOrgMock())
+	denied := client.NewUnexpectedResponseError(403, `kube token request failed: status 403, body: {"detail":"You do not have access to this cluster"}`)
+
+	err := decorateKubeTokenError(denied, "ankra-prod", otherOrgClusterID)
+	if !strings.Contains(err.Error(), "ankra cluster access grant <your-email> --cluster ankra-prod --role view") {
+		t.Errorf("403 error = %v, want the access-grant suggestion", err)
+	}
+
+	transport := errors.New("dial tcp: connection refused")
+	if got := decorateKubeTokenError(transport, "ankra-prod", otherOrgClusterID); got != transport {
+		t.Errorf("transport error = %v, want it passed through unchanged", got)
+	}
+}
+
+func TestKubeconfigAddPinsTheOwningOrganisationForACrossOrgID(t *testing.T) {
+	// The other half of the fix: the written context must be self-contained.
+	// Pinning the (wrong) selected organisation here is what produced a
+	// kubeconfig entry that 404s on first use.
+	withOrgScopeMock(t, crossOrgMock())
+	path := filepath.Join(t.TempDir(), "config")
+	resetKubeconfigFlags(path)
+	kubeconfigClusterFlag = otherOrgClusterID
+
+	var out bytes.Buffer
+	if err := kubeconfigAdd(&out); err != nil {
+		t.Fatalf("kubeconfig add failed: %v", err)
+	}
+	config, err := kubeconfig.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := config.ManagedContextNames()
+	if len(names) != 1 || names[0] != "ankra-ankra-prod" {
+		t.Fatalf("context names = %v, want [ankra-ankra-prod]", names)
+	}
+	want := "cluster kube-token --cluster " + otherOrgClusterID + " --org " + owningOrgID
+	if got := strings.Join(execArgsForUser(t, config, "ankra-ankra-prod"), " "); got != want {
+		t.Errorf("exec args = %q, want %q", got, want)
+	}
+}
+
+func TestFindClusterInOtherOrganisationsRejectsNames(t *testing.T) {
+	// Cluster names are unique only within an organisation, so searching for
+	// one across organisations would mean guessing. The search declines, and
+	// declining counts as inconclusive rather than as "does not exist".
+	withOrgScopeMock(t, crossOrgMock())
+
+	search := findClusterInOtherOrganisations("ankra-prod")
+	if search.found {
+		t.Fatal("a name must not resolve across organisations")
+	}
+	if search.err == nil {
+		t.Fatal("declining to search must be reported as inconclusive")
+	}
+}

--- a/cmd/cluster_org_scope_test.go
+++ b/cmd/cluster_org_scope_test.go
@@ -153,6 +153,23 @@ func withOrgScopeMock(t *testing.T, mock *orgScopeMock) *orgScopeMock {
 	return mock
 }
 
+// writeSelectedCluster plants what 'ankra cluster select' would have written,
+// so the no-flag path has a selection to read.
+func writeSelectedCluster(t *testing.T, clusterID, name string) {
+	t.Helper()
+	path, err := selectedClusterFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	selection := `{"id":"` + clusterID + `","name":"` + name + `"}`
+	if err := os.WriteFile(path, []byte(selection), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestResolveKubeTokenClusterIDAdoptsTheOwningOrganisation(t *testing.T) {
 	// The bug: the exec credential plugin passes no organisation, so a
 	// cluster ID from another organisation used to be forwarded verbatim and
@@ -573,6 +590,42 @@ func TestDecorateKubeTokenErrorSkipsTheSweepWhenTheOrganisationIsKnown(t *testin
 	}
 	if mock.listOrganisationsCalls != 1 {
 		t.Errorf("organisations listed %d times, want 1", mock.listOrganisationsCalls)
+	}
+}
+
+func TestResolveGatewayClusterIDTreatsTheSelectionLikeATypedID(t *testing.T) {
+	// 'ankra cluster select' writes a local file that outlives the
+	// organisation selected alongside it, so omitting --cluster must not fail
+	// where passing the very same id succeeds.
+	// The explicit path, for comparison.
+	explicitMock := withOrgScopeMock(t, crossOrgMock())
+	wantID, wantSettled, wantErr := resolveGatewayClusterID(otherOrgClusterID, nil)
+	if wantErr != nil {
+		t.Fatalf("explicit --cluster failed: %v", wantErr)
+	}
+	wantScope := explicitMock.override
+
+	// The same id, supplied by the selection file instead of the flag.
+	mock := withOrgScopeMock(t, crossOrgMock())
+	writeSelectedCluster(t, otherOrgClusterID, "ankra-prod")
+
+	gotID, gotSettled, err := resolveGatewayClusterID("", nil)
+	if err != nil {
+		t.Fatalf("selected cluster in another organisation failed where the same id via --cluster succeeded: %v", err)
+	}
+	if gotID != wantID || gotSettled != wantSettled {
+		t.Errorf("no-flag path = (%q, %v), explicit path = (%q, %v); the same id must resolve the same way",
+			gotID, gotSettled, wantID, wantSettled)
+	}
+	if mock.override != wantScope {
+		t.Errorf("no-flag organisation scope = %q, explicit = %q", mock.override, wantScope)
+	}
+	if mock.override != owningOrgID {
+		t.Errorf("organisation scope = %q, want the owner %q adopted", mock.override, owningOrgID)
+	}
+	// And the mint that follows now succeeds, which is the whole point.
+	if _, err := apiClient.GetClusterKubeToken(context.Background(), gotID); err != nil {
+		t.Errorf("token mint after adoption failed: %v", err)
 	}
 }
 

--- a/cmd/cluster_org_scope_test.go
+++ b/cmd/cluster_org_scope_test.go
@@ -39,6 +39,10 @@ type orgScopeMock struct {
 	// failByIDCalls makes the first n by-ID lookups fail for a reason that
 	// says nothing about the cluster, modelling a single bad response.
 	failByIDCalls int
+
+	// failByIDCallNumbers fails specific by-ID lookups by 1-based call
+	// number, for the cases where which lookup fails is the whole point.
+	failByIDCallNumbers map[int]bool
 }
 
 // scope is the organisation the current request resolves against: the
@@ -75,6 +79,9 @@ func (m *orgScopeMock) GetClusterByID(clusterID string) (client.ClusterListItem,
 	m.byIDScopes = append(m.byIDScopes, m.scope())
 	if m.failByIDCalls > 0 {
 		m.failByIDCalls--
+		return client.ClusterListItem{}, errors.New("request failed: unexpected EOF")
+	}
+	if m.failByIDCallNumbers[len(m.byIDScopes)] {
 		return client.ClusterListItem{}, errors.New("request failed: unexpected EOF")
 	}
 	for _, cluster := range m.clustersByOrg[m.scope()] {
@@ -176,7 +183,7 @@ func TestResolveGatewayClusterIDNotifiesWhenAdopting(t *testing.T) {
 	withOrgScopeMock(t, crossOrgMock())
 
 	var notes bytes.Buffer
-	if _, err := resolveGatewayClusterID(otherOrgClusterID, &notes); err != nil {
+	if _, _, err := resolveGatewayClusterID(otherOrgClusterID, &notes); err != nil {
 		t.Fatalf("resolve failed: %v", err)
 	}
 	note := notes.String()
@@ -223,7 +230,7 @@ func TestResolveGatewayClusterIDLeavesScopeAloneWhenTheClusterIsInScope(t *testi
 	mock := withOrgScopeMock(t, crossOrgMock())
 
 	const inScope = "22222222-2222-2222-2222-222222222222"
-	if _, err := resolveGatewayClusterID(inScope, nil); err != nil {
+	if _, _, err := resolveGatewayClusterID(inScope, nil); err != nil {
 		t.Fatalf("resolve failed: %v", err)
 	}
 	if mock.override != "" {
@@ -244,7 +251,7 @@ func TestResolveGatewayClusterIDHonoursAnExplicitOrganisationOverride(t *testing
 	mock := withOrgScopeMock(t, crossOrgMock())
 	mock.override = owningOrgID
 
-	if _, err := resolveGatewayClusterID(otherOrgClusterID, nil); err != nil {
+	if _, _, err := resolveGatewayClusterID(otherOrgClusterID, nil); err != nil {
 		t.Fatalf("resolve failed: %v", err)
 	}
 	if mock.override != owningOrgID {
@@ -261,7 +268,7 @@ func TestResolveGatewayClusterIDNamesTheOrganisationsSearched(t *testing.T) {
 	mock := withOrgScopeMock(t, crossOrgMock())
 	const unknown = "99999999-9999-9999-9999-999999999999"
 
-	_, err := resolveGatewayClusterID(unknown, nil)
+	_, _, err := resolveGatewayClusterID(unknown, nil)
 	if err == nil {
 		t.Fatal("expected an error for a cluster no organisation has")
 	}
@@ -289,7 +296,7 @@ func TestResolveGatewayClusterIDPassesThroughWhenTheSearchCannotRun(t *testing.T
 	mock := withOrgScopeMock(t, crossOrgMock())
 	mock.listOrganisationsErr = errors.New("dial tcp: connection refused")
 
-	clusterID, err := resolveGatewayClusterID(otherOrgClusterID, nil)
+	clusterID, _, err := resolveGatewayClusterID(otherOrgClusterID, nil)
 	if err != nil {
 		t.Fatalf("an inconclusive search must not fail the command: %v", err)
 	}
@@ -306,7 +313,7 @@ func TestResolveGatewayClusterIDSurvivesOneBadLookup(t *testing.T) {
 	mock.failByIDCalls = 1
 	const inScope = "22222222-2222-2222-2222-222222222222"
 
-	clusterID, err := resolveGatewayClusterID(inScope, nil)
+	clusterID, _, err := resolveGatewayClusterID(inScope, nil)
 	if err != nil {
 		t.Fatalf("one bad lookup failed the command: %v", err)
 	}
@@ -324,7 +331,7 @@ func TestExplainKubeTokenNotFoundNamesTheOwningOrganisation(t *testing.T) {
 	withOrgScopeMock(t, crossOrgMock())
 	original := client.NewUnexpectedResponseError(404, `kube token request failed: status 404, body: {"detail":"Cluster not found"}`)
 
-	err := decorateKubeTokenError(original, otherOrgClusterID, otherOrgClusterID)
+	err := decorateKubeTokenError(original, otherOrgClusterID, otherOrgClusterID, false)
 	for _, fragment := range []string{
 		`is not in organisation "Depict" (` + selectedOrgID + `)`,
 		`it belongs to "Ankra AB" (` + owningOrgID + `)`,
@@ -350,13 +357,13 @@ func TestDecorateKubeTokenErrorLeavesOtherStatusesToTheAccessSuggestion(t *testi
 	withOrgScopeMock(t, crossOrgMock())
 	denied := client.NewUnexpectedResponseError(403, `kube token request failed: status 403, body: {"detail":"You do not have access to this cluster"}`)
 
-	err := decorateKubeTokenError(denied, "ankra-prod", otherOrgClusterID)
+	err := decorateKubeTokenError(denied, "ankra-prod", otherOrgClusterID, false)
 	if !strings.Contains(err.Error(), "ankra cluster access grant <your-email> --cluster ankra-prod --role view") {
 		t.Errorf("403 error = %v, want the access-grant suggestion", err)
 	}
 
 	transport := errors.New("dial tcp: connection refused")
-	if got := decorateKubeTokenError(transport, "ankra-prod", otherOrgClusterID); got != transport {
+	if got := decorateKubeTokenError(transport, "ankra-prod", otherOrgClusterID, false); got != transport {
 		t.Errorf("transport error = %v, want it passed through unchanged", got)
 	}
 }
@@ -410,8 +417,32 @@ func TestFindClusterInOtherOrganisationsNeverCountsAFailedLookupAsAMiss(t *testi
 
 	// And an inconclusive search must not fail the command.
 	mock.failByIDCalls = 3
-	if _, err := resolveGatewayClusterID(unknown, nil); err != nil {
+	if _, _, err := resolveGatewayClusterID(unknown, nil); err != nil {
 		t.Errorf("inconclusive search failed the command: %v", err)
+	}
+}
+
+func TestResolveGatewayClusterIDNeverCallsAFailedRetryAnAbsence(t *testing.T) {
+	// Both lookups against the scoped organisation fail for a reason that
+	// says nothing about the cluster, and the search finds it nowhere else.
+	// The scoped organisation has still never answered, so this is UNKNOWN,
+	// not "no such cluster": the id goes to the backend as before.
+	mock := withOrgScopeMock(t, crossOrgMock())
+	const unknown = "99999999-9999-9999-9999-999999999999"
+	// Fail the in-scope lookup and the in-scope retry, but let the two
+	// cross-organisation lookups answer cleanly so the search itself is
+	// conclusive.
+	mock.failByIDCallNumbers = map[int]bool{1: true, 4: true}
+
+	clusterID, _, err := resolveGatewayClusterID(unknown, nil)
+	if err != nil {
+		t.Fatalf("a scoped organisation that never answered must not become an absence: %v", err)
+	}
+	if clusterID != unknown {
+		t.Errorf("cluster id = %q, want the input passed through", clusterID)
+	}
+	if len(mock.byIDScopes) != 4 {
+		t.Errorf("by-id lookups = %v, want 4 (in-scope, two searches, in-scope retry)", mock.byIDScopes)
 	}
 }
 
@@ -422,7 +453,7 @@ func TestResolveGatewayClusterIDNeverReplacesAnExplicitOrganisation(t *testing.T
 	mock := withOrgScopeMock(t, crossOrgMock())
 	mock.override = "org-acme"
 
-	_, err := resolveGatewayClusterID(otherOrgClusterID, nil)
+	_, _, err := resolveGatewayClusterID(otherOrgClusterID, nil)
 	if err == nil {
 		t.Fatal("expected an error rather than a silent switch away from the pinned organisation")
 	}
@@ -461,6 +492,115 @@ func TestKubeconfigAddRefusesToWriteAContextItKnowsIsBroken(t *testing.T) {
 	}
 	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
 		t.Errorf("no kubeconfig should be written on failure: %s", path)
+	}
+}
+
+func TestKubeconfigAddDoesNotCallASilentOrganisationAnAbsence(t *testing.T) {
+	// The fourth site of the same class, latent until both callers were put
+	// through one resolver: kubeconfig had its own in-scope lookup whose
+	// failure fell straight into the definitive not-found branch. Here the
+	// scoped organisation never answers while the search answers cleanly, so
+	// the outcome is unknown and the command must still reach the backend.
+	mock := withOrgScopeMock(t, crossOrgMock())
+	mock.failByIDCallNumbers = map[int]bool{1: true, 4: true}
+	path := filepath.Join(t.TempDir(), "config")
+	resetKubeconfigFlags(path)
+	kubeconfigClusterFlag = "99999999-9999-9999-9999-999999999999"
+
+	var out bytes.Buffer
+	err := kubeconfigAdd(&out)
+	if err == nil {
+		t.Fatal("the backend still 404s the mint, so this must fail")
+	}
+	if len(mock.tokenScopes) == 0 {
+		t.Errorf("resolution stopped before the mint: an organisation that never answered was read as an absence (error: %v)", err)
+	}
+}
+
+func TestLookUpClusterInScopeSeparatesAbsenceFromSilence(t *testing.T) {
+	// The primitive the whole flow now goes through. found() and absent() are
+	// deliberately not each other's negation: a lookup that never completed is
+	// neither, which is what stops "no answer" being spelled as "no cluster".
+	mock := withOrgScopeMock(t, crossOrgMock())
+	const inScope = "22222222-2222-2222-2222-222222222222"
+	const unknown = "99999999-9999-9999-9999-999999999999"
+
+	present := lookUpClusterInScope(inScope)
+	if !present.found() || present.absent() || present.cluster.Name != "depict-prod" {
+		t.Errorf("present lookup = %+v, want found and not absent", present)
+	}
+
+	missing := lookUpClusterInScope(unknown)
+	if missing.found() || !missing.absent() {
+		t.Errorf("clean miss = %+v, want absent and not found", missing)
+	}
+
+	mock.failByIDCalls = 1
+	silent := lookUpClusterInScope(inScope)
+	if silent.found() {
+		t.Errorf("failed lookup = %+v, must not be found", silent)
+	}
+	if silent.absent() {
+		t.Errorf("failed lookup = %+v, must not be absent either: no answer is not an absence", silent)
+	}
+	if silent.unanswered == nil {
+		t.Error("a failed lookup must carry why it could not be completed")
+	}
+}
+
+func TestDecorateKubeTokenErrorSkipsTheSweepWhenTheOrganisationIsKnown(t *testing.T) {
+	// When the caller already established which organisation has the cluster,
+	// a mint 404 is not an organisation-scoping problem, so the N+1 sweep
+	// cannot change the answer. kubectl reruns the plugin constantly, so it
+	// must not pay for it.
+	mock := withOrgScopeMock(t, crossOrgMock())
+	notFound := client.NewUnexpectedResponseError(404, `kube token request failed: status 404, body: {"detail":"Cluster not found"}`)
+
+	err := decorateKubeTokenError(notFound, otherOrgClusterID, otherOrgClusterID, true)
+	if mock.listOrganisationsCalls != 0 {
+		t.Errorf("organisations listed %d times, want 0", mock.listOrganisationsCalls)
+	}
+	if len(mock.byIDScopes) != 0 {
+		t.Errorf("by-id lookups = %v, want none", mock.byIDScopes)
+	}
+	if err != notFound {
+		t.Errorf("error = %v, want the original 404 passed through", err)
+	}
+
+	// Unknown organisation: the sweep is exactly what produces the message.
+	if err := decorateKubeTokenError(notFound, otherOrgClusterID, otherOrgClusterID, false); !strings.Contains(err.Error(), "it belongs to") {
+		t.Errorf("error = %v, want the owning organisation named", err)
+	}
+	if mock.listOrganisationsCalls != 1 {
+		t.Errorf("organisations listed %d times, want 1", mock.listOrganisationsCalls)
+	}
+}
+
+func TestResolveGatewayClusterIDReportsWhetherTheOrganisationIsSettled(t *testing.T) {
+	// The flag that gates the sweep has to be true exactly when the owner is
+	// known, or the gate either wastes calls or suppresses the message.
+	const inScope = "22222222-2222-2222-2222-222222222222"
+	const unknown = "99999999-9999-9999-9999-999999999999"
+
+	withOrgScopeMock(t, crossOrgMock())
+	if _, settled, err := resolveGatewayClusterID(inScope, nil); err != nil || !settled {
+		t.Errorf("in-scope id: settled = %v, err = %v; want settled", settled, err)
+	}
+
+	withOrgScopeMock(t, crossOrgMock())
+	if _, settled, err := resolveGatewayClusterID(otherOrgClusterID, nil); err != nil || !settled {
+		t.Errorf("adopted id: settled = %v, err = %v; want settled", settled, err)
+	}
+
+	withOrgScopeMock(t, crossOrgMock())
+	if _, settled, err := resolveGatewayClusterID("depict-prod", nil); err != nil || !settled {
+		t.Errorf("name hit: settled = %v, err = %v; want settled", settled, err)
+	}
+
+	inconclusive := withOrgScopeMock(t, crossOrgMock())
+	inconclusive.listOrganisationsErr = errors.New("dial tcp: connection refused")
+	if _, settled, err := resolveGatewayClusterID(unknown, nil); err != nil || settled {
+		t.Errorf("inconclusive: settled = %v, err = %v; want unsettled so the error can still explain", settled, err)
 	}
 }
 

--- a/cmd/cluster_org_scope_test.go
+++ b/cmd/cluster_org_scope_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -67,7 +68,7 @@ func (m *orgScopeMock) GetCluster(name string) (client.ClusterListItem, error) {
 			return cluster, nil
 		}
 	}
-	return client.ClusterListItem{}, errors.New("no cluster found for name " + name)
+	return client.ClusterListItem{}, fmt.Errorf("no cluster found for name %q: %w", name, client.ErrClusterNotFound)
 }
 
 func (m *orgScopeMock) GetClusterByID(clusterID string) (client.ClusterListItem, error) {
@@ -81,7 +82,7 @@ func (m *orgScopeMock) GetClusterByID(clusterID string) (client.ClusterListItem,
 			return cluster, nil
 		}
 	}
-	return client.ClusterListItem{}, errors.New("no cluster found for id " + clusterID)
+	return client.ClusterListItem{}, fmt.Errorf("no cluster found for id %q: %w", clusterID, client.ErrClusterNotFound)
 }
 
 func (m *orgScopeMock) GetClusterKubeToken(_ context.Context, clusterID string) (*client.KubeToken, error) {
@@ -384,6 +385,98 @@ func TestKubeconfigAddPinsTheOwningOrganisationForACrossOrgID(t *testing.T) {
 	want := "cluster kube-token --cluster " + otherOrgClusterID + " --org " + owningOrgID
 	if got := strings.Join(execArgsForUser(t, config, "ankra-ankra-prod"), " "); got != want {
 		t.Errorf("exec args = %q, want %q", got, want)
+	}
+}
+
+func TestFindClusterInOtherOrganisationsNeverCountsAFailedLookupAsAMiss(t *testing.T) {
+	// A lookup that failed is not a miss. Counting one would claim an
+	// organisation was searched when it never answered, and turn "we do not
+	// know" into "it does not exist".
+	mock := withOrgScopeMock(t, crossOrgMock())
+	// Two organisations are searched (Acme, then Ankra AB); fail both.
+	mock.failByIDCalls = 3 // the in-scope lookup plus both searches
+	const unknown = "99999999-9999-9999-9999-999999999999"
+
+	search := findClusterInOtherOrganisations(unknown)
+	if search.found {
+		t.Fatal("no organisation answered; nothing can have been found")
+	}
+	if search.err == nil {
+		t.Fatal("failed lookups must make the search inconclusive")
+	}
+	if len(search.searchedLabels) != 0 {
+		t.Errorf("searched labels = %v, want none: those organisations never answered", search.searchedLabels)
+	}
+
+	// And an inconclusive search must not fail the command.
+	mock.failByIDCalls = 3
+	if _, err := resolveGatewayClusterID(unknown, nil); err != nil {
+		t.Errorf("inconclusive search failed the command: %v", err)
+	}
+}
+
+func TestResolveGatewayClusterIDNeverReplacesAnExplicitOrganisation(t *testing.T) {
+	// --org / ANKRA_ORG states which organisation to use. Silently running
+	// somewhere else would defeat the point, so the search only informs the
+	// error: it names the owner and the exact retry.
+	mock := withOrgScopeMock(t, crossOrgMock())
+	mock.override = "org-acme"
+
+	_, err := resolveGatewayClusterID(otherOrgClusterID, nil)
+	if err == nil {
+		t.Fatal("expected an error rather than a silent switch away from the pinned organisation")
+	}
+	if mock.override != "org-acme" {
+		t.Errorf("organisation scope = %q, want the explicit pin %q to survive", mock.override, "org-acme")
+	}
+	for _, fragment := range []string{
+		`it belongs to "Ankra AB" (` + owningOrgID + `)`,
+		"ankra --org " + owningOrgID,
+	} {
+		if !strings.Contains(err.Error(), fragment) {
+			t.Errorf("error %q is missing %q", err, fragment)
+		}
+	}
+}
+
+func TestKubeconfigAddRefusesToWriteAContextItKnowsIsBroken(t *testing.T) {
+	// A raw-ID context pins whatever organisation is in scope, so writing one
+	// after a search that settled the question just moves the 404 to first
+	// use.
+	withOrgScopeMock(t, crossOrgMock())
+	path := filepath.Join(t.TempDir(), "config")
+	resetKubeconfigFlags(path)
+	kubeconfigClusterFlag = "99999999-9999-9999-9999-999999999999"
+
+	var out bytes.Buffer
+	err := kubeconfigAdd(&out)
+	if err == nil {
+		t.Fatal("expected an error for a cluster no organisation has")
+	}
+	if !strings.Contains(err.Error(), "not found in the 2 other organisation(s) you belong to") {
+		t.Errorf("error = %v, want the organisations searched to be named", err)
+	}
+	if code := exitCodeFor(err); code != exitNotFound {
+		t.Errorf("exit code = %d, want %d", code, exitNotFound)
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Errorf("no kubeconfig should be written on failure: %s", path)
+	}
+}
+
+func TestNotInScopedOrganisationErrorReadsAsProseWithoutAScopeLabel(t *testing.T) {
+	// Nothing local identifies the scope (no override, no saved selection),
+	// so the message must not name an organisation called "the selected
+	// organisation".
+	search := organisationScopeSearch{err: errors.New("dial tcp: connection refused")}
+
+	err := notInScopedOrganisationError(search, otherOrgClusterID, nil)
+	want := "cluster " + otherOrgClusterID + " is not in the organisation this command is scoped to"
+	if !strings.HasPrefix(err.Error(), want) {
+		t.Errorf("error = %q, want it to start with %q", err, want)
+	}
+	if !strings.Contains(err.Error(), "could not be checked") {
+		t.Errorf("error = %q, want it to admit the search did not run", err)
 	}
 }
 

--- a/internal/client/clusters.go
+++ b/internal/client/clusters.go
@@ -4,10 +4,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	neturl "net/url"
 )
+
+// ErrClusterNotFound marks a lookup that completed and found nothing, as
+// opposed to one that could not be completed. Callers that act on a cluster's
+// absence must test for it: a transport or authorisation failure says nothing
+// about whether the cluster exists.
+var ErrClusterNotFound = errors.New("cluster not found")
 
 // ClusterListItem mirrors cluster's ClusterListItem from
 // src/usecase/cluster/list_clusters.py. Backend fields the CLI does not
@@ -85,7 +92,7 @@ func (c *Client) GetCluster(name string) (ClusterListItem, error) {
 			return cluster, nil
 		}
 	}
-	return ClusterListItem{}, fmt.Errorf("no cluster found for name %q", name)
+	return ClusterListItem{}, fmt.Errorf("no cluster found for name %q: %w", name, ErrClusterNotFound)
 }
 
 // GetClusterByID looks up a cluster by its UUID. Passing an explicit page
@@ -103,7 +110,7 @@ func (c *Client) GetClusterByID(clusterID string) (ClusterListItem, error) {
 			return cluster, nil
 		}
 	}
-	return ClusterListItem{}, fmt.Errorf("no cluster found for id %q", clusterID)
+	return ClusterListItem{}, fmt.Errorf("no cluster found for id %q: %w", clusterID, ErrClusterNotFound)
 }
 
 func (c *Client) DeleteCluster(ctx context.Context, name string) error {


### PR DESCRIPTION
## What & why

Bead: ankra-btmyn

`kubectl` against an Ankra context failed with a misleading 404 whenever the
CLI's selected organisation was not the one that owns the cluster:

```
Error: kube token request failed: status 404, body: {"detail":"Cluster not found"}
... executable ankra failed with exit code 3
```

The cluster exists, the caller holds a grant on it, and the kubeconfig even
embeds the cluster UUID in the server URL. The platform resolves a cluster
reference *inside the organisation the request is scoped to*, and the exec
credential plugin passes no organisation at all, so the id resolved inside the
selected organisation and came back as a bare 404 that blames the *cluster*.
On a machine that works across organisations that sends you to check access
grants and RBAC for what is an organisation-selection problem. `ankra cluster
access grant` had the same behaviour and needed an explicit `--org`.

This PR does both halves the bead asks for.

**Resolution.** A cluster id the scoped organisation does not have is now
looked up across the organisations the caller belongs to, and the request runs
against the one that owns it (`cmd/cluster_org_scope.go`). Only ids are
searched: cluster names are unique only within an organisation, so resolving
one across them would mean guessing which same-named cluster was meant. The
lookup re-scopes **this invocation only** and never touches the persistently
selected organisation, so parallel sessions in other workspaces are
undisturbed.

**Self-contained kubeconfig entries.** `ankra cluster kubeconfig add <id>`
does the same lookup, so an id from another organisation writes a context
pinned to the *real* owner. Previously that path fell back to the selected
organisation, i.e. it baked the wrong `--org` into the exec args and produced
a context that 404s on first use. Entries that already pin `--org` are
unaffected, and entries written before pinning existed now work through the
resolution above.

**Diagnostics.** When the cluster really is nowhere, the error names the
organisation the request was scoped to and the ones that were searched
instead of repeating `Cluster not found`. A 404 from the mint itself is
decorated the same way, and when the owner is found it says so:

```
kube token request failed: status 404, body: {"detail":"Cluster not found"}
cluster 1111...1111 is not in organisation "Depict" (org-depict); it belongs to "Ankra AB" (org-ankra).
Retry scoped to the owning organisation:
  ankra --org org-ankra <command>   (or ANKRA_ORG=org-ankra)
Or re-add the context so it pins the organisation itself and survives 'ankra org switch':
  ankra cluster kubeconfig add 1111...1111
```

`ankra cluster access` list/grant/revoke get the same resolution and print a
one-line note (stderr, so `-o json|yaml` stays parseable) naming the
organisation they ran against. `kube-token` stays silent: kubectl re-runs the
credential plugin on every command, so a note there would be per-invocation
noise.

**Not regressed:** `ANKRA_ORG=<org> kubectl ...` short-circuits the lookup
entirely (root resolves it into the client override before the command runs,
the first by-id lookup then succeeds, and no organisation list is fetched).
Nothing calls `ankra org switch`.

**Failure-mode care:** a search that could not run proves nothing about a
cluster, so an unreachable organisation list leaves the id to the backend
exactly as before, and a single bad lookup is re-checked rather than promoted
into "this cluster does not exist".

## Test plan

`cmd/cluster_org_scope_test.go` models the backend behaviour that makes the
bug possible (every reference resolves inside the scoped organisation, 404
otherwise) and pins:

- a cross-organisation id resolves and the mint then runs in the owning organisation;
- the credential-plugin path writes nothing to stderr, the `cluster access` path does;
- an in-scope cluster costs no extra calls and leaves the scope untouched;
- an explicit `--org`/`ANKRA_ORG` override survives and skips the search (the documented workaround);
- an id no organisation has names the scoped organisation and every organisation searched, and exits 3;
- an unreachable organisation list passes the id through instead of failing;
- one bad lookup does not become "not found";
- a 404 from the mint names the owning organisation and keeps the original error in the chain (exit code unchanged);
- 403 still gets the access-grant suggestion, transport errors still pass through untouched;
- `kubeconfig add` with a cross-organisation id writes `--org <owner>` and the real cluster name.

The resolution and kubeconfig tests were each confirmed to fail with their
half of the change reverted.

Gates run locally: `gofmt -l` clean on touched files, `go test -race -count=1
-timeout=120s ./...` green, `golangci-lint run` 0 issues (also via the
pre-commit hook).

## Docs checklist

- [x] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); `ankra cluster kube-token`'s `Long` help now describes the cross-organisation lookup.
