### PR TITLE
feat(backup): vaults delete --destroy-provider-resources cleans up the cloud side too (ankra-0xsdd.27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Ankra CLI Changelog
 
+## v0.14.0-rc2 — 2026-08-28
+
+### Added
+
+- **`ankra backup vaults delete --destroy-provider-resources` cleans up the
+  cloud side too.** A plain delete still removes only Ankra's record and the
+  keys it stored - the bucket and anything Ankra created for it stay in your
+  account, and the command now says so. With the flag, the platform empties
+  and deletes the bucket and removes the resource it minted (the UpCloud
+  object storage service, the DigitalOcean Spaces key); the confirmation
+  prompt names the bucket first, because every restore point in it is lost.
+  It is refused for a vault that registers a bucket you created yourself.
+
 ## v0.14.0-rc1 — 2026-08-28
 
 ### Added

--- a/cmd/backup_vaults.go
+++ b/cmd/backup_vaults.go
@@ -489,21 +489,51 @@ var backupVaultsVerifyCmd = &cobra.Command{
 var backupVaultsDeleteCmd = &cobra.Command{
 	Use:   "delete [vault-name|vault-id]",
 	Short: "Delete a backup vault",
-	Args:  cobra.ExactArgs(1),
+	Long: `Delete a backup vault.
+
+By default this removes only Ankra's record of the vault and the access keys
+it stored: the bucket, everything in it, and any provider resource Ankra
+created for it are left in your cloud account.
+
+--destroy-provider-resources also destroys what Ankra created for an
+Ankra-provisioned vault - it empties and deletes the bucket, and removes the
+UpCloud object storage service or DigitalOcean Spaces key that was minted
+for it. Restore points in that bucket are gone for good. It is refused for a
+vault that registers a bucket you created yourself.`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		yes, _ := cmd.Flags().GetBool("yes")
+		destroyProviderResources, _ := cmd.Flags().GetBool("destroy-provider-resources")
 		vaultID, resolveError := resolveBackupVaultID(apiClient, args[0])
 		if resolveError != nil {
 			return resolveError
 		}
-		if confirmError := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
-			fmt.Sprintf("Delete backup vault %q? [y/N]: ", args[0]), yes); confirmError != nil {
+		prompt := fmt.Sprintf("Delete backup vault %q? [y/N]: ", args[0])
+		if destroyProviderResources {
+			// Name the bucket that is about to be emptied: the vault name
+			// alone does not tell the operator what data is at stake.
+			vault, getError := apiClient.GetBackupVault(vaultID)
+			if getError != nil {
+				return backupLaneError("reading backup vault", getError)
+			}
+			if vault.Kind != "ankra_provisioned" {
+				return fmt.Errorf("backup vault %q registers a bucket you created, so Ankra will not destroy it; "+
+					"delete it without --destroy-provider-resources and remove the bucket yourself", args[0])
+			}
+			prompt = fmt.Sprintf("Delete backup vault %q AND destroy bucket %q on %s, including every restore point in it? [y/N]: ",
+				args[0], vault.Bucket, vault.Provider)
+		}
+		if confirmError := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(), prompt, yes); confirmError != nil {
 			return confirmError
 		}
-		if deleteError := apiClient.DeleteBackupVault(vaultID); deleteError != nil {
+		if deleteError := apiClient.DeleteBackupVault(vaultID, destroyProviderResources); deleteError != nil {
 			return backupLaneError("deleting backup vault", deleteError)
 		}
-		fmt.Printf("Backup vault '%s' deleted.\n", args[0])
+		if destroyProviderResources {
+			fmt.Printf("Backup vault '%s' deleted; its provider resources are being destroyed.\n", args[0])
+			return nil
+		}
+		fmt.Printf("Backup vault '%s' deleted. Its bucket and any provider resources Ankra created are untouched.\n", args[0])
 		return nil
 	},
 }
@@ -529,6 +559,9 @@ func init() {
 	registerAsyncWriteFlags(backupVaultsProvisionCmd)
 
 	backupVaultsDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
+	backupVaultsDeleteCmd.Flags().Bool("destroy-provider-resources", false,
+		"Also destroy what Ankra created for this vault: empty and delete the bucket (every restore point in it is lost) "+
+			"and remove the provider resource minted for it. Ankra-provisioned vaults only")
 
 	registerStructuredOutputFlags(backupVaultsListCmd, backupVaultsGetCmd)
 

--- a/cmd/backup_vaults_teardown_test.go
+++ b/cmd/backup_vaults_teardown_test.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+func provisionedVaultForDelete() *client.BackupVault {
+	credentialID := backupVaultProvisionCredentialID
+	return &client.BackupVault{
+		ID: backupVaultTestID, Name: "offsite", Kind: "ankra_provisioned", Provider: "upcloud",
+		Endpoint: "https://9qk50.upcloudobjects.com", Region: "europe-1", Bucket: "ankra-offsite-0d9c1f9e",
+		PathStyle: true, Status: "ready", ProvisionedViaCredentialID: &credentialID,
+		CreatedAt: "2026-08-28T00:00:00Z", UpdatedAt: "2026-08-28T00:00:00Z",
+	}
+}
+
+func resetBackupVaultsDeleteFlags(t *testing.T) {
+	t.Helper()
+	reset := func() {
+		for _, name := range []string{"yes", "destroy-provider-resources"} {
+			flag := backupVaultsDeleteCmd.Flags().Lookup(name)
+			_ = flag.Value.Set("false")
+			flag.Changed = false
+		}
+	}
+	reset()
+	t.Cleanup(reset)
+}
+
+// TestBackupVaultsDeleteLeavesProviderResourcesByDefault pins the safe
+// default: no teardown is requested, and the output says the bucket stayed.
+func TestBackupVaultsDeleteLeavesProviderResourcesByDefault(t *testing.T) {
+	mock := &backupVaultsMock{vaults: []client.BackupVault{*provisionedVaultForDelete()}, vault: provisionedVaultForDelete()}
+	setMockClient(t, mock)
+	resetBackupVaultsDeleteFlags(t)
+
+	var executeError error
+	output := captureStdout(t, func() {
+		_, executeError = executeCommand("backup", "vaults", "delete", "offsite", "--yes")
+	})
+	if executeError != nil {
+		t.Fatal(executeError)
+	}
+	if mock.destroyRequested {
+		t.Fatal("a plain delete must not ask for a teardown")
+	}
+	if !strings.Contains(output, "untouched") {
+		t.Fatalf("output must say the bucket stayed:\n%s", output)
+	}
+}
+
+// The forced delete names the bucket in the prompt before it destroys it -
+// the vault name alone does not tell an operator what data is at stake.
+func TestBackupVaultsDeleteWithDestroyNamesTheBucketAndRequests(t *testing.T) {
+	mock := &backupVaultsMock{vaults: []client.BackupVault{*provisionedVaultForDelete()}, vault: provisionedVaultForDelete()}
+	setMockClient(t, mock)
+	resetBackupVaultsDeleteFlags(t)
+
+	// No --yes here: the prompt itself is what must name the bucket. It is
+	// written to the command's out writer, which executeCommand captures.
+	rootCmd.SetIn(strings.NewReader("y\n"))
+	t.Cleanup(func() { rootCmd.SetIn(nil) })
+
+	var executeError error
+	var prompt string
+	stdout := captureStdout(t, func() {
+		prompt, executeError = executeCommand("backup", "vaults", "delete", "offsite", "--destroy-provider-resources")
+	})
+	if executeError != nil {
+		t.Fatal(executeError)
+	}
+	if !mock.destroyRequested {
+		t.Fatal("the flag must reach the API call")
+	}
+	for _, fragment := range []string{"ankra-offsite-0d9c1f9e", "upcloud", "every restore point in it"} {
+		if !strings.Contains(prompt, fragment) {
+			t.Errorf("prompt missing %q:\n%s", fragment, prompt)
+		}
+	}
+	if !strings.Contains(stdout, "being destroyed") {
+		t.Errorf("output missing the teardown notice:\n%s", stdout)
+	}
+}
+
+// A bring-your-own vault is refused client-side, so no destructive request
+// is ever sent for a bucket Ankra did not create.
+func TestBackupVaultsDeleteRefusesToDestroyABringYourOwnBucket(t *testing.T) {
+	vault := provisionedVaultForDelete()
+	vault.Kind = "customer_s3"
+	vault.ProvisionedViaCredentialID = nil
+	mock := &backupVaultsMock{vaults: []client.BackupVault{*vault}, vault: vault}
+	setMockClient(t, mock)
+	resetBackupVaultsDeleteFlags(t)
+
+	_, executeError := executeCommand("backup", "vaults", "delete", "offsite", "--destroy-provider-resources", "--yes")
+	if executeError == nil || !strings.Contains(executeError.Error(), "registers a bucket you created") {
+		t.Fatalf("expected the refusal, got %v", executeError)
+	}
+	if mock.deleteCalls != 0 {
+		t.Fatal("no delete may be sent for a refused teardown")
+	}
+}

--- a/cmd/backup_vaults_test.go
+++ b/cmd/backup_vaults_test.go
@@ -25,6 +25,7 @@ type backupVaultsMock struct {
 	createdVault     *client.BackupVault
 	verifiedVault    *client.BackupVault
 	deletedID        string
+	destroyRequested bool
 	deleteCalls      int
 }
 
@@ -67,9 +68,10 @@ func (mock *backupVaultsMock) VerifyBackupVault(vaultID string) (*client.BackupV
 	return mock.verifiedVault, nil
 }
 
-func (mock *backupVaultsMock) DeleteBackupVault(vaultID string) error {
+func (mock *backupVaultsMock) DeleteBackupVault(vaultID string, destroyProviderResources bool) error {
 	mock.deleteCalls++
 	mock.deletedID = vaultID
+	mock.destroyRequested = destroyProviderResources
 	return nil
 }
 

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -527,7 +527,7 @@ func (m baseMock) VerifyBackupVault(vaultID string) (*client.BackupVault, error)
 	return nil, errors.New("not implemented")
 }
 
-func (m baseMock) DeleteBackupVault(vaultID string) error {
+func (m baseMock) DeleteBackupVault(vaultID string, destroyProviderResources bool) error {
 	return errors.New("not implemented")
 }
 

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -47,7 +47,7 @@ type APIClient interface {
 	CreateBackupVault(request client.CreateBackupVaultRequest) (*client.BackupVault, error)
 	ProvisionBackupVault(request client.ProvisionBackupVaultRequest) (*client.BackupVault, error)
 	VerifyBackupVault(vaultID string) (*client.BackupVault, error)
-	DeleteBackupVault(vaultID string) error
+	DeleteBackupVault(vaultID string, destroyProviderResources bool) error
 
 	ListExecutions(opts client.ListExecutionsOptions) (client.ExecutionListResponse, error)
 	GetExecution(executionID string) (client.ExecutionDetail, error)

--- a/internal/client/backup_vaults.go
+++ b/internal/client/backup_vaults.go
@@ -122,9 +122,15 @@ func (c *Client) VerifyBackupVault(vaultID string) (*BackupVault, error) {
 	return &result, nil
 }
 
-// DeleteBackupVault deletes one backup vault.
+// DeleteBackupVault deletes one backup vault. With
+// destroyProviderResources the platform also destroys what it created for
+// an Ankra-provisioned vault - the bucket and everything in it, plus the
+// provider handle - which it refuses for a bring-your-own vault.
 // DELETE /api/v1/org/backup-vaults/{vault_id}
-func (c *Client) DeleteBackupVault(vaultID string) error {
+func (c *Client) DeleteBackupVault(vaultID string, destroyProviderResources bool) error {
 	url := fmt.Sprintf("%s/api/v1/org/backup-vaults/%s", c.BaseURL, neturl.PathEscape(vaultID))
+	if destroyProviderResources {
+		url += "?destroy_provider_resources=true"
+	}
 	return c.sendJSON(http.MethodDelete, url, nil, nil)
 }

--- a/internal/client/backup_vaults_test.go
+++ b/internal/client/backup_vaults_test.go
@@ -189,7 +189,7 @@ func TestDeleteBackupVault_AcceptsNoContent(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}
 	testClient := newTestClient(t, handler)
-	if deleteError := testClient.DeleteBackupVault("vault-1"); deleteError != nil {
+	if deleteError := testClient.DeleteBackupVault("vault-1", false); deleteError != nil {
 		t.Fatalf("DeleteBackupVault: %v", deleteError)
 	}
 }
@@ -200,9 +200,34 @@ func TestDeleteBackupVault_NotFoundCarries404(t *testing.T) {
 			"detail": "Backup vault not found."})
 	}
 	testClient := newTestClient(t, handler)
-	deleteError := testClient.DeleteBackupVault("vault-missing")
+	deleteError := testClient.DeleteBackupVault("vault-missing", false)
 	var unexpected *UnexpectedResponseError
 	if !errors.As(deleteError, &unexpected) || unexpected.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected an UnexpectedResponseError carrying 404, got %v", deleteError)
+	}
+}
+
+// TestDeleteBackupVault_DestroyAddsTheQueryParameter pins the wire shape of
+// the forced teardown: the destructive intent travels as an explicit query
+// parameter, and a plain delete never carries it.
+func TestDeleteBackupVault_DestroyAddsTheQueryParameter(t *testing.T) {
+	var seenQuery string
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		seenQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusNoContent)
+	}
+	testClient := newTestClient(t, handler)
+	if deleteError := testClient.DeleteBackupVault("vault-1", true); deleteError != nil {
+		t.Fatalf("DeleteBackupVault: %v", deleteError)
+	}
+	if seenQuery != "destroy_provider_resources=true" {
+		t.Fatalf("query = %q", seenQuery)
+	}
+
+	if deleteError := testClient.DeleteBackupVault("vault-1", false); deleteError != nil {
+		t.Fatalf("DeleteBackupVault: %v", deleteError)
+	}
+	if seenQuery != "" {
+		t.Fatalf("a plain delete must send no query, got %q", seenQuery)
 	}
 }


### PR DESCRIPTION
feat(backup): `vaults delete --destroy-provider-resources` cleans up the cloud side too (ankra-0xsdd.27)

Deleting a vault only ever removed Ankra's record and the keys it stored;
the bucket Ankra had created stayed in the account and nothing said so.

The plain delete now says it ("Its bucket and any provider resources Ankra
created are untouched."), and the new flag destroys them: the platform
empties and deletes the bucket and removes the resource it minted - the
UpCloud object storage service, the DigitalOcean Spaces key (cluster#2076).

Because that destroys data, the command reads the vault first and the
confirmation prompt names the bucket, its provider, and that every restore
point in it is lost; a vault that registers a bucket the user created is
refused client-side, so no destructive request is ever sent for a bucket
Ankra did not create.

Changelog opens v0.14.0-rc2 (rc1 is tagged).
