### PR TITLE
fix(encrypt): `cluster encrypt -f` changes only the line it adds and recognises section-qualified paths (PLA-806)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Ankra CLI Changelog
 
+## v0.14.0-rc3 — 2026-08-28
+
+### Fixed
+
+- **`ankra cluster encrypt -f` changes only the line it adds.** Recording an
+  encrypted path used to re-encode the whole cluster file in the CLI's own
+  YAML style, so a file the platform had written - indentless sequences,
+  folded long lines - came back with every sequence re-indented: a 600-line
+  diff in a GitOps repository to add one entry. The entry is now spliced into
+  the file's own bytes at the position the parser reports, in whatever style
+  the file uses; nothing else moves.
+- **Section-qualified `encrypted_paths` entries are recognised.** The
+  platform writes entries as `stringData.PASSWORD`; the CLI compared them to
+  the bare key name, found no match, and appended every key again as a bare
+  name - `--all-data` on a Secret with 15 recorded keys produced 31 entries
+  in two spellings. Entries are now compared by key name with the section
+  stripped, as the platform reads them, and a new entry is spelled the way
+  the file already spells its entries. `ankra cluster manifests upgrade`
+  merges its detected paths the same way.
+
 ## v0.14.0-rc2 — 2026-08-28
 
 ### Added

