### PR TITLE
feat(backup): vaults provision needs no arguments (ankra-0xsdd.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## v0.14.0-rc3 — 2026-08-28
 
+### Added
+
+- **`ankra backup vaults provision` needs no arguments.** Letting Ankra set a
+  vault up is now one command: the name defaults to `backups` (then
+  `backups-2` and so on, against the vaults that already exist), the
+  credential to the only one Ankra can provision from, and the region to that
+  provider's usual one - and the command prints what it chose before it
+  creates anything. Pass any of them to override. With several usable
+  credentials it still asks which, rather than guessing.
+
 ### Fixed
 
 - **`ankra cluster encrypt -f` changes only the line it adds.** Recording an

--- a/cmd/backup_vaults.go
+++ b/cmd/backup_vaults.go
@@ -304,6 +304,70 @@ var provisionableBackupVaultProviders = map[string]bool{
 	"hetzner": true, "upcloud": true, "digitalocean": true, "scaleway": true,
 }
 
+// backupVaultDefaultRegions is the region each provider gets when none was
+// given - the same defaults the dashboard opens with. A provider absent
+// here has no safe default and asks for --region.
+var backupVaultDefaultRegions = map[string]string{
+	"hetzner":      "fsn1",
+	"upcloud":      "europe-1",
+	"digitalocean": "fra1",
+	"scaleway":     "fr-par",
+}
+
+// defaultBackupVaultName is the name a vault gets when none was given:
+// "backups", then "backups-2" and so on, so a second vault still needs no
+// argument and never collides with the platform's unique-name rule.
+func defaultBackupVaultName(existing []client.BackupVault) string {
+	taken := make(map[string]bool, len(existing))
+	for _, vault := range existing {
+		taken[vault.Name] = true
+	}
+	if !taken["backups"] {
+		return "backups"
+	}
+	for suffix := 2; ; suffix++ {
+		candidate := fmt.Sprintf("backups-%d", suffix)
+		if !taken[candidate] {
+			return candidate
+		}
+	}
+}
+
+// selectProvisionCredential resolves --credential, or picks the only
+// credential Ankra can provision from when the flag was omitted. It refuses
+// to guess between several: the dashboard shows which one it preselected
+// before you press the button, and a command cannot.
+func selectProvisionCredential(reference string) (client.Credential, error) {
+	if strings.TrimSpace(reference) != "" {
+		return resolveProvisionCredential(reference)
+	}
+	credentials, listError := apiClient.ListCredentials(nil)
+	if listError != nil {
+		return client.Credential{}, fmt.Errorf("listing credentials: %w", listError)
+	}
+	candidates := make([]client.Credential, 0, len(credentials))
+	for _, credential := range credentials {
+		if provisionableBackupVaultProviders[credential.Provider] {
+			candidates = append(candidates, credential)
+		}
+	}
+	if len(candidates) == 1 {
+		return candidates[0], nil
+	}
+	if len(candidates) == 0 {
+		return client.Credential{}, errors.New(
+			"this organisation has no Hetzner, UpCloud, DigitalOcean or Scaleway credential to provision a bucket from; " +
+				"add one under credentials, or register a bucket you own with 'ankra backup vaults create'")
+	}
+	described := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		described = append(described, fmt.Sprintf("%s (%s)", candidate.Name, candidate.Provider))
+	}
+	return client.Credential{}, fmt.Errorf(
+		"this organisation has %d credentials Ankra can provision from, so pass --credential: %s",
+		len(candidates), strings.Join(described, ", "))
+}
+
 // resolveProvisionCredential finds one of the organisation's provider
 // credentials by name or id, so the command can tell Hetzner apart before
 // it asks for keys.
