### PR TITLE
feat(managed): AKS options, pool placement and spot flags; ankra credentials azure

### DIFF
--- a/cmd/azure_credentials.go
+++ b/cmd/azure_credentials.go
@@ -1,0 +1,146 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/manifoldco/promptui"
+	"github.com/spf13/cobra"
+)
+
+// azureClientSecretEnv lets automation pass the service principal secret
+// without an interactive prompt (expand it from a secret manager into the
+// process environment; never put it on the command line).
+const azureClientSecretEnv = "AZURE_CLIENT_SECRET"
+
+var azureCredCmd = &cobra.Command{
+	Use:     "azure",
+	Aliases: []string{"az"},
+	Short:   "Manage Azure credentials",
+	Long:    "Commands to list and create Azure service principal credentials used for Azure Kubernetes Service (AKS).",
+}
+
+var azureCredListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List Azure credentials",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		creds, err := apiClient.ListAzureCredentials()
+		if err != nil {
+			return fmt.Errorf("listing Azure credentials: %w", err)
+		}
+
+		if creds == nil {
+			creds = []client.AzureCredentialListItem{}
+		}
+		if handled, err := renderStructured(cmd, creds); err != nil {
+			return err
+		} else if handled {
+			return nil
+		}
+
+		if len(creds) == 0 {
+			fmt.Println("No Azure credentials found.")
+			return nil
+		}
+
+		t := table.NewWriter()
+		t.SetOutputMirror(os.Stdout)
+		t.SetStyle(table.StyleRounded)
+		t.AppendHeader(table.Row{"ID", "Name", "Available", "Created"})
+		t.SetColumnConfigs([]table.ColumnConfig{
+			{Number: 1, WidthMin: 36},
+			{Number: 2, WidthMin: 20},
+			{Number: 3, WidthMin: 10},
+			{Number: 4, WidthMin: 15},
+		})
+
+		for _, cred := range creds {
+			available := "yes"
+			if !cred.Available {
+				available = "no"
+			}
+			t.AppendRow(table.Row{
+				cred.ID,
+				cred.Name,
+				available,
+				formatTimeAgo(cred.CreatedAt),
+			})
+		}
+		t.Render()
+		return nil
+	},
+}
+
+var azureCredCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create an Azure service principal credential",
+	Long: `Store an Azure service principal for AKS. The client secret is read from
+the ` + azureClientSecretEnv + ` environment variable when set, and prompted
+for (masked) otherwise - it is never accepted as a flag.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name, _ := cmd.Flags().GetString("name")
+		subscriptionID, _ := cmd.Flags().GetString("subscription-id")
+		tenantID, _ := cmd.Flags().GetString("tenant-id")
+		clientID, _ := cmd.Flags().GetString("client-id")
+
+		clientSecret := os.Getenv(azureClientSecretEnv)
+		if clientSecret == "" {
+			prompt := promptui.Prompt{
+				Label: "Azure client secret",
+				Mask:  '*',
+				Validate: func(input string) error {
+					if len(input) == 0 {
+						return fmt.Errorf("client secret cannot be empty")
+					}
+					return nil
+				},
+			}
+			secretValue, err := prompt.Run()
+			if err != nil {
+				return errors.New("prompt cancelled")
+			}
+			clientSecret = secretValue
+		}
+
+		result, err := apiClient.CreateAzureCredential(client.CreateAzureCredentialRequest{
+			Name:           name,
+			SubscriptionID: subscriptionID,
+			TenantID:       tenantID,
+			ClientID:       clientID,
+			ClientSecret:   clientSecret,
+		})
+		if err != nil {
+			return fmt.Errorf("creating Azure credential: %w", err)
+		}
+
+		if !result.Success {
+			msg := "failed to create Azure credential:"
+			for _, e := range result.Errors {
+				msg += fmt.Sprintf("\n  - %s: %s", e.Key, e.Message)
+			}
+			return errors.New(msg)
+		}
+
+		fmt.Printf("Azure credential '%s' created successfully!\n", name)
+		return nil
+	},
+}
+
+func init() {
+	azureCredCreateCmd.Flags().String("name", "", "Credential name")
+	azureCredCreateCmd.Flags().String("subscription-id", "", "Azure subscription ID the service principal manages")
+	azureCredCreateCmd.Flags().String("tenant-id", "", "Microsoft Entra tenant ID")
+	azureCredCreateCmd.Flags().String("client-id", "", "Service principal application (client) ID")
+	_ = azureCredCreateCmd.MarkFlagRequired("name")
+	_ = azureCredCreateCmd.MarkFlagRequired("subscription-id")
+	_ = azureCredCreateCmd.MarkFlagRequired("tenant-id")
+	_ = azureCredCreateCmd.MarkFlagRequired("client-id")
+
+	azureCredCmd.AddCommand(azureCredListCmd, azureCredCreateCmd)
+	credentialsCmd.AddCommand(azureCredCmd)
+	registerStructuredOutputFlags(azureCredListCmd)
+}

--- a/cmd/cluster_managed.go
+++ b/cmd/cluster_managed.go
@@ -42,6 +42,14 @@ var managedCreateCmd = &cobra.Command{
 		if autoscalingError != nil {
 			return autoscalingError
 		}
+		placement, placementError := parseManagedPoolPlacementFlags(cmd, provider, false)
+		if placementError != nil {
+			return placementError
+		}
+		aksOptions, aksError := parseAksOptionsFlags(cmd, provider)
+		if aksError != nil {
+			return aksError
+		}
 
 		request := client.CreateManagedClusterRequest{
 			Name:         name,
@@ -49,12 +57,14 @@ var managedCreateCmd = &cobra.Command{
 			Location:     location,
 			NodePools: []client.ManagedClusterNodePoolRequest{
 				{
-					Name:        nodePoolName,
-					Size:        nodePoolSize,
-					Count:       nodePoolCount,
-					Autoscaling: autoscaling,
+					Name:                     nodePoolName,
+					Size:                     nodePoolSize,
+					Count:                    nodePoolCount,
+					Autoscaling:              autoscaling,
+					ManagedNodePoolPlacement: placement,
 				},
 			},
+			Aks: aksOptions,
 		}
 		if provider == client.ManagedK8sProviderKapsule {
 			if privateNetworkID == "" {
@@ -173,12 +183,17 @@ var managedNodePoolAddCmd = &cobra.Command{
 		if autoscalingError != nil {
 			return autoscalingError
 		}
+		placement, placementError := parseManagedPoolPlacementFlags(cmd, provider, true)
+		if placementError != nil {
+			return placementError
+		}
 
 		result, err := apiClient.AddManagedNodePool(provider, clusterID, client.AddManagedNodePoolRequest{
-			Name:        name,
-			Size:        size,
-			Count:       count,
-			Autoscaling: autoscaling,
+			Name:                     name,
+			Size:                     size,
+			Count:                    count,
+			Autoscaling:              autoscaling,
+			ManagedNodePoolPlacement: placement,
 		})
 		if err != nil {
 			return fmt.Errorf("adding node pool: %w", err)
@@ -566,6 +581,140 @@ func parseManagedAutoscalingFlags(cmd *cobra.Command) (*client.ManagedNodePoolAu
 	return &client.ManagedNodePoolAutoscaling{Enabled: true, MinCount: minCount, MaxCount: maxCount}, nil
 }
 
+// aksOnlyFlags are the create flags that only make sense with --provider
+// aks; naming one with another provider is a usage error rather than a
+// silently ignored flag.
+var aksOnlyFlags = []string{"resource-group", "network-plugin", "sku-tier", "private-cluster", "vnet-subnet-id", "maintenance-window"}
+
+// aksPlacementFlags are the pool placement flags the AKS lane accepts on the
+// initial pool (create) and on node-pool add.
+var aksPlacementFlags = []string{"zone", "os-disk-type", "os-disk-size-gb", "spot", "spot-max-price"}
+
+func refuseFlagsForProvider(cmd *cobra.Command, provider client.ManagedK8sProvider, flagNames []string) error {
+	for _, flagName := range flagNames {
+		if cmd.Flags().Lookup(flagName) != nil && cmd.Flags().Changed(flagName) {
+			return withExitCode(exitUsage, fmt.Errorf("--%s is only supported with --provider aks, not %q", flagName, provider))
+		}
+	}
+	return nil
+}
+
+// parseAksOptionsFlags reads the Azure control-plane flags into the aks
+// options block. --maintenance-window takes "<Weekday>:<start-hour>:<hours>"
+// (for example Saturday:22:4, UTC).
+func parseAksOptionsFlags(cmd *cobra.Command, provider client.ManagedK8sProvider) (*client.AksClusterOptions, error) {
+	if provider != client.ManagedK8sProviderAks {
+		return nil, refuseFlagsForProvider(cmd, provider, aksOnlyFlags)
+	}
+	options := &client.AksClusterOptions{}
+	touched := false
+	if cmd.Flags().Changed("resource-group") {
+		resourceGroup, _ := cmd.Flags().GetString("resource-group")
+		options.ResourceGroup = &resourceGroup
+		touched = true
+	}
+	if cmd.Flags().Changed("network-plugin") {
+		networkPlugin, _ := cmd.Flags().GetString("network-plugin")
+		if networkPlugin != "azure" && networkPlugin != "kubenet" {
+			return nil, withExitCode(exitUsage, fmt.Errorf("--network-plugin must be azure or kubenet, not %q", networkPlugin))
+		}
+		options.NetworkPlugin = networkPlugin
+		touched = true
+	}
+	if cmd.Flags().Changed("sku-tier") {
+		skuTier, _ := cmd.Flags().GetString("sku-tier")
+		if skuTier != "Free" && skuTier != "Standard" && skuTier != "Premium" {
+			return nil, withExitCode(exitUsage, fmt.Errorf("--sku-tier must be Free, Standard or Premium, not %q", skuTier))
+		}
+		options.SkuTier = &skuTier
+		touched = true
+	}
+	if cmd.Flags().Changed("private-cluster") {
+		options.PrivateCluster, _ = cmd.Flags().GetBool("private-cluster")
+		touched = true
+	}
+	if cmd.Flags().Changed("vnet-subnet-id") {
+		subnetID, _ := cmd.Flags().GetString("vnet-subnet-id")
+		options.VnetSubnetID = &subnetID
+		touched = true
+	}
+	if cmd.Flags().Changed("maintenance-window") {
+		rawWindow, _ := cmd.Flags().GetString("maintenance-window")
+		window, windowError := parseAksMaintenanceWindow(rawWindow)
+		if windowError != nil {
+			return nil, windowError
+		}
+		options.MaintenanceWindow = window
+		touched = true
+	}
+	if !touched {
+		return nil, nil
+	}
+	return options, nil
+}
+
+func parseAksMaintenanceWindow(raw string) (*client.AksMaintenanceWindow, error) {
+	parts := strings.Split(raw, ":")
+	if len(parts) != 3 {
+		return nil, withExitCode(exitUsage, fmt.Errorf("--maintenance-window must be <Weekday>:<start-hour>:<hours>, for example Saturday:22:4, not %q", raw))
+	}
+	var startHour, durationHours int
+	if _, scanError := fmt.Sscanf(parts[1], "%d", &startHour); scanError != nil || startHour < 0 || startHour > 23 {
+		return nil, withExitCode(exitUsage, fmt.Errorf("--maintenance-window start hour must be 0-23, not %q", parts[1]))
+	}
+	if _, scanError := fmt.Sscanf(parts[2], "%d", &durationHours); scanError != nil || durationHours < 4 || durationHours > 24 {
+		return nil, withExitCode(exitUsage, fmt.Errorf("--maintenance-window duration must be 4-24 hours, not %q", parts[2]))
+	}
+	return &client.AksMaintenanceWindow{Day: parts[0], StartHour: startHour, DurationHours: durationHours}, nil
+}
+
+// parseManagedPoolPlacementFlags reads --zone, --os-disk-type,
+// --os-disk-size-gb and (on node-pool add) --spot / --spot-max-price. The
+// initial pool of a cluster is the AKS System pool, which cannot run on
+// spot, so create does not register the spot flags.
+func parseManagedPoolPlacementFlags(cmd *cobra.Command, provider client.ManagedK8sProvider, allowSpot bool) (client.ManagedNodePoolPlacement, error) {
+	var placement client.ManagedNodePoolPlacement
+	if provider != client.ManagedK8sProviderAks {
+		return placement, refuseFlagsForProvider(cmd, provider, aksPlacementFlags)
+	}
+	if cmd.Flags().Changed("zone") {
+		zone, _ := cmd.Flags().GetString("zone")
+		placement.Zone = &zone
+	}
+	if cmd.Flags().Changed("os-disk-type") {
+		diskType, _ := cmd.Flags().GetString("os-disk-type")
+		if diskType != "Managed" && diskType != "Ephemeral" {
+			return placement, withExitCode(exitUsage, fmt.Errorf("--os-disk-type must be Managed or Ephemeral, not %q", diskType))
+		}
+		placement.RootVolumeType = &diskType
+	}
+	if cmd.Flags().Changed("os-disk-size-gb") {
+		diskSize, _ := cmd.Flags().GetInt("os-disk-size-gb")
+		if diskSize < 30 {
+			return placement, withExitCode(exitUsage, fmt.Errorf("--os-disk-size-gb must be at least 30, not %d", diskSize))
+		}
+		placement.RootVolumeSizeGB = &diskSize
+	}
+	if !allowSpot {
+		return placement, nil
+	}
+	spot, _ := cmd.Flags().GetBool("spot")
+	if cmd.Flags().Changed("spot-max-price") && !spot {
+		return placement, withExitCode(exitUsage, errors.New("--spot-max-price requires --spot"))
+	}
+	if spot {
+		placement.Spot = &client.ManagedNodePoolSpot{Enabled: true}
+		if cmd.Flags().Changed("spot-max-price") {
+			maxPrice, _ := cmd.Flags().GetFloat64("spot-max-price")
+			if maxPrice <= 0 {
+				return placement, withExitCode(exitUsage, fmt.Errorf("--spot-max-price must be greater than 0, not %v", maxPrice))
+			}
+			placement.Spot.MaxPrice = &maxPrice
+		}
+	}
+	return placement, nil
+}
+
 // managedLifecycleError decorates stop/start API refusals: when the backend
 // answers that the provider cannot stop or start clusters, remind the user
 // that only AKS currently supports it.
@@ -595,6 +744,15 @@ func init() {
 	managedCreateCmd.Flags().Bool("autoscaling", false, "Enable autoscaling for the initial node pool")
 	managedCreateCmd.Flags().Int("autoscaling-min", 0, "Minimum node count while autoscaling (requires --autoscaling)")
 	managedCreateCmd.Flags().Int("autoscaling-max", 0, "Maximum node count while autoscaling (requires --autoscaling)")
+	managedCreateCmd.Flags().String("resource-group", "", "AKS: existing resource group to adopt (default: Ankra creates and owns ankra-<name>)")
+	managedCreateCmd.Flags().String("network-plugin", "", "AKS: network plugin, azure (default) or kubenet")
+	managedCreateCmd.Flags().String("sku-tier", "", "AKS: control-plane tier, Free (default), Standard (uptime SLA) or Premium")
+	managedCreateCmd.Flags().Bool("private-cluster", false, "AKS: private API server endpoint")
+	managedCreateCmd.Flags().String("vnet-subnet-id", "", "AKS: ARM id of the subnet every node pool joins (default: AKS-managed VNet)")
+	managedCreateCmd.Flags().String("maintenance-window", "", "AKS: planned maintenance window as <Weekday>:<start-hour>:<hours> in UTC, e.g. Saturday:22:4")
+	managedCreateCmd.Flags().String("zone", "", "AKS: availability zone(s) for the initial pool, comma-separated (e.g. 1,2,3)")
+	managedCreateCmd.Flags().String("os-disk-type", "", "AKS: OS disk type for the initial pool, Managed or Ephemeral")
+	managedCreateCmd.Flags().Int("os-disk-size-gb", 0, "AKS: OS disk size in GB for the initial pool (at least 30)")
 	_ = managedCreateCmd.MarkFlagRequired("provider")
 	_ = managedCreateCmd.MarkFlagRequired("name")
 	_ = managedCreateCmd.MarkFlagRequired("credential-id")
@@ -613,6 +771,11 @@ func init() {
 	managedNodePoolAddCmd.Flags().Bool("autoscaling", false, "Enable autoscaling for the node pool")
 	managedNodePoolAddCmd.Flags().Int("autoscaling-min", 0, "Minimum node count while autoscaling (requires --autoscaling)")
 	managedNodePoolAddCmd.Flags().Int("autoscaling-max", 0, "Maximum node count while autoscaling (requires --autoscaling)")
+	managedNodePoolAddCmd.Flags().String("zone", "", "AKS: availability zone(s), comma-separated (e.g. 1,2,3)")
+	managedNodePoolAddCmd.Flags().String("os-disk-type", "", "AKS: OS disk type, Managed or Ephemeral")
+	managedNodePoolAddCmd.Flags().Int("os-disk-size-gb", 0, "AKS: OS disk size in GB (at least 30)")
+	managedNodePoolAddCmd.Flags().Bool("spot", false, "AKS: run the pool on spot capacity (never the cluster's first pool)")
+	managedNodePoolAddCmd.Flags().Float64("spot-max-price", 0, "AKS: hourly spot price cap in USD (requires --spot; default: up to the on-demand price)")
 	_ = managedNodePoolAddCmd.MarkFlagRequired("provider")
 	_ = managedNodePoolAddCmd.MarkFlagRequired("name")
 	_ = managedNodePoolAddCmd.MarkFlagRequired("size")

--- a/cmd/cluster_managed_test.go
+++ b/cmd/cluster_managed_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 
 	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type managedClusterMock struct {
@@ -474,5 +477,123 @@ func TestManagedStop_UnrelatedErrorHasNoAKSHint(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "only AKS") {
 		t.Errorf("AKS hint should only appear on provider refusals, got: %v", err)
+	}
+}
+
+// resetManagedFlags clears the package-level cobra flag state the managed
+// commands keep between invocations: a flag one test passes would otherwise
+// still read as Changed in the next test of the same process.
+func resetManagedFlags(t *testing.T) {
+	t.Helper()
+	for _, command := range []*cobra.Command{managedCreateCmd, managedNodePoolAddCmd, managedNodePoolUpdateCmd} {
+		command.Flags().VisitAll(func(flag *pflag.Flag) {
+			if flag.Changed {
+				_ = flag.Value.Set(flag.DefValue)
+				flag.Changed = false
+			}
+		})
+	}
+}
+
+func TestManagedCreate_AksSendsOptionsAndPlacement(t *testing.T) {
+	resetManagedFlags(t)
+	t.Cleanup(func() { resetManagedFlags(t) })
+	mock := &managedClusterMock{}
+	_, err := runWithInput(t, mock, "", managedCreateArgs(
+		"--provider", "aks", "--location", "westeurope", "--node-pool-size", "Standard_D2s_v5",
+		"--resource-group", "platform-rg", "--network-plugin", "kubenet", "--sku-tier", "Standard",
+		"--private-cluster", "--vnet-subnet-id", "/subscriptions/s/resourceGroups/net/providers/Microsoft.Network/virtualNetworks/v/subnets/aks",
+		"--maintenance-window", "Saturday:22:4",
+		"--zone", "1,2", "--os-disk-type", "Ephemeral", "--os-disk-size-gb", "128")...)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mock.createRequests) != 1 {
+		t.Fatalf("expected one create request, got %d", len(mock.createRequests))
+	}
+	request := mock.createRequests[0]
+	aks := request.Aks
+	if aks == nil {
+		t.Fatal("expected the aks options block")
+	}
+	if aks.ResourceGroup == nil || *aks.ResourceGroup != "platform-rg" || aks.NetworkPlugin != "kubenet" ||
+		aks.SkuTier == nil || *aks.SkuTier != "Standard" || !aks.PrivateCluster ||
+		aks.VnetSubnetID == nil || !strings.HasSuffix(*aks.VnetSubnetID, "/subnets/aks") {
+		t.Fatalf("aks options drifted: %+v", aks)
+	}
+	if aks.MaintenanceWindow == nil || aks.MaintenanceWindow.Day != "Saturday" || aks.MaintenanceWindow.StartHour != 22 || aks.MaintenanceWindow.DurationHours != 4 {
+		t.Fatalf("maintenance window drifted: %+v", aks.MaintenanceWindow)
+	}
+	pool := request.NodePools[0]
+	if pool.Zone == nil || *pool.Zone != "1,2" || pool.RootVolumeType == nil || *pool.RootVolumeType != "Ephemeral" ||
+		pool.RootVolumeSizeGB == nil || *pool.RootVolumeSizeGB != 128 {
+		t.Fatalf("pool placement drifted: %+v", pool.ManagedNodePoolPlacement)
+	}
+	if pool.Spot != nil {
+		t.Fatal("the initial pool never carries spot (it is the AKS System pool)")
+	}
+}
+
+func TestManagedCreate_AksFlagsRefusedForOtherProviders(t *testing.T) {
+	resetManagedFlags(t)
+	t.Cleanup(func() { resetManagedFlags(t) })
+	mock := &managedClusterMock{}
+	_, err := runWithInput(t, mock, "", managedCreateArgs("--provider", "doks", "--sku-tier", "Standard")...)
+	if err == nil || !strings.Contains(err.Error(), "--sku-tier") || !strings.Contains(err.Error(), "aks") {
+		t.Fatalf("expected a usage error naming --sku-tier and aks, got %v", err)
+	}
+	if len(mock.createRequests) != 0 {
+		t.Fatal("no request may be sent when a flag is refused")
+	}
+	resetManagedFlags(t)
+	_, err = runWithInput(t, mock, "", managedCreateArgs("--provider", "doks", "--zone", "1")...)
+	if err == nil || !strings.Contains(err.Error(), "--zone") {
+		t.Fatalf("expected a usage error naming --zone, got %v", err)
+	}
+}
+
+func TestManagedCreate_AksMaintenanceWindowValidation(t *testing.T) {
+	resetManagedFlags(t)
+	t.Cleanup(func() { resetManagedFlags(t) })
+	mock := &managedClusterMock{}
+	_, err := runWithInput(t, mock, "", managedCreateArgs("--provider", "aks", "--maintenance-window", "Saturday:22")...)
+	if err == nil || !strings.Contains(err.Error(), "<Weekday>:<start-hour>:<hours>") {
+		t.Fatalf("expected the format error, got %v", err)
+	}
+	resetManagedFlags(t)
+	_, err = runWithInput(t, mock, "", managedCreateArgs("--provider", "aks", "--maintenance-window", "Saturday:22:2")...)
+	if err == nil || !strings.Contains(err.Error(), "4-24") {
+		t.Fatalf("expected the duration error, got %v", err)
+	}
+}
+
+func TestManagedNodePoolAdd_AksSpot(t *testing.T) {
+	resetManagedFlags(t)
+	t.Cleanup(func() { resetManagedFlags(t) })
+	mock := &managedClusterMock{}
+	_, err := runWithInput(t, mock, "",
+		"cluster", "managed", "node-pool", "add", "cluster-1",
+		"--provider", "aks", "--name", "batch", "--size", "Standard_E4s_v5", "--count", "3",
+		"--spot", "--spot-max-price", "0.05", "--zone", "3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mock.addPoolRequests) != 1 {
+		t.Fatalf("expected one add request, got %d", len(mock.addPoolRequests))
+	}
+	request := mock.addPoolRequests[0]
+	if request.Spot == nil || !request.Spot.Enabled || request.Spot.MaxPrice == nil || *request.Spot.MaxPrice != 0.05 {
+		t.Fatalf("spot drifted: %+v", request.Spot)
+	}
+	if request.Zone == nil || *request.Zone != "3" {
+		t.Fatalf("zone drifted: %+v", request.Zone)
+	}
+
+	resetManagedFlags(t)
+	_, err = runWithInput(t, mock, "",
+		"cluster", "managed", "node-pool", "add", "cluster-1",
+		"--provider", "aks", "--name", "batch", "--size", "Standard_E4s_v5", "--spot-max-price", "0.05")
+	if err == nil || !strings.Contains(err.Error(), "requires --spot") {
+		t.Fatalf("expected --spot-max-price to require --spot, got %v", err)
 	}
 }

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -3564,3 +3564,11 @@ func (m baseMock) GetAIAutonomyState() (*client.AIAutonomyState, error) {
 func (m baseMock) SetAIAutonomyPause(paused bool, reason string) (*client.AIAutonomyOutcome, error) {
 	return nil, errors.New("not implemented")
 }
+
+func (baseMock) ListAzureCredentials() ([]client.AzureCredentialListItem, error) {
+	return nil, nil
+}
+
+func (baseMock) CreateAzureCredential(client.CreateAzureCredentialRequest) (*client.CreateAzureCredentialResponse, error) {
+	return &client.CreateAzureCredentialResponse{Success: true}, nil
+}

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -457,6 +457,8 @@ type APIClient interface {
 	ResyncUpcloudClusterSSHKeys(clusterID string) (*client.ResyncSSHKeysResult, error)
 
 	ListUpcloudCredentials() ([]client.UpcloudCredentialListItem, error)
+	ListAzureCredentials() ([]client.AzureCredentialListItem, error)
+	CreateAzureCredential(req client.CreateAzureCredentialRequest) (*client.CreateAzureCredentialResponse, error)
 	CreateUpcloudCredential(req client.CreateUpcloudCredentialRequest) (*client.CreateUpcloudCredentialResponse, error)
 	ListUpcloudSSHKeyCredentials() ([]client.UpcloudCredentialListItem, error)
 	CreateUpcloudSSHKeyCredential(req client.CreateSSHKeyCredentialRequest) (*client.CreateSSHKeyCredentialResponse, error)

--- a/internal/client/azure_credentials.go
+++ b/internal/client/azure_credentials.go
@@ -1,0 +1,46 @@
+package client
+
+// AzureCredentialListItem is one stored Azure service principal.
+type AzureCredentialListItem struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	Provider       string `json:"provider"`
+	OrganisationID string `json:"organisation_id"`
+	System         bool   `json:"system"`
+	Available      bool   `json:"available"`
+	CreatedAt      string `json:"created_at"`
+	UpdatedAt      string `json:"updated_at"`
+}
+
+// CreateAzureCredentialRequest mirrors the API's AzureCredentialCreateRequest:
+// the service principal Ankra uses for AKS.
+type CreateAzureCredentialRequest struct {
+	Name           string `json:"name"`
+	SubscriptionID string `json:"subscription_id"`
+	TenantID       string `json:"tenant_id"`
+	ClientID       string `json:"client_id"`
+	ClientSecret   string `json:"client_secret"`
+}
+
+type CreateAzureCredentialResponse struct {
+	Success bool            `json:"success"`
+	Errors  []ResourceError `json:"errors,omitempty"`
+}
+
+func (c *Client) ListAzureCredentials() ([]AzureCredentialListItem, error) {
+	url := c.BaseURL + "/api/v1/credentials/azure"
+	var creds []AzureCredentialListItem
+	if err := c.getJSON(url, &creds); err != nil {
+		return nil, err
+	}
+	return creds, nil
+}
+
+func (c *Client) CreateAzureCredential(req CreateAzureCredentialRequest) (*CreateAzureCredentialResponse, error) {
+	url := c.BaseURL + "/api/v1/credentials/azure"
+	created, err := c.doCreateCredential(url, req)
+	if err != nil {
+		return nil, err
+	}
+	return &CreateAzureCredentialResponse{Success: created.Success, Errors: created.Errors}, nil
+}

--- a/internal/client/managed_clusters.go
+++ b/internal/client/managed_clusters.go
@@ -25,6 +25,23 @@ type ManagedNodePoolAutoscaling struct {
 	MaxCount int  `json:"max_count"`
 }
 
+// ManagedNodePoolSpot asks for a pool on spot / preemptible capacity (AKS);
+// MaxPrice is the hourly cap in the provider's currency, nil = on-demand cap.
+type ManagedNodePoolSpot struct {
+	Enabled  bool     `json:"enabled"`
+	MaxPrice *float64 `json:"max_price,omitempty"`
+}
+
+// ManagedNodePoolPlacement carries the provider-specific pool placement
+// members shared by the create and add-pool requests: availability
+// zone(s), the OS / root disk, and spot capacity.
+type ManagedNodePoolPlacement struct {
+	Zone             *string              `json:"zone,omitempty"`
+	RootVolumeType   *string              `json:"root_volume_type,omitempty"`
+	RootVolumeSizeGB *int                 `json:"root_volume_size_gb,omitempty"`
+	Spot             *ManagedNodePoolSpot `json:"spot,omitempty"`
+}
+
 type ManagedClusterNodePoolRequest struct {
 	Name        string                      `json:"name"`
 	Size        string                      `json:"size"`
@@ -32,6 +49,25 @@ type ManagedClusterNodePoolRequest struct {
 	Labels      map[string]string           `json:"labels,omitempty"`
 	Taints      []NodeTaint                 `json:"taints,omitempty"`
 	Autoscaling *ManagedNodePoolAutoscaling `json:"autoscaling,omitempty"`
+	ManagedNodePoolPlacement
+}
+
+// AksMaintenanceWindow pins when Azure may run control-plane upgrades and
+// node reboots: an English weekday, a 0-23 UTC start hour, 4-24 hours.
+type AksMaintenanceWindow struct {
+	Day           string `json:"day"`
+	StartHour     int    `json:"start_hour"`
+	DurationHours int    `json:"duration_hours"`
+}
+
+// AksClusterOptions carries the Azure-specific create options.
+type AksClusterOptions struct {
+	ResourceGroup     *string               `json:"resource_group,omitempty"`
+	NetworkPlugin     string                `json:"network_plugin,omitempty"`
+	PrivateCluster    bool                  `json:"private_cluster"`
+	SkuTier           *string               `json:"sku_tier,omitempty"`
+	VnetSubnetID      *string               `json:"vnet_subnet_id,omitempty"`
+	MaintenanceWindow *AksMaintenanceWindow `json:"maintenance_window,omitempty"`
 }
 
 // KapsuleClusterOptions carries the Scaleway Kapsule-specific create options;
@@ -51,6 +87,7 @@ type CreateManagedClusterRequest struct {
 	GitopsRepository     *string                         `json:"gitops_repository,omitempty"`
 	GitopsBranch         *string                         `json:"gitops_branch,omitempty"`
 	Kapsule              *KapsuleClusterOptions          `json:"kapsule,omitempty"`
+	Aks                  *AksClusterOptions              `json:"aks,omitempty"`
 }
 
 type CreateManagedClusterResponse struct {
@@ -83,6 +120,7 @@ type AddManagedNodePoolRequest struct {
 	Labels      map[string]string           `json:"labels,omitempty"`
 	Taints      []NodeTaint                 `json:"taints,omitempty"`
 	Autoscaling *ManagedNodePoolAutoscaling `json:"autoscaling,omitempty"`
+	ManagedNodePoolPlacement
 }
 
 type AddManagedNodePoolResponse struct {


### PR DESCRIPTION
Companion to ankraio/cluster#2075 (backend). Closes the gap the AKS guide used to admit: "network plugin, SKU tier, private-cluster, resource group … are set from the portal or the API".

- `cluster managed create --provider aks`: `--resource-group`, `--network-plugin`, `--sku-tier`, `--private-cluster`, `--vnet-subnet-id`, `--maintenance-window <Weekday>:<start-hour>:<hours>`, and `--zone` / `--os-disk-type` / `--os-disk-size-gb` for the initial pool.
- `cluster managed node-pool add`: the same placement flags plus `--spot` / `--spot-max-price`.
- Any of these with another provider is a usage error naming the flag.
- `credentials azure list|create` (secret via `AZURE_CLIENT_SECRET` or masked prompt).
- Client types: `ManagedNodePoolPlacement`, `ManagedNodePoolSpot`, `AksClusterOptions`, `AksMaintenanceWindow`, `CreateAzureCredential`.

Tests cover the aks block + placement on create, refusal for other providers, maintenance-window parsing, and spot on add (with a cobra flag reset between runs - flags are package globals in this test binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FcfWCW4uAyZhwSgBQ33GhF