### PR TITLE
fix(backup): recovery advice that matches the vault, and a lookup that says why it failed (ankra-0xsdd.28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Ankra CLI Changelog
 
-## v0.14.0-rc3 — 2026-08-28
+## v0.14.0-rc4 — 2026-08-28
 
 ### Added
 
@@ -11,6 +11,23 @@
   provider's usual one - and the command prints what it chose before it
   creates anything. Pass any of them to override. With several usable
   credentials it still asks which, rather than guessing.
+
+### Fixed
+
+- **A failed provisioning is no longer told to fix its access keys.** For a
+  vault Ankra provisioned there are none to fix - the run never got as far
+  as minting any - and re-verifying cannot make a bucket exist. `get` and a
+  failed `provision` now say to delete it with
+  `--destroy-provider-resources`, which also clears whatever the run had
+  already created, and provision again. A vault that verified before, or one
+  whose bucket you registered yourself, still points at the keys.
+- **A vault name that cannot be looked up says why.** When listing failed,
+  the name was handed to the API unchanged and came back as a uuid-parsing
+  validation error - which reads as a typo for a name that was right. The
+  command now reports the real reason it could not resolve the name; an id
+  still needs no lookup at all.
+
+## v0.14.0-rc3 — 2026-08-28
 
 ### Fixed
 

--- a/cmd/backup_vaults.go
+++ b/cmd/backup_vaults.go
@@ -70,10 +70,10 @@ func resolveBackupVaultID(vaults APIClient, reference string) (string, error) {
 	}
 	listing, listError := vaults.ListBackupVaults()
 	if listError != nil {
-		// The lookup is a convenience, not the operation. If listing is
-		// unavailable, hand the reference to the API unchanged and let the
-		// real call decide.
-		return reference, nil
+		// Passing the name through unchanged made the API answer a
+		// uuid-parsing validation error, which reads as "you typed the name
+		// wrong" for a name that was right. Report why the lookup failed.
+		return "", backupLaneError("looking up backup vault "+reference, listError)
 	}
 	matched := []client.BackupVault{}
 	for _, vault := range listing.Items {
@@ -97,11 +97,20 @@ func resolveBackupVaultID(vaults APIClient, reference string) (string, error) {
 	}
 }
 
-// backupVaultVerifyHint tells the user what to do after a failed credential
-// check: the stored keys are replaced by recreating them server-side, so the
-// actionable next step is fixing the keys at the provider and re-verifying.
-func backupVaultVerifyHint(vaultName string) string {
-	return fmt.Sprintf("fix the access keys, then run 'ankra backup vaults verify %s'", vaultName)
+// backupVaultVerifyHint tells the user what to do after a failed check. The
+// answer depends on how the vault was meant to get its bucket: a vault
+// Ankra provisioned that has never verified never got as far as minting
+// keys, so there are none to fix and re-verifying cannot make the bucket
+// exist (the API answers 409 for exactly that) - the way out is to delete
+// it, which also clears whatever the run had already created, and provision
+// again. Anywhere else the keys are the user's own and re-verifying is the
+// point.
+func backupVaultVerifyHint(vault *client.BackupVault) string {
+	if vault.Kind == "ankra_provisioned" && (vault.LastVerifiedAt == nil || *vault.LastVerifiedAt == "") {
+		return fmt.Sprintf("provisioning did not finish, so run "+
+			"'ankra backup vaults delete %s --destroy-provider-resources' and provision again", vault.Name)
+	}
+	return fmt.Sprintf("fix the access keys, then run 'ankra backup vaults verify %s'", vault.Name)
 }
 
 // backupVaultStatusError turns a vault whose verification failed into a
@@ -112,7 +121,7 @@ func backupVaultStatusError(vault *client.BackupVault) error {
 	if vault.ErrorExcerpt != nil && *vault.ErrorExcerpt != "" {
 		message += ": " + *vault.ErrorExcerpt
 	}
-	return fmt.Errorf("%s - %s", message, backupVaultVerifyHint(vault.Name))
+	return fmt.Errorf("%s - %s", message, backupVaultVerifyHint(vault))
 }
 
 func printBackupVault(vault *client.BackupVault) {
@@ -149,7 +158,7 @@ func printBackupVault(vault *client.BackupVault) {
 		} else {
 			fmt.Println("  (no error detail recorded)")
 		}
-		fmt.Printf("\nTo recover: %s\n", backupVaultVerifyHint(vault.Name))
+		fmt.Printf("\nTo recover: %s\n", backupVaultVerifyHint(vault))
 	}
 }
 

--- a/cmd/backup_vaults_test.go
+++ b/cmd/backup_vaults_test.go
@@ -169,16 +169,65 @@ func TestResolveBackupVaultIDReportsDuplicateNames(t *testing.T) {
 	}
 }
 