--- a/cmd/cluster_encrypt.go
+++ b/cmd/cluster_encrypt.go
@@ -678,27 +678,26 @@ func runEncryptManifestFile(cmd *cobra.Command, manifestName string, leafKeys []
 
 	fmt.Printf("Updated manifest file: %s\n", manifestFilePath)
 
-	// Update the cluster YAML with encrypted_paths. The file is mutated at
-	// the yaml.Node level so fields the CLI structs do not model
-	// (deploy_wave, prometheus_metrics, future keys), comments, and ordering
-	// survive the rewrite of this GitOps source of truth.
-	missingKeys := make([]string, 0, len(leafKeys))
+	// Update the cluster YAML with encrypted_paths. Entries are matched by
+	// key name however the file spells them - the platform writes
+	// "stringData.PASSWORD", the CLI's grammar is the bare "PASSWORD", and
+	// the platform reads both as one entry - and a new entry follows the
+	// file's spelling. It is spliced into the file's own bytes at the
+	// position the parser reports, so this GitOps source of truth changes by
+	// exactly the line being added; re-encoding the tree would reflow every
+	// sequence of a platform-written file.
+	newEntries := make([]string, 0, len(leafKeys))
 	for _, leafKey := range leafKeys {
-		if !containsString(foundManifest.EncryptedPaths, leafKey) {
-			missingKeys = append(missingKeys, leafKey)
+		if !containsEncryptedPath(foundManifest.EncryptedPaths, leafKey) {
+			newEntries = append(newEntries, encryptedPathEntry(foundManifest.EncryptedPaths, leafKey, secretKeySection(manifestContent, leafKey)))
 		}
 	}
-	if len(missingKeys) > 0 {
-		clusterDoc, err := parseClusterYAMLDoc(clusterData)
+	if len(newEntries) > 0 {
+		updatedClusterData, err := spliceManifestEncryptedPaths(clusterData, manifestName, newEntries)
 		if err != nil {
 			return fmt.Errorf("failed to update cluster file: %w", err)
 		}
-		for _, leafKey := range missingKeys {
-			if err := appendManifestEncryptedPath(clusterDoc, manifestName, leafKey); err != nil {
-				return fmt.Errorf("failed to update cluster file: %w", err)
-			}
-		}
-		if err := writeClusterFile(encryptClusterFile, clusterDoc); err != nil {
+		if err := os.WriteFile(encryptClusterFile, updatedClusterData, 0o644); err != nil {
 			return fmt.Errorf("failed to update cluster file: %w", err)
 		}
 
@@ -797,28 +796,22 @@ func runEncryptAddonFile(cmd *cobra.Command, leafKeys []string) error {
 
 	fmt.Printf("Updated addon configuration file: %s\n", addonFilePath)
 
-	// Update the cluster YAML with encrypted_paths in the configuration. The
-	// file is mutated at the yaml.Node level so fields the CLI structs do not
-	// model (deploy_wave, prometheus_metrics, future keys), comments, and
-	// ordering survive the rewrite of this GitOps source of truth.
+	// Update the cluster YAML with encrypted_paths in the configuration -
+	// matched by key name, spelled like the file, spliced into the file's own
+	// bytes; see runEncryptManifestFile.
 	encryptedPaths := getEncryptedPathsFromConfig(foundAddon.Configuration)
-	missingKeys := make([]string, 0, len(leafKeys))
+	newEntries := make([]string, 0, len(leafKeys))
 	for _, leafKey := range leafKeys {
-		if !containsString(encryptedPaths, leafKey) {
-			missingKeys = append(missingKeys, leafKey)
+		if !containsEncryptedPath(encryptedPaths, leafKey) {
+			newEntries = append(newEntries, encryptedPathEntry(encryptedPaths, leafKey, ""))
 		}
 	}
-	if len(missingKeys) > 0 {
-		clusterDoc, err := parseClusterYAMLDoc(clusterData)
+	if len(newEntries) > 0 {
+		updatedClusterData, err := spliceAddonEncryptedPaths(clusterData, encryptAddonName, newEntries)
 		if err != nil {
 			return fmt.Errorf("failed to update cluster file: %w", err)
 		}
-		for _, leafKey := range missingKeys {
-			if err := appendAddonEncryptedPath(clusterDoc, encryptAddonName, leafKey); err != nil {
-				return fmt.Errorf("failed to update cluster file: %w", err)
-			}
-		}
-		if err := writeClusterFile(encryptClusterFile, clusterDoc); err != nil {
+		if err := os.WriteFile(encryptClusterFile, updatedClusterData, 0o644); err != nil {
 			return fmt.Errorf("failed to update cluster file: %w", err)
 		}
 
@@ -899,29 +892,117 @@ func collectEncryptedLeafKeys(node *yaml.Node, isDocumentRoot bool, seenPaths ma
 	}
 }
 
-// unionStringLists merges the given lists preserving first-seen order and
-// dropping duplicates.
-func unionStringLists(lists ...[]string) []string {
-	seenValues := map[string]bool{}
+// unionEncryptedPaths merges encrypted_paths lists preserving first-seen
+// order. Two entries naming the same key in different spellings
+// ("stringData.PASSWORD" and "PASSWORD") are one entry; the first spelling
+// seen is kept. Globs are compared verbatim.
+func unionEncryptedPaths(lists ...[]string) []string {
+	seenKeys := map[string]bool{}
 	var merged []string
 	for _, list := range lists {
-		for _, value := range list {
-			if !seenValues[value] {
-				seenValues[value] = true
-				merged = append(merged, value)
+		for _, entry := range list {
+			leaf := encryptedPathLeaf(entry)
+			if !seenKeys[leaf] {
+				seenKeys[leaf] = true
+				merged = append(merged, entry)
 			}
 		}
 	}
 	return merged
 }
 
-func containsString(slice []string, str string) bool {
-	for _, s := range slice {
-		if s == str {
+// encryptedPathLeaf returns the key name an encrypted_paths entry names: the
+// entry with a leading "data." or "stringData." section removed, the two the
+// platform strips when it reads the list. A glob entry is returned as
+// written; globs are compared verbatim.
+func encryptedPathLeaf(entry string) string {
+	if isEncryptKeyGlob(entry) {
+		return entry
+	}
+	return entry[len(encryptedPathSection(entry)):]
+}
+
+// encryptedPathSection returns the section an exact entry names in front of
+// its key ("data." or "stringData."), or "" for a bare or glob entry.
+func encryptedPathSection(entry string) string {
+	if isEncryptKeyGlob(entry) {
+		return ""
+	}
+	for _, sectionPrefix := range encryptKeySectionPrefixes {
+		if strings.HasPrefix(entry, sectionPrefix) {
+			return sectionPrefix
+		}
+	}
+	return ""
+}
+
+// containsEncryptedPath reports whether entries already record leafKey,
+// however they spell it.
+func containsEncryptedPath(entries []string, leafKey string) bool {
+	wanted := encryptedPathLeaf(leafKey)
+	for _, entry := range entries {
+		if encryptedPathLeaf(entry) == wanted {
 			return true
 		}
 	}
 	return false
+}
+
+// encryptedPathEntry spells leafKey the way entries already spell theirs.
+// The platform reads every spelling alike; matching the file keeps a GitOps
+// diff to the line being added. When every exact entry carries a section,
+// the new one does too - the section holding the key when the caller knows
+// it, else the one section the file agrees on. Otherwise, or when the list
+// is empty, the entry is the bare key: the CLI's own grammar.
+func encryptedPathEntry(entries []string, leafKey, section string) string {
+	leaf := encryptedPathLeaf(leafKey)
+	sections := map[string]bool{}
+	exactEntries := 0
+	for _, entry := range entries {
+		if isEncryptKeyGlob(entry) {
+			continue
+		}
+		exactEntries++
+		sections[encryptedPathSection(entry)] = true
+	}
+	if exactEntries == 0 || sections[""] {
+		return leaf
+	}
+	if section != "" {
+		return section + "." + leaf
+	}
+	if len(sections) == 1 {
+		for onlySection := range sections {
+			return onlySection + leaf
+		}
+	}
+	return leaf
+}
+
+// secretKeySection reports which Secret section - "data" or "stringData" -
+// holds leafKey in manifestYAML, or "" when neither does.
+func secretKeySection(manifestYAML []byte, leafKey string) string {
+	decoder := yaml.NewDecoder(bytes.NewReader(manifestYAML))
+	for {
+		var document yaml.Node
+		decodeErr := decoder.Decode(&document)
+		if decodeErr != nil {
+			return ""
+		}
+		rootNode := &document
+		if rootNode.Kind == yaml.DocumentNode && len(rootNode.Content) > 0 {
+			rootNode = resolveYAMLAlias(rootNode.Content[0])
+		}
+		if rootNode == nil || rootNode.Kind != yaml.MappingNode {
+			continue
+		}
+		for _, sectionKey := range []string{"data", "stringData"} {
+			section := yamlMapValue(rootNode, sectionKey)
+			if section != nil && section.Kind == yaml.MappingNode && mapIndexOf(section, leafKey) >= 0 {
+				return sectionKey
+			}
+		}
+	}
 }
 
 func getEncryptedPathsFromConfig(config map[string]interface{}) []string {
@@ -1041,8 +1122,8 @@ func runEncryptManifestCluster(cmd *cobra.Command, manifestName string, leafKeys
 
 	newPaths := append([]string{}, manifest.EncryptedPaths...)
 	for _, leafKey := range leafKeys {
-		if !containsString(newPaths, leafKey) {
-			newPaths = append(newPaths, leafKey)
+		if !containsEncryptedPath(newPaths, leafKey) {
+			newPaths = append(newPaths, encryptedPathEntry(newPaths, leafKey, ""))
 		}
 	}
 
@@ -1113,8 +1194,8 @@ func runEncryptAddonCluster(cmd *cobra.Command, addonName string, leafKeys []str
 	}
 	newPaths := append([]string{}, existingPaths...)
 	for _, leafKey := range leafKeys {
-		if !containsString(newPaths, leafKey) {
-			newPaths = append(newPaths, leafKey)
+		if !containsEncryptedPath(newPaths, leafKey) {
+			newPaths = append(newPaths, encryptedPathEntry(newPaths, leafKey, ""))
 		}
 	}
 

--- a/cmd/cluster_encrypt_paths_test.go
+++ b/cmd/cluster_encrypt_paths_test.go
@@ -1,0 +1,249 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// The platform spells encrypted_paths section-qualified ("stringData.PASSWORD")
+// and reads the bare key name as the same entry. The CLI used to compare the
+// two as strings, find nothing, and append every key again as a bare name -
+// then re-encode the whole cluster file in its own style on the way out.
+// These tests hold a platform-written file to what it deserves: the CLI
+// recognises the entries it already has, spells a new one the way the file
+// does, and changes nothing else.
+
+// platformStyleClusterYAML is a cluster file as the platform writes it:
+// indentless sequences, a folded long scalar, alphabetical keys, and an
+// encrypted_paths entry in the platform's section-qualified spelling.
+const platformStyleClusterYAML = `apiVersion: v1
+kind: ImportCluster
+metadata:
+  name: prod
+spec:
+  stacks:
+  - addons: []
+    description: a description long enough that the platform's emitter folds it
+      onto a second line, which must come back exactly as it was
+    manifests:
+    - encrypted_paths:
+      - data.username
+      force: false
+      from_file: manifests/secret.yaml
+      name: db-secret
+    name: core
+`
+
+const bothKeysEncryptedManifestYAML = `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: web
+type: Opaque
+data:
+  username: ENC[AES256_GCM,data:abc,iv:def,tag:ghi,type:str]
+  password: ENC[AES256_GCM,data:jkl,iv:mno,tag:pqr,type:str]
+sops:
+  age:
+    - recipient: age1example
+  lastmodified: "2026-06-11T00:00:00Z"
+  mac: ENC[AES256_GCM,data:mac]
+  encrypted_regex: ^(username|password)$
+`
+
+// writePlatformStyleFixture lays out a cluster file and its plaintext Secret
+// and returns the cluster path.
+func writePlatformStyleFixture(t *testing.T, clusterYAML string) string {
+	t.Helper()
+	dir := t.TempDir()
+	clusterPath := filepath.Join(dir, "cluster.yaml")
+	if err := os.WriteFile(clusterPath, []byte(clusterYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(dir, "manifests", "secret.yaml")
+	if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifestPath, []byte(plainSecretManifestYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return clusterPath
+}
+
+func runEncryptManifestCommand(t *testing.T, mock *upgradeMock, args ...string) string {
+	t.Helper()
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs(append([]string{"cluster", "encrypt", "manifest", "db-secret"}, args...))
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+	return out.String()
+}
+
+func TestRunEncryptManifest_PlatformStyleFileChangesByExactlyOneLine(t *testing.T) {
+	clusterPath := writePlatformStyleFixture(t, platformStyleClusterYAML)
+	mock := &upgradeMock{encryptResult: encryptedSecretManifestYAML}
+
+	runEncryptManifestCommand(t, mock, "--key", "password", "-f", clusterPath)
+
+	written, err := os.ReadFile(clusterPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// One line, in the file's own indentless style and section-qualified
+	// spelling; the folded description and every other sequence untouched.
+	want := strings.Replace(platformStyleClusterYAML,
+		"      - data.username\n",
+		"      - data.username\n      - data.password\n", 1)
+	if string(written) != want {
+		t.Errorf("cluster file changed beyond the one entry.\n--- got ---\n%s\n--- want ---\n%s", written, want)
+	}
+}
+
+func TestRunEncryptManifest_SectionQualifiedEntryCountsAsPresent(t *testing.T) {
+	clusterPath := writePlatformStyleFixture(t, platformStyleClusterYAML)
+	mock := &upgradeMock{encryptResult: bothKeysEncryptedManifestYAML}
+
+	runEncryptManifestCommand(t, mock, "--key", "username", "-f", clusterPath)
+
+	// The key is still encrypted; only the cluster file is left alone.
+	if len(mock.encryptCalls) != 1 || !reflect.DeepEqual(mock.encryptCalls[0].EncryptedPaths, []string{"username"}) {
+		t.Errorf("encrypt calls = %+v, want one call for username", mock.encryptCalls)
+	}
+	written, err := os.ReadFile(clusterPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(written) != platformStyleClusterYAML {
+		t.Errorf("cluster file should be byte-identical.\n--- got ---\n%s", written)
+	}
+}
+
+// The case seen in the field: --all-data on a Secret whose every key the
+// platform had already recorded. 15 entries became 31.
+func TestRunEncryptManifest_AllDataDoesNotDuplicateSectionQualifiedEntries(t *testing.T) {
+	source := strings.Replace(platformStyleClusterYAML,
+		"      - data.username\n",
+		"      - data.username\n      - data.password\n", 1)
+	clusterPath := writePlatformStyleFixture(t, source)
+	mock := &upgradeMock{encryptResult: bothKeysEncryptedManifestYAML}
+
+	runEncryptManifestCommand(t, mock, "--all-data", "-f", clusterPath)
+
+	if len(mock.encryptCalls) != 1 || !reflect.DeepEqual(mock.encryptCalls[0].EncryptedPaths, []string{"username", "password"}) {
+		t.Errorf("encrypt calls = %+v, want one call for username and password", mock.encryptCalls)
+	}
+	written, err := os.ReadFile(clusterPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(written) != source {
+		t.Errorf("cluster file should be byte-identical.\n--- got ---\n%s", written)
+	}
+}
+
+func TestRunEncryptManifest_PlatformStyleFileWithoutTheListGetsOneInItsStyle(t *testing.T) {
+	source := strings.Replace(platformStyleClusterYAML,
+		"    - encrypted_paths:\n      - data.username\n      force: false\n",
+		"    - force: false\n", 1)
+	clusterPath := writePlatformStyleFixture(t, source)
+	mock := &upgradeMock{encryptResult: encryptedSecretManifestYAML}
+
+	runEncryptManifestCommand(t, mock, "--key", "password", "-f", clusterPath)
+
+	written, err := os.ReadFile(clusterPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// No existing entry to copy a spelling from, so the CLI's own bare form;
+	// dashes level with the key, as every other sequence in the file.
+	want := strings.Replace(source,
+		"      name: db-secret\n",
+		"      name: db-secret\n      encrypted_paths:\n      - password\n", 1)
+	if string(written) != want {
+		t.Errorf("cluster file changed beyond the new list.\n--- got ---\n%s\n--- want ---\n%s", written, want)
+	}
+}
+
+func TestEncryptedPathLeaf_StripsTheSectionsThePlatformStrips(t *testing.T) {
+	cases := map[string]string{
+		"PASSWORD":             "PASSWORD",
+		"data.PASSWORD":        "PASSWORD",
+		"stringData.PASSWORD":  "PASSWORD",
+		"glob:stringData.DB_*": "glob:stringData.DB_*",
+		"other.PASSWORD":       "other.PASSWORD",
+	}
+	for entry, want := range cases {
+		if got := encryptedPathLeaf(entry); got != want {
+			t.Errorf("encryptedPathLeaf(%q) = %q, want %q", entry, got, want)
+		}
+	}
+}
+
+func TestContainsEncryptedPath_MatchesAcrossSpellings(t *testing.T) {
+	if !containsEncryptedPath([]string{"stringData.PASSWORD"}, "PASSWORD") {
+		t.Error("a section-qualified entry should count for the bare key")
+	}
+	if !containsEncryptedPath([]string{"PASSWORD"}, "stringData.PASSWORD") {
+		t.Error("a bare entry should count for the section-qualified key")
+	}
+	if containsEncryptedPath([]string{"glob:PASS*"}, "PASSWORD") {
+		t.Error("a glob is compared verbatim, never expanded")
+	}
+	if containsEncryptedPath([]string{"stringData.PASSWORD"}, "USERNAME") {
+		t.Error("a different key must not match")
+	}
+}
+
+func TestEncryptedPathEntry_FollowsTheFilesSpelling(t *testing.T) {
+	cases := []struct {
+		name     string
+		existing []string
+		leaf     string
+		section  string
+		want     string
+	}{
+		{"section-qualified file, section known", []string{"data.username"}, "password", "data", "data.password"},
+		{"bare file", []string{"username"}, "password", "data", "password"},
+		{"empty list", nil, "password", "data", "password"},
+		{"globs do not vote", []string{"glob:stringData.DB_*", "stringData.A"}, "B", "stringData", "stringData.B"},
+		{"section unknown but the file agrees on one", []string{"stringData.A", "stringData.B"}, "C", "", "stringData.C"},
+		{"section unknown and the file mixes sections", []string{"data.A", "stringData.B"}, "C", "", "C"},
+		{"mixed spellings fall back to bare", []string{"stringData.A", "B"}, "C", "stringData", "C"},
+	}
+	for _, tc := range cases {
+		if got := encryptedPathEntry(tc.existing, tc.leaf, tc.section); got != tc.want {
+			t.Errorf("%s: encryptedPathEntry(%v, %q, %q) = %q, want %q", tc.name, tc.existing, tc.leaf, tc.section, got, tc.want)
+		}
+	}
+}
+
+func TestSecretKeySection_FindsTheSectionHoldingTheKey(t *testing.T) {
+	manifest := []byte("apiVersion: v1\nkind: Secret\nmetadata:\n  name: s\ndata:\n  username: dXNlcg==\nstringData:\n  password: hunter2\n")
+	if got := secretKeySection(manifest, "username"); got != "data" {
+		t.Errorf("username section = %q, want data", got)
+	}
+	if got := secretKeySection(manifest, "password"); got != "stringData" {
+		t.Errorf("password section = %q, want stringData", got)
+	}
+	if got := secretKeySection(manifest, "missing"); got != "" {
+		t.Errorf("missing section = %q, want empty", got)
+	}
+}
+
+func TestUnionEncryptedPaths_KeepsTheFirstSpellingOfEachKey(t *testing.T) {
+	got := unionEncryptedPaths([]string{"stringData.A"}, []string{"A", "B"}, []string{"glob:X*", "stringData.B"})
+	want := []string{"stringData.A", "B", "glob:X*"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("unionEncryptedPaths = %v, want %v", got, want)
+	}
+}

--- a/cmd/cluster_manifests.go
+++ b/cmd/cluster_manifests.go
@@ -340,7 +340,7 @@ func runManifestsUpgrade(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("inspect manifest for SOPS metadata: %w", deriveErr)
 		}
 		if isSopsDocument || len(flags.EncryptedPaths) > 0 {
-			mergedPaths := unionStringLists(manifest.EncryptedPaths, derivedPaths, flags.EncryptedPaths)
+			mergedPaths := unionEncryptedPaths(manifest.EncryptedPaths, derivedPaths, flags.EncryptedPaths)
 			if len(mergedPaths) == 0 {
 				return errors.New("manifest content is SOPS-encrypted but no encrypted key paths could be derived; pass --encrypted-path <key> for each encrypted key so the backend keeps the encryption metadata")
 			}

--- a/cmd/cluster_yaml_edit.go
+++ b/cmd/cluster_yaml_edit.go
@@ -153,46 +153,6 @@ func findClusterListEntry(doc *yaml.Node, listKey, name string) (*yaml.Node, err
 	return nil, nil
 }
 
-// appendManifestEncryptedPath records leafKey in the encrypted_paths list of
-// the named manifest, creating the list when missing. Nothing else in the
-// document is touched.
-func appendManifestEncryptedPath(doc *yaml.Node, manifestName, leafKey string) error {
-	manifest, err := findClusterListEntry(doc, "manifests", manifestName)
-	if err != nil {
-		return err
-	}
-	if manifest == nil {
-		return fmt.Errorf("manifest %q not found in cluster YAML", manifestName)
-	}
-	return appendYAMLStringListEntry(manifest, "encrypted_paths", leafKey)
-}
-
-// appendAddonEncryptedPath records leafKey in the configuration.encrypted_paths
-// list of the named addon.
-func appendAddonEncryptedPath(doc *yaml.Node, addonName, leafKey string) error {
-	addon, err := findClusterListEntry(doc, "addons", addonName)
-	if err != nil {
-		return err
-	}
-	if addon == nil {
-		return fmt.Errorf("addon %q not found in cluster YAML", addonName)
-	}
-	configuration := yamlMapValue(addon, "configuration")
-	if configuration == nil || configuration.Kind != yaml.MappingNode {
-		return fmt.Errorf("addon %q has no configuration mapping in cluster YAML", addonName)
-	}
-	return appendYAMLStringListEntry(configuration, "encrypted_paths", leafKey)
-}
-
-func appendYAMLStringListEntry(mapping *yaml.Node, key, value string) error {
-	list, err := yamlMapEnsure(mapping, key, yaml.SequenceNode, "!!seq")
-	if err != nil {
-		return err
-	}
-	list.Content = append(list.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value})
-	return nil
-}
-
 // deepCopyYAMLNode returns a copy of n that is safe to graft into another
 // document. Aliases whose anchor lives inside the copied subtree keep pointing
 // at the copied anchor; aliases to anchors outside the subtree are expanded

--- a/cmd/cluster_yaml_edit_test.go
+++ b/cmd/cluster_yaml_edit_test.go
@@ -38,115 +38,12 @@ spec:
             from_file: values/grafana.yaml
 `
 
-func encodeClusterDoc(t *testing.T, doc *yaml.Node) string {
-	t.Helper()
-	var buf strings.Builder
-	encoder := yaml.NewEncoder(&buf)
-	encoder.SetIndent(2)
-	if err := encoder.Encode(doc); err != nil {
-		t.Fatalf("encode cluster doc: %v", err)
-	}
-	if err := encoder.Close(); err != nil {
-		t.Fatalf("close encoder: %v", err)
-	}
-	return buf.String()
-}
-
 func assertContainsAll(t *testing.T, output string, wants []string) {
 	t.Helper()
 	for _, want := range wants {
 		if !strings.Contains(output, want) {
 			t.Errorf("output is missing %q\n---\n%s", want, output)
 		}
-	}
-}
-
-func TestAppendManifestEncryptedPath_PreservesUnmodeledFields(t *testing.T) {
-	doc, err := parseClusterYAMLDoc([]byte(preservationClusterYAML))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := appendManifestEncryptedPath(doc, "db-secret", "password"); err != nil {
-		t.Fatalf("appendManifestEncryptedPath failed: %v", err)
-	}
-
-	output := encodeClusterDoc(t, doc)
-	assertContainsAll(t, output, []string{
-		"prometheus_metrics:",
-		"endpoint: https://prom.example.com",
-		"deploy_wave: 2",
-		"# prometheus scraping for this cluster",
-		"# after networking",
-	})
-
-	var roundTripped ImportClusterConfig
-	if err := yaml.Unmarshal([]byte(output), &roundTripped); err != nil {
-		t.Fatalf("parse output: %v", err)
-	}
-	paths := roundTripped.Spec.Stacks[0].Manifests[0].EncryptedPaths
-	if len(paths) != 1 || paths[0] != "password" {
-		t.Errorf("encrypted_paths = %v, want [password]", paths)
-	}
-}
-
-func TestAppendManifestEncryptedPath_AppendsToExistingList(t *testing.T) {
-	clusterYAML := strings.Replace(preservationClusterYAML,
-		"          from_file: manifests/secret.yaml\n",
-		"          from_file: manifests/secret.yaml\n          encrypted_paths:\n            - username\n", 1)
-	doc, err := parseClusterYAMLDoc([]byte(clusterYAML))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := appendManifestEncryptedPath(doc, "db-secret", "password"); err != nil {
-		t.Fatalf("appendManifestEncryptedPath failed: %v", err)
-	}
-
-	var roundTripped ImportClusterConfig
-	if err := yaml.Unmarshal([]byte(encodeClusterDoc(t, doc)), &roundTripped); err != nil {
-		t.Fatalf("parse output: %v", err)
-	}
-	paths := roundTripped.Spec.Stacks[0].Manifests[0].EncryptedPaths
-	if len(paths) != 2 || paths[0] != "username" || paths[1] != "password" {
-		t.Errorf("encrypted_paths = %v, want [username password]", paths)
-	}
-}
-
-func TestAppendManifestEncryptedPath_MissingManifest(t *testing.T) {
-	doc, err := parseClusterYAMLDoc([]byte(preservationClusterYAML))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := appendManifestEncryptedPath(doc, "nonexistent", "password"); err == nil {
-		t.Error("expected error for missing manifest")
-	}
-}
-
-func TestAppendAddonEncryptedPath_PreservesUnmodeledFields(t *testing.T) {
-	doc, err := parseClusterYAMLDoc([]byte(preservationClusterYAML))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := appendAddonEncryptedPath(doc, "grafana", "adminPassword"); err != nil {
-		t.Fatalf("appendAddonEncryptedPath failed: %v", err)
-	}
-
-	output := encodeClusterDoc(t, doc)
-	assertContainsAll(t, output, []string{
-		"prometheus_metrics:",
-		"deploy_wave: 2",
-		"# after networking",
-	})
-
-	var roundTripped ImportClusterConfig
-	if err := yaml.Unmarshal([]byte(output), &roundTripped); err != nil {
-		t.Fatalf("parse output: %v", err)
-	}
-	paths := getEncryptedPathsFromConfig(roundTripped.Spec.Stacks[0].Addons[0].Configuration)
-	if len(paths) != 1 || paths[0] != "adminPassword" {
-		t.Errorf("configuration.encrypted_paths = %v, want [adminPassword]", paths)
 	}
 }
 

--- a/cmd/cluster_yaml_splice.go
+++ b/cmd/cluster_yaml_splice.go
@@ -1,0 +1,267 @@
+package cmd
+
+// Text-level editing for cluster YAML files that must survive byte-for-byte.
+//
+// The yaml.Node helpers in cluster_yaml_edit.go keep comments, ordering and
+// unmodelled fields, but re-encoding the tree still reflows the file into
+// yaml.v3's house style: sequences indented under their key, long plain
+// scalars unfolded, quoting normalised. The platform writes cluster files in
+// a different style - indentless sequences, long lines folded - so
+// re-encoding a platform-written file changes every sequence in it: a
+// 600-line diff in a GitOps repository to record one encrypted path. The
+// helpers here locate the node to change through the parsed tree and splice
+// the new text into the original bytes, so the only lines that change are
+// the ones asked for.
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// spliceManifestEncryptedPaths records entries in the encrypted_paths list of
+// the named manifest, one text splice per entry. The tree is re-parsed between
+// splices because every insertion shifts the line numbers below it.
+func spliceManifestEncryptedPaths(source []byte, manifestName string, entries []string) ([]byte, error) {
+	for _, entry := range entries {
+		doc, err := parseClusterYAMLDoc(source)
+		if err != nil {
+			return nil, err
+		}
+		manifest, err := findClusterListEntry(doc, "manifests", manifestName)
+		if err != nil {
+			return nil, err
+		}
+		if manifest == nil {
+			return nil, fmt.Errorf("manifest %q not found in cluster YAML", manifestName)
+		}
+		source, err = spliceListEntry(source, doc, manifest, "encrypted_paths", entry)
+		if err != nil {
+			return nil, fmt.Errorf("record %s in encrypted_paths of manifest %q: %w", entry, manifestName, err)
+		}
+	}
+	return source, nil
+}
+
+// spliceAddonEncryptedPaths records entries in the configuration.encrypted_paths
+// list of the named addon, one text splice per entry.
+func spliceAddonEncryptedPaths(source []byte, addonName string, entries []string) ([]byte, error) {
+	for _, entry := range entries {
+		doc, err := parseClusterYAMLDoc(source)
+		if err != nil {
+			return nil, err
+		}
+		addon, err := findClusterListEntry(doc, "addons", addonName)
+		if err != nil {
+			return nil, err
+		}
+		if addon == nil {
+			return nil, fmt.Errorf("addon %q not found in cluster YAML", addonName)
+		}
+		configuration := yamlMapValue(addon, "configuration")
+		if configuration == nil || configuration.Kind != yaml.MappingNode {
+			return nil, fmt.Errorf("addon %q has no configuration mapping in cluster YAML", addonName)
+		}
+		source, err = spliceListEntry(source, doc, configuration, "encrypted_paths", entry)
+		if err != nil {
+			return nil, fmt.Errorf("record %s in encrypted_paths of addon %q: %w", entry, addonName, err)
+		}
+	}
+	return source, nil
+}
+
+// spliceListEntry returns source with value appended to the sequence stored
+// under key in mapping, creating the key when it is absent. mapping must
+// belong to doc, and doc must have been parsed from source unchanged: the
+// edit is placed by the line and column numbers the parser recorded.
+//
+// A block sequence gains one line whose prefix (indentation and dash) is
+// copied from its last item, so the file's own style is kept whatever it is.
+// A flow sequence is extended on its line. A missing key, or a key with no
+// value, is given a block sequence in the document's own sequence style.
+func spliceListEntry(source []byte, doc, mapping *yaml.Node, key, value string) ([]byte, error) {
+	if mapping == nil || mapping.Kind != yaml.MappingNode || len(mapping.Content) == 0 {
+		return nil, fmt.Errorf("cannot add %q: parent is not a mapping with entries", key)
+	}
+	if mapping.Style&yaml.FlowStyle != 0 {
+		return nil, fmt.Errorf("cannot add %q: the parent is a flow mapping on line %d; add the entry by hand", key, mapping.Line)
+	}
+	lines := strings.Split(string(source), "\n")
+	newline := "\n"
+	if strings.Contains(string(source), "\r\n") {
+		newline = "\r\n"
+	}
+
+	index := mapIndexOf(mapping, key)
+	if index < 0 {
+		keyIndent := mapping.Content[0].Column - 1
+		return insertLines(lines, newline, yamlNodeEndLine(mapping), []string{
+			strings.Repeat(" ", keyIndent) + key + ":",
+			strings.Repeat(" ", keyIndent+blockSequenceDashOffset(doc, lines)) + "- " + renderYAMLScalar(value, false),
+		}), nil
+	}
+
+	keyNode := mapping.Content[index]
+	valueNode := mapping.Content[index+1]
+	switch {
+	case valueNode.Kind == yaml.AliasNode:
+		return nil, fmt.Errorf("%s is a YAML alias; add the entry to the anchored list by hand", key)
+
+	case valueNode.Kind == yaml.SequenceNode && valueNode.Style&yaml.FlowStyle != 0:
+		return spliceFlowSequenceEntry(lines, newline, valueNode, value)
+
+	case valueNode.Kind == yaml.SequenceNode:
+		// Block sequences always hold at least one item; an empty one can
+		// only be written in flow style or as a bare key.
+		last := valueNode.Content[len(valueNode.Content)-1]
+		itemLine := lines[last.Line-1]
+		if last.Column-1 > len(itemLine) {
+			return nil, fmt.Errorf("%s: parser position is past the end of line %d", key, last.Line)
+		}
+		prefix := itemLine[:last.Column-1]
+		return insertLines(lines, newline, yamlNodeEndLine(last), []string{prefix + renderYAMLScalar(value, false)}), nil
+
+	case valueNode.Kind == yaml.ScalarNode && valueNode.Tag == "!!null":
+		// `encrypted_paths:` with nothing after it.
+		keyIndent := keyNode.Column - 1
+		return insertLines(lines, newline, keyNode.Line, []string{
+			strings.Repeat(" ", keyIndent+blockSequenceDashOffset(doc, lines)) + "- " + renderYAMLScalar(value, false),
+		}), nil
+
+	default:
+		return nil, fmt.Errorf("%s is a %s, expected a list", key, kindName(valueNode.Kind))
+	}
+}
+
+// spliceFlowSequenceEntry extends a single-line flow sequence such as
+// `encrypted_paths: []` or `[a, b]` on its own line.
+func spliceFlowSequenceEntry(lines []string, newline string, sequence *yaml.Node, value string) ([]byte, error) {
+	line := lines[sequence.Line-1]
+	open := sequence.Column - 1
+	if open >= len(line) || line[open] != '[' {
+		return nil, fmt.Errorf("flow list on line %d does not start where the parser reported", sequence.Line)
+	}
+	closeOffset := strings.Index(line[open:], "]")
+	if closeOffset < 0 {
+		return nil, fmt.Errorf("flow list on line %d spans several lines; add the entry by hand", sequence.Line)
+	}
+	close := open + closeOffset
+	rendered := renderYAMLScalar(value, true)
+	inner := strings.TrimRight(line[open+1:close], " ")
+	if strings.TrimSpace(inner) == "" {
+		inner = rendered
+	} else {
+		inner += ", " + rendered
+	}
+	lines[sequence.Line-1] = line[:open+1] + inner + line[close:]
+	return []byte(strings.Join(lines, "\n")), nil
+}
+
+// blockSequenceDashOffset reports how far the document indents a block
+// sequence's dashes past the key that owns it: 0 for the indentless style the
+// platform writes, 2 for yaml.v3's. Measured from the first block sequence
+// found; a document with none gets yaml.v3's style.
+func blockSequenceDashOffset(doc *yaml.Node, lines []string) int {
+	offset, found := findBlockSequenceDashOffset(doc, lines)
+	if !found || offset < 0 {
+		return 2
+	}
+	return offset
+}
+
+func findBlockSequenceDashOffset(node *yaml.Node, lines []string) (int, bool) {
+	if node == nil {
+		return 0, false
+	}
+	switch node.Kind {
+	case yaml.DocumentNode:
+		for _, child := range node.Content {
+			if offset, found := findBlockSequenceDashOffset(child, lines); found {
+				return offset, true
+			}
+		}
+	case yaml.MappingNode:
+		for entryIndex := 0; entryIndex+1 < len(node.Content); entryIndex += 2 {
+			keyNode := node.Content[entryIndex]
+			valueNode := node.Content[entryIndex+1]
+			if valueNode.Kind == yaml.SequenceNode && valueNode.Style&yaml.FlowStyle == 0 && len(valueNode.Content) > 0 {
+				item := valueNode.Content[0]
+				if item.Line >= 1 && item.Line <= len(lines) && item.Column-1 <= len(lines[item.Line-1]) {
+					dash := strings.LastIndex(lines[item.Line-1][:item.Column-1], "-")
+					if dash >= 0 {
+						return dash - (keyNode.Column - 1), true
+					}
+				}
+			}
+			if offset, found := findBlockSequenceDashOffset(valueNode, lines); found {
+				return offset, true
+			}
+		}
+	case yaml.SequenceNode:
+		for _, child := range node.Content {
+			if offset, found := findBlockSequenceDashOffset(child, lines); found {
+				return offset, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// yamlNodeEndLine returns the last line (1-based) a node occupies. Block
+// scalars are counted by their content; other scalars are taken as one line.
+func yamlNodeEndLine(node *yaml.Node) int {
+	if node == nil {
+		return 0
+	}
+	end := node.Line
+	if node.Kind == yaml.ScalarNode && (node.Style&yaml.LiteralStyle != 0 || node.Style&yaml.FoldedStyle != 0) {
+		content := strings.TrimRight(node.Value, "\n")
+		if content != "" {
+			end += strings.Count(content, "\n") + 1
+		}
+	}
+	for _, child := range node.Content {
+		if childEnd := yamlNodeEndLine(child); childEnd > end {
+			end = childEnd
+		}
+	}
+	return end
+}
+
+// insertLines returns the document with newLines placed after line afterLine
+// (1-based). Line endings match the file's.
+func insertLines(lines []string, newline string, afterLine int, newLines []string) []byte {
+	if newline == "\r\n" {
+		for index := range newLines {
+			newLines[index] += "\r"
+		}
+	}
+	if afterLine > len(lines) {
+		afterLine = len(lines)
+	}
+	result := make([]string, 0, len(lines)+len(newLines))
+	result = append(result, lines[:afterLine]...)
+	result = append(result, newLines...)
+	result = append(result, lines[afterLine:]...)
+	return []byte(strings.Join(result, "\n"))
+}
+
+// renderYAMLScalar spells value as yaml.v3 would, so a string that needs
+// quoting gets it. Inside a flow sequence the characters that delimit the
+// sequence also force quotes.
+func renderYAMLScalar(value string, flow bool) string {
+	encoded, err := yaml.Marshal(value)
+	if err != nil {
+		return strconv.Quote(value)
+	}
+	rendered := strings.TrimSuffix(string(encoded), "\n")
+	if strings.Contains(rendered, "\n") {
+		return strconv.Quote(value)
+	}
+	if flow && !strings.HasPrefix(rendered, "\"") && !strings.HasPrefix(rendered, "'") && strings.ContainsAny(rendered, ",[]{}:") {
+		return strconv.Quote(value)
+	}
+	return rendered
+}

--- a/cmd/cluster_yaml_splice_test.go
+++ b/cmd/cluster_yaml_splice_test.go
@@ -1,0 +1,232 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// The splice helpers exist so that recording one encrypted path changes one
+// line of a GitOps source of truth. Every test here therefore compares whole
+// files: the expectation is the input with exactly the asked-for lines added.
+
+func spliceDBSecretPath(t *testing.T, source, value string) string {
+	t.Helper()
+	got, err := spliceManifestEncryptedPaths([]byte(source), "db-secret", []string{value})
+	if err != nil {
+		t.Fatalf("splice: %v", err)
+	}
+	return string(got)
+}
+
+func assertSameBytes(t *testing.T, got, want string) {
+	t.Helper()
+	if got != want {
+		t.Errorf("file changed beyond the requested line.\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// platformClusterYAML is written the way the platform writes cluster files:
+// sequences indentless under their key, a long plain scalar folded across
+// two lines, keys in the platform's alphabetical order.
+const platformClusterYAML = `apiVersion: v1
+kind: ImportCluster
+metadata:
+  name: prod
+spec:
+  stacks:
+  - addons: []
+    description: a description long enough that the platform's emitter folds it
+      onto a second line, which must come back exactly as it was
+    manifests:
+    - encrypted_paths:
+      - stringData.PASSWORD
+      force: false # keep this comment
+      from_file: manifests/secret.yaml
+      name: db-secret
+    name: core
+`
+
+func TestSpliceListEntry_IndentlessBlockListGainsOneLineInItsOwnStyle(t *testing.T) {
+	got := spliceDBSecretPath(t, platformClusterYAML, "stringData.TOKEN")
+	want := strings.Replace(platformClusterYAML,
+		"      - stringData.PASSWORD\n",
+		"      - stringData.PASSWORD\n      - stringData.TOKEN\n", 1)
+	assertSameBytes(t, got, want)
+}
+
+func TestSpliceListEntry_IndentedBlockListGainsOneLineInItsOwnStyle(t *testing.T) {
+	source := `apiVersion: v1
+kind: ImportCluster
+metadata:
+  name: prod
+spec:
+  stacks:
+    - name: core
+      manifests:
+        - name: db-secret
+          from_file: manifests/secret.yaml
+          encrypted_paths:
+            - password
+`
+	got := spliceDBSecretPath(t, source, "token")
+	want := strings.Replace(source, "            - password\n", "            - password\n            - token\n", 1)
+	assertSameBytes(t, got, want)
+}
+
+func TestSpliceListEntry_MissingKeyIsCreatedIndentlessWhenTheDocumentIs(t *testing.T) {
+	source := strings.Replace(platformClusterYAML,
+		"    - encrypted_paths:\n      - stringData.PASSWORD\n      force: false # keep this comment\n",
+		"    - force: false # keep this comment\n", 1)
+	got := spliceDBSecretPath(t, source, "password")
+	// The list goes after the mapping's last line, dashes level with the key,
+	// because that is how every other sequence in the file is written.
+	want := strings.Replace(source,
+		"      name: db-secret\n",
+		"      name: db-secret\n      encrypted_paths:\n      - password\n", 1)
+	assertSameBytes(t, got, want)
+}
+
+func TestSpliceListEntry_MissingKeyIsCreatedIndentedWhenTheDocumentIs(t *testing.T) {
+	source := `apiVersion: v1
+kind: ImportCluster
+metadata:
+  name: prod
+spec:
+  stacks:
+    - name: core
+      manifests:
+        - name: db-secret
+          from_file: manifests/secret.yaml
+`
+	got := spliceDBSecretPath(t, source, "password")
+	want := strings.Replace(source,
+		"          from_file: manifests/secret.yaml\n",
+		"          from_file: manifests/secret.yaml\n          encrypted_paths:\n            - password\n", 1)
+	assertSameBytes(t, got, want)
+}
+
+func TestSpliceListEntry_EmptyFlowListIsFilledOnItsLine(t *testing.T) {
+	source := strings.Replace(platformClusterYAML,
+		"    - encrypted_paths:\n      - stringData.PASSWORD\n",
+		"    - encrypted_paths: [] # none yet\n", 1)
+	got := spliceDBSecretPath(t, source, "password")
+	want := strings.Replace(source, "encrypted_paths: [] # none yet", "encrypted_paths: [password] # none yet", 1)
+	assertSameBytes(t, got, want)
+}
+
+func TestSpliceListEntry_FlowListIsExtendedOnItsLine(t *testing.T) {
+	source := strings.Replace(platformClusterYAML,
+		"    - encrypted_paths:\n      - stringData.PASSWORD\n",
+		"    - encrypted_paths: [stringData.PASSWORD, stringData.USER]\n", 1)
+	got := spliceDBSecretPath(t, source, "stringData.TOKEN")
+	want := strings.Replace(source,
+		"[stringData.PASSWORD, stringData.USER]",
+		"[stringData.PASSWORD, stringData.USER, stringData.TOKEN]", 1)
+	assertSameBytes(t, got, want)
+}
+
+func TestSpliceListEntry_BareKeyWithNoValueGetsItsFirstItem(t *testing.T) {
+	source := strings.Replace(platformClusterYAML,
+		"    - encrypted_paths:\n      - stringData.PASSWORD\n",
+		"    - encrypted_paths:\n", 1)
+	got := spliceDBSecretPath(t, source, "password")
+	want := strings.Replace(source, "    - encrypted_paths:\n", "    - encrypted_paths:\n      - password\n", 1)
+	assertSameBytes(t, got, want)
+}
+
+func TestSpliceListEntry_GlobEntryIsWrittenVerbatim(t *testing.T) {
+	got := spliceDBSecretPath(t, platformClusterYAML, "glob:stringData.DB_*")
+	want := strings.Replace(platformClusterYAML,
+		"      - stringData.PASSWORD\n",
+		"      - stringData.PASSWORD\n      - glob:stringData.DB_*\n", 1)
+	assertSameBytes(t, got, want)
+}
+
+func TestSpliceListEntry_SeveralEntriesLandInOrder(t *testing.T) {
+	got, err := spliceManifestEncryptedPaths([]byte(platformClusterYAML), "db-secret", []string{"stringData.A", "stringData.B"})
+	if err != nil {
+		t.Fatalf("splice: %v", err)
+	}
+	want := strings.Replace(platformClusterYAML,
+		"      - stringData.PASSWORD\n",
+		"      - stringData.PASSWORD\n      - stringData.A\n      - stringData.B\n", 1)
+	assertSameBytes(t, string(got), want)
+}
+
+func TestSpliceListEntry_AliasedListIsRefusedRatherThanEditedThroughTheAnchor(t *testing.T) {
+	source := `apiVersion: v1
+kind: ImportCluster
+metadata:
+  name: prod
+x-shared: &shared
+  - password
+spec:
+  stacks:
+  - name: core
+    manifests:
+    - name: db-secret
+      from_file: manifests/secret.yaml
+      encrypted_paths: *shared
+`
+	_, err := spliceManifestEncryptedPaths([]byte(source), "db-secret", []string{"token"})
+	if err == nil || !strings.Contains(err.Error(), "alias") {
+		t.Fatalf("expected an alias refusal, got %v", err)
+	}
+}
+
+func TestSpliceListEntry_FlowMappingIsRefused(t *testing.T) {
+	source := `apiVersion: v1
+kind: ImportCluster
+metadata:
+  name: prod
+spec:
+  stacks:
+  - name: core
+    manifests:
+    - {name: db-secret, from_file: manifests/secret.yaml}
+`
+	_, err := spliceManifestEncryptedPaths([]byte(source), "db-secret", []string{"password"})
+	if err == nil || !strings.Contains(err.Error(), "flow") {
+		t.Fatalf("expected a flow-mapping refusal, got %v", err)
+	}
+}
+
+func TestSpliceListEntry_CRLFFileKeepsItsLineEndings(t *testing.T) {
+	source := strings.ReplaceAll(platformClusterYAML, "\n", "\r\n")
+	got := spliceDBSecretPath(t, source, "stringData.TOKEN")
+	want := strings.Replace(source,
+		"      - stringData.PASSWORD\r\n",
+		"      - stringData.PASSWORD\r\n      - stringData.TOKEN\r\n", 1)
+	assertSameBytes(t, got, want)
+}
+
+func TestSpliceAddonEncryptedPaths_CreatesTheListUnderConfiguration(t *testing.T) {
+	source := `apiVersion: v1
+kind: ImportCluster
+metadata:
+  name: prod
+spec:
+  stacks:
+  - addons:
+    - chart_name: grafana
+      configuration:
+        from_file: values/grafana.yaml
+      name: grafana
+    name: core
+`
+	got, err := spliceAddonEncryptedPaths([]byte(source), "grafana", []string{"adminPassword", "smtpPassword"})
+	if err != nil {
+		t.Fatalf("splice: %v", err)
+	}
+	want := strings.Replace(source,
+		"        from_file: values/grafana.yaml\n",
+		"        from_file: values/grafana.yaml\n        encrypted_paths:\n        - adminPassword\n        - smtpPassword\n", 1)
+	assertSameBytes(t, string(got), want)
+}
+
+func TestSpliceManifestEncryptedPaths_UnknownManifestIsAnError(t *testing.T) {
+	_, err := spliceManifestEncryptedPaths([]byte(platformClusterYAML), "nonexistent", []string{"password"})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected a not-found error, got %v", err)
+	}
+}

--- a/cmd/encrypt_test.go
+++ b/cmd/encrypt_test.go
@@ -160,29 +160,6 @@ spec:
 	})
 }
 
-func TestContainsString(t *testing.T) {
-	tests := []struct {
-		name     string
-		slice    []string
-		str      string
-		expected bool
-	}{
-		{"found", []string{"a", "b", "c"}, "b", true},
-		{"not found", []string{"a", "b", "c"}, "d", false},
-		{"empty slice", []string{}, "a", false},
-		{"nil slice", nil, "a", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := containsString(tt.slice, tt.str)
-			if result != tt.expected {
-				t.Errorf("containsString(%v, %q) = %v, want %v", tt.slice, tt.str, result, tt.expected)
-			}
-		})
-	}
-}
-
 func TestNormalizeEncryptKey(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -471,12 +448,12 @@ sops:
 	})
 }
 
-func TestUnionStringLists(t *testing.T) {
-	merged := unionStringLists([]string{"password"}, []string{"token", "password"}, []string{"apiKey"})
+func TestUnionEncryptedPaths(t *testing.T) {
+	merged := unionEncryptedPaths([]string{"password"}, []string{"token", "password"}, []string{"apiKey"})
 	if len(merged) != 3 || merged[0] != "password" || merged[1] != "token" || merged[2] != "apiKey" {
 		t.Errorf("merged = %v, want [password token apiKey]", merged)
 	}
-	if merged := unionStringLists(nil, nil); merged != nil {
+	if merged := unionEncryptedPaths(nil, nil); merged != nil {
 		t.Errorf("union of empties = %v, want nil", merged)
 	}
 }


### PR DESCRIPTION
Closes PLA-806.

## What was wrong

Recording one key in a platform-written cluster file with `ankra cluster encrypt manifest … -f tael-ops.yaml --all-data` produced a **602-line diff** and **31 `encrypted_paths` entries from 15**.

1. **Whole-file reflow.** The file is edited at the `yaml.Node` level (comments and order survive) but then re-encoded with yaml.v3, which indents sequences under their key. The platform writes indentless sequences and folds long lines, so every sequence in a platform-written file came back re-indented. `TestRunEncryptManifest_FileModePreservesUntouchedLinesByteForByte` passed only because its fixture was already in yaml.v3's style.
2. **Duplicate, mixed-spelling entries.** The platform spells entries `stringData.PASSWORD` and strips the section when reading them (`enginekit/clusterengine/encryptedpaths.go`); the CLI normalises keys to the bare leaf and compared the two as strings, so every recorded key looked missing and was appended again as a bare name. `manifests upgrade` merged with `unionStringLists` and had the same fault.

## What this does

- `cmd/cluster_yaml_splice.go`: the entry is spliced into the file's own bytes at the position the parser reports. A block list gains one line whose prefix is copied from its last item; a flow list is extended on its line; a missing key (or a bare `encrypted_paths:`) gets a list in the document's own sequence style; aliased lists and flow mappings are refused rather than edited blind. CRLF files keep their endings.
- Entries are compared by key name with the section stripped, globs verbatim (`encryptedPathLeaf` / `containsEncryptedPath`), in all four presence checks and in `unionEncryptedPaths` (was `unionStringLists`). A new entry is spelled the way the file already spells its entries (`encryptedPathEntry`, using the Secret section that holds the key when known).
- The superseded node-level appenders and their tests are removed; `clone` keeps `writeClusterFile`, which builds fresh documents.
- CHANGELOG: `v0.14.0-rc3 — Fixed`.

## Tests

- `cluster_yaml_splice_test.go`: whole-file byte comparisons for indentless and indented block lists, missing key in each style, empty and populated flow lists, bare key, glob verbatim, several entries, alias refusal, flow-mapping refusal, CRLF, addon configuration.
- `cluster_encrypt_paths_test.go`: the command on a platform-style file — one line added in the file's spelling; a section-qualified entry counts as present; `--all-data` on a fully recorded Secret leaves the file byte-identical (the field case); no list → one created in the file's style; unit tests for the leaf/spelling helpers.
- `go test ./...` green, `golangci-lint` 0 issues.

**Field check:** the fixed binary against a copy of the real `tael-ops.yaml` with a scratch Secret (`stringData.ALPHA` already recorded), `--all-data` through the real API: the cluster-file diff was exactly `+      - stringData.BETA`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StBUFfDHjGYkHLES7YJjhH
