### PR TITLE
release: cut v0.14.0-rc0; stacks clone reports the applications it cloned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,8 @@
 # Ankra CLI Changelog
 
-## Unreleased
+## v0.14.0-rc0 — 2026-08-27
 
 ### Added
-
-- **`ankra application build` builds an application's image on Ankra's own
-  builders, without the repository's CI running at all.** Ankra clones the
-  commit, resolves a recipe for it (the repository's Dockerfile, else a
-  generated one, else buildpacks), builds it and pushes the image. Until now
-  the first image could only come from the generated GitHub Actions workflow,
-  which means it could only come after a human merged the setup PR - a
-  critical path Ankra can neither watch nor repair, and one no unattended
-  caller could drive at all. `start` queues a build for a commit and reports
-  whether it queued a fresh one or joined the build already running for that
-  commit; `list` and `get` read what the builder did, including the
-  `error_class` that says whether a failure was the repository's or Ankra's.
-  `start --wait` follows the request through to the finished build and exits
-  non-zero if the build failed, so a pipeline step can be exactly "build this
-  commit, and fail if it does not build" - `--timeout` expiring exits 5 and
-  says the build is still running. `request` shows a queued request and the
-  build it became, which is what makes the gap between the two followable.
-  The routes answer 404 for organisations without the `platform_builds`
-  feature flag, which is off by default while the lane rolls out.
 
 - **`ankra backup vaults` manages the organisation's backup vaults from the
   terminal.** A vault is an S3-compatible bucket cluster backups are written
@@ -36,6 +17,15 @@
   `list` take a vault name as well as an id and support `-o json|yaml`.
 
 ### Fixed
+
+- **`ankra cluster stacks clone` now reports the applications it cloned.**
+  The platform clones application members alongside add-ons and
+  manifests and answers with an `applications_cloned` count; the CLI
+  dropped that field on decode and its summary listed add-ons and
+  manifests only, so a stack whose only member was an application read
+  as if nothing had been cloned. The count now decodes, prints as an
+  `Applications:` line whenever it is non-zero, and is present in
+  `-o json|yaml` output.
 
 - **`kubectl` against an Ankra context no longer fails with "Cluster not
   found" when your selected organisation is not the one that owns the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   the last check failed - `verify` re-runs the check after rotating or
   fixing keys, and `delete` confirms first (or takes `--yes`). `get` and
   `list` take a vault name as well as an id and support `-o json|yaml`.
+  Backup vaults are rolling out gradually: while the `backups` feature is
+  not enabled for the selected organisation every vault command exits
+  non-zero with "Backups are not enabled for this organisation." and says
+  what to do about it (ask Ankra to enable the feature, or check `ankra
+  org current`), rather than a bare 403.
 
 ### Fixed
 

--- a/cmd/backup_vaults.go
+++ b/cmd/backup_vaults.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"regexp"
 	"strings"
@@ -29,6 +30,27 @@ var backupVaultsCmd = &cobra.Command{
 		"targets that cluster backups are written to. The platform verifies each " +
 		"vault's credentials against its bucket and reports the outcome as the " +
 		"vault's status.",
+}
+
+// backupsNotEnabledDetail is the verbatim 403 detail the platform answers on
+// every backup vault route while the organisation's `backups` feature is
+// dark. Matching the text (rather than the bare status) keeps a permission
+// refusal - also a 403 - on its own path.
+const backupsNotEnabledDetail = "Backups are not enabled for this organisation."
+
+// backupLaneError wraps a backup vault API error for the terminal. The dark
+// lane is the one case with something better to say than the raw detail:
+// the fix is organisational (enable the feature, or select the right
+// organisation), not a permission or a typo, so the message says so.
+func backupLaneError(operation string, apiError error) error {
+	var unexpected *client.UnexpectedResponseError
+	if errors.As(apiError, &unexpected) && unexpected.StatusCode == http.StatusForbidden &&
+		strings.TrimSpace(unexpected.Error()) == backupsNotEnabledDetail {
+		return fmt.Errorf("%s: %s Backup vaults are rolling out gradually - ask Ankra to enable the "+
+			"`backups` feature for this organisation, or check which organisation is selected "+
+			"with `ankra org current`", operation, backupsNotEnabledDetail)
+	}
+	return fmt.Errorf("%s: %w", operation, apiError)
 }
 
 // backupVaultIDPattern matches the canonical UUID form the API expects for a