@@ -349,13 +413,18 @@ func waitForBackupVaultProvisioning(ctx context.Context, vaults APIClient, vault
 }
 
 var backupVaultsProvisionCmd = &cobra.Command{
-	Use:   "provision <name>",
+	Use:   "provision [name]",
 	Short: "Create a backup vault by letting Ankra provision the bucket from a provider credential",
 	Long: `Create a backup vault and let Ankra create the bucket for it, using one of
 the organisation's provider credentials (Hetzner, UpCloud, DigitalOcean or
-Scaleway). Ankra creates the bucket in the given region, mints or stores the
-access keys, verifies the bucket and registers the vault; the vault shows
-"provisioning" until that finishes.
+Scaleway). Ankra creates the bucket, mints or stores the access keys,
+verifies the bucket and registers the vault; the vault shows "provisioning"
+until that finishes.
+
+Everything is decided for you unless you say otherwise: the name defaults to
+"backups" (then "backups-2" and so on), the credential to the only one Ankra
+can provision from, and the region to that provider's usual one. The command
+prints what it chose before it creates anything.
 
 Hetzner alone needs its Object Storage key pair passed in (or prompted for):
 Hetzner issues those in the Cloud Console (Object Storage > Manage
@@ -363,18 +432,18 @@ credentials) and its Cloud API cannot mint them. The other providers need
 nothing beyond the credential.
 
 Examples:
+  ankra backup vaults provision
   ankra backup vaults provision offsite --credential upcloud-main --region europe-1 --wait
   ankra backup vaults provision offsite --credential hetzner-main --region fsn1`,
-	Args: cobra.ExactArgs(1),
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		name := args[0]
 		credentialReference, _ := cmd.Flags().GetString("credential")
 		region, _ := cmd.Flags().GetString("region")
 		bucket, _ := cmd.Flags().GetString("bucket")
 		accessKeyID, _ := cmd.Flags().GetString("access-key-id")
 		secretAccessKey, _ := cmd.Flags().GetString("secret-access-key")
 
-		credential, resolveError := resolveProvisionCredential(credentialReference)
+		credential, resolveError := selectProvisionCredential(credentialReference)
 		if resolveError != nil {
 			return resolveError
 		}
@@ -383,6 +452,26 @@ Examples:
 				"digitalocean and scaleway credentials - use 'ankra backup vaults create' to register a bucket you own",
 				credentialReference, credential.Provider)
 		}