-func TestResolveBackupVaultIDFallsBackWhenLookupIsUnavailable(t *testing.T) {
+// A name can only be resolved by listing; passing it through to a
+// uuid-typed path guaranteed a validation error that read as "you typed the
+// name wrong" for a name that was right. Report the real cause instead.
+func TestResolveBackupVaultIDReportsWhyTheLookupFailed(t *testing.T) {
 	mock := &backupVaultsMock{listError: errors.New("listing unavailable")}
 
 	resolved, resolveError := resolveBackupVaultID(mock, "offsite")
 
-	if resolveError != nil {
-		t.Fatalf("a failed lookup must not fail the command: %v", resolveError)
+	if resolveError == nil {
+		t.Fatal("a failed lookup must surface, not pass the name through")
 	}
-	if resolved != "offsite" {
-		t.Fatalf("the reference must pass through unchanged, got %q", resolved)
+	if !strings.Contains(resolveError.Error(), "listing unavailable") ||
+		!strings.Contains(resolveError.Error(), "offsite") {
+		t.Fatalf("the error must name the vault and the cause: %v", resolveError)
+	}
+	if resolved != "" {
+		t.Fatalf("no id may be returned alongside the error, got %q", resolved)
+	}
+}
+
+// An id needs no lookup, so a broken listing never blocks it.
+func TestResolveBackupVaultIDSkipsTheLookupForAnID(t *testing.T) {
+	mock := &backupVaultsMock{listError: errors.New("listing unavailable")}
+
+	resolved, resolveError := resolveBackupVaultID(mock, backupVaultTestID)
+
+	if resolveError != nil {
+		t.Fatalf("an id must not need the listing: %v", resolveError)
+	}
+	if resolved != backupVaultTestID {
+		t.Fatalf("resolved = %q", resolved)
+	}
+}
+
+// The recovery hint has to match how the vault was meant to get its bucket.
+func TestBackupVaultVerifyHintMatchesTheVaultKind(t *testing.T) {
+	verifiedAt := "2026-08-27T10:00:00Z"
+	cases := map[string]struct {
+		vault    client.BackupVault
+		expected string
+	}{
+		"provisioning never finished": {
+			vault:    client.BackupVault{Name: "offsite", Kind: "ankra_provisioned"},
+			expected: "--destroy-provider-resources",
+		},
+		"provisioned but verified before": {
+			vault:    client.BackupVault{Name: "offsite", Kind: "ankra_provisioned", LastVerifiedAt: &verifiedAt},
+			expected: "fix the access keys",
+		},
+		"bring your own": {
+			vault:    client.BackupVault{Name: "offsite", Kind: "customer_s3"},
+			expected: "fix the access keys",
+		},
+	}
+	for name, testCase := range cases {
+		hint := backupVaultVerifyHint(&testCase.vault)
+		if !strings.Contains(hint, testCase.expected) {
+			t.Errorf("%s: hint %q does not contain %q", name, hint, testCase.expected)
+		}
 	}
 }
 


### PR DESCRIPTION
fix(backup): recovery advice that matches the vault, and a lookup that says why it failed (ankra-0xsdd.28)

Two things an audit of the backup vault flow found in the CLI.

**A failed provisioning was told to fix its access keys.** For a vault
Ankra provisioned there are none to fix - the run never got as far as
minting any - and re-verifying cannot make a bucket exist (the API answers
409 for exactly that, cluster#2096). `get` and a failed `provision` now
point at `delete --destroy-provider-resources` and provisioning again,
which also clears whatever the run had already created. A provisioned vault
that verified before, and any bring-your-own vault, still point at the keys,
because there the keys and bucket do exist and only access broke.

**A vault name that could not be looked up produced a validation error.**
When `ListBackupVaults` failed, the name was handed to the API unchanged;
the route takes a uuid, so it came back as a uuid-parsing 422 - which reads
as "you typed the name wrong" for a name that was right. The lookup now
reports the real reason. An id still short-circuits before any listing, so
a broken list never blocks an id-addressed command. This replaces a test
that pinned the old pass-through: that behaviour could not succeed, only
mislead.

Changelog: opens v0.14.0-rc4, and moves the one-click provision entry out
of the rc3 section - rc3 was tagged at the encrypt fix, before that change
merged, so it shipped without it.
