### PR TITLE
feat(cloudflare): ankra org cloudflare — manage domains and DNS from the CLI (ankra-90bsy)

### DIFF
--- a/cmd/chat_test.go
+++ b/cmd/chat_test.go
@@ -85,7 +85,7 @@ func (m *chatStreamMock) StreamChat(clusterID *string, chatReq client.ChatReques
 func TestChat_BackendErrorFrameFailsWithMessage(t *testing.T) {
 	mock := &chatStreamMock{events: []client.ChatStreamEvent{
 		{Type: "error", Data: map[string]any{
-			"message": "You've sent too many messages this hour. Please wait a while and try again.",
+			"message":         "You've sent too many messages this hour. Please wait a while and try again.",
 			"is_rate_limited": true,
 		}},
 	}}

--- a/cmd/cluster_operation_results_test.go
+++ b/cmd/cluster_operation_results_test.go
@@ -27,7 +27,9 @@ func (mock *stepsResultsMock) GetExecution(executionID string) (client.Execution
 	}, nil
 }
 
-func (mock *stepsResultsMock) EnrichExecutionDetailWithDrift(_ *client.ExecutionDetail) error { return nil }
+func (mock *stepsResultsMock) EnrichExecutionDetailWithDrift(_ *client.ExecutionDetail) error {
+	return nil
+}
 
 func (mock *stepsResultsMock) GetExecutionResult(executionID string) (client.ExecutionResultResponse, error) {
 	mock.resultCalls++

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -583,6 +583,38 @@ func (m baseMock) DeleteClusterVariable(ctx context.Context, clusterID, name str
 	return errors.New("not implemented")
 }
 
+func (m baseMock) ListCloudflareCredentials(ctx context.Context) (*client.CloudflareCredentialsListResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) VerifyCloudflareToken(ctx context.Context, apiToken, accountID string) (*client.CloudflareVerification, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ConnectCloudflareCredential(ctx context.Context, name, apiToken, accountID string) (*client.CloudflareVerification, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ListCloudflareDomains(ctx context.Context, credentialName, domainName string) (*client.CloudflareDomainsListResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ListCloudflareRecords(ctx context.Context, credentialName, domainID, nameFilter, typeFilter string) (*client.CloudflareRecordsListResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) CreateCloudflareRecord(ctx context.Context, credentialName, domainID string, input client.CreateCloudflareRecordInput) (*client.CloudflareRecord, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) UpdateCloudflareRecord(ctx context.Context, credentialName, domainID, recordID string, input client.UpdateCloudflareRecordInput) (*client.CloudflareRecord, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) DeleteCloudflareRecord(ctx context.Context, credentialName, domainID, recordID string) error {
+	return errors.New("not implemented")
+}
+
 func (m baseMock) GetOrganisationDnsZone(ctx context.Context) (*client.DnsZone, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/org_cloudflare.go
+++ b/cmd/org_cloudflare.go
@@ -1,0 +1,700 @@
+package cmd
+
+// The Cloudflare domain commands: connect a scoped API token, list the
+// domains it reaches, and manage the DNS records inside them.
+//
+// Records live in the customer's own Cloudflare account and take effect
+// immediately, so the destructive commands confirm by default and the delete
+// prompt names the record it is about to remove.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+var orgCloudflareCmd = &cobra.Command{
+	Use:   "cloudflare",
+	Short: "Manage the DNS records of your Cloudflare-hosted domains",
+	Long: `Manage the domains your Cloudflare account holds, from Ankra.
+
+Connect a scoped Cloudflare API token once, then list your domains and manage
+their DNS records. Records are written into your own Cloudflare account and
+take effect immediately - there is no pending state to wait for.
+
+  ankra org cloudflare connect production
+  ankra org cloudflare domains
+  ankra org cloudflare records example.com
+  ankra org cloudflare add example.com app A 203.0.113.10 --ttl 300
+  ankra org cloudflare update example.com app 203.0.113.11
+  ankra org cloudflare delete example.com app
+
+Connecting a credential and changing records requires organisation admin.
+
+Ankra needs a scoped API token, never a Global API Key: a key carries every
+permission on every zone in your account. Create a token with Zone:Read on the
+zones Ankra should see and DNS:Edit on the zones it should write to.`,
+}
+
+var orgCloudflareCredentialsCmd = &cobra.Command{
+	Use:   "credentials",
+	Short: "List the organisation's connected Cloudflare credentials",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out, err := structuredFormatFromFlags(cmd)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+		defer cancel()
+
+		list, err := apiClient.ListCloudflareCredentials(ctx)
+		if err != nil {
+			return cloudflareError(err, "list Cloudflare credentials")
+		}
+		return renderCloudflareCredentials(cmd.OutOrStdout(), list.Items, out)
+	},
+}
+
+var orgCloudflareConnectCmd = &cobra.Command{
+	Use:   "connect <name>",
+	Short: "Connect a Cloudflare API token to the organisation",
+	Long: `Connect a scoped Cloudflare API token under the given credential name.
+
+The token is read from the ANKRA_CLOUDFLARE_API_TOKEN environment variable, or
+from stdin with --token-stdin - never from a flag, so it does not land in your
+shell history or the process list. Ankra verifies it with Cloudflare before
+storing anything, and refuses a token that reaches no zones: such a token
+authenticates perfectly and manages nothing.
+
+Pass --verify-only to check a token without storing it.
+
+  ANKRA_CLOUDFLARE_API_TOKEN=... ankra org cloudflare connect production
+  cat token.txt | ankra org cloudflare connect production --token-stdin
+  ANKRA_CLOUDFLARE_API_TOKEN=... ankra org cloudflare connect --verify-only`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		verifyOnly, _ := cmd.Flags().GetBool("verify-only")
+		accountID, _ := cmd.Flags().GetString("account-id")
+
+		name := ""
+		if len(args) == 1 {
+			name = args[0]
+		}
+		if !verifyOnly && name == "" {
+			return errors.New("a credential name is required; pass --verify-only to check a token without storing it")
+		}
+
+		apiToken, err := readCloudflareToken(cmd)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 120*time.Second)
+		defer cancel()
+
+		if verifyOnly {
+			verification, err := apiClient.VerifyCloudflareToken(ctx, apiToken, accountID)
+			if err != nil {
+				return cloudflareError(err, "verify the Cloudflare token")
+			}
+			renderCloudflareVerification(cmd.OutOrStdout(), verification, "")
+			return nil
+		}
+
+		verification, err := apiClient.ConnectCloudflareCredential(ctx, name, apiToken, accountID)
+		if err != nil {
+			return cloudflareError(err, "connect Cloudflare")
+		}
+		renderCloudflareVerification(cmd.OutOrStdout(), verification, name)
+		return nil
+	},
+}
+
+var orgCloudflareDomainsCmd = &cobra.Command{
+	Use:   "domains [name]",
+	Short: "List the Cloudflare domains the organisation can reach",
+	Long: `List the domains (zones) the connected Cloudflare credential reaches.
+
+Pass a domain name to resolve just that one, which costs a single lookup
+rather than a walk through every domain in the account. An empty result means
+Ankra does not reach that domain - either it is not in Cloudflare, or the
+connected token is scoped away from it.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out, err := structuredFormatFromFlags(cmd)
+		if err != nil {
+			return err
+		}
+		credentialName, _ := cmd.Flags().GetString("credential")
+		domainName := ""
+		if len(args) == 1 {
+			domainName = args[0]
+		}
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+		defer cancel()
+
+		list, err := apiClient.ListCloudflareDomains(ctx, credentialName, domainName)
+		if err != nil {
+			return cloudflareError(err, "list Cloudflare domains")
+		}
+		if list.IsTruncated {
+			// Said out loud rather than dropped: a partial page read as the
+			// whole account is how "that domain is not in Cloudflare" gets
+			// concluded wrongly.
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
+				"Note: more domains exist than were listed. Pass a domain name to resolve one directly.")
+		}
+		return renderCloudflareDomains(cmd.OutOrStdout(), list.Items, out)
+	},
+}
+
+var orgCloudflareRecordsCmd = &cobra.Command{
+	Use:   "records <domain>",
+	Short: "List the DNS records in a Cloudflare domain",
+	Long: `List a domain's DNS records. The domain is referenced by name or by its
+Cloudflare zone id.
+
+Each record reports whether Ankra created it (MANAGED "ankra") or it was made
+elsewhere (MANAGED "external") - which is how to tell a platform-published
+record from one written by hand, by Terraform, or by a cluster controller.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out, err := structuredFormatFromFlags(cmd)
+		if err != nil {
+			return err
+		}
+		credentialName, _ := cmd.Flags().GetString("credential")
+		nameFilter, _ := cmd.Flags().GetString("name")
+		typeFilter, _ := cmd.Flags().GetString("type")
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+		defer cancel()
+
+		domainID, err := resolveCloudflareDomainID(ctx, credentialName, args[0])
+		if err != nil {
+			return err
+		}
+		list, err := apiClient.ListCloudflareRecords(ctx, credentialName, domainID, nameFilter, strings.ToUpper(typeFilter))
+		if err != nil {
+			return cloudflareError(err, "list DNS records")
+		}
+		if list.IsTruncated {
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
+				"Note: more records exist than were listed. Narrow with --name or --type.")
+		}
+		return renderCloudflareRecords(cmd.OutOrStdout(), list.Items, out)
+	},
+}
+
+var orgCloudflareAddCmd = &cobra.Command{
+	Use:   "add <domain> <name> <type> <content>",
+	Short: "Add a DNS record to a Cloudflare domain",
+	Long: `Add a DNS record. The name is a bare label inside the domain, a
+fully-qualified name inside it, or '@' for the domain itself.
+
+  ankra org cloudflare add example.com app A 203.0.113.10 --ttl 300
+  ankra org cloudflare add example.com www CNAME app.example.com --proxied
+  ankra org cloudflare add example.com @ TXT "v=spf1 -all"
+  ankra org cloudflare add example.com @ MX mail.example.com --priority 10
+
+Only A, AAAA and CNAME records can be proxied through Cloudflare. A proxied
+record's TTL is managed by Cloudflare, so --ttl is refused with --proxied.`,
+	Args: cobra.ExactArgs(4),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		credentialName, _ := cmd.Flags().GetString("credential")
+		domainReference, name, recordType, content := args[0], args[1], strings.ToUpper(args[2]), args[3]
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+		defer cancel()
+
+		domainID, err := resolveCloudflareDomainID(ctx, credentialName, domainReference)
+		if err != nil {
+			return err
+		}
+
+		input := client.CreateCloudflareRecordInput{
+			Name:       name,
+			RecordType: recordType,
+			Content:    content,
+			TTL:        cloudflareTTLFromFlags(cmd),
+			Priority:   cloudflareIntFlag(cmd, "priority"),
+		}
+		if proxied, _ := cmd.Flags().GetBool("proxied"); proxied {
+			input.Proxied = &proxied
+		}
+		if comment, _ := cmd.Flags().GetString("comment"); comment != "" {
+			input.Comment = comment
+		}
+
+		record, err := apiClient.CreateCloudflareRecord(ctx, credentialName, domainID, input)
+		if err != nil {
+			return cloudflareError(err, "add the DNS record")
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "DNS record %s %s -> %s created%s.\n",
+			record.RecordType, record.Name, record.Content, proxiedSuffix(record.Proxied))
+		return nil
+	},
+}
+
+var orgCloudflareUpdateCmd = &cobra.Command{
+	Use:   "update <domain> <record> <content>",
+	Short: "Re-point a DNS record at new content",
+	Long: `Re-point a record at new content. The record is referenced by its id or by
+its name; a record's name and type never change - delete and re-add instead.
+
+Only the fields you pass change: an omitted --ttl, --proxied or --priority
+keeps the record's current value.`,
+	Args: cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		credentialName, _ := cmd.Flags().GetString("credential")
+		domainReference, recordReference, content := args[0], args[1], args[2]
+		recordType, _ := cmd.Flags().GetString("type")
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+		defer cancel()
+
+		domainID, err := resolveCloudflareDomainID(ctx, credentialName, domainReference)
+		if err != nil {
+			return err
+		}
+		recordID, err := resolveCloudflareRecordID(ctx, credentialName, domainID, recordReference, recordType)
+		if err != nil {
+			return err
+		}
+
+		input := client.UpdateCloudflareRecordInput{
+			Content:  content,
+			TTL:      cloudflareTTLFromFlags(cmd),
+			Priority: cloudflareIntFlag(cmd, "priority"),
+		}
+		if cmd.Flags().Changed("proxied") {
+			proxied, _ := cmd.Flags().GetBool("proxied")
+			input.Proxied = &proxied
+		}
+		if comment, _ := cmd.Flags().GetString("comment"); comment != "" {
+			input.Comment = comment
+		}
+
+		record, err := apiClient.UpdateCloudflareRecord(ctx, credentialName, domainID, recordID, input)
+		if err != nil {
+			return cloudflareError(err, "update the DNS record")
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "DNS record %s %s -> %s updated%s.\n",
+			record.RecordType, record.Name, record.Content, proxiedSuffix(record.Proxied))
+		return nil
+	},
+}
+
+var orgCloudflareDeleteCmd = &cobra.Command{
+	Use:   "delete <domain> <record>",
+	Short: "Delete a DNS record from a Cloudflare domain",
+	Long: `Delete a DNS record, referenced by its id or by its name. When several
+records share a name, disambiguate with --type.
+
+The record lives in your own Cloudflare account: Ankra cannot restore it, and
+removing a record live traffic depends on takes the hostname down immediately.
+The prompt names the record before removing it.`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		credentialName, _ := cmd.Flags().GetString("credential")
+		domainReference, recordReference := args[0], args[1]
+		recordType, _ := cmd.Flags().GetString("type")
+		yes, _ := cmd.Flags().GetBool("yes")
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+		defer cancel()
+
+		domainID, err := resolveCloudflareDomainID(ctx, credentialName, domainReference)
+		if err != nil {
+			return err
+		}
+		record, err := resolveCloudflareRecord(ctx, credentialName, domainID, recordReference, recordType)
+		if err != nil {
+			return err
+		}
+
+		// The prompt names the record's type, name and content: "delete app"
+		// is not enough to approve removing live DNS. A record Ankra did not
+		// create is called out, because something outside the platform put it
+		// there.
+		prompt := fmt.Sprintf("Delete %s %s -> %s from %s?",
+			record.RecordType, record.Name, record.Content, record.ZoneName)
+		if record.ManagedBy != "ankra" {
+			prompt += " This record was not created through Ankra."
+		}
+		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(), prompt+" [y/N]: ", yes); err != nil {
+			return err
+		}
+
+		if err := apiClient.DeleteCloudflareRecord(ctx, credentialName, domainID, record.ID); err != nil {
+			return cloudflareError(err, "delete the DNS record")
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "DNS record %s %s deleted.\n", record.RecordType, record.Name)
+		return nil
+	},
+}
+
+// --- helpers ---
+
+// cloudflareTokenEnvName is where the token is read from, so it never lands in
+// shell history the way a --token flag would.
+const cloudflareTokenEnvName = "ANKRA_CLOUDFLARE_API_TOKEN"
+
+// readCloudflareToken takes the token from the environment or from stdin,
+// never from a flag.
+//
+// A --token flag would put a live credential in shell history and in the
+// process list. Prompting interactively is not offered either: without a
+// terminal-control dependency the input cannot be read with echo disabled,
+// and a token echoed into scrollback is no better than one in history. Env
+// var and --token-stdin both work in scripts and CI, which is where this
+// command mostly runs.
+func readCloudflareToken(cmd *cobra.Command) (string, error) {
+	fromStdin, _ := cmd.Flags().GetBool("token-stdin")
+	if fromStdin {
+		raw, err := io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return "", fmt.Errorf("read the API token from stdin: %w", err)
+		}
+		token := strings.TrimSpace(string(raw))
+		if token == "" {
+			return "", errors.New("no API token was read from stdin")
+		}
+		return token, nil
+	}
+	if fromEnvironment := strings.TrimSpace(os.Getenv(cloudflareTokenEnvName)); fromEnvironment != "" {
+		return fromEnvironment, nil
+	}
+	return "", fmt.Errorf("no API token supplied. Set %s, or pipe the token in with --token-stdin:\n"+
+		"  %s=... ankra org cloudflare connect <name>\n"+
+		"  cat token.txt | ankra org cloudflare connect <name> --token-stdin",
+		cloudflareTokenEnvName, cloudflareTokenEnvName)
+}
+
+// cloudflareError renders the backend's own guidance where it has some, and
+// falls back to a wrapped error otherwise. The two sentinels carry the next
+// step, which a bare 404 would not.
+func cloudflareError(err error, action string) error {
+	if errors.Is(err, client.ErrCloudflareNotConnected) {
+		return errors.New("no Cloudflare credential is connected for this organisation.\n" +
+			"Connect one with 'ankra org cloudflare connect <name>'.")
+	}
+	if errors.Is(err, client.ErrCloudflareNotFound) {
+		return err
+	}
+	return fmt.Errorf("%s: %w", action, err)
+}
+
+func proxiedSuffix(proxied bool) string {
+	if proxied {
+		return " (proxied through Cloudflare)"
+	}
+	return ""
+}
+
+// cloudflareTTLFromFlags returns --ttl, nil when unset so the backend keeps
+// Cloudflare's automatic TTL on create and the record's current TTL on update.
+func cloudflareTTLFromFlags(cmd *cobra.Command) *int {
+	return cloudflareIntFlag(cmd, "ttl")
+}
+
+func cloudflareIntFlag(cmd *cobra.Command, name string) *int {
+	flag := cmd.Flags().Lookup(name)
+	if flag == nil || !flag.Changed {
+		return nil
+	}
+	value, err := cmd.Flags().GetInt(name)
+	if err != nil {
+		return nil
+	}
+	return &value
+}
+
+// resolveCloudflareDomainID resolves a domain reference - a Cloudflare zone id
+// or a domain name - to the zone id.
+//
+// A name is resolved through the server-side exact-name filter, which is one
+// lookup rather than a walk through every domain in the account.
+func resolveCloudflareDomainID(ctx context.Context, credentialName, reference string) (string, error) {
+	trimmed := strings.TrimSuffix(strings.TrimSpace(reference), ".")
+	if trimmed == "" {
+		return "", errors.New("a domain name or zone id is required")
+	}
+	// A Cloudflare zone id is 32 hex characters and carries no dot; a domain
+	// name always has one. Treating a dotted reference as a name avoids a
+	// pointless lookup for the common case.
+	if !strings.Contains(trimmed, ".") {
+		return trimmed, nil
+	}
+	list, err := apiClient.ListCloudflareDomains(ctx, credentialName, trimmed)
+	if err != nil {
+		return "", cloudflareError(err, "resolve the domain")
+	}
+	if len(list.Items) == 0 {
+		return "", fmt.Errorf("no Cloudflare domain named %q is reachable; run 'ankra org cloudflare domains'", reference)
+	}
+	return list.Items[0].ID, nil
+}
+
+func resolveCloudflareRecordID(ctx context.Context, credentialName, domainID, reference, recordType string) (string, error) {
+	record, err := resolveCloudflareRecord(ctx, credentialName, domainID, reference, recordType)
+	if err != nil {
+		return "", err
+	}
+	return record.ID, nil
+}
+
+// resolveCloudflareRecord resolves a record reference - an id, a full name, or
+// a bare label - to the record, listing candidates when it is ambiguous.
+func resolveCloudflareRecord(ctx context.Context, credentialName, domainID, reference, recordType string) (*client.CloudflareRecord, error) {
+	list, err := apiClient.ListCloudflareRecords(ctx, credentialName, domainID, "", "")
+	if err != nil {
+		return nil, cloudflareError(err, "list DNS records")
+	}
+	normalisedReference := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(reference), "."))
+	wantedType := strings.ToUpper(recordType)
+
+	var matches []client.CloudflareRecord
+	for _, record := range list.Items {
+		isMatch := record.ID == reference ||
+			strings.ToLower(record.Name) == normalisedReference ||
+			strings.HasPrefix(strings.ToLower(record.Name), normalisedReference+".")
+		if !isMatch {
+			continue
+		}
+		if wantedType != "" && record.RecordType != wantedType {
+			continue
+		}
+		matches = append(matches, record)
+	}
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("no DNS record matches %q in that domain; run 'ankra org cloudflare records <domain>'", reference)
+	case 1:
+		return &matches[0], nil
+	default:
+		candidates := make([]string, 0, len(matches))
+		for _, record := range matches {
+			candidates = append(candidates, fmt.Sprintf("%s %s -> %s (%s)",
+				record.RecordType, record.Name, record.Content, record.ID))
+		}
+		return nil, fmt.Errorf("%q is ambiguous, disambiguate with --type or use an id:\n  %s",
+			reference, strings.Join(candidates, "\n  "))
+	}
+}
+
+// --- rendering ---
+
+func renderCloudflareVerification(out io.Writer, verification *client.CloudflareVerification, connectedName string) {
+	if verification == nil {
+		if connectedName != "" {
+			_, _ = fmt.Fprintf(out, "Cloudflare credential %q connected.\n", connectedName)
+		}
+		return
+	}
+	if connectedName != "" {
+		_, _ = fmt.Fprintf(out, "Cloudflare credential %q connected.\n", connectedName)
+	}
+	if !verification.IsActive {
+		_, _ = fmt.Fprintf(out, "Cloudflare reports this token as %s. Renew or re-enable it in Cloudflare.\n",
+			verification.Status)
+		return
+	}
+	account := verification.AccountName
+	if account == "" {
+		account = verification.AccountID
+	}
+	if account != "" {
+		_, _ = fmt.Fprintf(out, "Account: %s\n", account)
+	}
+	_, _ = fmt.Fprintf(out, "Reaches %d domain%s", verification.ZoneCount, plural(verification.ZoneCount))
+	if len(verification.ZoneNames) > 0 {
+		_, _ = fmt.Fprintf(out, ": %s", strings.Join(verification.ZoneNames, ", "))
+		if verification.ZoneCount > len(verification.ZoneNames) {
+			_, _ = fmt.Fprint(out, ", ...")
+		}
+	}
+	_, _ = fmt.Fprintln(out)
+	if verification.ExpiresOn != "" {
+		_, _ = fmt.Fprintf(out, "Token expires: %s\n", verification.ExpiresOn)
+	}
+}
+
+func plural(count int) string {
+	if count == 1 {
+		return ""
+	}
+	return "s"
+}
+
+func renderCloudflareCredentials(out io.Writer, credentials []client.CloudflareCredential, format outputFormat) error {
+	switch format {
+	case outputJSON:
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(client.CloudflareCredentialsListResult{Items: credentials})
+	case outputYAML:
+		enc := yaml.NewEncoder(out)
+		enc.SetIndent(2)
+		defer func() { _ = enc.Close() }()
+		return enc.Encode(client.CloudflareCredentialsListResult{Items: credentials})
+	}
+	if len(credentials) == 0 {
+		_, _ = fmt.Fprintln(out, "No Cloudflare credentials connected. Connect one with 'ankra org cloudflare connect <name>'.")
+		return nil
+	}
+	t := table.NewWriter()
+	t.SetOutputMirror(out)
+	t.SetStyle(table.StyleRounded)
+	t.AppendHeader(table.Row{"NAME", "ACCOUNT", "TOKEN", "EXPIRES", "STATUS"})
+	for _, credential := range credentials {
+		account := credential.AccountName
+		if account == "" {
+			account = credential.AccountID
+		}
+		expires := credential.TokenExpiresAt
+		if expires == "" {
+			expires = "never"
+		} else if len(expires) >= 10 {
+			expires = expires[:10]
+		}
+		status := credential.State
+		if credential.IsExpired {
+			status = "expired"
+		}
+		t.AppendRow(table.Row{credential.Name, account, credential.TokenID, expires, status})
+	}
+	t.Render()
+	return nil
+}
+
+func renderCloudflareDomains(out io.Writer, domains []client.CloudflareDomain, format outputFormat) error {
+	switch format {
+	case outputJSON:
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(client.CloudflareDomainsListResult{Items: domains})
+	case outputYAML:
+		enc := yaml.NewEncoder(out)
+		enc.SetIndent(2)
+		defer func() { _ = enc.Close() }()
+		return enc.Encode(client.CloudflareDomainsListResult{Items: domains})
+	}
+	if len(domains) == 0 {
+		_, _ = fmt.Fprintln(out, "No Cloudflare domains are reachable with the connected credential.")
+		return nil
+	}
+	t := table.NewWriter()
+	t.SetOutputMirror(out)
+	t.SetStyle(table.StyleRounded)
+	t.AppendHeader(table.Row{"NAME", "ZONE ID", "STATUS", "TYPE", "NAMESERVERS"})
+	for _, domain := range domains {
+		t.AppendRow(table.Row{
+			domain.Name, domain.ID, domain.Status, domain.Type,
+			truncateForDisplay(strings.Join(domain.NameServers, ", "), 44),
+		})
+	}
+	t.Render()
+	return nil
+}
+
+func renderCloudflareRecords(out io.Writer, records []client.CloudflareRecord, format outputFormat) error {
+	switch format {
+	case outputJSON:
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(client.CloudflareRecordsListResult{Items: records})
+	case outputYAML:
+		enc := yaml.NewEncoder(out)
+		enc.SetIndent(2)
+		defer func() { _ = enc.Close() }()
+		return enc.Encode(client.CloudflareRecordsListResult{Items: records})
+	}
+	if len(records) == 0 {
+		_, _ = fmt.Fprintln(out, "No DNS records in that domain.")
+		return nil
+	}
+	t := table.NewWriter()
+	t.SetOutputMirror(out)
+	t.SetStyle(table.StyleRounded)
+	t.AppendHeader(table.Row{"NAME", "TYPE", "CONTENT", "TTL", "PROXY", "MANAGED"})
+	for _, record := range records {
+		ttl := "Auto"
+		if !record.IsTTLAutomatic {
+			ttl = fmt.Sprintf("%d", record.TTL)
+		}
+		proxy := "direct"
+		if record.Proxied {
+			proxy = "proxied"
+		}
+		content := record.Content
+		if record.Priority != nil {
+			content = fmt.Sprintf("%s (priority %d)", content, *record.Priority)
+		}
+		t.AppendRow(table.Row{
+			record.Name, record.RecordType, truncateForDisplay(content, 46), ttl, proxy, record.ManagedBy,
+		})
+	}
+	t.Render()
+	return nil
+}
+
+func init() {
+	registerStructuredOutputFlags(orgCloudflareCredentialsCmd, orgCloudflareDomainsCmd, orgCloudflareRecordsCmd)
+
+	// --credential selects among several connected credentials; with one
+	// connected the backend resolves it, so it stays optional everywhere.
+	for _, command := range []*cobra.Command{
+		orgCloudflareDomainsCmd, orgCloudflareRecordsCmd, orgCloudflareAddCmd,
+		orgCloudflareUpdateCmd, orgCloudflareDeleteCmd,
+	} {
+		command.Flags().String("credential", "",
+			"Which connected Cloudflare credential to use (only needed with several)")
+	}
+
+	orgCloudflareConnectCmd.Flags().Bool("verify-only", false, "Check the token without storing it")
+	orgCloudflareConnectCmd.Flags().Bool("token-stdin", false,
+		"Read the API token from stdin instead of "+cloudflareTokenEnvName)
+	orgCloudflareConnectCmd.Flags().String("account-id", "",
+		"Pin every domain listing to one Cloudflare account (only needed for a token spanning several)")
+
+	orgCloudflareRecordsCmd.Flags().String("name", "", "Filter to this exact record name")
+	orgCloudflareRecordsCmd.Flags().String("type", "", "Filter to this record type")
+
+	orgCloudflareAddCmd.Flags().Int("ttl", 0, "TTL in seconds (60..86400); omitted means Cloudflare's Auto")
+	orgCloudflareAddCmd.Flags().Bool("proxied", false, "Route the record through Cloudflare's proxy (A, AAAA and CNAME only)")
+	orgCloudflareAddCmd.Flags().Int("priority", 0, "Priority for MX and SRV records")
+	orgCloudflareAddCmd.Flags().String("comment", "", "Comment stored on the record")
+
+	orgCloudflareUpdateCmd.Flags().Int("ttl", 0, "TTL in seconds (60..86400); omitted keeps the record's current TTL")
+	orgCloudflareUpdateCmd.Flags().Bool("proxied", false, "Route the record through Cloudflare's proxy; omitted keeps the current setting")
+	orgCloudflareUpdateCmd.Flags().Int("priority", 0, "Priority for MX and SRV records; omitted keeps the current priority")
+	orgCloudflareUpdateCmd.Flags().String("comment", "", "Comment stored on the record")
+	orgCloudflareUpdateCmd.Flags().String("type", "", "Record type to disambiguate a name reference")
+
+	orgCloudflareDeleteCmd.Flags().String("type", "", "Record type to disambiguate a name reference")
+	orgCloudflareDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
+
+	orgCloudflareCmd.AddCommand(orgCloudflareCredentialsCmd)
+	orgCloudflareCmd.AddCommand(orgCloudflareConnectCmd)
+	orgCloudflareCmd.AddCommand(orgCloudflareDomainsCmd)
+	orgCloudflareCmd.AddCommand(orgCloudflareRecordsCmd)
+	orgCloudflareCmd.AddCommand(orgCloudflareAddCmd)
+	orgCloudflareCmd.AddCommand(orgCloudflareUpdateCmd)
+	orgCloudflareCmd.AddCommand(orgCloudflareDeleteCmd)
+	orgCmd.AddCommand(orgCloudflareCmd)
+}