+		name := ""
+		if len(args) == 1 {
+			name = strings.TrimSpace(args[0])
+		}
+		if name == "" {
+			existing, listError := apiClient.ListBackupVaults()
+			if listError != nil {
+				return backupLaneError("listing backup vaults", listError)
+			}
+			name = defaultBackupVaultName(existing.Items)
+		}
+		if region == "" {
+			region = backupVaultDefaultRegions[credential.Provider]
+			if region == "" {
+				return fmt.Errorf("pass --region: %s has no default region", credential.Provider)
+			}
+		}
+		fmt.Printf("Creating backup vault '%s' with credential '%s' (%s) in %s.\n",
+			name, credential.Name, credential.Provider, region)
+
 		if credential.Provider == "hetzner" {
 			if accessKeyID == "" {
 				prompt := promptui.Prompt{
@@ -549,13 +638,13 @@ func init() {
 	_ = backupVaultsCreateCmd.MarkFlagRequired("endpoint")
 	_ = backupVaultsCreateCmd.MarkFlagRequired("bucket")
 
-	backupVaultsProvisionCmd.Flags().String("credential", "", "Provider credential (name or id) Ankra creates the bucket with")
-	backupVaultsProvisionCmd.Flags().String("region", "", "Provider region for the bucket (e.g. fsn1, europe-1, fra1, fr-par)")
+	backupVaultsProvisionCmd.Flags().String("credential", "",
+		"Provider credential (name or id) Ankra creates the bucket with (default: the only one it can provision from)")
+	backupVaultsProvisionCmd.Flags().String("region", "",
+		"Provider region for the bucket (default: that provider's usual one - fsn1, europe-1, fra1, fr-par)")
 	backupVaultsProvisionCmd.Flags().String("bucket", "", "Bucket name (default: a unique name derived from the vault name)")
 	backupVaultsProvisionCmd.Flags().String("access-key-id", "", "Hetzner Object Storage access key (Hetzner only; prompted for when omitted)")
 	backupVaultsProvisionCmd.Flags().String("secret-access-key", "", "Hetzner Object Storage secret key (Hetzner only; prompted for hidden when omitted)")
-	_ = backupVaultsProvisionCmd.MarkFlagRequired("credential")
-	_ = backupVaultsProvisionCmd.MarkFlagRequired("region")
 	registerAsyncWriteFlags(backupVaultsProvisionCmd)
 
 	backupVaultsDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")

--- a/cmd/backup_vaults_oneclick_test.go
+++ b/cmd/backup_vaults_oneclick_test.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+func soleUpCloudCredential() []client.Credential {
+	return []client.Credential{
+		{ID: backupVaultProvisionCredentialID, Name: "upcloud-main", Provider: "upcloud", Available: true},
+		// A credential Ankra cannot provision from must not count towards
+		// the choice, so this one is ignored rather than ambiguous.
+		{ID: "0a1b2c3d-4e5f-4a6b-8c7d-9e0f1a2b3c4d", Name: "github-main", Provider: "github", Available: true},
+	}
+}
+
+// TestBackupVaultsProvisionNeedsNoArgumentsWithOneCredential pins the
+// one-command path: no name, no credential, no region, and the command
+// still knows what to do - and says so before it does it.
+func TestBackupVaultsProvisionNeedsNoArgumentsWithOneCredential(t *testing.T) {
+	mock := &backupVaultsMock{credentials: soleUpCloudCredential(), provisionedVault: provisioningVault("backups", "upcloud")}
+	setMockClient(t, mock)
+	resetBackupVaultsProvisionFlags(t)
+
+	var executeError error
+	output := captureStdout(t, func() {
+		_, executeError = executeCommand("backup", "vaults", "provision")
+	})
+	if executeError != nil {
+		t.Fatal(executeError)
+	}
+	expected := client.ProvisionBackupVaultRequest{
+		Name: "backups", CredentialID: backupVaultProvisionCredentialID, Region: "europe-1",
+	}
+	if mock.provisioned == nil || *mock.provisioned != expected {
+		t.Fatalf("request = %+v, want %+v", mock.provisioned, expected)
+	}
+	// Never silent about a default it chose.
+	for _, fragment := range []string{"backups", "upcloud-main", "europe-1"} {
+		if !strings.Contains(output, fragment) {
+			t.Errorf("output missing %q:\n%s", fragment, output)
+		}
+	}
+}
+
+// The default name steps past the vaults that already exist, so the second
+// vault also needs no argument.
+func TestBackupVaultsProvisionDefaultNameStepsPastExistingVaults(t *testing.T) {
+	existing := []client.BackupVault{
+		{ID: backupVaultTestID, Name: "backups"},
+		{ID: "e22a87f2-3ec4-41fe-a975-325661b7b7e2", Name: "backups-2"},
+	}
+	mock := &backupVaultsMock{
+		credentials: soleUpCloudCredential(), vaults: existing,
+		provisionedVault: provisioningVault("backups-3", "upcloud"),
+	}
+	setMockClient(t, mock)
+	resetBackupVaultsProvisionFlags(t)
+
+	if _, executeError := executeCommand("backup", "vaults", "provision"); executeError != nil {
+		t.Fatal(executeError)
+	}
+	if mock.provisioned == nil || mock.provisioned.Name != "backups-3" {
+		t.Fatalf("name = %+v, want backups-3", mock.provisioned)
+	}
+}
+
+// With more than one usable credential the command asks instead of
+// guessing: the dashboard shows its preselection before you press the
+// button, a command cannot.
+func TestBackupVaultsProvisionAsksWhichCredentialWhenSeveralQualify(t *testing.T) {
+	mock := &backupVaultsMock{credentials: provisionCredentials(), provisionedVault: provisioningVault("backups", "upcloud")}
+	setMockClient(t, mock)
+	resetBackupVaultsProvisionFlags(t)
+
+	_, executeError := executeCommand("backup", "vaults", "provision")
+	if executeError == nil || !strings.Contains(executeError.Error(), "pass --credential") {
+		t.Fatalf("expected the ambiguity refusal, got %v", executeError)
+	}
+	if !strings.Contains(executeError.Error(), "upcloud-main") || !strings.Contains(executeError.Error(), "hetzner-main") {
+		t.Fatalf("the refusal must name the candidates: %v", executeError)
+	}
+	if mock.provisioned != nil {
+		t.Fatal("no request may be sent while the credential is ambiguous")
+	}
+}
+
+func TestBackupVaultsProvisionExplainsAnOrganisationWithNoUsableCredential(t *testing.T) {
+	mock := &backupVaultsMock{
+		credentials:      []client.Credential{{ID: "x", Name: "github-main", Provider: "github"}},
+		provisionedVault: provisioningVault("backups", "upcloud"),
+	}
+	setMockClient(t, mock)
+	resetBackupVaultsProvisionFlags(t)
+
+	_, executeError := executeCommand("backup", "vaults", "provision")
+	if executeError == nil || !strings.Contains(executeError.Error(), "no Hetzner, UpCloud, DigitalOcean or Scaleway credential") {
+		t.Fatalf("expected the no-credential explanation, got %v", executeError)
+	}
+	if !strings.Contains(executeError.Error(), "backup vaults create") {
+		t.Fatalf("the explanation must offer the bring-your-own path: %v", executeError)
+	}
+}
+
+// An explicit name, credential and region still win over every default.
+func TestBackupVaultsProvisionExplicitArgumentsWin(t *testing.T) {
+	mock := &backupVaultsMock{credentials: provisionCredentials(), provisionedVault: provisioningVault("offsite", "upcloud")}
+	setMockClient(t, mock)
+	resetBackupVaultsProvisionFlags(t)
+
+	if _, executeError := executeCommand("backup", "vaults", "provision", "offsite",
+		"--credential", "upcloud-main", "--region", "us-1"); executeError != nil {
+		t.Fatal(executeError)
+	}
+	expected := client.ProvisionBackupVaultRequest{
+		Name: "offsite", CredentialID: backupVaultProvisionCredentialID, Region: "us-1",
+	}
+	if mock.provisioned == nil || *mock.provisioned != expected {
+		t.Fatalf("request = %+v, want %+v", mock.provisioned, expected)
+	}
+}


### PR DESCRIPTION
feat(backup): `vaults provision` needs no arguments (ankra-0xsdd.2)

Letting Ankra set a vault up still meant knowing three things - a name, a
credential and a region - which is the same form-filling the dashboard just
stopped asking for (portal#1682).

`ankra backup vaults provision` now decides all three:

- the name defaults to `backups`, then `backups-2` and so on against the
  vaults that already exist, so a second vault also needs no argument and
  never collides with the platform's unique-name rule,
- the credential defaults to the only one Ankra can provision from -
  credentials it cannot (github, ovh, ...) do not make the choice ambiguous,
- the region defaults to that provider's usual one (fsn1, europe-1, fra1,
  fr-par).

It is never silent about it: the command prints the name, credential and
region it chose before creating anything, and every one of them can still be
passed explicitly. With more than one usable credential it asks which,
naming the candidates, rather than guessing - the dashboard can show you its
preselection before you press the button and a command cannot.

An organisation with nothing to provision from gets an explanation that
points at both ways forward: add a credential, or register a bucket you own.

Changelog: added to the open v0.14.0-rc3 section.
