### PR TITLE
feat(security): ankra security overview/findings/finding/clusters with CISA KEV and EPSS intelligence (ankra-b6rtz)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Ankra CLI Changelog
 
+## Unreleased
+
+### Added
+
+- **The Security Center is readable from the terminal.** `ankra security
+  overview` prints the fleet's actionable totals, scanner coverage, the
+  remediation candidates, and - first - how many vulnerabilities CISA lists
+  as exploited in the wild, how many are past CISA's remediation deadline and
+  how many CISA links to ransomware. `ankra security findings` lists findings
+  exploited-in-the-wild first (CISA KEV, then EPSS, then severity), with
+  `--known-exploited`, `--severity`, `--status`, `--fixable`, `--cluster`,
+  `--addon`, `--namespace`, `--search`, `--sort` and `--order` mirroring the
+  portal's filters; every row shows the CISA deadline in explicit tense and
+  the EPSS probability. `ankra security finding <id>` quotes CISA's own entry
+  - vulnerability name, deadline and required action - above every current
+  occurrence, and `ankra security clusters` gives per-cluster posture with
+  the known-exploited count. All four take `-o json` for reporting.
+
 ## v0.14.0-rc4 — 2026-08-28
 
 ### Added

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -908,6 +908,22 @@ func (m baseMock) ListAPITokens() ([]client.APIToken, error) {
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) GetSecurityOverview(client.SecurityOverviewOptions) (*client.SecurityOverview, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ListSecurityFindings(client.SecurityFindingsOptions) (*client.SecurityFindingList, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetSecurityFinding(string) (*client.SecurityFindingDetail, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ListSecurityClusters(client.SecurityClustersOptions) (*client.SecurityClusterList, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) CreateAPIToken(name string, expiresAt *string, scopes []string) (*client.CreateAPITokenResponse, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/security.go
+++ b/cmd/security.go
@@ -1,0 +1,538 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+)
+
+var securityCmd = &cobra.Command{
+	Use:   "security",
+	Short: "Read the Security Center: exploited-in-the-wild findings, fleet posture and scanner coverage",
+	Long: `Read the organisation's Security Center - the same data the portal shows,
+for your own reporting and automation.
+
+Every finding carries its exploitation intelligence: whether CISA lists the
+CVE in its Known Exploited Vulnerabilities (KEV) catalog, with CISA's
+remediation deadline and required action, and the FIRST EPSS probability
+that it is exploited in the next 30 days. Findings sort by exploitability by
+default - CISA listing first, then EPSS, then severity - so the top of the
+list is what is actually being exploited, not what merely has the highest
+CVSS score.
+
+Pass -o json (or yaml) for the full API document.`,
+}
+
+var securityOverviewCmd = &cobra.Command{
+	Use:   "overview",
+	Short: "Fleet security summary: totals, CISA KEV exposure, scanner coverage and remediation candidates",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		clusterFlag, _ := cmd.Flags().GetString("cluster")
+		addonSlug, _ := cmd.Flags().GetString("addon")
+		options := client.SecurityOverviewOptions{AddonSlug: addonSlug}
+		if clusterFlag != "" {
+			clusterID, err := resolveClusterID(clusterFlag)
+			if err != nil {
+				return err
+			}
+			options.ClusterID = clusterID
+		}
+		overview, err := apiClient.GetSecurityOverview(options)
+		if err != nil {
+			return fmt.Errorf("reading security overview: %w", err)
+		}
+		if rendered, err := renderStructured(cmd, overview); rendered || err != nil {
+			return err
+		}
+		renderSecurityOverview(cmd, overview)
+		return nil
+	},
+}
+
+var securityFindingsCmd = &cobra.Command{
+	Use:   "findings",
+	Short: "List findings, exploited-in-the-wild first",
+	Long: `List the organisation's logical findings (one row per CVE and package,
+deduplicated across clusters and workloads).
+
+By default the list is the actionable set (open and acknowledged findings)
+sorted by exploitability. Narrow it with --known-exploited to the CVEs CISA
+lists as exploited in the wild, or with --severity, --status, --fixable,
+--cluster, --addon and --namespace.
+
+Examples:
+  ankra security findings --known-exploited
+  ankra security findings --severity critical --fixable true --sort epss
+  ankra security findings --cluster production --status any -o json`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		options, err := securityFindingsOptionsFromFlags(cmd)
+		if err != nil {
+			return err
+		}
+		list, err := apiClient.ListSecurityFindings(options)
+		if err != nil {
+			return fmt.Errorf("listing security findings: %w", err)
+		}
+		if rendered, err := renderStructured(cmd, list); rendered || err != nil {
+			return err
+		}
+		renderSecurityFindings(cmd, list, options)
+		return nil
+	},
+}
+
+var securityFindingCmd = &cobra.Command{
+	Use:   "finding <finding-id>",
+	Short: "Show one finding with CISA's guidance and every current occurrence",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		detail, err := apiClient.GetSecurityFinding(args[0])
+		if err != nil {
+			return fmt.Errorf("reading security finding: %w", err)
+		}
+		if rendered, err := renderStructured(cmd, detail); rendered || err != nil {
+			return err
+		}
+		renderSecurityFindingDetail(cmd, detail)
+		return nil
+	},
+}
+
+var securityClustersCmd = &cobra.Command{
+	Use:   "clusters",
+	Short: "Per-cluster security posture and scanner freshness",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		page, _ := cmd.Flags().GetInt("page")
+		pageSize, _ := cmd.Flags().GetInt("page-size")
+		search, _ := cmd.Flags().GetString("search")
+		status, _ := cmd.Flags().GetString("status")
+		sort, _ := cmd.Flags().GetString("sort")
+		order, _ := cmd.Flags().GetString("order")
+		list, err := apiClient.ListSecurityClusters(client.SecurityClustersOptions{
+			Page:     page,
+			PageSize: pageSize,
+			Search:   search,
+			Status:   status,
+			Sort:     sort,
+			Order:    order,
+		})
+		if err != nil {
+			return fmt.Errorf("listing cluster security posture: %w", err)
+		}
+		if rendered, err := renderStructured(cmd, list); rendered || err != nil {
+			return err
+		}
+		renderSecurityClusters(cmd, list)
+		return nil
+	},
+}
+
+// securityFindingsOptionsFromFlags turns the findings flags into API options.
+// --status defaults to the actionable set; "any" lifts the status filter,
+// and --fixable accepts true, false or any.
+func securityFindingsOptionsFromFlags(cmd *cobra.Command) (client.SecurityFindingsOptions, error) {
+	page, _ := cmd.Flags().GetInt("page")
+	pageSize, _ := cmd.Flags().GetInt("page-size")
+	search, _ := cmd.Flags().GetString("search")
+	severities, _ := cmd.Flags().GetStringSlice("severity")
+	statuses, _ := cmd.Flags().GetStringSlice("status")
+	fixableRaw, _ := cmd.Flags().GetString("fixable")
+	knownExploited, _ := cmd.Flags().GetBool("known-exploited")
+	clusterFlag, _ := cmd.Flags().GetString("cluster")
+	addonSlug, _ := cmd.Flags().GetString("addon")
+	namespace, _ := cmd.Flags().GetString("namespace")
+	sort, _ := cmd.Flags().GetString("sort")
+	order, _ := cmd.Flags().GetString("order")
+
+	options := client.SecurityFindingsOptions{
+		Page:       page,
+		PageSize:   pageSize,
+		Search:     search,
+		Severities: severities,
+		AddonSlug:  addonSlug,
+		Namespace:  namespace,
+		Sort:       sort,
+		Order:      order,
+	}
+	for _, status := range statuses {
+		if strings.EqualFold(strings.TrimSpace(status), "any") {
+			options.Statuses = nil
+			break
+		}
+		options.Statuses = append(options.Statuses, status)
+	}
+	switch strings.ToLower(strings.TrimSpace(fixableRaw)) {
+	case "", "any":
+	case "true", "yes":
+		fixable := true
+		options.Fixable = &fixable
+	case "false", "no":
+		fixable := false
+		options.Fixable = &fixable
+	default:
+		return options, withExitCode(exitUsage, fmt.Errorf("--fixable must be true, false or any, got %q", fixableRaw))
+	}
+	if knownExploited {
+		listed := true
+		options.KnownExploited = &listed
+	}
+	if clusterFlag != "" {
+		clusterID, err := resolveClusterID(clusterFlag)
+		if err != nil {
+			return options, err
+		}
+		options.ClusterID = clusterID
+	}
+	return options, nil
+}
+
+// exploitationCell renders a finding's exploitation intelligence for a table:
+// the KEV marker with CISA's deadline in explicit tense, a ransomware marker,
+// and the EPSS probability. A finding with neither renders "-", which means
+// "no exploit data", not "not exploited".
+func exploitationCell(intelligence client.SecurityExploitIntelligence) string {
+	parts := []string{}
+	if intelligence.KnownExploited {
+		parts = append(parts, text.FgRed.Sprint("KEV"))
+		if deadline := kevDeadlineText(intelligence.KevDueDate); deadline != "" {
+			parts = append(parts, deadline)
+		}
+		if intelligence.KevRansomwareUse {
+			parts = append(parts, text.FgRed.Sprint("ransomware"))
+		}
+	}
+	if epss := epssText(intelligence.EPSSScore, intelligence.EPSSPercentile); epss != "" {
+		parts = append(parts, epss)
+	}
+	if len(parts) == 0 {
+		return "-"
+	}
+	return strings.Join(parts, " · ")
+}
+
+// kevDeadlineText renders CISA's remediation deadline with explicit tense so
+// a passed deadline never reads as a future one.
+func kevDeadlineText(dueDate *string) string {
+	if dueDate == nil || *dueDate == "" {
+		return ""
+	}
+	due, parseError := time.Parse("2006-01-02", *dueDate)
+	if parseError != nil {
+		return "due " + *dueDate
+	}
+	if time.Now().UTC().After(due.Add(24 * time.Hour)) {
+		return text.FgRed.Sprintf("deadline passed %s", *dueDate)
+	}
+	return "due " + *dueDate
+}
+
+// epssText renders the EPSS probability as a percentage with its rank in
+// the upper half ("EPSS 94% · top 1%"); nothing when the platform holds no
+// score.
+func epssText(score *float64, percentile *float64) string {
+	if score == nil {
+		return ""
+	}
+	probability := fmt.Sprintf("%.0f%%", *score*100)
+	if *score < 0.1 && *score > 0 {
+		probability = fmt.Sprintf("%.1f%%", *score*100)
+	}
+	if percentile != nil && *percentile >= 0.5 {
+		top := int((1-*percentile)*100 + 0.5)
+		if top < 1 {
+			top = 1
+		}
+		return fmt.Sprintf("EPSS %s (top %d%%)", probability, top)
+	}
+	return "EPSS " + probability
+}
+
+func severityCell(severity string) string {
+	switch strings.ToUpper(severity) {
+	case "CRITICAL":
+		return text.FgHiRed.Sprint("CRITICAL")
+	case "HIGH":
+		return text.FgRed.Sprint("HIGH")
+	case "MEDIUM":
+		return text.FgYellow.Sprint("MEDIUM")
+	case "LOW":
+		return text.FgBlue.Sprint("LOW")
+	default:
+		return strings.ToUpper(severity)
+	}
+}
+
+func optionalTimeAgo(value *string) string {
+	if value == nil || *value == "" {
+		return "-"
+	}
+	return formatTimeAgo(*value)
+}
+
+func newSecurityTable(out io.Writer) table.Writer {
+	writer := table.NewWriter()
+	writer.SetOutputMirror(out)
+	writer.SetStyle(table.StyleRounded)
+	return writer
+}
+
+func renderSecurityOverview(cmd *cobra.Command, overview *client.SecurityOverview) {
+	out := cmd.OutOrStdout()
+	verdict := "Fleet is clear"
+	if overview.Totals.Actionable > 0 {
+		verdict = "Action required"
+	}
+	_, _ = fmt.Fprintf(out, "Fleet security: %s\n", verdict)
+	_, _ = fmt.Fprintf(out, "  %d actionable · %d with a fix available · %d acknowledged · %d accepted risk · %d resolved\n",
+		overview.Totals.Actionable, overview.FixableSevere, overview.Totals.Acknowledged,
+		overview.Totals.AcceptedRisk, overview.Totals.Resolved)
+	_, _ = fmt.Fprintf(out, "  observed by severity: %d critical · %d high · %d medium · %d low · %d unknown\n",
+		overview.Severity.Critical, overview.Severity.High, overview.Severity.Medium,
+		overview.Severity.Low, overview.Severity.Unknown)
+	_, _ = fmt.Fprintln(out)
+	renderKnownExploitedSummary(cmd, overview)
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintf(out, "Scanner coverage: %s - %d fresh · %d stale · %d unscanned of %d clusters",
+		overview.Scanner.Status, overview.Coverage.FreshClusters, overview.Coverage.StaleClusters,
+		overview.Coverage.UnscannedClusters, overview.Coverage.TotalClusters)
+	if overview.Coverage.LatestReportAt != nil {
+		_, _ = fmt.Fprintf(out, " (latest report %s)", formatTimeAgo(*overview.Coverage.LatestReportAt))
+	}
+	_, _ = fmt.Fprintln(out)
+	if len(overview.TopRemediation) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintln(out, "Top remediation candidates (known exploited first, then severity, fix availability and reach):")
+	writer := newSecurityTable(out)
+	writer.AppendHeader(table.Row{"#", "CVE", "Severity", "Exploitation", "Package", "Actionable", "Fixable", "Clusters", "Finding ID"})
+	for index, candidate := range overview.TopRemediation {
+		writer.AppendRow(table.Row{
+			index + 1,
+			candidate.CVEID,
+			severityCell(candidate.Severity),
+			exploitationCell(candidate.SecurityExploitIntelligence),
+			candidate.PackageName,
+			candidate.ActionableCount,
+			candidate.FixableOccurrences,
+			candidate.AffectedClusters,
+			candidate.FindingID,
+		})
+	}
+	writer.Render()
+}
+
+// renderKnownExploitedSummary is the CLI's copy of the portal's
+// exploited-in-the-wild banner. It never renders "nothing exploited" from a
+// catalog that has not been synced.
+func renderKnownExploitedSummary(cmd *cobra.Command, overview *client.SecurityOverview) {
+	out := cmd.OutOrStdout()
+	if overview.Intelligence.KevSyncedAt == nil {
+		_, _ = fmt.Fprintln(out, "Known exploited (CISA KEV): unknown - the CISA catalog has not been synced yet")
+		return
+	}
+	if overview.KnownExploitedFindings == 0 {
+		_, _ = fmt.Fprintf(out, "Known exploited (CISA KEV): none of the actionable findings are on CISA's catalog (%d CVEs listed, synced %s)\n",
+			overview.Intelligence.KevListed, formatTimeAgo(*overview.Intelligence.KevSyncedAt))
+		return
+	}
+	_, _ = fmt.Fprintln(out, text.FgRed.Sprintf("%d vulnerabilities in this fleet are being exploited in the wild (CISA KEV)",
+		overview.KnownExploitedFindings))
+	_, _ = fmt.Fprintf(out, "  %d actionable findings · %d occurrences · %d past CISA's remediation deadline · %d used in ransomware campaigns\n",
+		overview.KnownExploitedFindings, overview.KnownExploited, overview.KnownExploitedOverdue, overview.KnownExploitedRansomware)
+	_, _ = fmt.Fprintf(out, "  catalog: %d CVEs listed, synced %s. Fix these before anything ranked by CVSS alone:\n",
+		overview.Intelligence.KevListed, formatTimeAgo(*overview.Intelligence.KevSyncedAt))
+	_, _ = fmt.Fprintln(out, "  ankra security findings --known-exploited")
+}
+
+func renderSecurityFindings(cmd *cobra.Command, list *client.SecurityFindingList, options client.SecurityFindingsOptions) {
+	out := cmd.OutOrStdout()
+	if len(list.Result) == 0 {
+		_, _ = fmt.Fprintln(out, "No findings match these filters.")
+		return
+	}
+	writer := newSecurityTable(out)
+	writer.AppendHeader(table.Row{"CVE", "Severity", "Exploitation", "Package", "Clusters", "Workloads", "Open", "Fixable", "Last seen", "Finding ID"})
+	for _, finding := range list.Result {
+		writer.AppendRow(table.Row{
+			finding.CVEID,
+			severityCell(finding.Severity),
+			exploitationCell(finding.SecurityExploitIntelligence),
+			finding.PackageName + " (" + finding.PackageType + ")",
+			finding.AffectedClusters,
+			finding.AffectedWorkloads,
+			finding.DispositionCounts.Open,
+			finding.FixableOccurrences,
+			formatTimeAgo(finding.LastSeenAt),
+			finding.ID,
+		})
+	}
+	writer.Render()
+	_, _ = fmt.Fprintf(out, "Page %d of %d · %d findings", list.Pagination.Page, list.Pagination.TotalPages, list.Pagination.TotalCount)
+	if options.Sort != "" {
+		_, _ = fmt.Fprintf(out, " · sorted by %s %s", options.Sort, options.Order)
+	}
+	_, _ = fmt.Fprintln(out)
+	if list.Intelligence.KevSyncedAt == nil {
+		_, _ = fmt.Fprintln(out, "The CISA KEV catalog has not been synced yet, so known-exploited status is unknown for these findings.")
+		return
+	}
+	if options.KnownExploited != nil && *options.KnownExploited {
+		return
+	}
+	for _, facet := range list.Facets.Exploited {
+		if facet.Value == "known_exploited" && facet.Count > 0 {
+			_, _ = fmt.Fprintf(out, "%d findings are on CISA's Known Exploited Vulnerabilities catalog: ankra security findings --known-exploited\n", facet.Count)
+		}
+	}
+}
+
+func renderSecurityFindingDetail(cmd *cobra.Command, detail *client.SecurityFindingDetail) {
+	out := cmd.OutOrStdout()
+	finding := detail.Finding
+	_, _ = fmt.Fprintf(out, "%s  %s  %s (%s)\n", finding.CVEID, severityCell(finding.Severity), finding.PackageName, finding.PackageType)
+	if finding.Title != nil && *finding.Title != "" {
+		_, _ = fmt.Fprintln(out, *finding.Title)
+	}
+	_, _ = fmt.Fprintln(out)
+	if finding.KnownExploited {
+		_, _ = fmt.Fprintln(out, text.FgRed.Sprint("Known exploited in the wild (CISA KEV)"))
+		if finding.KevVulnerabilityName != nil {
+			vendor := strings.TrimSpace(strings.Join([]string{stringOrEmpty(finding.KevVendorProject), stringOrEmpty(finding.KevProduct)}, " "))
+			if vendor != "" {
+				_, _ = fmt.Fprintf(out, "  %s (%s)\n", *finding.KevVulnerabilityName, vendor)
+			} else {
+				_, _ = fmt.Fprintf(out, "  %s\n", *finding.KevVulnerabilityName)
+			}
+		}
+		if finding.KevDateAdded != nil {
+			_, _ = fmt.Fprintf(out, "  listed since %s\n", *finding.KevDateAdded)
+		}
+		if deadline := kevDeadlineText(finding.KevDueDate); deadline != "" {
+			_, _ = fmt.Fprintf(out, "  CISA %s\n", deadline)
+		}
+		if finding.KevRansomwareUse {
+			_, _ = fmt.Fprintln(out, "  "+text.FgRed.Sprint("used in ransomware campaigns"))
+		}
+		if finding.KevRequiredAction != nil {
+			_, _ = fmt.Fprintf(out, "  CISA required action: %s\n", *finding.KevRequiredAction)
+		}
+	} else {
+		_, _ = fmt.Fprintln(out, "Not on CISA's Known Exploited Vulnerabilities catalog")
+	}
+	if epss := epssText(finding.EPSSScore, finding.EPSSPercentile); epss != "" {
+		_, _ = fmt.Fprintf(out, "  %s exploitation probability in the next 30 days\n", epss)
+	}
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintf(out, "%d clusters · %d workloads · %d occurrences (%d open, %d acknowledged, %d accepted risk, %d resolved) · %d with a fix\n",
+		finding.AffectedClusters, finding.AffectedWorkloads, finding.Occurrences,
+		finding.DispositionCounts.Open, finding.DispositionCounts.Acknowledged,
+		finding.DispositionCounts.AcceptedRisk, finding.DispositionCounts.Resolved,
+		finding.FixableOccurrences)
+	if finding.PrimaryLink != nil && *finding.PrimaryLink != "" {
+		_, _ = fmt.Fprintf(out, "Advisory: %s\n", *finding.PrimaryLink)
+	}
+	if len(detail.Occurrences) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintln(out)
+	writer := newSecurityTable(out)
+	writer.AppendHeader(table.Row{"Cluster", "Workload", "Container", "Image", "Installed", "Fixed", "State", "Disposition"})
+	for _, occurrence := range detail.Occurrences {
+		workload := strings.TrimSpace(strings.Join([]string{
+			stringOrEmpty(occurrence.WorkloadNamespace) + "/" + stringOrEmpty(occurrence.WorkloadKind),
+			stringOrEmpty(occurrence.WorkloadName),
+		}, " "))
+		if occurrence.WorkloadName == nil {
+			workload = occurrence.ReportName + " (" + occurrence.ReportScope + ")"
+		}
+		writer.AppendRow(table.Row{
+			occurrence.ClusterName,
+			workload,
+			stringOrEmpty(occurrence.ContainerName),
+			stringOrEmpty(occurrence.ImageRef),
+			stringOrEmpty(occurrence.InstalledVersion),
+			stringOrEmpty(occurrence.FixedVersion),
+			occurrence.ScanState,
+			occurrence.EffectiveDisposition,
+		})
+	}
+	writer.Render()
+}
+
+func renderSecurityClusters(cmd *cobra.Command, list *client.SecurityClusterList) {
+	out := cmd.OutOrStdout()
+	if len(list.Result) == 0 {
+		_, _ = fmt.Fprintln(out, "No clusters match these filters.")
+		return
+	}
+	writer := newSecurityTable(out)
+	writer.AppendHeader(table.Row{"Cluster", "Environment", "Scanner", "Posture", "Actionable", "Known exploited", "Critical", "High", "Fixable severe", "Latest report"})
+	for _, cluster := range list.Result {
+		knownExploited := fmt.Sprintf("%d", cluster.KnownExploited)
+		if cluster.KnownExploited > 0 {
+			knownExploited = text.FgRed.Sprint(knownExploited)
+		}
+		writer.AppendRow(table.Row{
+			cluster.ClusterName,
+			stringOrEmpty(cluster.Environment),
+			cluster.ScannerStatus,
+			cluster.PostureStatus,
+			cluster.Actionable,
+			knownExploited,
+			cluster.Severity.Critical,
+			cluster.Severity.High,
+			cluster.FixableSevere,
+			optionalTimeAgo(cluster.LatestReportAt),
+		})
+	}
+	writer.Render()
+	_, _ = fmt.Fprintf(out, "Page %d of %d · %d clusters\n", list.Pagination.Page, list.Pagination.TotalPages, list.Pagination.TotalCount)
+}
+
+func stringOrEmpty(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func init() {
+	rootCmd.AddCommand(securityCmd)
+	securityCmd.AddCommand(securityOverviewCmd, securityFindingsCmd, securityFindingCmd, securityClustersCmd)
+
+	securityOverviewCmd.Flags().String("cluster", "", "Scope the overview to one cluster (name or id)")
+	securityOverviewCmd.Flags().String("addon", "", "Scope the overview to one add-on (slug)")
+
+	securityFindingsCmd.Flags().String("search", "", "Match CVE id, package name or title")
+	securityFindingsCmd.Flags().StringSlice("severity", nil, "Severity filter, repeatable: critical, high, medium, low, unknown")
+	securityFindingsCmd.Flags().StringSlice("status", []string{"open", "acknowledged"}, "Status filter, repeatable: open, acknowledged, accepted_risk, resolved, or any")
+	securityFindingsCmd.Flags().String("fixable", "any", "Fix availability: true, false or any")
+	securityFindingsCmd.Flags().Bool("known-exploited", false, "Only CVEs CISA lists as exploited in the wild (KEV)")
+	securityFindingsCmd.Flags().String("cluster", "", "Only findings observed on one cluster (name or id)")
+	securityFindingsCmd.Flags().String("addon", "", "Only findings attributed to one add-on (slug)")
+	securityFindingsCmd.Flags().String("namespace", "", "Only findings observed in one namespace")
+	securityFindingsCmd.Flags().String("sort", "exploitability", "Sort key: exploitability, epss, known_exploited, severity, first_seen_at, last_seen_at, affected_clusters, occurrences, package_name, cve_id")
+	securityFindingsCmd.Flags().String("order", "desc", "Sort order: asc or desc")
+	securityFindingsCmd.Flags().Int("page", 1, "Page number")
+	securityFindingsCmd.Flags().Int("page-size", 25, "Findings per page (max 100)")
+
+	securityClustersCmd.Flags().String("search", "", "Match cluster name")
+	securityClustersCmd.Flags().String("status", "", "Scanner or posture status filter: fresh, stale, unscanned, clean, critical, high, degraded")
+	securityClustersCmd.Flags().String("sort", "actionable", "Sort key: actionable, known_exploited, severity, observed, accepted_risk, latest_report_at, status, name")
+	securityClustersCmd.Flags().String("order", "desc", "Sort order: asc or desc")
+	securityClustersCmd.Flags().Int("page", 1, "Page number")
+	securityClustersCmd.Flags().Int("page-size", 50, "Clusters per page (max 100)")
+
+	registerStructuredOutputFlags(securityOverviewCmd, securityFindingsCmd, securityFindingCmd, securityClustersCmd)
+}

--- a/cmd/security_test.go
+++ b/cmd/security_test.go
@@ -1,0 +1,235 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+type securityMock struct {
+	baseMock
+	overview        *client.SecurityOverview
+	findings        *client.SecurityFindingList
+	findingsOptions *client.SecurityFindingsOptions
+	detail          *client.SecurityFindingDetail
+	clusters        *client.SecurityClusterList
+}
+
+func (m *securityMock) GetSecurityOverview(client.SecurityOverviewOptions) (*client.SecurityOverview, error) {
+	return m.overview, nil
+}
+
+func (m *securityMock) ListSecurityFindings(options client.SecurityFindingsOptions) (*client.SecurityFindingList, error) {
+	m.findingsOptions = &options
+	return m.findings, nil
+}
+
+func (m *securityMock) GetSecurityFinding(string) (*client.SecurityFindingDetail, error) {
+	return m.detail, nil
+}
+
+func (m *securityMock) ListSecurityClusters(client.SecurityClustersOptions) (*client.SecurityClusterList, error) {
+	return m.clusters, nil
+}
+
+func securityCommandTree() []*cobra.Command {
+	return []*cobra.Command{securityOverviewCmd, securityFindingsCmd, securityFindingCmd, securityClustersCmd}
+}
+
+func runSecurityCommand(t *testing.T, mock APIClient, args ...string) (string, error) {
+	t.Helper()
+	withTempHome(t)
+	setMockClient(t, mock)
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs(args)
+	t.Cleanup(func() { resetTreeFlags(t, securityCommandTree()...) })
+	executeError := rootCmd.Execute()
+	return stdout.String(), executeError
+}
+
+func securityFloatPointer(value float64) *float64 { return &value }
+
+func exploitedFinding() client.SecurityFinding {
+	return client.SecurityFinding{
+		ID:                 "632d93d6-f07b-4618-ad37-ae453409e928",
+		Provider:           "trivy_operator",
+		CVEID:              "CVE-2025-24813",
+		PackageType:        "maven",
+		PackageName:        "org.apache.tomcat.embed:tomcat-embed-core",
+		Severity:           "CRITICAL",
+		FirstSeenAt:        "2026-08-01T00:00:00Z",
+		LastSeenAt:         "2026-08-28T20:00:00Z",
+		Occurrences:        4,
+		AffectedClusters:   1,
+		AffectedWorkloads:  4,
+		FixableOccurrences: 4,
+		DispositionCounts:  client.SecurityDispositionCounts{Open: 4},
+		SecurityExploitIntelligence: client.SecurityExploitIntelligence{
+			KnownExploited:       true,
+			KevDateAdded:         stringPointer("2025-04-01"),
+			KevDueDate:           stringPointer("2025-04-22"),
+			KevRansomwareUse:     true,
+			EPSSScore:            securityFloatPointer(0.997),
+			EPSSPercentile:       securityFloatPointer(0.999),
+			KevVendorProject:     stringPointer("Apache"),
+			KevProduct:           stringPointer("Tomcat"),
+			KevVulnerabilityName: stringPointer("Apache Tomcat Path Equivalence Vulnerability"),
+			KevRequiredAction:    stringPointer("Apply mitigations per vendor instructions."),
+		},
+	}
+}
+
+func TestSecurityFindingsDefaultsToActionableExploitabilityAndMapsFlags(t *testing.T) {
+	mock := &securityMock{findings: &client.SecurityFindingList{
+		Result:       []client.SecurityFinding{exploitedFinding()},
+		Pagination:   client.SecurityPagination{Page: 1, PageSize: 25, TotalPages: 1, TotalCount: 1},
+		Facets:       client.SecurityFindingFacets{Exploited: []client.SecurityFacetCount{{Value: "known_exploited", Count: 22}}},
+		Intelligence: client.SecurityIntelligenceStatus{KevSyncedAt: stringPointer("2026-08-28T20:13:11Z"), KevListed: 1685},
+	}}
+
+	output, executeError := runSecurityCommand(t, mock, "security", "findings")
+	if executeError != nil {
+		t.Fatalf("security findings failed: %v", executeError)
+	}
+	options := mock.findingsOptions
+	if options == nil || options.Sort != "exploitability" || options.Order != "desc" ||
+		strings.Join(options.Statuses, ",") != "open,acknowledged" || options.KnownExploited != nil || options.Fixable != nil {
+		t.Fatalf("default options = %+v", options)
+	}
+	for _, expected := range []string{"CVE-2025-24813", "KEV", "deadline passed 2025-04-22", "ransomware", "EPSS 100% (top 1%)",
+		"22 findings are on CISA's Known Exploited Vulnerabilities catalog"} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("output lacks %q:\n%s", expected, output)
+		}
+	}
+
+	_, executeError = runSecurityCommand(t, mock, "security", "findings",
+		"--known-exploited", "--severity", "critical,high", "--status", "any", "--fixable", "false",
+		"--sort", "epss", "--order", "asc", "--page", "3", "--page-size", "50", "--search", "tomcat", "--namespace", "shop")
+	if executeError != nil {
+		t.Fatalf("security findings with flags failed: %v", executeError)
+	}
+	options = mock.findingsOptions
+	if options.KnownExploited == nil || !*options.KnownExploited || options.Fixable == nil || *options.Fixable ||
+		options.Statuses != nil || strings.Join(options.Severities, ",") != "critical,high" ||
+		options.Sort != "epss" || options.Order != "asc" || options.Page != 3 || options.PageSize != 50 ||
+		options.Search != "tomcat" || options.Namespace != "shop" {
+		t.Fatalf("mapped options = %+v", options)
+	}
+}
+
+func TestSecurityFindingsRejectsAnUnknownFixableValue(t *testing.T) {
+	mock := &securityMock{findings: &client.SecurityFindingList{}}
+	_, executeError := runSecurityCommand(t, mock, "security", "findings", "--fixable", "maybe")
+	if executeError == nil || !strings.Contains(executeError.Error(), "--fixable must be true, false or any") {
+		t.Fatalf("expected a usage error, got %v", executeError)
+	}
+	if exitCodeFor(executeError) != exitUsage {
+		t.Fatalf("expected exit code %d, got %d", exitUsage, exitCodeFor(executeError))
+	}
+}
+
+func TestSecurityFindingsStructuredOutputIsTheApiDocument(t *testing.T) {
+	mock := &securityMock{findings: &client.SecurityFindingList{
+		Result:     []client.SecurityFinding{exploitedFinding()},
+		Pagination: client.SecurityPagination{Page: 1, PageSize: 25, TotalPages: 1, TotalCount: 1},
+	}}
+	output, executeError := runSecurityCommand(t, mock, "security", "findings", "-o", "json")
+	if executeError != nil {
+		t.Fatalf("security findings -o json failed: %v", executeError)
+	}
+	var decoded map[string]any
+	if unmarshalError := json.Unmarshal([]byte(output), &decoded); unmarshalError != nil {
+		t.Fatalf("output is not JSON: %v\n%s", unmarshalError, output)
+	}
+	first := decoded["result"].([]any)[0].(map[string]any)
+	if first["known_exploited"] != true || first["kev_due_date"] != "2025-04-22" ||
+		first["kev_required_action"] != "Apply mitigations per vendor instructions." || first["epss_score"] != 0.997 {
+		t.Fatalf("structured row lacks the exploit intelligence: %+v", first)
+	}
+}
+
+func TestSecurityOverviewNeverReadsAnUnsyncedCatalogAsClean(t *testing.T) {
+	synced := &client.SecurityOverview{
+		Totals:                   client.SecurityTotals{Observed: 10, Actionable: 8},
+		KnownExploited:           91,
+		KnownExploitedFindings:   22,
+		KnownExploitedOverdue:    21,
+		KnownExploitedRansomware: 0,
+		Intelligence:             client.SecurityIntelligenceStatus{KevSyncedAt: stringPointer("2026-08-28T20:13:11Z"), KevListed: 1685},
+		Coverage:                 client.SecurityCoverage{TotalClusters: 27, FreshClusters: 11, StaleClusters: 1, UnscannedClusters: 15},
+		Scanner:                  client.SecurityScanner{Status: "degraded"},
+	}
+	output, executeError := runSecurityCommand(t, &securityMock{overview: synced}, "security", "overview")
+	if executeError != nil {
+		t.Fatalf("security overview failed: %v", executeError)
+	}
+	for _, expected := range []string{"22 vulnerabilities in this fleet are being exploited in the wild",
+		"21 past CISA's remediation deadline", "11 fresh · 1 stale · 15 unscanned of 27 clusters",
+		"ankra security findings --known-exploited"} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("output lacks %q:\n%s", expected, output)
+		}
+	}
+
+	unsynced := &client.SecurityOverview{Totals: client.SecurityTotals{Actionable: 8}}
+	output, executeError = runSecurityCommand(t, &securityMock{overview: unsynced}, "security", "overview")
+	if executeError != nil {
+		t.Fatalf("security overview (unsynced) failed: %v", executeError)
+	}
+	if !strings.Contains(output, "the CISA catalog has not been synced yet") || strings.Contains(output, "none of the actionable findings") {
+		t.Fatalf("an unsynced catalog must read as unknown, not clean:\n%s", output)
+	}
+}
+
+func TestSecurityFindingQuotesCisaGuidance(t *testing.T) {
+	detail := &client.SecurityFindingDetail{
+		Finding: exploitedFinding(),
+		Occurrences: []client.SecurityOccurrence{{
+			ID: "o1", ClusterID: "c1", ClusterName: "prod", ReportScope: "namespaced", ReportName: "replicaset-carts",
+			WorkloadKind: stringPointer("Deployment"), WorkloadNamespace: stringPointer("shop"), WorkloadName: stringPointer("carts"),
+			ContainerName: stringPointer("carts"), ImageRef: stringPointer("weaveworksdemos/carts:0.4.8"),
+			InstalledVersion: stringPointer("8.5.11"), FixedVersion: stringPointer("9.0.99"),
+			ScanState: "active", EffectiveDisposition: "none",
+		}},
+	}
+	output, executeError := runSecurityCommand(t, &securityMock{detail: detail}, "security", "finding", "632d93d6-f07b-4618-ad37-ae453409e928")
+	if executeError != nil {
+		t.Fatalf("security finding failed: %v", executeError)
+	}
+	for _, expected := range []string{"Known exploited in the wild (CISA KEV)",
+		"Apache Tomcat Path Equivalence Vulnerability (Apache Tomcat)", "listed since 2025-04-01",
+		"deadline passed 2025-04-22", "used in ransomware campaigns",
+		"CISA required action: Apply mitigations per vendor instructions.", "weaveworksdemos/carts:0.4.8", "9.0.99"} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("output lacks %q:\n%s", expected, output)
+		}
+	}
+}
+
+func TestSecurityClustersFlagsTheKnownExploitedCount(t *testing.T) {
+	clusters := &client.SecurityClusterList{
+		Result: []client.SecurityClusterPosture{{
+			ClusterID: "c1", ClusterName: "prod", Environment: stringPointer("production"),
+			ScannerStatus: "fresh", PostureStatus: "critical", Actionable: 8, KnownExploited: 4, FixableSevere: 3,
+			Severity: client.SecuritySeverityCounts{Critical: 1, High: 2},
+		}},
+		Pagination: client.SecurityPagination{Page: 1, PageSize: 50, TotalPages: 1, TotalCount: 1},
+	}
+	output, executeError := runSecurityCommand(t, &securityMock{clusters: clusters}, "security", "clusters")
+	if executeError != nil {
+		t.Fatalf("security clusters failed: %v", executeError)
+	}
+	for _, expected := range []string{"prod", "critical", "KNOWN EXPLOITED", "Page 1 of 1 · 1 clusters"} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("output lacks %q:\n%s", expected, output)
+		}
+	}
+}

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -37,6 +37,11 @@ type APIClient interface {
 	GetClusterAddonValues(ctx context.Context, clusterID, addonName string) (string, error)
 	UninstallAddon(ctx context.Context, clusterID, addonResourceID string, deletePermanently bool) (*client.UninstallAddonResult, error)
 
+	GetSecurityOverview(options client.SecurityOverviewOptions) (*client.SecurityOverview, error)
+	ListSecurityFindings(options client.SecurityFindingsOptions) (*client.SecurityFindingList, error)
+	GetSecurityFinding(findingID string) (*client.SecurityFindingDetail, error)
+	ListSecurityClusters(options client.SecurityClustersOptions) (*client.SecurityClusterList, error)
+
 	ListPowerSchedules(clusterID string) (*client.PowerScheduleListResult, error)
 	CreatePowerSchedule(clusterID string, request client.PowerScheduleRequest) (*client.PowerScheduleListResult, error)
 	UpdatePowerSchedule(clusterID, scheduleID string, request client.PowerScheduleRequest) (*client.PowerScheduleListResult, error)

--- a/internal/client/security.go
+++ b/internal/client/security.go
@@ -1,0 +1,381 @@
+package client
+
+import (
+	"fmt"
+	neturl "net/url"
+	"strconv"
+	"strings"
+)
+
+const securityBasePath = "/api/v1/org/security"
+
+// SecurityExploitIntelligence is the CISA KEV listing and FIRST EPSS
+// prediction the platform holds for a finding's CVE. KnownExploited is false
+// both for an unlisted CVE and before the catalog was ever synced; the
+// enclosing response's Intelligence block tells those apart.
+type SecurityExploitIntelligence struct {
+	KnownExploited       bool     `json:"known_exploited" yaml:"known_exploited"`
+	KevDateAdded         *string  `json:"kev_date_added" yaml:"kev_date_added"`
+	KevDueDate           *string  `json:"kev_due_date" yaml:"kev_due_date"`
+	KevRansomwareUse     bool     `json:"kev_ransomware_use" yaml:"kev_ransomware_use"`
+	EPSSScore            *float64 `json:"epss_score" yaml:"epss_score"`
+	EPSSPercentile       *float64 `json:"epss_percentile" yaml:"epss_percentile"`
+	KevVendorProject     *string  `json:"kev_vendor_project" yaml:"kev_vendor_project"`
+	KevProduct           *string  `json:"kev_product" yaml:"kev_product"`
+	KevVulnerabilityName *string  `json:"kev_vulnerability_name" yaml:"kev_vulnerability_name"`
+	KevRequiredAction    *string  `json:"kev_required_action" yaml:"kev_required_action"`
+}
+
+// SecurityIntelligenceStatus reports when the platform last applied each
+// public feed; a nil KevSyncedAt means the CISA catalog has never been synced.
+type SecurityIntelligenceStatus struct {
+	KevSyncedAt  *string `json:"kev_synced_at" yaml:"kev_synced_at"`
+	EPSSSyncedAt *string `json:"epss_synced_at" yaml:"epss_synced_at"`
+	KevListed    int     `json:"kev_listed" yaml:"kev_listed"`
+}
+
+// SecurityPagination is the shared list page envelope.
+type SecurityPagination struct {
+	Page       int `json:"page" yaml:"page"`
+	PageSize   int `json:"page_size" yaml:"page_size"`
+	TotalPages int `json:"total_pages" yaml:"total_pages"`
+	TotalCount int `json:"total_count" yaml:"total_count"`
+}
+
+// SecurityTotals splits observed risk from the actionable and disposition subsets.
+type SecurityTotals struct {
+	Observed     int `json:"observed" yaml:"observed"`
+	Actionable   int `json:"actionable" yaml:"actionable"`
+	Acknowledged int `json:"acknowledged" yaml:"acknowledged"`
+	AcceptedRisk int `json:"accepted_risk" yaml:"accepted_risk"`
+	Resolved     int `json:"resolved" yaml:"resolved"`
+}
+
+// SecuritySeverityCounts groups occurrence counts by severity.
+type SecuritySeverityCounts struct {
+	Critical int `json:"critical" yaml:"critical"`
+	High     int `json:"high" yaml:"high"`
+	Medium   int `json:"medium" yaml:"medium"`
+	Low      int `json:"low" yaml:"low"`
+	Unknown  int `json:"unknown" yaml:"unknown"`
+}
+
+// SecurityCoverage reports scanner fleet coverage and freshness.
+type SecurityCoverage struct {
+	TotalClusters     int     `json:"total_clusters" yaml:"total_clusters"`
+	ScannedClusters   int     `json:"scanned_clusters" yaml:"scanned_clusters"`
+	UnscannedClusters int     `json:"unscanned_clusters" yaml:"unscanned_clusters"`
+	StaleClusters     int     `json:"stale_clusters" yaml:"stale_clusters"`
+	FreshClusters     int     `json:"fresh_clusters" yaml:"fresh_clusters"`
+	LatestReportAt    *string `json:"latest_report_at" yaml:"latest_report_at"`
+}
+
+// SecurityScanner is the scoped scanner freshness state.
+type SecurityScanner struct {
+	Status            string  `json:"status" yaml:"status"`
+	LastScan          *string `json:"last_scan" yaml:"last_scan"`
+	FreshClusters     int     `json:"fresh_clusters" yaml:"fresh_clusters"`
+	StaleClusters     int     `json:"stale_clusters" yaml:"stale_clusters"`
+	UnscannedClusters int     `json:"unscanned_clusters" yaml:"unscanned_clusters"`
+	StaleAfterSeconds int     `json:"stale_after_seconds" yaml:"stale_after_seconds"`
+}
+
+// SecurityRemediationCandidate is one high-impact current finding.
+type SecurityRemediationCandidate struct {
+	FindingID                   string  `json:"finding_id" yaml:"finding_id"`
+	CVEID                       string  `json:"cve_id" yaml:"cve_id"`
+	PackageType                 string  `json:"package_type" yaml:"package_type"`
+	PackageName                 string  `json:"package_name" yaml:"package_name"`
+	Severity                    string  `json:"severity" yaml:"severity"`
+	Title                       *string `json:"title" yaml:"title"`
+	ActionableCount             int     `json:"actionable_count" yaml:"actionable_count"`
+	AffectedClusters            int     `json:"affected_clusters" yaml:"affected_clusters"`
+	AffectedWorkloads           int     `json:"affected_workloads" yaml:"affected_workloads"`
+	FixableOccurrences          int     `json:"fixable_occurrences" yaml:"fixable_occurrences"`
+	LastSeenAt                  string  `json:"last_seen_at" yaml:"last_seen_at"`
+	SecurityExploitIntelligence `yaml:",inline"`
+}
+
+// SecurityTrendPoint is one daily observed-findings point.
+type SecurityTrendPoint struct {
+	Date     string `json:"date" yaml:"date"`
+	Observed int    `json:"observed" yaml:"observed"`
+}
+
+// SecurityOverview is the organisation Security Center summary. The
+// KnownExploited* counts follow the CISA KEV catalog: occurrences, distinct
+// findings, findings past CISA's remediation deadline, and findings CISA
+// links to ransomware campaigns.
+type SecurityOverview struct {
+	Totals                   SecurityTotals                 `json:"totals" yaml:"totals"`
+	Severity                 SecuritySeverityCounts         `json:"severity" yaml:"severity"`
+	FixableSevere            int                            `json:"fixable_severe" yaml:"fixable_severe"`
+	KnownExploited           int                            `json:"known_exploited" yaml:"known_exploited"`
+	KnownExploitedFindings   int                            `json:"known_exploited_findings" yaml:"known_exploited_findings"`
+	KnownExploitedOverdue    int                            `json:"known_exploited_overdue" yaml:"known_exploited_overdue"`
+	KnownExploitedRansomware int                            `json:"known_exploited_ransomware" yaml:"known_exploited_ransomware"`
+	Intelligence             SecurityIntelligenceStatus     `json:"intelligence" yaml:"intelligence"`
+	Coverage                 SecurityCoverage               `json:"coverage" yaml:"coverage"`
+	Scanner                  SecurityScanner                `json:"scanner" yaml:"scanner"`
+	TopRemediation           []SecurityRemediationCandidate `json:"top_remediation_candidates" yaml:"top_remediation_candidates"`
+	ObservedTrend            []SecurityTrendPoint           `json:"observed_trend" yaml:"observed_trend"`
+	GeneratedAt              string                         `json:"generated_at" yaml:"generated_at"`
+}
+
+// SecurityDispositionCounts preserves mixed occurrence state on a finding.
+type SecurityDispositionCounts struct {
+	Open         int `json:"open" yaml:"open"`
+	Acknowledged int `json:"acknowledged" yaml:"acknowledged"`
+	AcceptedRisk int `json:"accepted_risk" yaml:"accepted_risk"`
+	Resolved     int `json:"resolved" yaml:"resolved"`
+}
+
+// SecurityFinding is one logical CVE/package finding with occurrence counts.
+type SecurityFinding struct {
+	ID                          string                    `json:"id" yaml:"id"`
+	Provider                    string                    `json:"provider" yaml:"provider"`
+	CVEID                       string                    `json:"cve_id" yaml:"cve_id"`
+	PackageType                 string                    `json:"package_type" yaml:"package_type"`
+	PackageName                 string                    `json:"package_name" yaml:"package_name"`
+	Severity                    string                    `json:"severity" yaml:"severity"`
+	Title                       *string                   `json:"title" yaml:"title"`
+	PrimaryLink                 *string                   `json:"primary_link" yaml:"primary_link"`
+	Score                       *float64                  `json:"score" yaml:"score"`
+	FirstSeenAt                 string                    `json:"first_seen_at" yaml:"first_seen_at"`
+	LastSeenAt                  string                    `json:"last_seen_at" yaml:"last_seen_at"`
+	Occurrences                 int                       `json:"occurrences" yaml:"occurrences"`
+	AffectedClusters            int                       `json:"affected_clusters" yaml:"affected_clusters"`
+	AffectedWorkloads           int                       `json:"affected_workloads" yaml:"affected_workloads"`
+	FixableOccurrences          int                       `json:"fixable_occurrences" yaml:"fixable_occurrences"`
+	DispositionCounts           SecurityDispositionCounts `json:"disposition_counts" yaml:"disposition_counts"`
+	SecurityExploitIntelligence `yaml:",inline"`
+}
+
+// SecurityFacetCount is one filter-chip count.
+type SecurityFacetCount struct {
+	Value string `json:"value" yaml:"value"`
+	Count int    `json:"count" yaml:"count"`
+}
+
+// SecurityFindingFacets carries the counts every list filter would return.
+type SecurityFindingFacets struct {
+	Severity  []SecurityFacetCount `json:"severity" yaml:"severity"`
+	Status    []SecurityFacetCount `json:"status" yaml:"status"`
+	Addons    []SecurityFacetCount `json:"addons" yaml:"addons"`
+	Clusters  []SecurityFacetCount `json:"clusters" yaml:"clusters"`
+	Exploited []SecurityFacetCount `json:"exploited" yaml:"exploited"`
+}
+
+// SecurityFindingList is the paginated findings collection.
+type SecurityFindingList struct {
+	Result       []SecurityFinding          `json:"result" yaml:"result"`
+	Pagination   SecurityPagination         `json:"pagination" yaml:"pagination"`
+	Facets       SecurityFindingFacets      `json:"facets" yaml:"facets"`
+	Scanner      SecurityScanner            `json:"scanner" yaml:"scanner"`
+	Intelligence SecurityIntelligenceStatus `json:"intelligence" yaml:"intelligence"`
+}
+
+// SecurityOccurrence is one scanner observation of a finding.
+type SecurityOccurrence struct {
+	ID                         string  `json:"id" yaml:"id"`
+	ClusterID                  string  `json:"cluster_id" yaml:"cluster_id"`
+	ClusterName                string  `json:"cluster_name" yaml:"cluster_name"`
+	ReportScope                string  `json:"report_scope" yaml:"report_scope"`
+	ReportName                 string  `json:"report_name" yaml:"report_name"`
+	ReportNamespace            *string `json:"report_namespace" yaml:"report_namespace"`
+	WorkloadKind               *string `json:"workload_kind" yaml:"workload_kind"`
+	WorkloadNamespace          *string `json:"workload_namespace" yaml:"workload_namespace"`
+	WorkloadName               *string `json:"workload_name" yaml:"workload_name"`
+	ContainerName              *string `json:"container_name" yaml:"container_name"`
+	ImageRef                   *string `json:"image_ref" yaml:"image_ref"`
+	InstalledVersion           *string `json:"installed_version" yaml:"installed_version"`
+	FixedVersion               *string `json:"fixed_version" yaml:"fixed_version"`
+	AddonSlug                  *string `json:"addon_slug" yaml:"addon_slug"`
+	AddonAttributionConfidence string  `json:"addon_attribution_confidence" yaml:"addon_attribution_confidence"`
+	ScanState                  string  `json:"scan_state" yaml:"scan_state"`
+	EffectiveDisposition       string  `json:"effective_disposition" yaml:"effective_disposition"`
+	FirstSeenAt                string  `json:"first_seen_at" yaml:"first_seen_at"`
+	LastSeenAt                 string  `json:"last_seen_at" yaml:"last_seen_at"`
+}
+
+// SecurityFindingDetail is one finding with its current occurrences.
+type SecurityFindingDetail struct {
+	Finding          SecurityFinding      `json:"finding" yaml:"finding"`
+	Occurrences      []SecurityOccurrence `json:"occurrences" yaml:"occurrences"`
+	MatchingPolicies []map[string]any     `json:"matching_policies" yaml:"matching_policies"`
+}
+
+// SecurityClusterPosture is one cluster's current security and scanner state.
+type SecurityClusterPosture struct {
+	ClusterID      string                 `json:"cluster_id" yaml:"cluster_id"`
+	ClusterName    string                 `json:"cluster_name" yaml:"cluster_name"`
+	Environment    *string                `json:"environment" yaml:"environment"`
+	ScannerStatus  string                 `json:"scanner_status" yaml:"scanner_status"`
+	PostureStatus  string                 `json:"posture_status" yaml:"posture_status"`
+	LatestReportAt *string                `json:"latest_report_at" yaml:"latest_report_at"`
+	Observed       int                    `json:"observed" yaml:"observed"`
+	Actionable     int                    `json:"actionable" yaml:"actionable"`
+	Acknowledged   int                    `json:"acknowledged" yaml:"acknowledged"`
+	AcceptedRisk   int                    `json:"accepted_risk" yaml:"accepted_risk"`
+	FixableSevere  int                    `json:"fixable_severe" yaml:"fixable_severe"`
+	KnownExploited int                    `json:"known_exploited" yaml:"known_exploited"`
+	Severity       SecuritySeverityCounts `json:"severity" yaml:"severity"`
+}
+
+// SecurityClusterList is the paginated fleet posture collection.
+type SecurityClusterList struct {
+	Result     []SecurityClusterPosture `json:"result" yaml:"result"`
+	Pagination SecurityPagination       `json:"pagination" yaml:"pagination"`
+}
+
+// SecurityOverviewOptions scopes the overview to one cluster and/or add-on.
+type SecurityOverviewOptions struct {
+	ClusterID string
+	AddonSlug string
+}
+
+// SecurityFindingsOptions mirrors the findings list filters and sorts:
+// Severities and Statuses repeat the query key, the two booleans are
+// tri-state (nil = not filtered), and Sort is one of the API's sort keys
+// (exploitability, epss, known_exploited, severity, last_seen_at, ...).
+type SecurityFindingsOptions struct {
+	Page           int
+	PageSize       int
+	Search         string
+	Severities     []string
+	Statuses       []string
+	Fixable        *bool
+	KnownExploited *bool
+	ClusterID      string
+	AddonSlug      string
+	Namespace      string
+	Sort           string
+	Order          string
+}
+
+// SecurityClustersOptions mirrors the cluster posture list controls.
+type SecurityClustersOptions struct {
+	Page     int
+	PageSize int
+	Search   string
+	Status   string
+	Sort     string
+	Order    string
+}
+
+func securityURL(base string, path string, query neturl.Values) string {
+	requestURL := base + securityBasePath + path
+	if encoded := query.Encode(); encoded != "" {
+		requestURL += "?" + encoded
+	}
+	return requestURL
+}
+
+func setPaging(query neturl.Values, page int, pageSize int) {
+	if page > 0 {
+		query.Set("page", strconv.Itoa(page))
+	}
+	if pageSize > 0 {
+		query.Set("page_size", strconv.Itoa(pageSize))
+	}
+}
+
+// GetSecurityOverview reads the organisation (or one cluster's) security
+// summary: totals, the CISA KEV counts, coverage and remediation candidates.
+func (c *Client) GetSecurityOverview(options SecurityOverviewOptions) (*SecurityOverview, error) {
+	query := neturl.Values{}
+	if options.ClusterID != "" {
+		query.Set("cluster_id", options.ClusterID)
+	}
+	if options.AddonSlug != "" {
+		query.Set("addon_slug", options.AddonSlug)
+	}
+	var overview SecurityOverview
+	if err := c.getJSON(securityURL(c.BaseURL, "/overview", query), &overview); err != nil {
+		return nil, fmt.Errorf("security overview request failed: %w", err)
+	}
+	return &overview, nil
+}
+
+// ListSecurityFindings pages through the organisation's logical findings.
+func (c *Client) ListSecurityFindings(options SecurityFindingsOptions) (*SecurityFindingList, error) {
+	query := neturl.Values{}
+	setPaging(query, options.Page, options.PageSize)
+	if search := strings.TrimSpace(options.Search); search != "" {
+		query.Set("search", search)
+	}
+	for _, severity := range options.Severities {
+		query.Add("severity", strings.ToLower(strings.TrimSpace(severity)))
+	}
+	for _, status := range options.Statuses {
+		query.Add("status", strings.ToLower(strings.TrimSpace(status)))
+	}
+	if options.Fixable != nil {
+		query.Set("fixable", strconv.FormatBool(*options.Fixable))
+	}
+	if options.KnownExploited != nil {
+		query.Set("known_exploited", strconv.FormatBool(*options.KnownExploited))
+	}
+	if options.ClusterID != "" {
+		query.Set("cluster_id", options.ClusterID)
+	}
+	if options.AddonSlug != "" {
+		query.Set("addon_slug", options.AddonSlug)
+	}
+	if options.Namespace != "" {
+		query.Set("namespace", options.Namespace)
+	}
+	if options.Sort != "" {
+		query.Set("sort", options.Sort)
+	}
+	if options.Order != "" {
+		query.Set("order", options.Order)
+	}
+	var list SecurityFindingList
+	if err := c.getJSON(securityURL(c.BaseURL, "/findings", query), &list); err != nil {
+		return nil, fmt.Errorf("security findings request failed: %w", err)
+	}
+	if list.Result == nil {
+		list.Result = []SecurityFinding{}
+	}
+	return &list, nil
+}
+
+// GetSecurityFinding reads one finding with its current occurrences.
+func (c *Client) GetSecurityFinding(findingID string) (*SecurityFindingDetail, error) {
+	var detail SecurityFindingDetail
+	requestURL := securityURL(c.BaseURL, "/findings/"+neturl.PathEscape(findingID), neturl.Values{})
+	if err := c.getJSON(requestURL, &detail); err != nil {
+		return nil, fmt.Errorf("security finding request failed: %w", err)
+	}
+	if detail.Occurrences == nil {
+		detail.Occurrences = []SecurityOccurrence{}
+	}
+	return &detail, nil
+}
+
+// ListSecurityClusters pages through the fleet's per-cluster posture.
+func (c *Client) ListSecurityClusters(options SecurityClustersOptions) (*SecurityClusterList, error) {
+	query := neturl.Values{}
+	setPaging(query, options.Page, options.PageSize)
+	if search := strings.TrimSpace(options.Search); search != "" {
+		query.Set("search", search)
+	}
+	if options.Status != "" {
+		query.Set("status", options.Status)
+	}
+	if options.Sort != "" {
+		query.Set("sort", options.Sort)
+	}
+	if options.Order != "" {
+		query.Set("order", options.Order)
+	}
+	var list SecurityClusterList
+	if err := c.getJSON(securityURL(c.BaseURL, "/clusters", query), &list); err != nil {
+		return nil, fmt.Errorf("security clusters request failed: %w", err)
+	}
+	if list.Result == nil {
+		list.Result = []SecurityClusterPosture{}
+	}
+	return &list, nil
+}

--- a/internal/client/security_test.go
+++ b/internal/client/security_test.go
@@ -1,0 +1,208 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func newSecurityTestServer(t *testing.T, body string, capture *http.Request) (*httptest.Server, *Client) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		*capture = *request
+		if request.Header.Get("Authorization") != "Bearer test-token" {
+			responseWriter.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, _ = responseWriter.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+	return server, New("test-token", server.URL)
+}
+
+func TestListSecurityFindingsEncodesEveryFilterAndSort(t *testing.T) {
+	var captured http.Request
+	_, apiClient := newSecurityTestServer(t, `{
+        "result": [{
+            "id": "632d93d6-f07b-4618-ad37-ae453409e928",
+            "provider": "trivy_operator", "cve_id": "CVE-2025-24813", "package_type": "maven",
+            "package_name": "org.apache.tomcat.embed:tomcat-embed-core", "severity": "CRITICAL",
+            "title": null, "primary_link": null, "score": 9.8,
+            "first_seen_at": "2026-08-01T00:00:00Z", "last_seen_at": "2026-08-28T20:00:00Z",
+            "occurrences": 4, "affected_clusters": 1, "affected_workloads": 4, "fixable_occurrences": 4,
+            "disposition_counts": {"open": 4, "acknowledged": 0, "accepted_risk": 0, "resolved": 0},
+            "known_exploited": true, "kev_date_added": "2025-04-01", "kev_due_date": "2025-04-22",
+            "kev_ransomware_use": false, "epss_score": 0.997, "epss_percentile": 0.999,
+            "kev_vendor_project": "Apache", "kev_product": "Tomcat",
+            "kev_vulnerability_name": "Apache Tomcat Path Equivalence Vulnerability",
+            "kev_required_action": "Apply mitigations per vendor instructions."
+        }],
+        "pagination": {"page": 2, "page_size": 10, "total_pages": 3, "total_count": 22},
+        "facets": {"severity": [], "status": [], "addons": [], "clusters": [], "exploited": [{"value": "known_exploited", "count": 22}]},
+        "scanner": {"status": "degraded", "last_scan": null, "fresh_clusters": 11, "stale_clusters": 1, "unscanned_clusters": 15, "stale_after_seconds": 7200},
+        "intelligence": {"kev_synced_at": "2026-08-28T20:13:11Z", "epss_synced_at": null, "kev_listed": 1685}
+    }`, &captured)
+
+	fixable := true
+	knownExploited := true
+	list, listError := apiClient.ListSecurityFindings(SecurityFindingsOptions{
+		Page:           2,
+		PageSize:       10,
+		Search:         " tomcat ",
+		Severities:     []string{"Critical", "high"},
+		Statuses:       []string{"open", "acknowledged"},
+		Fixable:        &fixable,
+		KnownExploited: &knownExploited,
+		ClusterID:      "0cfbf8ab-8f3a-4a9f-9a9c-5c1f0b4d1d1c",
+		AddonSlug:      "nginx-ingress",
+		Namespace:      "payments",
+		Sort:           "exploitability",
+		Order:          "desc",
+	})
+	if listError != nil {
+		t.Fatalf("ListSecurityFindings returned an error: %v", listError)
+	}
+	if captured.URL.Path != "/api/v1/org/security/findings" {
+		t.Fatalf("path = %s", captured.URL.Path)
+	}
+	expectedQuery := url.Values{
+		"page":            {"2"},
+		"page_size":       {"10"},
+		"search":          {"tomcat"},
+		"severity":        {"critical", "high"},
+		"status":          {"open", "acknowledged"},
+		"fixable":         {"true"},
+		"known_exploited": {"true"},
+		"cluster_id":      {"0cfbf8ab-8f3a-4a9f-9a9c-5c1f0b4d1d1c"},
+		"addon_slug":      {"nginx-ingress"},
+		"namespace":       {"payments"},
+		"sort":            {"exploitability"},
+		"order":           {"desc"},
+	}
+	if !reflect.DeepEqual(captured.URL.Query(), expectedQuery) {
+		t.Fatalf("query = %v, want %v", captured.URL.Query(), expectedQuery)
+	}
+	if len(list.Result) != 1 || list.Pagination.TotalCount != 22 {
+		t.Fatalf("decoded list = %+v", list)
+	}
+	finding := list.Result[0]
+	if !finding.KnownExploited || finding.KevDueDate == nil || *finding.KevDueDate != "2025-04-22" ||
+		finding.KevRequiredAction == nil || *finding.KevRequiredAction != "Apply mitigations per vendor instructions." ||
+		finding.EPSSScore == nil || *finding.EPSSScore != 0.997 {
+		t.Fatalf("exploit intelligence not decoded: %+v", finding.SecurityExploitIntelligence)
+	}
+	if list.Facets.Exploited[0].Count != 22 || list.Intelligence.KevListed != 1685 {
+		t.Fatalf("facets/intelligence not decoded: %+v %+v", list.Facets, list.Intelligence)
+	}
+}
+
+func TestListSecurityFindingsOmitsUnsetFiltersAndNormalisesEmptyResult(t *testing.T) {
+	var captured http.Request
+	_, apiClient := newSecurityTestServer(t, `{"result": null, "pagination": {"page": 1, "page_size": 25, "total_pages": 0, "total_count": 0},
+        "facets": {"severity": [], "status": [], "addons": [], "clusters": [], "exploited": []},
+        "scanner": {"status": "unscanned", "last_scan": null, "fresh_clusters": 0, "stale_clusters": 0, "unscanned_clusters": 0, "stale_after_seconds": 7200},
+        "intelligence": {"kev_synced_at": null, "epss_synced_at": null, "kev_listed": 0}}`, &captured)
+
+	list, listError := apiClient.ListSecurityFindings(SecurityFindingsOptions{})
+	if listError != nil {
+		t.Fatalf("ListSecurityFindings returned an error: %v", listError)
+	}
+	if captured.URL.RawQuery != "" {
+		t.Fatalf("an unfiltered list must send no query, got %q", captured.URL.RawQuery)
+	}
+	if list.Result == nil || len(list.Result) != 0 {
+		t.Fatalf("a null result must decode to an empty slice, got %#v", list.Result)
+	}
+	if list.Intelligence.KevSyncedAt != nil {
+		t.Fatalf("an unsynced catalog must stay nil, got %v", list.Intelligence.KevSyncedAt)
+	}
+}
+
+func TestGetSecurityOverviewScopesToClusterAndAddon(t *testing.T) {
+	var captured http.Request
+	_, apiClient := newSecurityTestServer(t, `{
+        "totals": {"observed": 10, "actionable": 8, "acknowledged": 1, "accepted_risk": 1, "resolved": 3},
+        "severity": {"critical": 1, "high": 2, "medium": 3, "low": 4, "unknown": 0},
+        "fixable_severe": 2, "known_exploited": 5, "known_exploited_findings": 2,
+        "known_exploited_overdue": 1, "known_exploited_ransomware": 1,
+        "intelligence": {"kev_synced_at": "2026-08-28T20:13:11Z", "epss_synced_at": "2026-08-28T20:13:12Z", "kev_listed": 1685},
+        "coverage": {"total_clusters": 1, "scanned_clusters": 1, "unscanned_clusters": 0, "stale_clusters": 0, "fresh_clusters": 1, "latest_report_at": "2026-08-28T20:25:14Z"},
+        "scanner": {"status": "fresh", "last_scan": "2026-08-28T20:25:14Z", "fresh_clusters": 1, "stale_clusters": 0, "unscanned_clusters": 0, "stale_after_seconds": 7200},
+        "top_remediation_candidates": [], "observed_trend": [], "generated_at": "2026-08-28T21:00:00Z"
+    }`, &captured)
+
+	overview, overviewError := apiClient.GetSecurityOverview(SecurityOverviewOptions{ClusterID: "abc", AddonSlug: "cert-manager"})
+	if overviewError != nil {
+		t.Fatalf("GetSecurityOverview returned an error: %v", overviewError)
+	}
+	if captured.URL.Path != "/api/v1/org/security/overview" ||
+		captured.URL.Query().Get("cluster_id") != "abc" || captured.URL.Query().Get("addon_slug") != "cert-manager" {
+		t.Fatalf("request = %s?%s", captured.URL.Path, captured.URL.RawQuery)
+	}
+	if overview.KnownExploitedFindings != 2 || overview.KnownExploitedOverdue != 1 || overview.KnownExploitedRansomware != 1 {
+		t.Fatalf("known-exploited counts not decoded: %+v", overview)
+	}
+}
+
+func TestGetSecurityFindingEscapesTheIdAndDecodesOccurrences(t *testing.T) {
+	var captured http.Request
+	_, apiClient := newSecurityTestServer(t, `{
+        "finding": {"id": "f1", "provider": "trivy_operator", "cve_id": "CVE-2020-1938", "package_type": "maven",
+            "package_name": "tomcat", "severity": "CRITICAL", "title": "Ghostcat", "primary_link": null, "score": null,
+            "first_seen_at": "2026-08-01T00:00:00Z", "last_seen_at": "2026-08-28T20:00:00Z",
+            "occurrences": 1, "affected_clusters": 1, "affected_workloads": 1, "fixable_occurrences": 1,
+            "disposition_counts": {"open": 1, "acknowledged": 0, "accepted_risk": 0, "resolved": 0},
+            "known_exploited": true, "kev_date_added": "2022-03-03", "kev_due_date": "2022-03-17",
+            "kev_ransomware_use": true, "epss_score": null, "epss_percentile": null,
+            "kev_vendor_project": null, "kev_product": null, "kev_vulnerability_name": null,
+            "kev_required_action": "Apply updates per vendor instructions."},
+        "occurrences": [{"id": "o1", "cluster_id": "c1", "cluster_name": "prod", "report_scope": "namespaced",
+            "report_name": "replicaset-x", "report_namespace": "shop", "workload_kind": "Deployment",
+            "workload_namespace": "shop", "workload_name": "carts", "container_name": "carts",
+            "image_ref": "weaveworksdemos/carts:0.4.8", "installed_version": "8.5.11", "fixed_version": "9.0.99",
+            "addon_slug": null, "addon_attribution_confidence": "none", "scan_state": "active",
+            "effective_disposition": "none", "first_seen_at": "2026-08-01T00:00:00Z", "last_seen_at": "2026-08-28T20:00:00Z"}],
+        "matching_policies": []
+    }`, &captured)
+
+	detail, detailError := apiClient.GetSecurityFinding("id with space")
+	if detailError != nil {
+		t.Fatalf("GetSecurityFinding returned an error: %v", detailError)
+	}
+	if captured.URL.Path != "/api/v1/org/security/findings/id with space" {
+		t.Fatalf("path = %q", captured.URL.Path)
+	}
+	if len(detail.Occurrences) != 1 || detail.Occurrences[0].ClusterName != "prod" ||
+		!detail.Finding.KevRansomwareUse || detail.Finding.KevRequiredAction == nil {
+		t.Fatalf("detail not decoded: %+v", detail)
+	}
+}
+
+func TestListSecurityClustersEncodesControls(t *testing.T) {
+	var captured http.Request
+	_, apiClient := newSecurityTestServer(t, `{"result": [{"cluster_id": "c1", "cluster_name": "prod", "environment": "production",
+        "scanner_status": "fresh", "posture_status": "critical", "latest_report_at": "2026-08-28T20:25:14Z",
+        "observed": 10, "actionable": 8, "acknowledged": 0, "accepted_risk": 2, "fixable_severe": 3, "known_exploited": 4,
+        "severity": {"critical": 1, "high": 2, "medium": 3, "low": 4, "unknown": 0}}],
+        "pagination": {"page": 1, "page_size": 50, "total_pages": 1, "total_count": 1}}`, &captured)
+
+	list, listError := apiClient.ListSecurityClusters(SecurityClustersOptions{
+		Page: 1, PageSize: 50, Search: "prod", Status: "critical", Sort: "known_exploited", Order: "desc",
+	})
+	if listError != nil {
+		t.Fatalf("ListSecurityClusters returned an error: %v", listError)
+	}
+	expectedQuery := url.Values{
+		"page": {"1"}, "page_size": {"50"}, "search": {"prod"}, "status": {"critical"},
+		"sort": {"known_exploited"}, "order": {"desc"},
+	}
+	if captured.URL.Path != "/api/v1/org/security/clusters" || !reflect.DeepEqual(captured.URL.Query(), expectedQuery) {
+		t.Fatalf("request = %s?%s", captured.URL.Path, captured.URL.RawQuery)
+	}
+	if len(list.Result) != 1 || list.Result[0].KnownExploited != 4 {
+		t.Fatalf("clusters not decoded: %+v", list)
+	}
+}


### PR DESCRIPTION
Bead: ankra-b6rtz (follow-on to PLA-807)

The Security Center had no CLI read: the only way to pull the CISA KEV / EPSS fields into customer reporting was a bearer curl against /api/v1/org/security/*. This adds the `ankra security` command group on those bearer twins:

- `ankra security overview [--cluster] [--addon]` - fleet totals, scanner coverage, remediation candidates, and first the exploited-in-the-wild summary: findings CISA lists, occurrences, how many are past CISA's remediation deadline, how many CISA links to ransomware. An unsynced catalog reads as unknown, never as clean.
- `ankra security findings` - actionable findings sorted by exploitability (KEV, then EPSS, then severity) by default; `--known-exploited`, `--severity`, `--status` (`any` lifts the filter), `--fixable true|false|any`, `--cluster`, `--addon`, `--namespace`, `--search`, `--sort`, `--order`, `--page`, `--page-size`. Rows show the KEV marker, CISA's deadline in explicit tense, a ransomware marker and the EPSS probability.
- `ankra security finding <id>` - CISA's own entry (vulnerability name, vendor/product, listed date, deadline, required action), EPSS, counts and every current occurrence.
- `ankra security clusters` - per-cluster posture with the known-exploited count.
- All four take `-o json|yaml`.

Tests: client query encoding for every filter/sort (httptest), and command tests through the cobra tree with a mock (defaults, flag mapping, usage error on a bad `--fixable`, structured output carrying the intelligence fields, the unsynced-catalog wording, CISA guidance on the detail, the known-exploited column). `make lint` 0 issues, `go test ./...` green. CHANGELOG entry under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVUWU7e87JaZJB938KSFmz