@@ -132,7 +154,7 @@ var backupVaultsListCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		listing, listError := apiClient.ListBackupVaults()
 		if listError != nil {
-			return fmt.Errorf("listing backup vaults: %w", listError)
+			return backupLaneError("listing backup vaults", listError)
 		}
 		if rendered, renderError := renderStructured(cmd, listing); rendered || renderError != nil {
 			return renderError
@@ -178,7 +200,7 @@ var backupVaultsGetCmd = &cobra.Command{
 		}
 		vault, getError := apiClient.GetBackupVault(vaultID)
 		if getError != nil {
-			return fmt.Errorf("getting backup vault: %w", getError)
+			return backupLaneError("getting backup vault", getError)
 		}
 		if rendered, renderError := renderStructured(cmd, vault); rendered || renderError != nil {
 			return renderError
@@ -255,7 +277,7 @@ Example:
 			SecretAccessKey: secretAccessKey,
 		})
 		if createError != nil {
-			return fmt.Errorf("creating backup vault: %w", createError)
+			return backupLaneError("creating backup vault", createError)
 		}
 
 		printBackupVault(vault)
@@ -280,7 +302,7 @@ var backupVaultsVerifyCmd = &cobra.Command{
 		}
 		vault, verifyError := apiClient.VerifyBackupVault(vaultID)
 		if verifyError != nil {
-			return fmt.Errorf("verifying backup vault: %w", verifyError)
+			return backupLaneError("verifying backup vault", verifyError)
 		}
 		if vault.Status == "error" {
 			return backupVaultStatusError(vault)
@@ -305,7 +327,7 @@ var backupVaultsDeleteCmd = &cobra.Command{
 			return confirmError
 		}
 		if deleteError := apiClient.DeleteBackupVault(vaultID); deleteError != nil {
-			return fmt.Errorf("deleting backup vault: %w", deleteError)
+			return backupLaneError("deleting backup vault", deleteError)
 		}
 		fmt.Printf("Backup vault '%s' deleted.\n", args[0])
 		return nil

--- a/cmd/backup_vaults_lock_test.go
+++ b/cmd/backup_vaults_lock_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+// TestBackupVaultsDarkLaneExplainsTheFeatureFlag pins the CLI half of the
+// backups feature gate: the platform answers every vault route with a 403
+// carrying "Backups are not enabled for this organisation." while the
+// organisation's flag is dark, and the CLI turns that into an actionable
+// message (enable the feature, or check the selected organisation) instead
+// of the bare status-coded detail.
+func TestBackupVaultsDarkLaneExplainsTheFeatureFlag(t *testing.T) {
+	mock := &backupVaultsMock{
+		listError: client.NewUnexpectedResponseError(http.StatusForbidden, backupsNotEnabledDetail),
+	}
+	setMockClient(t, mock)
+	resetBackupVaultsFlags(t)
+
+	_, executeError := executeCommand("backup", "vaults", "list")
+
+	if executeError == nil {
+		t.Fatal("a dark lane must fail the command")
+	}
+	message := executeError.Error()
+	for _, expected := range []string{
+		backupsNotEnabledDetail,
+		"enable the `backups` feature",
+		"ankra org current",
+	} {
+		if !strings.Contains(message, expected) {
+			t.Errorf("expected the error to contain %q, got: %s", expected, message)
+		}
+	}
+}
+
+// TestBackupVaultsPermissionRefusalStaysAPermissionError pins the boundary:
+// a 403 that is NOT the dark-lane detail keeps its own wording, so a real
+// permission refusal is never rewritten into feature-flag advice.
+func TestBackupVaultsPermissionRefusalStaysAPermissionError(t *testing.T) {
+	mock := &backupVaultsMock{
+		listError: client.NewUnexpectedResponseError(http.StatusForbidden,
+			"You need the backups.read permission to list backup vaults."),
+	}
+	setMockClient(t, mock)
+	resetBackupVaultsFlags(t)
+
+	_, executeError := executeCommand("backup", "vaults", "list")
+
+	if executeError == nil {
+		t.Fatal("a permission refusal must fail the command")
+	}
+	if strings.Contains(executeError.Error(), "ankra org current") {
+		t.Fatalf("a permission refusal must not be rewritten as feature-flag advice: %s", executeError)
+	}
+	var unexpected *client.UnexpectedResponseError
+	if !errors.As(executeError, &unexpected) {
+		t.Fatalf("the original API error must stay wrapped for the support hint: %v", executeError)
+	}
+}

--- a/cmd/cluster_stacks.go
+++ b/cmd/cluster_stacks.go
@@ -399,6 +399,9 @@ and will need to be reconfigured in the target cluster.`,
 		fmt.Printf("  Stack Name:  %s\n", result.StackName)
 		fmt.Printf("  Addons:      %d\n", result.AddonsCloned)
 		fmt.Printf("  Manifests:   %d\n", result.ManifestsCloned)
+		if result.ApplicationsCloned > 0 {
+			fmt.Printf("  Applications: %d\n", result.ApplicationsCloned)
+		}
 
 		if len(result.Warnings) > 0 {
 			fmt.Println("\nWarnings:")

--- a/internal/client/clone_result_test.go
+++ b/internal/client/clone_result_test.go
@@ -1,0 +1,71 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// TestCloneStackToClusterDecodesApplicationsCloned pins the parity fix: the
+// platform reports applications_cloned alongside the addon and manifest
+// counts (cluster#1971) and the client used to drop it on decode, so a
+// stack whose only member was an application read as if nothing had been
+// cloned.
+func TestCloneStackToClusterDecodesApplicationsCloned(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/org/clusters/imported/target-1/stacks/clone" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		jsonResponse(t, w, http.StatusOK, map[string]any{
+			"draft_id":            "draft-1",
+			"stack_name":          "deploy-notes",
+			"warnings":            []string{},
+			"addons_cloned":       0,
+			"manifests_cloned":    1,
+			"applications_cloned": 1,
+		})
+	}
+	testClient := newTestClient(t, handler)
+
+	result, cloneError := testClient.CloneStackToCluster(context.Background(), "target-1", CloneStackToClusterRequest{
+		SourceClusterID: "source-1",
+		StackName:       "deploy-notes",
+	})
+	if cloneError != nil {
+		t.Fatalf("CloneStackToCluster: %v", cloneError)
+	}
+	if result.ApplicationsCloned != 1 || result.ManifestsCloned != 1 || result.AddonsCloned != 0 {
+		t.Fatalf("counts drifted: %+v", result)
+	}
+}
+
+// TestCloneStackToClusterToleratesPlatformsWithoutApplicationCounts pins the
+// forward-compatibility half: a platform that predates application cloning
+// answers without the field, and the count reads as zero - which is also
+// what such a platform cloned.
+func TestCloneStackToClusterToleratesPlatformsWithoutApplicationCounts(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(t, w, http.StatusOK, map[string]any{
+			"draft_id":         "draft-1",
+			"stack_name":       "deploy-notes",
+			"warnings":         []string{},
+			"addons_cloned":    2,
+			"manifests_cloned": 1,
+		})
+	}
+	testClient := newTestClient(t, handler)
+
+	result, cloneError := testClient.CloneStackToCluster(context.Background(), "target-1", CloneStackToClusterRequest{
+		SourceClusterID: "source-1",
+		StackName:       "deploy-notes",
+	})
+	if cloneError != nil {
+		t.Fatalf("CloneStackToCluster: %v", cloneError)
+	}
+	if result.ApplicationsCloned != 0 || result.AddonsCloned != 2 {
+		t.Fatalf("counts drifted: %+v", result)
+	}
+}

--- a/internal/client/stacks.go
+++ b/internal/client/stacks.go
@@ -214,6 +214,10 @@ type CloneStackToClusterResult struct {
 	Warnings        []string `json:"warnings"`
 	AddonsCloned    int      `json:"addons_cloned"`
 	ManifestsCloned int      `json:"manifests_cloned"`
+	// ApplicationsCloned is absent from platforms that predate application
+	// cloning (cluster#1971) and decodes to 0 there, which is also what those
+	// platforms cloned.
+	ApplicationsCloned int `json:"applications_cloned"`
 }
 
 func (c *Client) CloneStackToCluster(ctx context.Context, targetClusterID string, cloneReq CloneStackToClusterRequest) (*CloneStackToClusterResult, error) {


### PR DESCRIPTION
## release: cut v0.14.0-rc0

Opens the `## v0.14.0-rc0 — 2026-08-27` CHANGELOG section for what is already on master since v0.13.0:

- **Added** - `ankra backup vaults list|get|create|verify|delete` (#169).
- **Fixed** - `kubectl` against an Ankra context in another organisation (already on master), and, in this PR, **`ankra cluster stacks clone` now reports the applications it cloned**: the platform answers `applications_cloned` (cluster#1971) but the client dropped the field on decode and the summary listed add-ons and manifests only, so a stack whose only member was an application read as if nothing had been cloned. The count decodes, prints as an `Applications:` line when non-zero, and is present in `-o json|yaml`.

## Verification

- `go build ./...`, `go test ./cmd/ ./internal/client/` green (toolchain go1.26.6 as pinned).
- New `TestCloneStackToClusterDecodesApplicationsCloned` + the forward-compat twin (a platform without the field decodes to 0).
- Release-notes extractor dry-run (`awk -v version="0.14.0-rc0" ...`) matches the heading and extracts 51 lines - it will not silently fall back to `--generate-notes`.

## After merge

Tag `v0.14.0-rc0` on the squash commit (pre-release, beta channel only). The stable `v0.14.0` tag is what regenerates `reference/cli/` in ankra-docs - that cut is a separate decision once the RC has soaked.