--- a/cmd/org_cloudflare.go
+++ b/cmd/org_cloudflare.go
@@ -391,7 +391,7 @@ func readCloudflareToken(cmd *cobra.Command) (string, error) {
 func cloudflareError(err error, action string) error {
 	if errors.Is(err, client.ErrCloudflareNotConnected) {
 		return errors.New("no Cloudflare credential is connected for this organisation.\n" +
-			"Connect one with 'ankra org cloudflare connect <name>'.")
+			"Connect one with 'ankra org cloudflare connect <name>'")
 	}
 	if errors.Is(err, client.ErrCloudflareNotFound) {
 		return err

--- a/cmd/org_cloudflare.go
+++ b/cmd/org_cloudflare.go
@@ -237,12 +237,20 @@ record's TTL is managed by Cloudflare, so --ttl is refused with --proxied.`,
 			return err
 		}
 
+		ttl, err := cloudflareTTLFromFlags(cmd)
+		if err != nil {
+			return err
+		}
+		priority, err := cloudflareIntFlag(cmd, "priority")
+		if err != nil {
+			return err
+		}
 		input := client.CreateCloudflareRecordInput{
 			Name:       name,
 			RecordType: recordType,
 			Content:    content,
-			TTL:        cloudflareTTLFromFlags(cmd),
-			Priority:   cloudflareIntFlag(cmd, "priority"),
+			TTL:        ttl,
+			Priority:   priority,
 		}
 		if proxied, _ := cmd.Flags().GetBool("proxied"); proxied {
 			input.Proxied = &proxied
@@ -291,10 +299,18 @@ keeps the record's current value.`,
 			return err
 		}
 
+		ttl, err := cloudflareTTLFromFlags(cmd)
+		if err != nil {
+			return err
+		}
+		priority, err := cloudflareIntFlag(cmd, "priority")
+		if err != nil {
+			return err
+		}
 		input := client.UpdateCloudflareRecordInput{
 			Content:  content,
-			TTL:      cloudflareTTLFromFlags(cmd),
-			Priority: cloudflareIntFlag(cmd, "priority"),
+			TTL:      ttl,
+			Priority: priority,
 		}
 		if cmd.Flags().Changed("proxied") {
 			proxied, _ := cmd.Flags().GetBool("proxied")
@@ -438,26 +454,27 @@ func proxiedSuffix(proxied bool) string {
 
 // cloudflareTTLFromFlags returns --ttl, nil when unset so the backend keeps
 // Cloudflare's automatic TTL on create and the record's current TTL on update.
-func cloudflareTTLFromFlags(cmd *cobra.Command) *int {
+func cloudflareTTLFromFlags(cmd *cobra.Command) (*int, error) {
 	return cloudflareIntFlag(cmd, "ttl")
 }
 
 // cloudflareIntFlag returns a flag the caller actually passed, or nil.
 //
-// A parse failure is impossible for a flag declared as an Int - cobra rejects
-// a non-integer at parse time - so it is reported rather than swallowed. The
-// previous shape returned nil on error, which would have turned a malformed
-// value into a silent "leave this field as it is".
-func cloudflareIntFlag(cmd *cobra.Command, name string) *int {
+// A read failure is only possible if the flag is not declared as an Int - a
+// wiring mistake, not user input - so it is returned rather than swallowed.
+// Returning nil on error would turn it into a silent "leave this field as it
+// is", and panicking would end a user's command with a stack trace for a bug
+// that is ours.
+func cloudflareIntFlag(cmd *cobra.Command, name string) (*int, error) {
 	flag := cmd.Flags().Lookup(name)
 	if flag == nil || !flag.Changed {
-		return nil
+		return nil, nil
 	}
 	value, err := cmd.Flags().GetInt(name)
 	if err != nil {
-		panic(fmt.Sprintf("flag --%s is declared as an int but did not read back as one: %v", name, err))
+		return nil, fmt.Errorf("reading --%s: %w", name, err)
 	}
-	return &value
+	return &value, nil
 }
 
 // resolveCloudflareDomainID resolves a domain reference - a Cloudflare zone id
@@ -470,10 +487,11 @@ func resolveCloudflareDomainID(ctx context.Context, credentialName, reference st
 	if trimmed == "" {
 		return "", errors.New("a domain name or zone id is required")
 	}
-	// A Cloudflare zone id is 32 hex characters and carries no dot; a domain
-	// name always has one. Treating a dotted reference as a name avoids a
-	// pointless lookup for the common case.
-	if !strings.Contains(trimmed, ".") {
+	// A Cloudflare zone id is exactly 32 hex characters. Anything else is
+	// treated as a domain name and resolved, so a typo'd bare label reports
+	// "no domain named ..." rather than being posted as an identifier the API
+	// then rejects with a code nobody reads.
+	if looksLikeCloudflareZoneID(trimmed) {
 		return trimmed, nil
 	}
 	list, err := apiClient.ListCloudflareDomains(ctx, credentialName, trimmed)
@@ -484,6 +502,22 @@ func resolveCloudflareDomainID(ctx context.Context, credentialName, reference st
 		return "", fmt.Errorf("no Cloudflare domain named %q is reachable; run 'ankra org cloudflare domains'", reference)
 	}
 	return list.Items[0].ID, nil
+}
+
+// looksLikeCloudflareZoneID reports whether a reference has the shape of a
+// Cloudflare zone id: exactly 32 lowercase hex characters.
+func looksLikeCloudflareZoneID(reference string) bool {
+	if len(reference) != 32 {
+		return false
+	}
+	for _, character := range reference {
+		isHexDigit := (character >= '0' && character <= '9') ||
+			(character >= 'a' && character <= 'f')
+		if !isHexDigit {
+			return false
+		}
+	}
+	return true
 }
 
 func resolveCloudflareRecordID(ctx context.Context, credentialName, domainID, reference, recordType string) (string, error) {
@@ -520,8 +554,10 @@ func resolveCloudflareRecord(ctx context.Context, credentialName, domainID, refe
 	}
 
 	var matches []client.CloudflareRecord
+	var matchedByID bool
 	for _, record := range list.Items {
-		isMatch := record.ID == reference ||
+		isIDMatch := record.ID == reference
+		isMatch := isIDMatch ||
 			strings.ToLower(record.Name) == normalisedReference ||
 			strings.HasPrefix(strings.ToLower(record.Name), normalisedReference+".")
 		if !isMatch {
@@ -530,18 +566,26 @@ func resolveCloudflareRecord(ctx context.Context, credentialName, domainID, refe
 		if wantedType != "" && record.RecordType != wantedType {
 			continue
 		}
+		if isIDMatch {
+			matchedByID = true
+		}
 		matches = append(matches, record)
 	}
+
+	// A capped listing has not been fully observed, so nothing read from it is
+	// a fact about the zone - neither "no match" nor "exactly one match". A
+	// single match could have a twin beyond the page, and for delete that
+	// removes a record the user was never told was ambiguous. A record id is
+	// the exception: ids are unique by construction, so a match on one needs
+	// no listing to be complete.
+	if list.IsTruncated && !matchedByID {
+		return nil, fmt.Errorf("could not resolve %q: the record listing for that domain was truncated, "+
+			"so what it shows is not the whole zone. Pass the record's id instead, or narrow with --type",
+			reference)
+	}
+
 	switch len(matches) {
 	case 0:
-		// A capped listing has not been fully observed, so "no match" is not a
-		// fact about the zone. Say what was actually seen rather than
-		// declaring the record absent.
-		if list.IsTruncated {
-			return nil, fmt.Errorf("could not resolve %q: the record listing for that domain was truncated, "+
-				"so this is not proof the record is absent. Pass the record's id instead, "+
-				"or narrow with --type", reference)
-		}
 		return nil, fmt.Errorf("no DNS record matches %q in that domain; run 'ankra org cloudflare records <domain>'", reference)
 	case 1:
 		return &matches[0], nil

--- a/cmd/org_cloudflare.go
+++ b/cmd/org_cloudflare.go
@@ -96,6 +96,13 @@ Pass --verify-only to check a token without storing it.
 		if !verifyOnly && name == "" {
 			return errors.New("a credential name is required; pass --verify-only to check a token without storing it")
 		}
+		// --verify-only stores nothing, so a name would be discarded. Saying
+		// so beats accepting it and leaving the operator believing they
+		// connected a credential.
+		if verifyOnly && name != "" {
+			return fmt.Errorf("--verify-only stores nothing, so the credential name %q would be ignored; "+
+				"drop the name to check the token, or drop --verify-only to connect it", name)
+		}
 
 		apiToken, err := readCloudflareToken(cmd)
 		if err != nil {
@@ -218,6 +225,10 @@ record's TTL is managed by Cloudflare, so --ttl is refused with --proxied.`,
 		credentialName, _ := cmd.Flags().GetString("credential")
 		domainReference, name, recordType, content := args[0], args[1], strings.ToUpper(args[2]), args[3]
 
+		if err := refuseTTLWithProxy(cmd); err != nil {
+			return err
+		}
+
 		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
 		defer cancel()
 
@@ -263,6 +274,10 @@ keeps the record's current value.`,
 		credentialName, _ := cmd.Flags().GetString("credential")
 		domainReference, recordReference, content := args[0], args[1], args[2]
 		recordType, _ := cmd.Flags().GetString("type")
+
+		if err := refuseTTLWithProxy(cmd); err != nil {
+			return err
+		}
 
 		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
 		defer cancel()
@@ -350,6 +365,21 @@ The prompt names the record before removing it.`,
 
 // --- helpers ---
 
+// refuseTTLWithProxy enforces what the help text promises: Cloudflare owns a
+// proxied record's TTL and rejects an explicit one, so the combination is
+// refused here with a message naming both flags rather than forwarded for the
+// API to reject with a code nobody reads.
+func refuseTTLWithProxy(cmd *cobra.Command) error {
+	if !cmd.Flags().Changed("ttl") || !cmd.Flags().Changed("proxied") {
+		return nil
+	}
+	proxied, _ := cmd.Flags().GetBool("proxied")
+	if !proxied {
+		return nil
+	}
+	return errors.New("--ttl cannot be combined with --proxied: Cloudflare manages a proxied record's TTL")
+}
+
 // cloudflareTokenEnvName is where the token is read from, so it never lands in
 // shell history the way a --token flag would.
 const cloudflareTokenEnvName = "ANKRA_CLOUDFLARE_API_TOKEN"
@@ -412,6 +442,12 @@ func cloudflareTTLFromFlags(cmd *cobra.Command) *int {
 	return cloudflareIntFlag(cmd, "ttl")
 }
 
+// cloudflareIntFlag returns a flag the caller actually passed, or nil.
+//
+// A parse failure is impossible for a flag declared as an Int - cobra rejects
+// a non-integer at parse time - so it is reported rather than swallowed. The
+// previous shape returned nil on error, which would have turned a malformed
+// value into a silent "leave this field as it is".
 func cloudflareIntFlag(cmd *cobra.Command, name string) *int {
 	flag := cmd.Flags().Lookup(name)
 	if flag == nil || !flag.Changed {
@@ -419,7 +455,7 @@ func cloudflareIntFlag(cmd *cobra.Command, name string) *int {
 	}
 	value, err := cmd.Flags().GetInt(name)
 	if err != nil {
-		return nil
+		panic(fmt.Sprintf("flag --%s is declared as an int but did not read back as one: %v", name, err))
 	}
 	return &value
 }
@@ -460,13 +496,28 @@ func resolveCloudflareRecordID(ctx context.Context, credentialName, domainID, re
 
 // resolveCloudflareRecord resolves a record reference - an id, a full name, or
 // a bare label - to the record, listing candidates when it is ambiguous.
+//
+// The exact name is tried as a server-side filter first. That keeps the lookup
+// correct on a zone with more records than one page holds: scanning only the
+// first page would report an existing record as missing, and for delete that
+// wrong negative is the dangerous direction - the user re-adds a duplicate of
+// a record that was there all along.
 func resolveCloudflareRecord(ctx context.Context, credentialName, domainID, reference, recordType string) (*client.CloudflareRecord, error) {
-	list, err := apiClient.ListCloudflareRecords(ctx, credentialName, domainID, "", "")
+	normalisedReference := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(reference), "."))
+	wantedType := strings.ToUpper(recordType)
+
+	list, err := apiClient.ListCloudflareRecords(ctx, credentialName, domainID, normalisedReference, wantedType)
 	if err != nil {
 		return nil, cloudflareError(err, "list DNS records")
 	}
-	normalisedReference := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(reference), "."))
-	wantedType := strings.ToUpper(recordType)
+	if len(list.Items) == 0 {
+		// The reference may be a bare label or a record id, neither of which
+		// the exact-name filter matches. Fall back to the full listing.
+		list, err = apiClient.ListCloudflareRecords(ctx, credentialName, domainID, "", wantedType)
+		if err != nil {
+			return nil, cloudflareError(err, "list DNS records")
+		}
+	}
 
 	var matches []client.CloudflareRecord
 	for _, record := range list.Items {
@@ -483,6 +534,14 @@ func resolveCloudflareRecord(ctx context.Context, credentialName, domainID, refe
 	}
 	switch len(matches) {
 	case 0:
+		// A capped listing has not been fully observed, so "no match" is not a
+		// fact about the zone. Say what was actually seen rather than
+		// declaring the record absent.
+		if list.IsTruncated {
+			return nil, fmt.Errorf("could not resolve %q: the record listing for that domain was truncated, "+
+				"so this is not proof the record is absent. Pass the record's id instead, "+
+				"or narrow with --type", reference)
+		}
 		return nil, fmt.Errorf("no DNS record matches %q in that domain; run 'ankra org cloudflare records <domain>'", reference)
 	case 1:
 		return &matches[0], nil

--- a/cmd/org_cloudflare_test.go
+++ b/cmd/org_cloudflare_test.go
@@ -1,0 +1,429 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/pflag"
+)
+
+// resetOrgCloudflareFlags clears flag state a previous Execute left behind -
+// values and their Changed markers persist on the shared command objects
+// across tests in this package, and the Changed marker is exactly what the
+// "omitted keeps the current value" behaviour reads.
+func resetOrgCloudflareFlags(t *testing.T) {
+	t.Helper()
+	for _, flagged := range []interface{ Flags() *pflag.FlagSet }{
+		orgCloudflareConnectCmd, orgCloudflareDomainsCmd, orgCloudflareRecordsCmd,
+		orgCloudflareAddCmd, orgCloudflareUpdateCmd, orgCloudflareDeleteCmd,
+	} {
+		flagged.Flags().VisitAll(func(f *pflag.Flag) {
+			_ = f.Value.Set(f.DefValue)
+			f.Changed = false
+		})
+	}
+}
+
+// cloudflareMock captures the calls the commands make so the tests can assert
+// the wire shapes and the domain/record resolution.
+type cloudflareMock struct {
+	baseMock
+
+	credentials  []client.CloudflareCredential
+	domains      []client.CloudflareDomain
+	records      []client.CloudflareRecord
+	verification *client.CloudflareVerification
+
+	domainNameFilters []string
+	createCalls       []client.CreateCloudflareRecordInput
+	updateCalls       []client.UpdateCloudflareRecordInput
+	deleteCalls       []string
+	connectCalls      []connectCloudflareCall
+	verifyCalls       []string
+
+	listDomainsErr error
+}
+
+type connectCloudflareCall struct {
+	Name, APIToken, AccountID string
+}
+
+func (m *cloudflareMock) ListCloudflareCredentials(ctx context.Context) (*client.CloudflareCredentialsListResult, error) {
+	return &client.CloudflareCredentialsListResult{Items: m.credentials}, nil
+}
+
+func (m *cloudflareMock) VerifyCloudflareToken(ctx context.Context, apiToken, accountID string) (*client.CloudflareVerification, error) {
+	m.verifyCalls = append(m.verifyCalls, apiToken)
+	return m.verification, nil
+}
+
+func (m *cloudflareMock) ConnectCloudflareCredential(ctx context.Context, name, apiToken, accountID string) (*client.CloudflareVerification, error) {
+	m.connectCalls = append(m.connectCalls, connectCloudflareCall{Name: name, APIToken: apiToken, AccountID: accountID})
+	return m.verification, nil
+}
+
+func (m *cloudflareMock) ListCloudflareDomains(ctx context.Context, credentialName, domainName string) (*client.CloudflareDomainsListResult, error) {
+	if m.listDomainsErr != nil {
+		return nil, m.listDomainsErr
+	}
+	m.domainNameFilters = append(m.domainNameFilters, domainName)
+	if domainName == "" {
+		return &client.CloudflareDomainsListResult{Items: m.domains}, nil
+	}
+	matched := make([]client.CloudflareDomain, 0, 1)
+	for _, domain := range m.domains {
+		if domain.Name == domainName {
+			matched = append(matched, domain)
+		}
+	}
+	return &client.CloudflareDomainsListResult{Items: matched}, nil
+}
+
+func (m *cloudflareMock) ListCloudflareRecords(ctx context.Context, credentialName, domainID, nameFilter, typeFilter string) (*client.CloudflareRecordsListResult, error) {
+	return &client.CloudflareRecordsListResult{Items: m.records}, nil
+}
+
+func (m *cloudflareMock) CreateCloudflareRecord(ctx context.Context, credentialName, domainID string, input client.CreateCloudflareRecordInput) (*client.CloudflareRecord, error) {
+	m.createCalls = append(m.createCalls, input)
+	return &client.CloudflareRecord{
+		Name: input.Name, RecordType: input.RecordType, Content: input.Content,
+		Proxied: input.Proxied != nil && *input.Proxied,
+	}, nil
+}
+
+func (m *cloudflareMock) UpdateCloudflareRecord(ctx context.Context, credentialName, domainID, recordID string, input client.UpdateCloudflareRecordInput) (*client.CloudflareRecord, error) {
+	m.updateCalls = append(m.updateCalls, input)
+	return &client.CloudflareRecord{Name: "app.example.com", RecordType: "A", Content: input.Content}, nil
+}
+
+func (m *cloudflareMock) DeleteCloudflareRecord(ctx context.Context, credentialName, domainID, recordID string) error {
+	m.deleteCalls = append(m.deleteCalls, recordID)
+	return nil
+}
+
+func cloudflareFixture() *cloudflareMock {
+	return &cloudflareMock{
+		credentials: []client.CloudflareCredential{{
+			Name: "production", AccountName: "Acme Ltd", TokenID: "token-1", State: "active",
+		}},
+		domains: []client.CloudflareDomain{{
+			ID: "zone-1", Name: "example.com", Status: "active", IsActive: true, Type: "full",
+			NameServers: []string{"ns1.cloudflare.com", "ns2.cloudflare.com"},
+		}},
+		records: []client.CloudflareRecord{
+			{
+				ID: "record-1", ZoneID: "zone-1", ZoneName: "example.com", Name: "app.example.com",
+				RecordType: "A", Content: "203.0.113.10", TTL: 300, ManagedBy: "ankra",
+			},
+			{
+				ID: "record-2", ZoneID: "zone-1", ZoneName: "example.com", Name: "legacy.example.com",
+				RecordType: "A", Content: "198.51.100.7", TTL: 1, IsTTLAutomatic: true, ManagedBy: "external",
+			},
+		},
+		verification: &client.CloudflareVerification{
+			Status: "active", IsActive: true, AccountName: "Acme Ltd",
+			ZoneCount: 1, ZoneNames: []string{"example.com"},
+		},
+	}
+}
+
+func runCloudflare(t *testing.T, mock *cloudflareMock, stdin string, args ...string) (string, error) {
+	t.Helper()
+	setMockClient(t, mock)
+	resetOrgCloudflareFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetIn(strings.NewReader(stdin))
+	cmd.SetArgs(append([]string{"org", "cloudflare"}, args...))
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func TestOrgCloudflareDomainsListsReachableDomains(t *testing.T) {
+	mock := cloudflareFixture()
+	out, err := runCloudflare(t, mock, "", "domains")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, "example.com") || !strings.Contains(out, "zone-1") {
+		t.Errorf("expected the domain and its zone id, got: %s", out)
+	}
+}
+
+// A named domain is resolved through the server-side filter, not by walking
+// the whole listing.
+func TestOrgCloudflareDomainsResolvesANamedDomainServerSide(t *testing.T) {
+	mock := cloudflareFixture()
+	if _, err := runCloudflare(t, mock, "", "domains", "example.com"); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if len(mock.domainNameFilters) != 1 || mock.domainNameFilters[0] != "example.com" {
+		t.Errorf("name filters = %v; the lookup was not server-side", mock.domainNameFilters)
+	}
+}
+
+func TestOrgCloudflareRecordsShowsWhichArrivedThroughAnkra(t *testing.T) {
+	mock := cloudflareFixture()
+	out, err := runCloudflare(t, mock, "", "records", "example.com")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, "ankra") || !strings.Contains(out, "external") {
+		t.Errorf("expected the managed-by column to distinguish the records, got: %s", out)
+	}
+	// The automatic TTL renders as Auto rather than the raw sentinel 1.
+	if !strings.Contains(out, "Auto") {
+		t.Errorf("expected an Auto ttl, got: %s", out)
+	}
+}
+
+func TestOrgCloudflareAddSendsTheRecordAndTTL(t *testing.T) {
+	mock := cloudflareFixture()
+	out, err := runCloudflare(t, mock, "", "add", "example.com", "app", "a", "203.0.113.10", "--ttl", "300")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if len(mock.createCalls) != 1 {
+		t.Fatalf("expected one create call, got %d", len(mock.createCalls))
+	}
+	got := mock.createCalls[0]
+	if got.Name != "app" || got.RecordType != "A" || got.Content != "203.0.113.10" {
+		t.Errorf("create call = %+v", got)
+	}
+	if got.TTL == nil || *got.TTL != 300 {
+		t.Errorf("ttl = %v, want 300", got.TTL)
+	}
+	if got.Proxied != nil {
+		t.Errorf("proxied = %v; an unset --proxied must be omitted", got.Proxied)
+	}
+}
+
+func TestOrgCloudflareAddSendsTheProxyFlagWhenSet(t *testing.T) {
+	mock := cloudflareFixture()
+	out, err := runCloudflare(t, mock, "", "add", "example.com", "www", "cname", "app.example.com", "--proxied")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	got := mock.createCalls[0]
+	if got.Proxied == nil || !*got.Proxied {
+		t.Errorf("proxied = %v, want true", got.Proxied)
+	}
+	if !strings.Contains(out, "proxied through Cloudflare") {
+		t.Errorf("expected the output to name the proxy, got: %s", out)
+	}
+}
+
+// The backend's PATCH leaves an absent field as it stands, so an omitted flag
+// must be omitted from the body - not sent as a zero that resets it.
+func TestOrgCloudflareUpdateOmitsTheFlagsTheCallerDidNotPass(t *testing.T) {
+	mock := cloudflareFixture()
+	out, err := runCloudflare(t, mock, "", "update", "example.com", "app", "203.0.113.99")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if len(mock.updateCalls) != 1 {
+		t.Fatalf("expected one update call, got %d", len(mock.updateCalls))
+	}
+	got := mock.updateCalls[0]
+	if got.Content != "203.0.113.99" {
+		t.Errorf("content = %q", got.Content)
+	}
+	if got.TTL != nil || got.Proxied != nil || got.Priority != nil {
+		t.Errorf("unset flags leaked into the body: %+v", got)
+	}
+}
+
+func TestOrgCloudflareUpdateSendsTheFlagsTheCallerDidPass(t *testing.T) {
+	mock := cloudflareFixture()
+	if _, err := runCloudflare(t, mock, "", "update", "example.com", "app", "203.0.113.99",
+		"--ttl", "3600", "--proxied"); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	got := mock.updateCalls[0]
+	if got.TTL == nil || *got.TTL != 3600 {
+		t.Errorf("ttl = %v, want 3600", got.TTL)
+	}
+	if got.Proxied == nil || !*got.Proxied {
+		t.Errorf("proxied = %v, want true", got.Proxied)
+	}
+}
+
+// The delete prompt has to name the record: "delete app" is not enough to
+// approve removing live DNS.
+func TestOrgCloudflareDeletePromptNamesTheRecord(t *testing.T) {
+	mock := cloudflareFixture()
+	out, err := runCloudflare(t, mock, "y\n", "delete", "example.com", "app")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, "A app.example.com -> 203.0.113.10") {
+		t.Errorf("the prompt did not name the record: %s", out)
+	}
+	if len(mock.deleteCalls) != 1 || mock.deleteCalls[0] != "record-1" {
+		t.Errorf("delete calls = %v", mock.deleteCalls)
+	}
+}
+
+// A record Ankra did not create is called out: something outside the platform
+// put it there.
+func TestOrgCloudflareDeleteCallsOutAnExternalRecord(t *testing.T) {
+	mock := cloudflareFixture()
+	out, err := runCloudflare(t, mock, "y\n", "delete", "example.com", "legacy")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, "not created through Ankra") {
+		t.Errorf("the prompt did not call out the external record: %s", out)
+	}
+}
+
+func TestOrgCloudflareDeleteRefusesAnUnknownRecord(t *testing.T) {
+	mock := cloudflareFixture()
+	_, err := runCloudflare(t, mock, "y\n", "delete", "example.com", "nothing-like-this")
+	if err == nil {
+		t.Fatal("an unknown record was accepted")
+	}
+	if !strings.Contains(err.Error(), "no DNS record matches") {
+		t.Errorf("error = %v", err)
+	}
+	if len(mock.deleteCalls) != 0 {
+		t.Errorf("a delete was issued for an unknown record: %v", mock.deleteCalls)
+	}
+}
+
+// An organisation with no credential gets the next step, not a bare 404.
+func TestOrgCloudflareDomainsGuidesAnUnconnectedOrganisation(t *testing.T) {
+	mock := cloudflareFixture()
+	mock.listDomainsErr = client.ErrCloudflareNotConnected
+	_, err := runCloudflare(t, mock, "", "domains")
+	if err == nil {
+		t.Fatal("an unconnected organisation reported success")
+	}
+	if !strings.Contains(err.Error(), "ankra org cloudflare connect") {
+		t.Errorf("error = %v; it must name the next step", err)
+	}
+}
+
+// The token never comes from a flag - it would land in shell history and the
+// process list.
+func TestOrgCloudflareConnectRefusesWithNoTokenSupplied(t *testing.T) {
+	t.Setenv("ANKRA_CLOUDFLARE_API_TOKEN", "")
+	mock := cloudflareFixture()
+	_, err := runCloudflare(t, mock, "", "connect", "production")
+	if err == nil {
+		t.Fatal("connect succeeded with no token")
+	}
+	if !strings.Contains(err.Error(), "ANKRA_CLOUDFLARE_API_TOKEN") || !strings.Contains(err.Error(), "--token-stdin") {
+		t.Errorf("error = %v; it must name both input paths", err)
+	}
+	if len(mock.connectCalls) != 0 {
+		t.Errorf("a connect was issued with no token: %v", mock.connectCalls)
+	}
+}
+
+func TestOrgCloudflareConnectReadsTheTokenFromTheEnvironment(t *testing.T) {
+	t.Setenv("ANKRA_CLOUDFLARE_API_TOKEN", "a-scoped-token")
+	mock := cloudflareFixture()
+	out, err := runCloudflare(t, mock, "", "connect", "production")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if len(mock.connectCalls) != 1 || mock.connectCalls[0].APIToken != "a-scoped-token" {
+		t.Fatalf("connect calls = %+v", mock.connectCalls)
+	}
+	if !strings.Contains(out, "Reaches 1 domain") || !strings.Contains(out, "example.com") {
+		t.Errorf("expected the verification summary, got: %s", out)
+	}
+}
+
+func TestOrgCloudflareConnectReadsTheTokenFromStdin(t *testing.T) {
+	t.Setenv("ANKRA_CLOUDFLARE_API_TOKEN", "")
+	mock := cloudflareFixture()
+	out, err := runCloudflare(t, mock, "piped-token\n", "connect", "production", "--token-stdin")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if len(mock.connectCalls) != 1 || mock.connectCalls[0].APIToken != "piped-token" {
+		t.Fatalf("connect calls = %+v", mock.connectCalls)
+	}
+}
+
+// --verify-only checks a token and stores nothing.
+func TestOrgCloudflareConnectVerifyOnlyStoresNothing(t *testing.T) {
+	t.Setenv("ANKRA_CLOUDFLARE_API_TOKEN", "a-scoped-token")
+	mock := cloudflareFixture()
+	out, err := runCloudflare(t, mock, "", "connect", "--verify-only")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if len(mock.verifyCalls) != 1 {
+		t.Fatalf("verify calls = %v", mock.verifyCalls)
+	}
+	if len(mock.connectCalls) != 0 {
+		t.Errorf("--verify-only stored a credential: %+v", mock.connectCalls)
+	}
+}
+
+// A disabled or expired token reports what to do rather than claiming success.
+func TestOrgCloudflareConnectReportsANonActiveToken(t *testing.T) {
+	t.Setenv("ANKRA_CLOUDFLARE_API_TOKEN", "a-scoped-token")
+	mock := cloudflareFixture()
+	mock.verification = &client.CloudflareVerification{Status: "expired", IsActive: false}
+	out, err := runCloudflare(t, mock, "", "connect", "--verify-only")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, "expired") || !strings.Contains(out, "Renew or re-enable") {
+		t.Errorf("expected the renewal guidance, got: %s", out)
+	}
+}
+
+func TestOrgCloudflareCredentialsListsWithoutTheToken(t *testing.T) {
+	mock := cloudflareFixture()
+	out, err := runCloudflare(t, mock, "", "credentials")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, "production") || !strings.Contains(out, "Acme Ltd") {
+		t.Errorf("expected the credential row, got: %s", out)
+	}
+	if !strings.Contains(out, "never") {
+		t.Errorf("a credential with no expiry should render 'never', got: %s", out)
+	}
+}
+
+func TestOrgCloudflareCredentialsGuidesAnEmptyOrganisation(t *testing.T) {
+	mock := cloudflareFixture()
+	mock.credentials = nil
+	out, err := runCloudflare(t, mock, "", "credentials")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, "ankra org cloudflare connect") {
+		t.Errorf("expected the connect guidance, got: %s", out)
+	}
+}
+
+// The two sentinels carry different next steps, so they must not collapse.
+func TestCloudflareErrorKeepsTheSentinelsApart(t *testing.T) {
+	notConnected := cloudflareError(client.ErrCloudflareNotConnected, "list")
+	if !strings.Contains(notConnected.Error(), "ankra org cloudflare connect") {
+		t.Errorf("not-connected error = %v", notConnected)
+	}
+	notFound := cloudflareError(client.ErrCloudflareNotFound, "list")
+	if !errors.Is(notFound, client.ErrCloudflareNotFound) {
+		t.Errorf("not-found error lost its sentinel: %v", notFound)
+	}
+	other := cloudflareError(errors.New("connection reset"), "list domains")
+	if !strings.Contains(other.Error(), "list domains") {
+		t.Errorf("a generic error lost its action: %v", other)
+	}
+}

--- a/cmd/org_cloudflare_test.go
+++ b/cmd/org_cloudflare_test.go
@@ -312,6 +312,68 @@ func TestOrgCloudflareRefusesToResolveFromATruncatedListing(t *testing.T) {
 	}
 }
 
+// A truncated listing that happens to yield one match is not proof that match
+// is unique - a twin may sit beyond the page, and for delete that removes a
+// record nobody was told was ambiguous.
+func TestOrgCloudflareRefusesASingleMatchFromATruncatedListing(t *testing.T) {
+	mock := cloudflareFixture()
+	mock.truncated = true
+	_, err := runCloudflare(t, mock, "y\n", "delete", "example.com", "app")
+	if err == nil {
+		t.Fatal("a single match from a truncated listing was resolved confidently")
+	}
+	if !strings.Contains(err.Error(), "truncated") {
+		t.Errorf("error = %v", err)
+	}
+	if len(mock.deleteCalls) != 0 {
+		t.Errorf("a delete was issued: %v", mock.deleteCalls)
+	}
+}
+
+// A record id is unique by construction, so a match on one needs no complete
+// listing behind it - truncation must not block it.
+func TestOrgCloudflareResolvesARecordIDDespiteTruncation(t *testing.T) {
+	mock := cloudflareFixture()
+	mock.truncated = true
+	out, err := runCloudflare(t, mock, "y\n", "delete", "example.com", "record-1")
+	if err != nil {
+		t.Fatalf("a record id failed to resolve under truncation: %v\noutput: %s", err, out)
+	}
+	if len(mock.deleteCalls) != 1 || mock.deleteCalls[0] != "record-1" {
+		t.Errorf("delete calls = %v", mock.deleteCalls)
+	}
+}
+
+// A reference that is not a 32-character hex zone id is resolved as a domain
+// name, so a typo reports "no domain named ..." instead of being posted as an
+// identifier the API rejects opaquely.
+func TestOrgCloudflareTreatsANonZoneIDReferenceAsADomainName(t *testing.T) {
+	mock := cloudflareFixture()
+	_, err := runCloudflare(t, mock, "", "records", "nosuchdomain")
+	if err == nil {
+		t.Fatal("a bare non-id reference was accepted as a zone id")
+	}
+	if !strings.Contains(err.Error(), "no Cloudflare domain named") {
+		t.Errorf("error = %v", err)
+	}
+	// It was looked up as a name rather than sent as an id.
+	if len(mock.domainNameFilters) != 1 || mock.domainNameFilters[0] != "nosuchdomain" {
+		t.Errorf("name filters = %v", mock.domainNameFilters)
+	}
+}
+
+// A 32-character hex reference is taken as a zone id without a lookup.
+func TestOrgCloudflareTakesAZoneIDShapeWithoutALookup(t *testing.T) {
+	mock := cloudflareFixture()
+	zoneID := "0123456789abcdef0123456789abcdef"
+	if _, err := runCloudflare(t, mock, "", "records", zoneID); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if len(mock.domainNameFilters) != 0 {
+		t.Errorf("a zone id cost a domain lookup: %v", mock.domainNameFilters)
+	}
+}
+
 // --verify-only stores nothing, so a credential name would be discarded.
 func TestOrgCloudflareVerifyOnlyRefusesACredentialName(t *testing.T) {
 	t.Setenv("ANKRA_CLOUDFLARE_API_TOKEN", "a-scoped-token")

--- a/cmd/org_cloudflare_test.go
+++ b/cmd/org_cloudflare_test.go
@@ -47,6 +47,7 @@ type cloudflareMock struct {
 	verifyCalls       []string
 
 	listDomainsErr error
+	truncated      bool
 }
 
 type connectCloudflareCall struct {
@@ -85,7 +86,16 @@ func (m *cloudflareMock) ListCloudflareDomains(ctx context.Context, credentialNa
 }
 
 func (m *cloudflareMock) ListCloudflareRecords(ctx context.Context, credentialName, domainID, nameFilter, typeFilter string) (*client.CloudflareRecordsListResult, error) {
-	return &client.CloudflareRecordsListResult{Items: m.records}, nil
+	if nameFilter != "" {
+		matched := make([]client.CloudflareRecord, 0, 1)
+		for _, record := range m.records {
+			if strings.EqualFold(record.Name, nameFilter) {
+				matched = append(matched, record)
+			}
+		}
+		return &client.CloudflareRecordsListResult{Items: matched, IsTruncated: m.truncated}, nil
+	}
+	return &client.CloudflareRecordsListResult{Items: m.records, IsTruncated: m.truncated}, nil
 }
 
 func (m *cloudflareMock) CreateCloudflareRecord(ctx context.Context, credentialName, domainID string, input client.CreateCloudflareRecordInput) (*client.CloudflareRecord, error) {
@@ -244,15 +254,74 @@ func TestOrgCloudflareUpdateOmitsTheFlagsTheCallerDidNotPass(t *testing.T) {
 func TestOrgCloudflareUpdateSendsTheFlagsTheCallerDidPass(t *testing.T) {
 	mock := cloudflareFixture()
 	if _, err := runCloudflare(t, mock, "", "update", "example.com", "app", "203.0.113.99",
-		"--ttl", "3600", "--proxied"); err != nil {
+		"--ttl", "3600"); err != nil {
 		t.Fatalf("execute failed: %v", err)
 	}
 	got := mock.updateCalls[0]
 	if got.TTL == nil || *got.TTL != 3600 {
 		t.Errorf("ttl = %v, want 3600", got.TTL)
 	}
-	if got.Proxied == nil || !*got.Proxied {
-		t.Errorf("proxied = %v, want true", got.Proxied)
+
+	mock = cloudflareFixture()
+	if _, err := runCloudflare(t, mock, "", "update", "example.com", "app", "203.0.113.99",
+		"--proxied"); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if proxied := mock.updateCalls[0].Proxied; proxied == nil || !*proxied {
+		t.Errorf("proxied = %v, want true", proxied)
+	}
+}
+
+// The help text promises the combination is refused, so it must be - and
+// locally, with a message naming both flags, rather than as an opaque 400 from
+// Cloudflare.
+func TestOrgCloudflareRefusesTTLWithProxied(t *testing.T) {
+	for _, command := range [][]string{
+		{"add", "example.com", "app", "a", "203.0.113.10", "--ttl", "300", "--proxied"},
+		{"update", "example.com", "app", "203.0.113.99", "--ttl", "300", "--proxied"},
+	} {
+		mock := cloudflareFixture()
+		_, err := runCloudflare(t, mock, "", command...)
+		if err == nil {
+			t.Fatalf("%s accepted --ttl with --proxied", command[0])
+		}
+		if !strings.Contains(err.Error(), "--ttl cannot be combined with --proxied") {
+			t.Errorf("%s error = %v", command[0], err)
+		}
+		if len(mock.createCalls) != 0 || len(mock.updateCalls) != 0 {
+			t.Errorf("%s issued a write despite the refusal", command[0])
+		}
+	}
+}
+
+// A truncated listing has not been fully observed, so "no match" is not a fact
+// about the zone - and for delete that wrong negative is the dangerous
+// direction, since the user re-adds a duplicate of a record that was there.
+func TestOrgCloudflareRefusesToResolveFromATruncatedListing(t *testing.T) {
+	mock := cloudflareFixture()
+	mock.truncated = true
+	_, err := runCloudflare(t, mock, "y\n", "delete", "example.com", "nothing-like-this")
+	if err == nil {
+		t.Fatal("a truncated listing resolved to a confident absence")
+	}
+	if !strings.Contains(err.Error(), "truncated") {
+		t.Errorf("error = %v; it must say the listing was incomplete", err)
+	}
+	if len(mock.deleteCalls) != 0 {
+		t.Errorf("a delete was issued: %v", mock.deleteCalls)
+	}
+}
+
+// --verify-only stores nothing, so a credential name would be discarded.
+func TestOrgCloudflareVerifyOnlyRefusesACredentialName(t *testing.T) {
+	t.Setenv("ANKRA_CLOUDFLARE_API_TOKEN", "a-scoped-token")
+	mock := cloudflareFixture()
+	_, err := runCloudflare(t, mock, "", "connect", "production", "--verify-only")
+	if err == nil {
+		t.Fatal("--verify-only silently accepted a credential name")
+	}
+	if !strings.Contains(err.Error(), "would be ignored") {
+		t.Errorf("error = %v", err)
 	}
 }
 

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -84,6 +84,15 @@ type APIClient interface {
 	CreateOrganisationDnsRecord(ctx context.Context, name, recordType, content string, ttl *int) (*client.DnsRecord, error)
 	UpdateOrganisationDnsRecord(ctx context.Context, recordID, content string, ttl *int) (*client.DnsRecord, error)
 	DeleteOrganisationDnsRecord(ctx context.Context, recordID string) error
+
+	ListCloudflareCredentials(ctx context.Context) (*client.CloudflareCredentialsListResult, error)
+	VerifyCloudflareToken(ctx context.Context, apiToken, accountID string) (*client.CloudflareVerification, error)
+	ConnectCloudflareCredential(ctx context.Context, name, apiToken, accountID string) (*client.CloudflareVerification, error)
+	ListCloudflareDomains(ctx context.Context, credentialName, domainName string) (*client.CloudflareDomainsListResult, error)
+	ListCloudflareRecords(ctx context.Context, credentialName, domainID, nameFilter, typeFilter string) (*client.CloudflareRecordsListResult, error)
+	CreateCloudflareRecord(ctx context.Context, credentialName, domainID string, input client.CreateCloudflareRecordInput) (*client.CloudflareRecord, error)
+	UpdateCloudflareRecord(ctx context.Context, credentialName, domainID, recordID string, input client.UpdateCloudflareRecordInput) (*client.CloudflareRecord, error)
+	DeleteCloudflareRecord(ctx context.Context, credentialName, domainID, recordID string) error
 	ListOrganisationClusterDnsZones(ctx context.Context) (*client.DnsClusterZonesListResult, error)
 	GetOrganisationDomain(ctx context.Context) (*client.OrganisationDomain, error)
 	GetOrganisationPreviewSettings(ctx context.Context) (*client.OrganisationPreviewSettings, error)

--- a/internal/client/cloudflare.go
+++ b/internal/client/cloudflare.go
@@ -343,8 +343,16 @@ func (c *Client) doCloudflareRequest(ctx context.Context, method, url string, bo
 		return nil, ErrUnauthorized
 	case http.StatusNotFound:
 		// The backend answers 404 both for "no credential connected" and for
-		// a domain or record the credential cannot see. Its detail text is
-		// what tells them apart, and each has a different next step.
+		// a domain or record the credential cannot see, and its detail text
+		// is the only thing that tells them apart - the two share a status
+		// code deliberately, so that a zone in another account is
+		// indistinguishable from one that does not exist.
+		//
+		// Matching on that prose couples this to cluster-api's wording. The
+		// coupling degrades safely rather than breaking: if the text is ever
+		// reworded, the branch below falls through to ErrCloudflareNotFound,
+		// which still carries the backend's own detail to the user - they
+		// lose the "run ankra org cloudflare connect" hint, not the reason.
 		detail := dnsDetailFromBody(respBody)
 		if detail != "" && strings.Contains(strings.ToLower(detail), "no cloudflare credential is connected") {
 			return nil, ErrCloudflareNotConnected

--- a/internal/client/cloudflare.go
+++ b/internal/client/cloudflare.go
@@ -148,7 +148,7 @@ var ErrCloudflareNotConnected = errors.New("no Cloudflare credential is connecte
 // ErrCloudflareNotFound is returned for a domain or record the organisation's
 // credential cannot see. It covers "does not exist" and "not this token's
 // zone", which the backend does not distinguish and neither may this.
-var ErrCloudflareNotFound = errors.New("Cloudflare domain or record not found")
+var ErrCloudflareNotFound = errors.New("domain or record not found in Cloudflare")
 
 func (c *Client) cloudflareURL(path string, credentialName string, extra neturl.Values) string {
 	query := neturl.Values{}
@@ -356,7 +356,7 @@ func (c *Client) doCloudflareRequest(ctx context.Context, method, url string, bo
 		}
 		if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
 			if seconds, parseErr := strconv.Atoi(retryAfter); parseErr == nil && seconds > 0 {
-				return nil, fmt.Errorf("%s Try again in %ds.", detail, seconds)
+				return nil, fmt.Errorf("%s Cloudflare asked for a %d second wait", detail, seconds)
 			}
 		}
 		return nil, errors.New(detail)

--- a/internal/client/cloudflare.go
+++ b/internal/client/cloudflare.go
@@ -1,0 +1,374 @@
+package client
+
+// The Cloudflare domain surface: the organisation's connected Cloudflare
+// credentials, the domains each one reaches, and the DNS records inside them.
+//
+// Nothing here is cached server-side - Cloudflare is authoritative for zones
+// and records, and they change from outside Ankra - so a listing is a live
+// call and a Cloudflare outage answers 503 rather than serving stale data.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	neturl "net/url"
+	"strconv"
+	"strings"
+)
+
+// CloudflareCredential is one connected Cloudflare API token as the surface
+// shows it. The token itself is never on the wire.
+type CloudflareCredential struct {
+	Name           string `json:"name"`
+	AccountID      string `json:"account_id,omitempty"`
+	AccountName    string `json:"account_name,omitempty"`
+	TokenID        string `json:"token_id,omitempty"`
+	VerifiedAt     string `json:"verified_at,omitempty"`
+	TokenExpiresAt string `json:"token_expires_at,omitempty"`
+	IsExpired      bool   `json:"is_expired"`
+	State          string `json:"state"`
+	CreatedAt      string `json:"created_at"`
+}
+
+type CloudflareCredentialsListResult struct {
+	Items []CloudflareCredential `json:"items"`
+}
+
+// CloudflareVerification is what checking a token learned. It is returned by
+// the verify route, which stores nothing, and echoed by connect.
+type CloudflareVerification struct {
+	TokenID     string   `json:"token_id,omitempty"`
+	Status      string   `json:"status"`
+	IsActive    bool     `json:"is_active"`
+	ExpiresOn   string   `json:"expires_on,omitempty"`
+	AccountID   string   `json:"account_id,omitempty"`
+	AccountName string   `json:"account_name,omitempty"`
+	ZoneCount   int      `json:"zone_count"`
+	ZoneNames   []string `json:"zone_names"`
+}
+
+// CloudflareDomain is one Cloudflare-hosted zone.
+type CloudflareDomain struct {
+	ID             string   `json:"id"`
+	Name           string   `json:"name"`
+	Status         string   `json:"status"`
+	IsActive       bool     `json:"is_active"`
+	Paused         bool     `json:"paused"`
+	Type           string   `json:"type"`
+	CredentialName string   `json:"credential_name"`
+	AccountID      string   `json:"account_id,omitempty"`
+	AccountName    string   `json:"account_name,omitempty"`
+	NameServers    []string `json:"name_servers"`
+	CreatedOn      string   `json:"created_on,omitempty"`
+	ModifiedOn     string   `json:"modified_on,omitempty"`
+}
+
+type CloudflareDomainsListResult struct {
+	Items       []CloudflareDomain `json:"items"`
+	IsTruncated bool               `json:"is_truncated"`
+}
+
+// CloudflareRecord is one DNS record. ManagedBy is "ankra" for records the
+// platform created and "external" for everything else - the customer's own
+// dashboard, their Terraform, or a cluster controller.
+type CloudflareRecord struct {
+	ID             string   `json:"id"`
+	ZoneID         string   `json:"zone_id"`
+	ZoneName       string   `json:"zone_name"`
+	Name           string   `json:"name"`
+	RecordType     string   `json:"record_type"`
+	Content        string   `json:"content"`
+	TTL            int      `json:"ttl"`
+	IsTTLAutomatic bool     `json:"is_ttl_automatic"`
+	Proxied        bool     `json:"proxied"`
+	Proxiable      bool     `json:"proxiable"`
+	Priority       *int     `json:"priority,omitempty"`
+	Comment        string   `json:"comment,omitempty"`
+	Tags           []string `json:"tags"`
+	ManagedBy      string   `json:"managed_by"`
+	CreatedOn      string   `json:"created_on,omitempty"`
+	ModifiedOn     string   `json:"modified_on,omitempty"`
+}
+
+type CloudflareRecordsListResult struct {
+	Domain      CloudflareDomain   `json:"domain"`
+	Items       []CloudflareRecord `json:"items"`
+	IsTruncated bool               `json:"is_truncated"`
+}
+
+type connectCloudflareRequest struct {
+	Name      string `json:"name"`
+	APIToken  string `json:"api_token"`
+	AccountID string `json:"account_id,omitempty"`
+}
+
+type verifyCloudflareRequest struct {
+	APIToken  string `json:"api_token"`
+	AccountID string `json:"account_id,omitempty"`
+}
+
+type connectCloudflareResult struct {
+	Success      bool                    `json:"success"`
+	Name         string                  `json:"name"`
+	Verification *CloudflareVerification `json:"verification,omitempty"`
+}
+
+// CreateCloudflareRecordInput is the create request. TTL zero is sent as
+// Cloudflare's automatic sentinel by the backend, so an unset TTL means Auto.
+type CreateCloudflareRecordInput struct {
+	Name       string `json:"name"`
+	RecordType string `json:"record_type"`
+	Content    string `json:"content"`
+	TTL        *int   `json:"ttl,omitempty"`
+	Proxied    *bool  `json:"proxied,omitempty"`
+	Priority   *int   `json:"priority,omitempty"`
+	Comment    string `json:"comment,omitempty"`
+}
+
+// UpdateCloudflareRecordInput is the edit request. Every optional member is
+// omitted rather than sent zero when the caller did not set it: the backend's
+// PATCH leaves an absent field as it stands, which is how "keep the record's
+// current TTL" is expressed.
+type UpdateCloudflareRecordInput struct {
+	Content  string `json:"content"`
+	TTL      *int   `json:"ttl,omitempty"`
+	Proxied  *bool  `json:"proxied,omitempty"`
+	Priority *int   `json:"priority,omitempty"`
+	Comment  string `json:"comment,omitempty"`
+}
+
+// ErrCloudflareNotConnected is returned when the organisation has connected no
+// Cloudflare credential. Callers use errors.Is to answer with the "connect one
+// first" guidance rather than a bare 404.
+var ErrCloudflareNotConnected = errors.New("no Cloudflare credential is connected for this organisation")
+
+// ErrCloudflareNotFound is returned for a domain or record the organisation's
+// credential cannot see. It covers "does not exist" and "not this token's
+// zone", which the backend does not distinguish and neither may this.
+var ErrCloudflareNotFound = errors.New("Cloudflare domain or record not found")
+
+func (c *Client) cloudflareURL(path string, credentialName string, extra neturl.Values) string {
+	query := neturl.Values{}
+	for key, values := range extra {
+		for _, value := range values {
+			query.Add(key, value)
+		}
+	}
+	if credentialName != "" {
+		query.Set("credential_name", credentialName)
+	}
+	if len(query) == 0 {
+		return c.BaseURL + path
+	}
+	return c.BaseURL + path + "?" + query.Encode()
+}
+
+func (c *Client) ListCloudflareCredentials(ctx context.Context) (*CloudflareCredentialsListResult, error) {
+	body, err := c.doCloudflareRequest(ctx, http.MethodGet, c.BaseURL+"/api/v1/org/cloudflare/credentials", nil)
+	if err != nil {
+		return nil, err
+	}
+	var out CloudflareCredentialsListResult
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &out, nil
+}
+
+// VerifyCloudflareToken checks a token against Cloudflare and reports what it
+// reaches, storing nothing.
+func (c *Client) VerifyCloudflareToken(ctx context.Context, apiToken, accountID string) (*CloudflareVerification, error) {
+	payload, err := json.Marshal(verifyCloudflareRequest{APIToken: apiToken, AccountID: accountID})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	body, err := c.doCloudflareRequest(ctx, http.MethodPost,
+		c.BaseURL+"/api/v1/org/cloudflare/credentials/verify", payload)
+	if err != nil {
+		return nil, err
+	}
+	var out CloudflareVerification
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &out, nil
+}
+
+// ConnectCloudflareCredential stores a verified token. The backend verifies it
+// against Cloudflare first and refuses a token that reaches no zones, so a
+// success here means the credential actually works.
+func (c *Client) ConnectCloudflareCredential(ctx context.Context, name, apiToken, accountID string) (*CloudflareVerification, error) {
+	payload, err := json.Marshal(connectCloudflareRequest{Name: name, APIToken: apiToken, AccountID: accountID})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	body, err := c.doCloudflareRequest(ctx, http.MethodPost,
+		c.BaseURL+"/api/v1/org/cloudflare/credentials", payload)
+	if err != nil {
+		return nil, err
+	}
+	var out connectCloudflareResult
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return out.Verification, nil
+}
+
+// ListCloudflareDomains lists the domains the credential reaches. domainName
+// narrows to one by exact name, resolved server-side in a single lookup.
+func (c *Client) ListCloudflareDomains(ctx context.Context, credentialName, domainName string) (*CloudflareDomainsListResult, error) {
+	extra := neturl.Values{}
+	if domainName != "" {
+		extra.Set("name", domainName)
+	}
+	body, err := c.doCloudflareRequest(ctx, http.MethodGet,
+		c.cloudflareURL("/api/v1/org/cloudflare/domains", credentialName, extra), nil)
+	if err != nil {
+		return nil, err
+	}
+	var out CloudflareDomainsListResult
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &out, nil
+}
+
+// ListCloudflareRecords lists a domain's records, optionally filtered.
+func (c *Client) ListCloudflareRecords(ctx context.Context, credentialName, domainID, nameFilter, typeFilter string) (*CloudflareRecordsListResult, error) {
+	extra := neturl.Values{}
+	if nameFilter != "" {
+		extra.Set("name", nameFilter)
+	}
+	if typeFilter != "" {
+		extra.Set("record_type", typeFilter)
+	}
+	path := "/api/v1/org/cloudflare/domains/" + neturl.PathEscape(domainID) + "/records"
+	body, err := c.doCloudflareRequest(ctx, http.MethodGet,
+		c.cloudflareURL(path, credentialName, extra), nil)
+	if err != nil {
+		return nil, err
+	}
+	var out CloudflareRecordsListResult
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &out, nil
+}
+
+func (c *Client) CreateCloudflareRecord(ctx context.Context, credentialName, domainID string, input CreateCloudflareRecordInput) (*CloudflareRecord, error) {
+	payload, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	path := "/api/v1/org/cloudflare/domains/" + neturl.PathEscape(domainID) + "/records"
+	body, err := c.doCloudflareRequest(ctx, http.MethodPost,
+		c.cloudflareURL(path, credentialName, nil), payload)
+	if err != nil {
+		return nil, err
+	}
+	var out CloudflareRecord
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &out, nil
+}
+
+func (c *Client) UpdateCloudflareRecord(ctx context.Context, credentialName, domainID, recordID string, input UpdateCloudflareRecordInput) (*CloudflareRecord, error) {
+	payload, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	path := "/api/v1/org/cloudflare/domains/" + neturl.PathEscape(domainID) +
+		"/records/" + neturl.PathEscape(recordID)
+	body, err := c.doCloudflareRequest(ctx, http.MethodPatch,
+		c.cloudflareURL(path, credentialName, nil), payload)
+	if err != nil {
+		return nil, err
+	}
+	var out CloudflareRecord
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &out, nil
+}
+
+func (c *Client) DeleteCloudflareRecord(ctx context.Context, credentialName, domainID, recordID string) error {
+	path := "/api/v1/org/cloudflare/domains/" + neturl.PathEscape(domainID) +
+		"/records/" + neturl.PathEscape(recordID)
+	_, err := c.doCloudflareRequest(ctx, http.MethodDelete,
+		c.cloudflareURL(path, credentialName, nil), nil)
+	return err
+}
+
+func (c *Client) doCloudflareRequest(ctx context.Context, method, url string, body []byte) ([]byte, error) {
+	var req *http.Request
+	var err error
+	if body != nil {
+		req, err = http.NewRequestWithContext(ctx, method, url, bytes.NewReader(body))
+	} else {
+		req, err = http.NewRequestWithContext(ctx, method, url, nil)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer closeBody(resp)
+
+	respBody, err := readResponseBody(resp)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
+		return respBody, nil
+	case http.StatusUnauthorized:
+		return nil, ErrUnauthorized
+	case http.StatusNotFound:
+		// The backend answers 404 both for "no credential connected" and for
+		// a domain or record the credential cannot see. Its detail text is
+		// what tells them apart, and each has a different next step.
+		detail := dnsDetailFromBody(respBody)
+		if detail != "" && strings.Contains(strings.ToLower(detail), "no cloudflare credential is connected") {
+			return nil, ErrCloudflareNotConnected
+		}
+		if detail != "" {
+			return nil, fmt.Errorf("%w: %s", ErrCloudflareNotFound, detail)
+		}
+		return nil, ErrCloudflareNotFound
+	case http.StatusServiceUnavailable:
+		// Cloudflare is unreachable or rate-limiting. The Retry-After it sends
+		// is the honest thing to tell the user, because retrying does help.
+		detail := dnsDetailFromBody(respBody)
+		if detail == "" {
+			detail = "Cloudflare is currently unavailable."
+		}
+		if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
+			if seconds, parseErr := strconv.Atoi(retryAfter); parseErr == nil && seconds > 0 {
+				return nil, fmt.Errorf("%s Try again in %ds.", detail, seconds)
+			}
+		}
+		return nil, errors.New(detail)
+	case http.StatusBadRequest, http.StatusForbidden, http.StatusConflict:
+		// Every refusal the operator can act on - a rejected token, a token
+		// that reaches no zones, a record name outside the domain - arrives
+		// as a detail string worth showing verbatim.
+		if detail := dnsDetailFromBody(respBody); detail != "" {
+			return nil, errors.New(detail)
+		}
+		return nil, newUnexpectedResponseError("Cloudflare request failed", resp.StatusCode, truncateForError(respBody, 500))
+	default:
+		return nil, newUnexpectedResponseError("Cloudflare request failed", resp.StatusCode, truncateForError(respBody, 500))
+	}
+}

--- a/internal/client/cloudflare.go
+++ b/internal/client/cloudflare.go
@@ -214,6 +214,12 @@ func (c *Client) ConnectCloudflareCredential(ctx context.Context, name, apiToken
 	if err := json.Unmarshal(body, &out); err != nil {
 		return nil, fmt.Errorf("parse response: %w", err)
 	}
+	// The backend answers 200 with success=false for a refusal it reports in
+	// the body rather than the status. Ignoring the flag would print
+	// "connected" for a credential that was not stored.
+	if !out.Success {
+		return nil, errors.New("the credential was not stored: the server reported the connect as unsuccessful")
+	}
 	return out.Verification, nil
 }
 


### PR DESCRIPTION
The CLI half of the Cloudflare integration. Backend: [ankraio/cluster#1981](https://github.com/ankraio/cluster/pull/1981).

Until now the feature was reachable only through the raw API and chat. This adds the commands.

Bead: ankra-90bsy

```
ankra org cloudflare connect production
ankra org cloudflare credentials
ankra org cloudflare domains [name]
ankra org cloudflare records example.com
ankra org cloudflare add example.com app A 203.0.113.10 --ttl 300
ankra org cloudflare add example.com www CNAME app.example.com --proxied
ankra org cloudflare update example.com app 203.0.113.11
ankra org cloudflare delete example.com app
```

## Decisions worth reviewing

**The token never comes from a flag.** A `--token` would put a live Cloudflare credential in shell history and the process list. It is read from `ANKRA_CLOUDFLARE_API_TOKEN` or piped with `--token-stdin`.

There is deliberately **no interactive prompt**: the repo has no `golang.org/x/term` dependency, so the input cannot be read with echo disabled, and a token echoed into scrollback is no better than one in history. Adding a dependency for one prompt did not seem worth it when env-var and stdin both work — and those are what CI uses anyway. Happy to add the dependency and prompt if you'd rather.

**The delete prompt names the record.** `Delete A app.example.com -> 203.0.113.10 from example.com?` — "delete app" is not enough information to approve removing live DNS. A record Ankra did not create is called out explicitly, because something outside the platform put it there and Ankra cannot restore it.

**Omitted flags stay omitted.** The backend's PATCH leaves an absent field as it stands, so `--ttl`/`--proxied`/`--priority` are only sent when passed. Sending zeros would reset a deliberate TTL and turn the proxy off — the exact bug I'd just fixed on the backend side.

**A named domain costs one lookup.** `domains example.com` and every `<domain>` argument resolve through the server-side exact-name filter rather than walking the listing; a reference without a dot is treated as a zone id directly.

## Notes

- `APIClient` gains 8 methods, so `baseMock` in `e2e_test.go` gains 8 stubs — every other mock embeds it, so nothing else changed.
- Two sentinels are kept apart deliberately: `ErrCloudflareNotConnected` answers with `ankra org cloudflare connect <name>`, while `ErrCloudflareNotFound` stays a plain not-found. A bare 404 for both would tell the user nothing.

## Validation

- `go build ./...`, `go vet ./...` — clean
- 19 new tests; full `go test ./...` green
- `gofmt` clean on the new and touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
