### PR TITLE
feat(migrate): ankra migrate export, restore and data - a Docker deployment's databases into the cluster through a backup vault (ankra-k6ikc.1, ankra-k6ikc.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,21 @@
   container through its own environment. Module authors get the same verb:
   a module that lists `export` under its capabilities is asked to dump, with
   its stderr relayed live as progress (`examples/modules/README.md`).
+- **`ankra migrate restore` loads an export into the cluster, and `ankra
+  migrate data` does export and restore in one go.** The dumps go straight
+  from this machine to the organisation's backup vault through presigned
+  URLs, the platform verifies every object arrived at the size the export
+  recorded, and the cluster's agent runs the restore inside the cluster -
+  roles and globals first, then each database with the engine's own tools,
+  against the Service and Secret `convert` generated. Ankra never holds the
+  data, and nothing on this machine needs kubectl or a database client. The
+  vault is picked automatically when the organisation has exactly one that
+  is ready (`--vault` otherwise), the cluster defaults to the selected one,
+  `--wait` follows the restore to completion or failure with every job's
+  state as it changes, and `ankra migrate restore-status <import-id>`
+  reports on one started earlier. A restore needs the `backups` feature,
+  the converted stack applied, and a cluster agent that supports data
+  restores; the platform names whichever is missing.
 - **A converted database always gets a Service.** `ankra migrate convert`
   only generated a Service for workloads with published ports, so a compose
   database nobody exposed to the host - the usual case - was unreachable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,13 @@
   `--option project=<name>` for a compose project that runs under a
   different name, and `--option databases.<workload>=a,b` to pick databases.
   Passwords never cross the host's command line: every dump runs inside the
-  container through its own environment. Module authors get the same verb:
+  container through its own environment, and the dumps are written readable
+  by you alone. Roles come across without their passwords - the cluster's
+  own user keeps the password from its Secret, and the export says which
+  other roles need one set afterwards - and PostgreSQL's maintenance
+  database `postgres` is left out unless the image keeps the application's
+  data there (`POSTGRES_DB`, or its default), with a hint on how to include
+  it otherwise. Module authors get the same verb:
   a module that lists `export` under its capabilities is asked to dump, with
   its stderr relayed live as progress (`examples/modules/README.md`).
 - **`ankra migrate restore` loads an export into the cluster, and `ankra
@@ -32,8 +38,10 @@
   vault is picked automatically when the organisation has exactly one that
   is ready (`--vault` otherwise), the cluster defaults to the selected one,
   `--wait` follows the restore to completion or failure with every job's
-  state as it changes, and `ankra migrate restore-status <import-id>`
-  reports on one started earlier. A restore needs the `backups` feature,
+  state as it changes (`--timeout` bounds only that wait, never an upload),
+  and `ankra migrate restore-status <import-id>` reports on one started
+  earlier. A dump above 5 GiB is refused before anything is registered -
+  one presigned upload carries at most that much. A restore needs the `backups` feature,
   the converted stack applied, and a cluster agent that supports data
   restores; the platform names whichever is missing.
 - **A converted database always gets a Service.** `ankra migrate convert`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@
 
 ### Added
 
+- **`ankra migrate export` dumps the databases a Docker deployment runs, ready
+  to be restored into the cluster.** `ankra migrate convert` moved the
+  workloads but left every database volume empty; the data had to be copied
+  by hand. `ankra migrate export` now finds every PostgreSQL and MySQL/MariaDB
+  service in a compose project (or the running daemon), dumps each database
+  through the docker CLI - `pg_dump -Fc` plus roles and globals, or
+  `mysqldump` - and writes a self-describing directory: the dumps, a
+  `manifest.json` that names the Service and Secret `convert` generated for
+  each database so a restore knows exactly where to load it, and a
+  `SHA256SUMS` file. A deployment on another host is dumped the way docker
+  reaches it (`--option docker-host=ssh://root@host`), with
+  `--option project=<name>` for a compose project that runs under a
+  different name, and `--option databases.<workload>=a,b` to pick databases.
+  Passwords never cross the host's command line: every dump runs inside the
+  container through its own environment. Module authors get the same verb:
+  a module that lists `export` under its capabilities is asked to dump, with
+  its stderr relayed live as progress (`examples/modules/README.md`).
+- **A converted database always gets a Service.** `ankra migrate convert`
+  only generated a Service for workloads with published ports, so a compose
+  database nobody exposed to the host - the usual case - was unreachable
+  from the other workloads once in the cluster. Database images now get a
+  Service on their default port regardless.
 - **The Security Center is readable from the terminal.** `ankra security
   overview` prints the fleet's actionable totals, scanner coverage, the
   remediation candidates, and - first - how many vulnerabilities CISA lists

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,15 +39,23 @@ the un-injected fallback; never bump it for a release.
   `ankra-module-<name>` executables, and the JSON-over-stdio protocol they
   speak. `internal/migrate/docker` is the built-in module and the reference
   implementation; `examples/modules/` holds a complete external one.
-  Nothing under `migrate` may call the platform API - every command there is
-  annotated `annotationRequiresAuth: "false"` and must work offline.
+  Nothing under `internal/migrate` may call the platform API: `convert`,
+  `detect`, `modules` and `export` are annotated
+  `annotationRequiresAuth: "false"` and work offline. The one online lane is
+  `cmd/migrate_restore.go` (`restore`, `restore-status`, `data`), annotated
+  `"true"`, which drives the backup-vault import routes through
+  `internal/client`.
 - `internal/migrate` — `ankra migrate`: the module contract (`Module`,
   `Description`, `Detection`, `Result`), the registry that discovers
   `ankra-module-<name>` executables, and the JSON-over-stdio protocol they
   speak. `internal/migrate/docker` is the built-in module and the reference
   implementation; `examples/modules/` holds a complete external one.
-  Nothing under `migrate` may call the platform API - every command there is
-  annotated `annotationRequiresAuth: "false"` and must work offline.
+  Nothing under `internal/migrate` may call the platform API: `convert`,
+  `detect`, `modules` and `export` are annotated
+  `annotationRequiresAuth: "false"` and work offline. The one online lane is
+  `cmd/migrate_restore.go` (`restore`, `restore-status`, `data`), annotated
+  `"true"`, which drives the backup-vault import routes through
+  `internal/client`.
 - `internal/skills` — embedded agent skills, vendored from the sibling
   `ankra-skills` repo (`make generate` / `make verify-skills`; in the split
   repo the embedded copy is canonical). `clients.go` is the table of every

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ per command family:
 | [ankra org](https://docs.ankra.ai/reference/cli/org) | Manage organisations, members, roles, org variables, DNS, and MCP tool servers |
 | [ankra profile](https://docs.ankra.ai/reference/cli/profile) | Open profile authentication settings (MFA, passkeys) in the browser |
 | [ankra skills](https://docs.ankra.ai/reference/cli/skills) | Install Ankra Agent Skills into Cursor or Claude Code |
-| [ankra migrate](https://docs.ankra.ai/reference/cli/migrate) | Convert a docker-compose file, Dockerfile, or running containers into Ankra cluster and stack definitions; extensible with `ankra-module-<name>` executables |
+| [ankra migrate](https://docs.ankra.ai/reference/cli/migrate) | Convert a docker-compose file, Dockerfile, or running containers into Ankra cluster and stack definitions, and export their databases for a restore into the cluster; extensible with `ankra-module-<name>` executables |
 | [ankra stack-profiles](https://docs.ankra.ai/reference/cli/stack-profiles) | Manage reusable stack profiles |
 | [ankra support](https://docs.ankra.ai/reference/cli/support) | Create and track Ankra support requests |
 | [ankra tokens](https://docs.ankra.ai/reference/cli/tokens) | Manage API tokens |

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -535,6 +535,26 @@ func (m baseMock) DeleteBackupVault(vaultID string, destroyProviderResources boo
 	return errors.New("not implemented")
 }
 
+func (m baseMock) CreateBackupVaultImport(vaultID string, request client.CreateBackupVaultImportRequest) (*client.CreateBackupVaultImportResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) CompleteBackupVaultImport(vaultID string, importID string) (*client.BackupVaultImport, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) RestoreBackupVaultImport(vaultID string, importID string) (*client.BackupVaultImport, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetBackupVaultImport(vaultID string, importID string) (*client.BackupVaultImport, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) UploadPresignedObject(ctx context.Context, uploadURL string, body io.Reader, size int64) error {
+	return errors.New("not implemented")
+}
+
 func (m baseMock) ListExecutions(opts client.ListExecutionsOptions) (client.ExecutionListResponse, error) {
 	return client.ExecutionListResponse{}, errors.New("not implemented")
 }

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -551,7 +551,7 @@ func (m baseMock) GetBackupVaultImport(vaultID string, importID string) (*client
 	return nil, errors.New("not implemented")
 }
 
-func (m baseMock) UploadPresignedObject(ctx context.Context, uploadURL string, body io.Reader, size int64) error {
+func (m baseMock) UploadPresignedObject(ctx context.Context, method string, uploadURL string, body io.ReadSeeker, size int64) error {
 	return errors.New("not implemented")
 }
 

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -38,6 +39,26 @@ var newMigrateRegistry = func() *migrate.Registry {
 
 func init() {
 	rootCmd.AddCommand(migrateCmd)
+}
+
+// selectMigrateModule picks the module by name, or by asking each one about
+// the directory and taking the most confident answer.
+func selectMigrateModule(cmd *cobra.Command, registry *migrate.Registry, dir, name string) (migrate.Module, error) {
+	if name != "" {
+		module, err := registry.Lookup(cmd.Context(), name)
+		if err != nil {
+			return nil, withExitCode(exitNotFound, err)
+		}
+		return module, nil
+	}
+	candidates, notes := registry.Detect(cmd.Context(), dir)
+	for _, note := range notes {
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), note)
+	}
+	if len(candidates) == 0 || candidates[0].Err != nil || candidates[0].Detection.Confidence == 0 {
+		return nil, withExitCode(exitNotFound, fmt.Errorf("no module recognises %s (run `ankra migrate detect %s` to see why)", dir, dir))
+	}
+	return candidates[0].Module, nil
 }
 
 var migrateNamePattern = regexp.MustCompile(`[^a-z0-9-]+`)

--- a/cmd/migrate_convert.go
+++ b/cmd/migrate_convert.go
@@ -39,6 +39,7 @@ pass --module to choose explicitly. Module-specific settings go through
   --option use-environment=true               let your shell satisfy ${VAR} references
   --option project=<name>                     compose project, for source=daemon
   --option containers=a,b                     specific containers, for source=daemon
+  --option docker-host=ssh://root@host        a remote daemon, for source=daemon
   --option image.<workload>=<registry/repo:tag>  image for a locally built workload
   --option ingress.<workload>=<host>          expose a workload through an Ingress
   --option cluster-issuer=letsencrypt-prod    request TLS for every Ingress
@@ -92,22 +93,9 @@ func runMigrateConvert(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	registry := newMigrateRegistry()
-	var module migrate.Module
-	if migrateConvertModule != "" {
-		module, err = registry.Lookup(cmd.Context(), migrateConvertModule)
-		if err != nil {
-			return withExitCode(exitNotFound, err)
-		}
-	} else {
-		candidates, notes := registry.Detect(cmd.Context(), dir)
-		for _, note := range notes {
-			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), note)
-		}
-		if len(candidates) == 0 || candidates[0].Err != nil || candidates[0].Detection.Confidence == 0 {
-			return withExitCode(exitNotFound, fmt.Errorf("no module recognises %s (run `ankra migrate detect %s` to see why)", dir, dir))
-		}
-		module = candidates[0].Module
+	module, err := selectMigrateModule(cmd, newMigrateRegistry(), dir, migrateConvertModule)
+	if err != nil {
+		return err
 	}
 
 	clusterName := migrateConvertClusterName

--- a/cmd/migrate_export.go
+++ b/cmd/migrate_export.go
@@ -43,7 +43,8 @@ Each dump is a snapshot of a live server. Rehearse with the source running,
 then stop its writers and export once more right before the final cutover.
 
 The output directory is self-contained: manifest.json describes every
-artifact and where it belongs, and SHA256SUMS lets 'sha256sum -c' verify it.`,
+artifact and where it belongs, and SHA256SUMS lets 'sha256sum -c' verify it.
+Load it into the cluster with 'ankra migrate restore <out>'.`,
 	Example: `  ankra migrate export ./app --out ./app-data
   ankra migrate export ./app --option docker-host=ssh://root@203.0.113.7 --option project=aura-office
   ankra migrate export --option databases.postgres=office,pdns`,
@@ -68,35 +69,65 @@ type migrateExportSummary struct {
 	Manifest migrate.ExportManifest `json:"manifest" yaml:"manifest"`
 }
 
+// migrateExportRequest is what an export needs beyond the source directory.
+type migrateExportRequest struct {
+	Module    string
+	Out       string
+	Namespace string
+	Options   []string
+	Force     bool
+}
+
 func runMigrateExport(cmd *cobra.Command, args []string) error {
 	dir, err := migrateSourceDir(args)
 	if err != nil {
 		return err
 	}
-	options, err := parseMigrateOptions(migrateExportOptions)
+	summary, err := performMigrateExport(cmd, dir, migrateExportRequest{
+		Module:    migrateExportModule,
+		Out:       migrateExportOut,
+		Namespace: migrateExportNamespace,
+		Options:   migrateExportOptions,
+		Force:     migrateExportForce,
+	})
 	if err != nil {
 		return err
 	}
-	module, err := selectMigrateModule(cmd, newMigrateRegistry(), dir, migrateExportModule)
-	if err != nil {
+	if handled, err := renderStructured(cmd, summary); handled || err != nil {
 		return err
+	}
+	printMigrateExportSummary(cmd, summary)
+	return nil
+}
+
+// performMigrateExport dumps the databases behind dir into the output
+// directory and writes the manifest; it is the step 'ankra migrate data'
+// shares with 'ankra migrate export'.
+func performMigrateExport(cmd *cobra.Command, dir string, request migrateExportRequest) (migrateExportSummary, error) {
+	options, err := parseMigrateOptions(request.Options)
+	if err != nil {
+		return migrateExportSummary{}, err
+	}
+	module, err := selectMigrateModule(cmd, newMigrateRegistry(), dir, request.Module)
+	if err != nil {
+		return migrateExportSummary{}, err
 	}
 	moduleName := module.Describe().Name
 	exporter, ok := migrate.ExporterFor(module)
 	if !ok {
-		return withExitCode(exitUsage, fmt.Errorf("the %s module converts workloads but does not export data (run `ankra migrate modules` to see which modules do)", moduleName))
+		return migrateExportSummary{}, withExitCode(exitUsage, fmt.Errorf("the %s module converts workloads but does not export data (run `ankra migrate modules` to see which modules do)", moduleName))
 	}
 
-	namespace := migrateExportNamespace
+	namespace := request.Namespace
 	if namespace == "" {
 		namespace = migrateResourceName(filepath.Base(dir))
 	}
-	out, err := filepath.Abs(migrateExportOut)
+	out, err := filepath.Abs(request.Out)
 	if err != nil {
-		return withExitCode(exitUsage, err)
+		return migrateExportSummary{}, withExitCode(exitUsage, err)
 	}
-	if err := ensureMigrateOutDir(out, migrateExportForce); err != nil {
-		return err
+	if err := ensureMigrateOutDir(out, request.Force); err != nil {
+		return migrateExportSummary{}, err
 	}
 
 	export, err := exporter.Export(cmd.Context(), migrate.ExportRequest{
@@ -107,27 +138,25 @@ func runMigrateExport(cmd *cobra.Command, args []string) error {
 		Progress:  cmd.ErrOrStderr(),
 	})
 	if err != nil {
-		return fmt.Errorf("%s: %w", moduleName, err)
+		return migrateExportSummary{}, fmt.Errorf("%s: %w", moduleName, err)
 	}
 	manifest, err := migrate.FinaliseExport(out, moduleName, dir, export, time.Now())
 	if err != nil {
-		return fmt.Errorf("%s: %w", moduleName, err)
+		return migrateExportSummary{}, fmt.Errorf("%s: %w", moduleName, err)
 	}
 	if err := migrate.WriteExportManifest(out, manifest); err != nil {
-		return err
+		return migrateExportSummary{}, err
 	}
+	return migrateExportSummary{Module: moduleName, Out: out, Manifest: manifest}, nil
+}
 
-	summary := migrateExportSummary{Module: moduleName, Out: out, Manifest: manifest}
-	if handled, err := renderStructured(cmd, summary); handled || err != nil {
-		return err
-	}
-
+func printMigrateExportSummary(cmd *cobra.Command, summary migrateExportSummary) {
 	writer := table.NewWriter()
 	writer.SetOutputMirror(cmd.OutOrStdout())
 	writer.SetStyle(table.StyleRounded)
 	writer.AppendHeader(table.Row{"WORKLOAD", "ENGINE", "DATABASE", "FILE", "SIZE"})
 	artifacts := 0
-	for _, database := range manifest.Databases {
+	for _, database := range summary.Manifest.Databases {
 		for _, artifact := range database.Artifacts {
 			artifacts++
 			label := artifact.Database
@@ -139,8 +168,8 @@ func runMigrateExport(cmd *cobra.Command, args []string) error {
 	}
 	writer.Render()
 
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Wrote %d artifact(s), %s and %s to %s\n", artifacts, migrate.ExportManifestFileName, migrate.ExportChecksumsFileName, out)
-	for _, database := range manifest.Databases {
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Wrote %d artifact(s), %s and %s to %s\n", artifacts, migrate.ExportManifestFileName, migrate.ExportChecksumsFileName, summary.Out)
+	for _, database := range summary.Manifest.Databases {
 		target := database.Target
 		password := "no password"
 		if target.PasswordSecret != "" {
@@ -149,8 +178,7 @@ func runMigrateExport(cmd *cobra.Command, args []string) error {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s restores into %s:%d in namespace %s as %s, %s\n",
 			database.Workload, target.Host, target.Port, target.Namespace, target.Username, password)
 	}
-	printMigrateWarnings(cmd, manifest.Warnings)
-	return nil
+	printMigrateWarnings(cmd, summary.Manifest.Warnings)
 }
 
 func formatByteSize(size int64) string {

--- a/cmd/migrate_export.go
+++ b/cmd/migrate_export.go
@@ -1,0 +1,169 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+
+	"ankra/internal/migrate"
+)
+
+var (
+	migrateExportModule    string
+	migrateExportOut       string
+	migrateExportNamespace string
+	migrateExportOptions   []string
+	migrateExportForce     bool
+)
+
+var migrateExportCmd = &cobra.Command{
+	Use:   "export [dir]",
+	Short: "Dump the databases behind a deployment into a directory ready to be restored into the cluster",
+	Long: `Dump every database the deployment in a directory (default: the current one)
+runs - PostgreSQL and MySQL/MariaDB today - into an output directory, with a
+manifest.json that says where each dump restores to: the Service that
+'ankra migrate convert' generated for the database and the Secret holding its
+password.
+
+The dumps are taken through the docker CLI from the running containers, so
+the source must be up. A deployment on another host is reached the way docker
+itself reaches it:
+
+  --option docker-host=ssh://root@203.0.113.7  dump from a remote Docker daemon
+  --option project=<name>                      the compose project name, when it
+                                               differs from the directory name
+  --option container.<workload>=<name>         dump from a specific container
+  --option databases.<workload>=a,b            only these databases (default: all)
+  --option profiles=app,dns                    compose profiles, as for convert
+
+Each dump is a snapshot of a live server. Rehearse with the source running,
+then stop its writers and export once more right before the final cutover.
+
+The output directory is self-contained: manifest.json describes every
+artifact and where it belongs, and SHA256SUMS lets 'sha256sum -c' verify it.`,
+	Example: `  ankra migrate export ./app --out ./app-data
+  ankra migrate export ./app --option docker-host=ssh://root@203.0.113.7 --option project=aura-office
+  ankra migrate export --option databases.postgres=office,pdns`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runMigrateExport,
+}
+
+func init() {
+	migrateExportCmd.Flags().StringVar(&migrateExportModule, "module", "", "Module to use (default: the most confident detection)")
+	migrateExportCmd.Flags().StringVar(&migrateExportOut, "out", "ankra-migration-data", "Output directory")
+	migrateExportCmd.Flags().StringVar(&migrateExportNamespace, "namespace", "", "Namespace the converted workloads run in (default: the directory name, as for convert)")
+	migrateExportCmd.Flags().StringArrayVar(&migrateExportOptions, "option", nil, "Module option as key=value (repeatable)")
+	migrateExportCmd.Flags().BoolVar(&migrateExportForce, "force", false, "Overwrite an output directory that is not empty")
+	registerStructuredOutputFlags(migrateExportCmd)
+	migrateCmd.AddCommand(migrateExportCmd)
+}
+
+// migrateExportSummary is the structured shape of a completed export.
+type migrateExportSummary struct {
+	Module   string                 `json:"module" yaml:"module"`
+	Out      string                 `json:"out" yaml:"out"`
+	Manifest migrate.ExportManifest `json:"manifest" yaml:"manifest"`
+}
+
+func runMigrateExport(cmd *cobra.Command, args []string) error {
+	dir, err := migrateSourceDir(args)
+	if err != nil {
+		return err
+	}
+	options, err := parseMigrateOptions(migrateExportOptions)
+	if err != nil {
+		return err
+	}
+	module, err := selectMigrateModule(cmd, newMigrateRegistry(), dir, migrateExportModule)
+	if err != nil {
+		return err
+	}
+	moduleName := module.Describe().Name
+	exporter, ok := migrate.ExporterFor(module)
+	if !ok {
+		return withExitCode(exitUsage, fmt.Errorf("the %s module converts workloads but does not export data (run `ankra migrate modules` to see which modules do)", moduleName))
+	}
+
+	namespace := migrateExportNamespace
+	if namespace == "" {
+		namespace = migrateResourceName(filepath.Base(dir))
+	}
+	out, err := filepath.Abs(migrateExportOut)
+	if err != nil {
+		return withExitCode(exitUsage, err)
+	}
+	if err := ensureMigrateOutDir(out, migrateExportForce); err != nil {
+		return err
+	}
+
+	export, err := exporter.Export(cmd.Context(), migrate.ExportRequest{
+		Dir:       dir,
+		OutputDir: out,
+		Namespace: namespace,
+		Options:   options,
+		Progress:  cmd.ErrOrStderr(),
+	})
+	if err != nil {
+		return fmt.Errorf("%s: %w", moduleName, err)
+	}
+	manifest, err := migrate.FinaliseExport(out, moduleName, dir, export, time.Now())
+	if err != nil {
+		return fmt.Errorf("%s: %w", moduleName, err)
+	}
+	if err := migrate.WriteExportManifest(out, manifest); err != nil {
+		return err
+	}
+
+	summary := migrateExportSummary{Module: moduleName, Out: out, Manifest: manifest}
+	if handled, err := renderStructured(cmd, summary); handled || err != nil {
+		return err
+	}
+
+	writer := table.NewWriter()
+	writer.SetOutputMirror(cmd.OutOrStdout())
+	writer.SetStyle(table.StyleRounded)
+	writer.AppendHeader(table.Row{"WORKLOAD", "ENGINE", "DATABASE", "FILE", "SIZE"})
+	artifacts := 0
+	for _, database := range manifest.Databases {
+		for _, artifact := range database.Artifacts {
+			artifacts++
+			label := artifact.Database
+			if artifact.Kind == migrate.ArtifactKindGlobals {
+				label = "(roles and globals)"
+			}
+			writer.AppendRow(table.Row{database.Workload, database.Engine + " " + database.ServerVersion, label, artifact.Path, formatByteSize(artifact.SizeBytes)})
+		}
+	}
+	writer.Render()
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Wrote %d artifact(s), %s and %s to %s\n", artifacts, migrate.ExportManifestFileName, migrate.ExportChecksumsFileName, out)
+	for _, database := range manifest.Databases {
+		target := database.Target
+		password := "no password"
+		if target.PasswordSecret != "" {
+			password = fmt.Sprintf("password from Secret %s key %s", target.PasswordSecret, target.PasswordKey)
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s restores into %s:%d in namespace %s as %s, %s\n",
+			database.Workload, target.Host, target.Port, target.Namespace, target.Username, password)
+	}
+	printMigrateWarnings(cmd, manifest.Warnings)
+	return nil
+}
+
+func formatByteSize(size int64) string {
+	const unit = 1024
+	if size < unit {
+		return fmt.Sprintf("%d B", size)
+	}
+	value := float64(size)
+	suffixes := "KMGTPE"
+	exponent := 0
+	for value >= unit && exponent < len(suffixes) {
+		value /= unit
+		exponent++
+	}
+	return fmt.Sprintf("%.1f %ciB", value, suffixes[exponent-1])
+}

--- a/cmd/migrate_export_test.go
+++ b/cmd/migrate_export_test.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// fakeDockerScript answers the docker calls the export makes for the
+// migrateTestCompose fixture: one postgres service holding one database.
+const fakeDockerScript = `#!/bin/sh
+case "$*" in
+  *"ps -q"*) echo abc123 ;;
+  *"SHOW server_version"*) echo 17.2 ;;
+  *"SELECT datname"*) echo office ;;
+  *pg_dumpall*) printf -- '-- globals\n' ;;
+  *"pg_dump "*) printf 'PGDMP\001\002fake' ;;
+  *) echo "unexpected docker call: $*" >&2; exit 1 ;;
+esac
+`
+
+// plainModule is an external module without the export capability.
+const plainModule = `#!/bin/sh
+case "$1" in
+  describe) printf '%s' '{"name":"plain","version":"0.1","protocol":1,"summary":"no export"}' ;;
+  detect) printf '%s' '{"confidence":0,"reason":"never"}' ;;
+  *) exit 2 ;;
+esac
+`
+
+func resetMigrateExportFlags() {
+	migrateExportModule = ""
+	migrateExportOut = "ankra-migration-data"
+	migrateExportNamespace = ""
+	migrateExportOptions = nil
+	migrateExportForce = false
+	_ = migrateExportCmd.Flags().Set("output", "")
+}
+
+// fakeDockerOnPath puts a docker stand-in and the plain module on a PATH of
+// their own, so the export exercises the real docker module against a
+// scripted daemon without touching this machine's docker.
+func fakeDockerOnPath(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stand-ins")
+	}
+	offlineRegistry(t)
+	resetMigrateExportFlags()
+	binDir := t.TempDir()
+	for name, body := range map[string]string{"docker": fakeDockerScript, "ankra-module-plain": plainModule} {
+		if err := os.WriteFile(filepath.Join(binDir, name), []byte(body), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", binDir)
+}
+
+func TestMigrateExportNeedsNoLogin(t *testing.T) {
+	sub, _, err := migrateCmd.Find([]string{"export"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if commandRequiresAuth(sub) {
+		t.Error("ankra migrate export must work offline")
+	}
+}
+
+func TestMigrateExportWritesManifest(t *testing.T) {
+	fakeDockerOnPath(t)
+	dir := writeMigrateFixture(t)
+	out := filepath.Join(t.TempDir(), "data")
+
+	stdout, stderr, err := runMigrate(t, "export", dir, "--out", out)
+	if err != nil {
+		t.Fatalf("%v\n%s", err, stderr)
+	}
+	if !strings.Contains(stdout, "Wrote 2 artifact(s)") || !strings.Contains(stdout, "db restores into db:5432 in namespace shop as postgres, password from Secret db-secrets key POSTGRES_PASSWORD") {
+		t.Errorf("stdout:\n%s", stdout)
+	}
+	if !strings.Contains(stderr, "db: dumping database office") {
+		t.Errorf("progress belongs on stderr, got:\n%s", stderr)
+	}
+	for _, file := range []string{"manifest.json", "SHA256SUMS", "db/globals.sql", "db/office.dump"} {
+		if _, err := os.Stat(filepath.Join(out, filepath.FromSlash(file))); err != nil {
+			t.Errorf("%s missing: %v", file, err)
+		}
+	}
+	manifest, err := os.ReadFile(filepath.Join(out, "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, fragment := range []string{`"module": "docker"`, `"engine": "postgres"`, `"database": "office"`, `"format": "pg_custom"`, `"sha256": "`} {
+		if !strings.Contains(string(manifest), fragment) {
+			t.Errorf("manifest.json lacks %s:\n%s", fragment, manifest)
+		}
+	}
+
+	// A second export into the same directory refuses without --force.
+	resetMigrateExportFlags()
+	_, _, err = runMigrate(t, "export", dir, "--out", out)
+	if exitCodeFor(err) != exitUsage {
+		t.Errorf("non-empty output dir should exit %d, got %v", exitUsage, err)
+	}
+	resetMigrateExportFlags()
+	if _, _, err = runMigrate(t, "export", dir, "--out", out, "--force"); err != nil {
+		t.Errorf("--force should overwrite: %v", err)
+	}
+}
+
+func TestMigrateExportStructuredOutput(t *testing.T) {
+	fakeDockerOnPath(t)
+	dir := writeMigrateFixture(t)
+	stdout, _, err := runMigrate(t, "export", dir, "--out", filepath.Join(t.TempDir(), "data"), "-o", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(stdout), "{") || !strings.Contains(stdout, `"module": "docker"`) || !strings.Contains(stdout, `"password_secret": "db-secrets"`) {
+		t.Errorf("json output must be the only thing on stdout:\n%s", stdout)
+	}
+}
+
+func TestMigrateExportRefusesModulesWithoutExport(t *testing.T) {
+	fakeDockerOnPath(t)
+	dir := writeMigrateFixture(t)
+	_, _, err := runMigrate(t, "export", dir, "--out", filepath.Join(t.TempDir(), "data"), "--module", "plain")
+	if exitCodeFor(err) != exitUsage || !strings.Contains(err.Error(), "does not export data") {
+		t.Errorf("a module without the capability should exit %d and say so, got %v", exitUsage, err)
+	}
+}
+
+func TestMigrateExportSurfacesDockerFailures(t *testing.T) {
+	fakeDockerOnPath(t)
+	dir := writeMigrateFixture(t)
+	_, _, err := runMigrate(t, "export", dir, "--out", filepath.Join(t.TempDir(), "data"), "--option", "databases.db=missing", "--option", "container.db=db-1")
+	if err != nil {
+		t.Fatalf("naming the container and database must skip the lookups: %v", err)
+	}
+	resetMigrateExportFlags()
+	_, _, err = runMigrate(t, "export", t.TempDir(), "--out", filepath.Join(t.TempDir(), "data"))
+	if exitCodeFor(err) != exitNotFound {
+		t.Errorf("an unrecognised directory should exit %d, got %v", exitNotFound, err)
+	}
+}
+
+func TestFormatByteSize(t *testing.T) {
+	cases := map[int64]string{0: "0 B", 1023: "1023 B", 1024: "1.0 KiB", 1536: "1.5 KiB", 5 << 20: "5.0 MiB", 3 << 30: "3.0 GiB"}
+	for size, want := range cases {
+		if got := formatByteSize(size); got != want {
+			t.Errorf("formatByteSize(%d) = %q, want %q", size, got, want)
+		}
+	}
+}

--- a/cmd/migrate_export_test.go
+++ b/cmd/migrate_export_test.go
@@ -16,6 +16,7 @@ case "$*" in
   *"SHOW server_version"*) echo 17.2 ;;
   *"SELECT datname"*) echo office ;;
   *pg_dumpall*) printf -- '-- globals\n' ;;
+  *"-d boom"*) echo 'pg_dump: error: connection to server failed: FATAL: database "boom" does not exist' >&2; exit 1 ;;
   *"pg_dump "*) printf 'PGDMP\001\002fake' ;;
   *) echo "unexpected docker call: $*" >&2; exit 1 ;;
 esac
@@ -134,9 +135,13 @@ func TestMigrateExportRefusesModulesWithoutExport(t *testing.T) {
 func TestMigrateExportSurfacesDockerFailures(t *testing.T) {
 	fakeDockerOnPath(t)
 	dir := writeMigrateFixture(t)
-	_, _, err := runMigrate(t, "export", dir, "--out", filepath.Join(t.TempDir(), "data"), "--option", "databases.db=missing", "--option", "container.db=db-1")
-	if err != nil {
-		t.Fatalf("naming the container and database must skip the lookups: %v", err)
+	out := filepath.Join(t.TempDir(), "data")
+	_, _, err := runMigrate(t, "export", dir, "--out", out, "--option", "databases.db=boom", "--option", "container.db=db-1")
+	if err == nil || !strings.Contains(err.Error(), "db:") || !strings.Contains(err.Error(), `database "boom" does not exist`) {
+		t.Errorf("the dump's own error must reach the user with the workload named, got %v", err)
+	}
+	if _, statError := os.Stat(filepath.Join(out, "manifest.json")); statError == nil {
+		t.Error("a failed export must not leave a manifest behind")
 	}
 	resetMigrateExportFlags()
 	_, _, err = runMigrate(t, "export", t.TempDir(), "--out", filepath.Join(t.TempDir(), "data"))

--- a/cmd/migrate_modules.go
+++ b/cmd/migrate_modules.go
@@ -39,6 +39,22 @@ exit fails the verb and the module's stderr is shown as the reason.
 Warnings are for anything the module could not translate faithfully: a
 partial conversion a person can finish beats none.
 
+A module that lists "export" under "capabilities" in its description also
+answers a fourth verb, which backs 'ankra migrate export':
+
+  ankra-module-<name> export
+      <- {"dir":"...","output_dir":"/abs/path","namespace":"...","options":{}}
+      -> {"databases":[{"workload":"db","engine":"postgres","server_version":"17.2",
+           "target":{"namespace":"...","host":"db","port":5432,"username":"app",
+                     "password_secret":"db-secrets","password_key":"POSTGRES_PASSWORD"},
+           "artifacts":[{"path":"db/globals.sql","kind":"globals","format":"sql"},
+                        {"path":"db/app.dump","kind":"database","format":"pg_custom","database":"app"}]}],
+          "warnings":["..."]}
+
+The module writes the dumps under output_dir and reports their paths; the
+CLI measures sizes and checksums itself. Stderr is relayed live while an
+export runs, so narrate progress there.
+
 The protocol version is ` + fmt.Sprint(migrate.ProtocolVersion) + `. The reference implementation is the built-in
 'docker' module; a worked external example lives in the CLI repository under
 examples/modules/.`,

--- a/cmd/migrate_restore.go
+++ b/cmd/migrate_restore.go
@@ -64,9 +64,9 @@ provision' creates one), the converted stack applied to the cluster
 The vault is picked automatically when the organisation has exactly one
 ready vault; pass --vault otherwise.
 
-Pass --wait to follow the restore to its end; without it the command returns
-once the restore is running, and 'ankra migrate restore-status <import-id>'
-reports progress.`,
+Pass --wait to follow the restore to its end; --timeout bounds only that
+wait, never the upload. Without --wait the command returns once the restore
+is running, and 'ankra migrate restore-status <import-id>' reports progress.`,
 	Example: `  ankra migrate restore ./app-data --cluster shop --wait
   ankra migrate restore ./app-data --cluster shop --vault backups --stack shop
   ankra migrate restore ./app-data -o json`,
@@ -93,7 +93,8 @@ var migrateDataCmd = &cobra.Command{
 	Long: `Run 'ankra migrate export' on the directory (default: the current one) and
 'ankra migrate restore' on the result, back to back: the one command that
 moves a Docker deployment's data into the cluster once its workloads are
-running there. Every flag of both commands applies.
+running there. Every flag of both commands applies. The cluster and the
+vault are resolved before anything is dumped, so a wrong target fails fast.
 
 Each dump is a snapshot of a live server. Rehearse while the source is
 running, then stop its writers and run it once more for the real cutover.`,
@@ -130,12 +131,27 @@ func init() {
 	migrateCmd.AddCommand(migrateDataCmd)
 }
 
-// migrateRestoreOptions is what a restore needs beyond the export directory.
-type migrateRestoreOptions struct {
-	Cluster string
-	Stack   string
-	Vault   string
-	Wait    bool
+// migrateRestoreTargets is where a restore goes, resolved once up front so
+// a wrong cluster or an ambiguous vault fails before any work is done.
+type migrateRestoreTargets struct {
+	clusterID   string
+	clusterName string
+	vaultID     string
+	stackName   string
+}
+
+// resolveMigrateRestoreTargets turns the --cluster / --vault / --stack flags
+// into ids; an empty stack is derived later from the export.
+func resolveMigrateRestoreTargets(clusterFlag string, vaultFlag string, stackFlag string) (migrateRestoreTargets, error) {
+	clusterID, clusterName, err := resolveClusterForCmd(clusterFlag)
+	if err != nil {
+		return migrateRestoreTargets{}, err
+	}
+	vaultID, err := resolveImportVaultID(vaultFlag)
+	if err != nil {
+		return migrateRestoreTargets{}, err
+	}
+	return migrateRestoreTargets{clusterID: clusterID, clusterName: clusterName, vaultID: vaultID, stackName: stackFlag}, nil
 }
 
 func runMigrateRestore(cmd *cobra.Command, args []string) error {
@@ -147,15 +163,11 @@ func runMigrateRestore(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	requestContext, cancel, err := asyncWriteRequestContext(cmd)
+	targets, err := resolveMigrateRestoreTargets(migrateRestoreCluster, migrateRestoreVault, migrateRestoreStack)
 	if err != nil {
 		return err
 	}
-	defer cancel()
-
-	imported, err := performMigrateRestore(cmd, requestContext, exportDir, migrateRestoreOptions{
-		Cluster: migrateRestoreCluster, Stack: migrateRestoreStack, Vault: migrateRestoreVault, Wait: wait,
-	})
+	imported, err := performMigrateRestore(cmd, exportDir, targets, wait)
 	if err != nil {
 		return err
 	}
@@ -171,19 +183,13 @@ func runMigrateRestoreStatus(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	requestContext, cancel, err := asyncWriteRequestContext(cmd)
-	if err != nil {
-		return err
-	}
-	defer cancel()
-
 	vaultID, err := resolveImportVaultID(migrateRestoreStatusVault)
 	if err != nil {
 		return err
 	}
 	var imported *client.BackupVaultImport
 	if wait {
-		imported, err = waitForMigrateRestore(requestContext, cmd, vaultID, args[0])
+		imported, err = waitForMigrateRestore(cmd, vaultID, args[0])
 	} else {
 		imported, err = apiClient.GetBackupVaultImport(vaultID, args[0])
 		if err != nil {
@@ -209,11 +215,10 @@ func runMigrateData(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	requestContext, cancel, err := asyncWriteRequestContext(cmd)
+	targets, err := resolveMigrateRestoreTargets(migrateDataCluster, migrateDataVault, migrateDataStack)
 	if err != nil {
 		return err
 	}
-	defer cancel()
 
 	exported, err := performMigrateExport(cmd, dir, migrateExportRequest{
 		Module: migrateDataModule, Out: migrateDataOut, Namespace: migrateDataNamespace,
@@ -224,9 +229,7 @@ func runMigrateData(cmd *cobra.Command, args []string) error {
 	}
 	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Exported %d database server(s) to %s\n", len(exported.Manifest.Databases), exported.Out)
 
-	imported, err := performMigrateRestore(cmd, requestContext, exported.Out, migrateRestoreOptions{
-		Cluster: migrateDataCluster, Stack: migrateDataStack, Vault: migrateDataVault, Wait: wait,
-	})
+	imported, err := performMigrateRestore(cmd, exported.Out, targets, wait)
 	if err != nil {
 		return err
 	}
@@ -238,9 +241,10 @@ func runMigrateData(cmd *cobra.Command, args []string) error {
 }
 
 // performMigrateRestore registers the export, uploads its artifacts, has the
-// platform verify them, dispatches the restore, and - with Wait - follows it
-// to a terminal state.
-func performMigrateRestore(cmd *cobra.Command, ctx context.Context, exportDir string, options migrateRestoreOptions) (*client.BackupVaultImport, error) {
+// platform verify them, dispatches the restore, and - with wait - follows it
+// to a terminal state. The uploads run under the command's own context: a
+// dump takes as long as it takes, and only the wait is bounded by --timeout.
+func performMigrateRestore(cmd *cobra.Command, exportDir string, targets migrateRestoreTargets, wait bool) (*client.BackupVaultImport, error) {
 	manifest, err := migrate.ReadExportManifest(exportDir)
 	if err != nil {
 		return nil, withExitCode(exitUsage, fmt.Errorf("%s is not an export directory: %w", exportDir, err))
@@ -249,23 +253,23 @@ func performMigrateRestore(cmd *cobra.Command, ctx context.Context, exportDir st
 	if err != nil {
 		return nil, err
 	}
-	clusterID, clusterName, err := resolveClusterForCmd(options.Cluster)
-	if err != nil {
-		return nil, err
-	}
-	vaultID, err := resolveImportVaultID(options.Vault)
-	if err != nil {
-		return nil, err
-	}
-	stackName := options.Stack
+	stackName := targets.stackName
 	if stackName == "" {
 		stackName = migrateResourceName(filepath.Base(exportSourceDir(manifest, exportDir)))
 	}
+	for _, database := range manifest.Databases {
+		for _, artifact := range database.Artifacts {
+			if artifact.SizeBytes > client.PresignedUploadMaximumBytes {
+				return nil, withExitCode(exitUsage, fmt.Errorf("artifact %s is %s; a single upload carries at most %s, and multipart uploads are not supported yet",
+					artifact.Path, formatByteSize(artifact.SizeBytes), formatByteSize(client.PresignedUploadMaximumBytes)))
+			}
+		}
+	}
 
 	progress := cmd.ErrOrStderr()
-	_, _ = fmt.Fprintf(progress, "Registering the import for cluster %s\n", clusterName)
-	created, err := apiClient.CreateBackupVaultImport(vaultID, client.CreateBackupVaultImportRequest{
-		ClusterID: clusterID, StackName: stackName, Manifest: rawManifest,
+	_, _ = fmt.Fprintf(progress, "Registering the import for cluster %s\n", targets.clusterName)
+	created, err := apiClient.CreateBackupVaultImport(targets.vaultID, client.CreateBackupVaultImportRequest{
+		ClusterID: targets.clusterID, StackName: stackName, Manifest: rawManifest,
 	})
 	if err != nil {
 		return nil, backupLaneError("registering the import", err)
@@ -281,25 +285,25 @@ func performMigrateRestore(cmd *cobra.Command, ctx context.Context, exportDir st
 			return nil, fmt.Errorf("artifact %s is %d bytes but the manifest recorded %d; run `ankra migrate export` again", upload.Path, info.Size(), upload.SizeBytes)
 		}
 		_, _ = fmt.Fprintf(progress, "Uploading %s (%s)\n", upload.Path, formatByteSize(info.Size()))
-		if uploadError := uploadMigrateArtifact(ctx, localPath, upload, info.Size()); uploadError != nil {
+		if uploadError := uploadMigrateArtifact(cmd.Context(), localPath, upload, info.Size()); uploadError != nil {
 			return nil, fmt.Errorf("uploading %s: %w", upload.Path, uploadError)
 		}
 	}
 
 	_, _ = fmt.Fprintln(progress, "Verifying the upload")
-	completed, err := apiClient.CompleteBackupVaultImport(vaultID, created.Import.ID)
+	completed, err := apiClient.CompleteBackupVaultImport(targets.vaultID, created.Import.ID)
 	if err != nil {
 		return nil, backupLaneError("verifying the import", err)
 	}
-	_, _ = fmt.Fprintf(progress, "Restoring %d database server(s) into cluster %s\n", len(completed.Databases), clusterName)
-	restoring, err := apiClient.RestoreBackupVaultImport(vaultID, created.Import.ID)
+	_, _ = fmt.Fprintf(progress, "Restoring %d database server(s) into cluster %s\n", len(completed.Databases), targets.clusterName)
+	restoring, err := apiClient.RestoreBackupVaultImport(targets.vaultID, created.Import.ID)
 	if err != nil {
 		return nil, backupLaneError("starting the restore", err)
 	}
-	if !options.Wait {
+	if !wait {
 		return restoring, nil
 	}
-	return waitForMigrateRestore(ctx, cmd, vaultID, restoring.ID)
+	return waitForMigrateRestore(cmd, targets.vaultID, restoring.ID)
 }
 
 func uploadMigrateArtifact(ctx context.Context, localPath string, upload client.BackupVaultImportUpload, size int64) error {
@@ -308,7 +312,7 @@ func uploadMigrateArtifact(ctx context.Context, localPath string, upload client.
 		return openError
 	}
 	defer func() { _ = file.Close() }()
-	return apiClient.UploadPresignedObject(ctx, upload.URL, file, size)
+	return apiClient.UploadPresignedObject(ctx, upload.Method, upload.URL, file, size)
 }
 
 // exportSourceDir is where the export was taken from, when the manifest
@@ -351,8 +355,13 @@ func resolveImportVaultID(reference string) (string, error) {
 }
 
 // waitForMigrateRestore re-reads the import until it completes or fails,
-// narrating each step's state change; the context carries the --timeout.
-func waitForMigrateRestore(ctx context.Context, cmd *cobra.Command, vaultID string, importID string) (*client.BackupVaultImport, error) {
+// narrating each step's state change, within the --timeout budget.
+func waitForMigrateRestore(cmd *cobra.Command, vaultID string, importID string) (*client.BackupVaultImport, error) {
+	waitContext, cancel, contextError := asyncWriteRequestContext(cmd)
+	if contextError != nil {
+		return nil, contextError
+	}
+	defer cancel()
 	progress := cmd.ErrOrStderr()
 	lastSeen := map[string]string{}
 	for {
@@ -373,12 +382,15 @@ func waitForMigrateRestore(ctx context.Context, cmd *cobra.Command, vaultID stri
 			return current, nil
 		case client.BackupVaultImportStatusFailed:
 			return current, migrateRestoreFailure(current)
+		case client.BackupVaultImportStatusRestoring:
 		case client.BackupVaultImportStatusUploading, client.BackupVaultImportStatusUploaded:
 			return current, fmt.Errorf("import %s is %s; no restore is running for it", current.ID, current.Status)
+		default:
+			return current, fmt.Errorf("import %s reports status %q, which this CLI does not know; upgrade the CLI", current.ID, current.Status)
 		}
 		select {
-		case <-ctx.Done():
-			return current, asyncWriteError("waiting for the restore", true, ctx.Err())
+		case <-waitContext.Done():
+			return current, asyncWriteError("waiting for the restore", true, waitContext.Err())
 		case <-time.After(migrateRestorePollInterval):
 		}
 	}

--- a/cmd/migrate_restore.go
+++ b/cmd/migrate_restore.go
@@ -1,0 +1,432 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+
+	"ankra/internal/client"
+	"ankra/internal/migrate"
+)
+
+// The restore lane is the one part of 'ankra migrate' that talks to the
+// platform: an export directory travels into the cluster through a backup
+// vault. The CLI uploads each dump straight to the vault's bucket with the
+// presigned URLs the platform mints, asks the platform to verify they
+// arrived, and the platform runs the restore inside the cluster - so the
+// data never passes through Ankra, and nothing on this machine needs
+// kubectl or a database client.
+
+var (
+	migrateRestoreCluster string
+	migrateRestoreStack   string
+	migrateRestoreVault   string
+
+	migrateRestoreStatusVault string
+
+	migrateDataModule    string
+	migrateDataOut       string
+	migrateDataNamespace string
+	migrateDataOptions   []string
+	migrateDataForce     bool
+	migrateDataCluster   string
+	migrateDataStack     string
+	migrateDataVault     string
+)
+
+// migrateRestorePollInterval is how often --wait re-reads the import; tests
+// shorten it.
+var migrateRestorePollInterval = 5 * time.Second
+
+var migrateRestoreCmd = &cobra.Command{
+	Use:   "restore <export-dir>",
+	Short: "Load an exported deployment's databases into a cluster through a backup vault",
+	Long: `Load the databases 'ankra migrate export' dumped into the cluster that now
+runs the converted deployment. The export directory's manifest says where
+each dump belongs - the Service and Secret 'ankra migrate convert' generated
+for the database - so nothing has to be looked up by hand.
+
+The dumps are uploaded straight to the organisation's backup vault with
+presigned URLs, the platform verifies every object arrived intact, and the
+cluster's agent runs the restore inside the cluster: roles and globals
+first, then each database with the engine's own tools. Ankra never holds
+the data, and this machine needs neither kubectl nor a database client.
+
+Prerequisites: a backup vault in the organisation ('ankra backup vaults
+provision' creates one), the converted stack applied to the cluster
+('ankra cluster apply'), and a cluster agent that supports data restores.
+The vault is picked automatically when the organisation has exactly one
+ready vault; pass --vault otherwise.
+
+Pass --wait to follow the restore to its end; without it the command returns
+once the restore is running, and 'ankra migrate restore-status <import-id>'
+reports progress.`,
+	Example: `  ankra migrate restore ./app-data --cluster shop --wait
+  ankra migrate restore ./app-data --cluster shop --vault backups --stack shop
+  ankra migrate restore ./app-data -o json`,
+	Args:        cobra.ExactArgs(1),
+	Annotations: map[string]string{annotationRequiresAuth: "true"},
+	RunE:        runMigrateRestore,
+}
+
+var migrateRestoreStatusCmd = &cobra.Command{
+	Use:   "restore-status <import-id>",
+	Short: "Report the progress of a restore started by 'ankra migrate restore'",
+	Long: `Read an import and the state of its restore jobs, one per database server.
+Pass --wait to block until the restore has completed or failed.`,
+	Example: `  ankra migrate restore-status 6f1c8e2a-... --vault backups
+  ankra migrate restore-status 6f1c8e2a-... --wait`,
+	Args:        cobra.ExactArgs(1),
+	Annotations: map[string]string{annotationRequiresAuth: "true"},
+	RunE:        runMigrateRestoreStatus,
+}
+
+var migrateDataCmd = &cobra.Command{
+	Use:   "data [dir]",
+	Short: "Export a deployment's databases and restore them into a cluster in one go",
+	Long: `Run 'ankra migrate export' on the directory (default: the current one) and
+'ankra migrate restore' on the result, back to back: the one command that
+moves a Docker deployment's data into the cluster once its workloads are
+running there. Every flag of both commands applies.
+
+Each dump is a snapshot of a live server. Rehearse while the source is
+running, then stop its writers and run it once more for the real cutover.`,
+	Example: `  ankra migrate data ./app --cluster shop --wait
+  ankra migrate data ./app --option docker-host=ssh://root@203.0.113.7 --option project=aura-office --cluster shop --wait`,
+	Args:        cobra.MaximumNArgs(1),
+	Annotations: map[string]string{annotationRequiresAuth: "true"},
+	RunE:        runMigrateData,
+}
+
+func init() {
+	migrateRestoreCmd.Flags().StringVar(&migrateRestoreCluster, "cluster", "", "Cluster to restore into, by name or id (default: the selected cluster)")
+	migrateRestoreCmd.Flags().StringVar(&migrateRestoreStack, "stack", "", "Stack the data belongs to (default: derived from the export)")
+	migrateRestoreCmd.Flags().StringVar(&migrateRestoreVault, "vault", "", "Backup vault to upload through, by name or id (default: the organisation's only ready vault)")
+	registerAsyncWriteFlags(migrateRestoreCmd)
+	registerStructuredOutputFlags(migrateRestoreCmd)
+	migrateCmd.AddCommand(migrateRestoreCmd)
+
+	migrateRestoreStatusCmd.Flags().StringVar(&migrateRestoreStatusVault, "vault", "", "Backup vault the import went through, by name or id (default: the organisation's only ready vault)")
+	registerAsyncWriteFlags(migrateRestoreStatusCmd)
+	registerStructuredOutputFlags(migrateRestoreStatusCmd)
+	migrateCmd.AddCommand(migrateRestoreStatusCmd)
+
+	migrateDataCmd.Flags().StringVar(&migrateDataModule, "module", "", "Module to use (default: the most confident detection)")
+	migrateDataCmd.Flags().StringVar(&migrateDataOut, "out", "ankra-migration-data", "Output directory for the export")
+	migrateDataCmd.Flags().StringVar(&migrateDataNamespace, "namespace", "", "Namespace the converted workloads run in (default: the directory name, as for convert)")
+	migrateDataCmd.Flags().StringArrayVar(&migrateDataOptions, "option", nil, "Module option as key=value (repeatable)")
+	migrateDataCmd.Flags().BoolVar(&migrateDataForce, "force", false, "Overwrite an output directory that is not empty")
+	migrateDataCmd.Flags().StringVar(&migrateDataCluster, "cluster", "", "Cluster to restore into, by name or id (default: the selected cluster)")
+	migrateDataCmd.Flags().StringVar(&migrateDataStack, "stack", "", "Stack the data belongs to (default: derived from the export)")
+	migrateDataCmd.Flags().StringVar(&migrateDataVault, "vault", "", "Backup vault to upload through, by name or id (default: the organisation's only ready vault)")
+	registerAsyncWriteFlags(migrateDataCmd)
+	registerStructuredOutputFlags(migrateDataCmd)
+	migrateCmd.AddCommand(migrateDataCmd)
+}
+
+// migrateRestoreOptions is what a restore needs beyond the export directory.
+type migrateRestoreOptions struct {
+	Cluster string
+	Stack   string
+	Vault   string
+	Wait    bool
+}
+
+func runMigrateRestore(cmd *cobra.Command, args []string) error {
+	exportDir, err := migrateSourceDir(args)
+	if err != nil {
+		return err
+	}
+	wait, err := asyncWriteWaitFlag(cmd)
+	if err != nil {
+		return err
+	}
+	requestContext, cancel, err := asyncWriteRequestContext(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	imported, err := performMigrateRestore(cmd, requestContext, exportDir, migrateRestoreOptions{
+		Cluster: migrateRestoreCluster, Stack: migrateRestoreStack, Vault: migrateRestoreVault, Wait: wait,
+	})
+	if err != nil {
+		return err
+	}
+	if handled, err := renderStructured(cmd, imported); handled || err != nil {
+		return err
+	}
+	printMigrateRestoreOutcome(cmd, imported, wait)
+	return nil
+}
+
+func runMigrateRestoreStatus(cmd *cobra.Command, args []string) error {
+	wait, err := asyncWriteWaitFlag(cmd)
+	if err != nil {
+		return err
+	}
+	requestContext, cancel, err := asyncWriteRequestContext(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	vaultID, err := resolveImportVaultID(migrateRestoreStatusVault)
+	if err != nil {
+		return err
+	}
+	var imported *client.BackupVaultImport
+	if wait {
+		imported, err = waitForMigrateRestore(requestContext, cmd, vaultID, args[0])
+	} else {
+		imported, err = apiClient.GetBackupVaultImport(vaultID, args[0])
+		if err != nil {
+			err = backupLaneError("reading the import", err)
+		}
+	}
+	if err != nil {
+		return err
+	}
+	if handled, err := renderStructured(cmd, imported); handled || err != nil {
+		return err
+	}
+	printMigrateRestoreOutcome(cmd, imported, wait)
+	return nil
+}
+
+func runMigrateData(cmd *cobra.Command, args []string) error {
+	dir, err := migrateSourceDir(args)
+	if err != nil {
+		return err
+	}
+	wait, err := asyncWriteWaitFlag(cmd)
+	if err != nil {
+		return err
+	}
+	requestContext, cancel, err := asyncWriteRequestContext(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	exported, err := performMigrateExport(cmd, dir, migrateExportRequest{
+		Module: migrateDataModule, Out: migrateDataOut, Namespace: migrateDataNamespace,
+		Options: migrateDataOptions, Force: migrateDataForce,
+	})
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Exported %d database server(s) to %s\n", len(exported.Manifest.Databases), exported.Out)
+
+	imported, err := performMigrateRestore(cmd, requestContext, exported.Out, migrateRestoreOptions{
+		Cluster: migrateDataCluster, Stack: migrateDataStack, Vault: migrateDataVault, Wait: wait,
+	})
+	if err != nil {
+		return err
+	}
+	if handled, err := renderStructured(cmd, imported); handled || err != nil {
+		return err
+	}
+	printMigrateRestoreOutcome(cmd, imported, wait)
+	return nil
+}
+
+// performMigrateRestore registers the export, uploads its artifacts, has the
+// platform verify them, dispatches the restore, and - with Wait - follows it
+// to a terminal state.
+func performMigrateRestore(cmd *cobra.Command, ctx context.Context, exportDir string, options migrateRestoreOptions) (*client.BackupVaultImport, error) {
+	manifest, err := migrate.ReadExportManifest(exportDir)
+	if err != nil {
+		return nil, withExitCode(exitUsage, fmt.Errorf("%s is not an export directory: %w", exportDir, err))
+	}
+	rawManifest, err := os.ReadFile(filepath.Join(exportDir, migrate.ExportManifestFileName))
+	if err != nil {
+		return nil, err
+	}
+	clusterID, clusterName, err := resolveClusterForCmd(options.Cluster)
+	if err != nil {
+		return nil, err
+	}
+	vaultID, err := resolveImportVaultID(options.Vault)
+	if err != nil {
+		return nil, err
+	}
+	stackName := options.Stack
+	if stackName == "" {
+		stackName = migrateResourceName(filepath.Base(exportSourceDir(manifest, exportDir)))
+	}
+
+	progress := cmd.ErrOrStderr()
+	_, _ = fmt.Fprintf(progress, "Registering the import for cluster %s\n", clusterName)
+	created, err := apiClient.CreateBackupVaultImport(vaultID, client.CreateBackupVaultImportRequest{
+		ClusterID: clusterID, StackName: stackName, Manifest: rawManifest,
+	})
+	if err != nil {
+		return nil, backupLaneError("registering the import", err)
+	}
+
+	for _, upload := range created.Uploads {
+		localPath := filepath.Join(exportDir, filepath.FromSlash(upload.Path))
+		info, statError := os.Stat(localPath)
+		if statError != nil {
+			return nil, fmt.Errorf("artifact %s is missing from %s: %w", upload.Path, exportDir, statError)
+		}
+		if info.Size() != upload.SizeBytes {
+			return nil, fmt.Errorf("artifact %s is %d bytes but the manifest recorded %d; run `ankra migrate export` again", upload.Path, info.Size(), upload.SizeBytes)
+		}
+		_, _ = fmt.Fprintf(progress, "Uploading %s (%s)\n", upload.Path, formatByteSize(info.Size()))
+		if uploadError := uploadMigrateArtifact(ctx, localPath, upload, info.Size()); uploadError != nil {
+			return nil, fmt.Errorf("uploading %s: %w", upload.Path, uploadError)
+		}
+	}
+
+	_, _ = fmt.Fprintln(progress, "Verifying the upload")
+	completed, err := apiClient.CompleteBackupVaultImport(vaultID, created.Import.ID)
+	if err != nil {
+		return nil, backupLaneError("verifying the import", err)
+	}
+	_, _ = fmt.Fprintf(progress, "Restoring %d database server(s) into cluster %s\n", len(completed.Databases), clusterName)
+	restoring, err := apiClient.RestoreBackupVaultImport(vaultID, created.Import.ID)
+	if err != nil {
+		return nil, backupLaneError("starting the restore", err)
+	}
+	if !options.Wait {
+		return restoring, nil
+	}
+	return waitForMigrateRestore(ctx, cmd, vaultID, restoring.ID)
+}
+
+func uploadMigrateArtifact(ctx context.Context, localPath string, upload client.BackupVaultImportUpload, size int64) error {
+	file, openError := os.Open(localPath)
+	if openError != nil {
+		return openError
+	}
+	defer func() { _ = file.Close() }()
+	return apiClient.UploadPresignedObject(ctx, upload.URL, file, size)
+}
+
+// exportSourceDir is where the export was taken from, when the manifest
+// remembers it; the export directory itself otherwise.
+func exportSourceDir(manifest migrate.ExportManifest, exportDir string) string {
+	if manifest.SourceDir != "" {
+		return manifest.SourceDir
+	}
+	return exportDir
+}
+
+// resolveImportVaultID picks the vault by name or id, or - with nothing
+// given - the organisation's only ready vault, which is the common case.
+func resolveImportVaultID(reference string) (string, error) {
+	if reference != "" {
+		return resolveBackupVaultID(apiClient, reference)
+	}
+	listing, listError := apiClient.ListBackupVaults()
+	if listError != nil {
+		return "", backupLaneError("listing backup vaults", listError)
+	}
+	ready := []client.BackupVault{}
+	for _, vault := range listing.Items {
+		if vault.Status == "ready" {
+			ready = append(ready, vault)
+		}
+	}
+	switch len(ready) {
+	case 1:
+		return ready[0].ID, nil
+	case 0:
+		return "", withExitCode(exitUsage, fmt.Errorf("the organisation has no ready backup vault; create one with `ankra backup vaults provision`, or pass --vault"))
+	default:
+		names := make([]string, 0, len(ready))
+		for _, vault := range ready {
+			names = append(names, vault.Name)
+		}
+		return "", withExitCode(exitUsage, fmt.Errorf("the organisation has %d ready backup vaults (%s); pass --vault to choose one", len(ready), strings.Join(names, ", ")))
+	}
+}
+
+// waitForMigrateRestore re-reads the import until it completes or fails,
+// narrating each step's state change; the context carries the --timeout.
+func waitForMigrateRestore(ctx context.Context, cmd *cobra.Command, vaultID string, importID string) (*client.BackupVaultImport, error) {
+	progress := cmd.ErrOrStderr()
+	lastSeen := map[string]string{}
+	for {
+		current, getError := apiClient.GetBackupVaultImport(vaultID, importID)
+		if getError != nil {
+			return nil, backupLaneError("reading the import", getError)
+		}
+		if current.Restore != nil {
+			for _, step := range current.Restore.Steps {
+				if lastSeen[step.StepID] != step.Status {
+					lastSeen[step.StepID] = step.Status
+					_, _ = fmt.Fprintf(progress, "  %s: %s\n", step.Workload, step.Status)
+				}
+			}
+		}
+		switch current.Status {
+		case client.BackupVaultImportStatusCompleted:
+			return current, nil
+		case client.BackupVaultImportStatusFailed:
+			return current, migrateRestoreFailure(current)
+		case client.BackupVaultImportStatusUploading, client.BackupVaultImportStatusUploaded:
+			return current, fmt.Errorf("import %s is %s; no restore is running for it", current.ID, current.Status)
+		}
+		select {
+		case <-ctx.Done():
+			return current, asyncWriteError("waiting for the restore", true, ctx.Err())
+		case <-time.After(migrateRestorePollInterval):
+		}
+	}
+}
+
+func migrateRestoreFailure(imported *client.BackupVaultImport) error {
+	reason := "see the restore job's log in the cluster"
+	if imported.ErrorExcerpt != nil && *imported.ErrorExcerpt != "" {
+		reason = *imported.ErrorExcerpt
+	}
+	return fmt.Errorf("the restore of import %s failed: %s", imported.ID, reason)
+}
+
+func printMigrateRestoreOutcome(cmd *cobra.Command, imported *client.BackupVaultImport, waited bool) {
+	out := cmd.OutOrStdout()
+	if !waited && imported.Status == client.BackupVaultImportStatusRestoring {
+		_, _ = fmt.Fprintf(out, "Restore started (import %s).\n", imported.ID)
+		_, _ = fmt.Fprintf(out, "The cluster's agent is loading the data in the background. Follow it with:\n  ankra migrate restore-status %s --wait\n", imported.ID)
+		return
+	}
+	writer := table.NewWriter()
+	writer.SetOutputMirror(out)
+	writer.SetStyle(table.StyleRounded)
+	writer.AppendHeader(table.Row{"WORKLOAD", "ENGINE", "TARGET", "STATUS"})
+	stepStatus := map[string]client.BackupVaultImportRestoreStep{}
+	if imported.Restore != nil {
+		for _, step := range imported.Restore.Steps {
+			stepStatus[step.Workload] = step
+		}
+	}
+	for _, database := range imported.Databases {
+		status := imported.Status
+		if step, ok := stepStatus[database.Workload]; ok {
+			status = step.Status
+			if step.ErrorExcerpt != "" {
+				status += ": " + step.ErrorExcerpt
+			}
+		}
+		target := fmt.Sprintf("%s/%s:%d", database.Target.Namespace, database.Target.Host, database.Target.Port)
+		writer.AppendRow(table.Row{database.Workload, database.Engine, target, status})
+	}
+	writer.Render()
+	switch imported.Status {
+	case client.BackupVaultImportStatusCompleted:
+		_, _ = fmt.Fprintf(out, "Restore complete: %d database server(s) loaded (import %s).\n", len(imported.Databases), imported.ID)
+	case client.BackupVaultImportStatusRestoring:
+		_, _ = fmt.Fprintf(out, "Restore still running (import %s).\n", imported.ID)
+	default:
+		_, _ = fmt.Fprintf(out, "Import %s is %s.\n", imported.ID, imported.Status)
+	}
+}

--- a/cmd/migrate_restore_test.go
+++ b/cmd/migrate_restore_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,6 +36,7 @@ const migrateRestoreTestManifest = `{
 type migrateRestoreMock struct {
 	baseMock
 	vaults       []client.BackupVault
+	vaultIDs     []string
 	createdWith  *client.CreateBackupVaultImportRequest
 	uploads      map[string]int64
 	completed    int
@@ -51,6 +54,7 @@ func (mock *migrateRestoreMock) ListBackupVaults() (*client.BackupVaultListResul
 // CreateBackupVaultImport mints one upload per artifact the submitted
 // manifest lists, at the size it recorded - what the platform does.
 func (mock *migrateRestoreMock) CreateBackupVaultImport(vaultID string, request client.CreateBackupVaultImportRequest) (*client.CreateBackupVaultImportResult, error) {
+	mock.vaultIDs = append(mock.vaultIDs, vaultID)
 	mock.createdWith = &request
 	var manifest struct {
 		Databases []struct {
@@ -76,7 +80,10 @@ func (mock *migrateRestoreMock) CreateBackupVaultImport(vaultID string, request 
 	return &client.CreateBackupVaultImportResult{Import: imported, Uploads: uploads}, nil
 }
 
-func (mock *migrateRestoreMock) UploadPresignedObject(_ context.Context, uploadURL string, body io.Reader, size int64) error {
+func (mock *migrateRestoreMock) UploadPresignedObject(_ context.Context, method string, uploadURL string, body io.ReadSeeker, size int64) error {
+	if method != http.MethodPut {
+		return fmt.Errorf("the platform minted a %s upload; the CLI must use it as given", method)
+	}
 	if mock.uploadFailOn != "" && strings.Contains(uploadURL, mock.uploadFailOn) {
 		return errors.New("403 SignatureDoesNotMatch")
 	}
@@ -186,6 +193,7 @@ func resetMigrateRestoreFlags() {
 		}
 		_ = sub.Flags().Set("wait", "false")
 		_ = sub.Flags().Set("output", "")
+		_ = sub.Flags().Set("timeout", sub.Flags().Lookup("timeout").DefValue)
 	}
 }
 
@@ -308,6 +316,57 @@ func TestMigrateRestoreVaultSelection(t *testing.T) {
 	installMigrateRestoreMock(t, mock)
 	if _, _, err = runMigrate(t, "restore", dir, "--cluster", migrateRestoreTestCluster, "--vault", "archive2"); err != nil {
 		t.Errorf("--vault by name should resolve: %v", err)
+	}
+	for _, vaultID := range mock.vaultIDs {
+		if vaultID != readyVault("archive2").ID {
+			t.Errorf("every import call must go to the chosen vault, got %v", mock.vaultIDs)
+		}
+	}
+	if len(mock.vaultIDs) == 0 {
+		t.Error("the import lifecycle must have been driven")
+	}
+}
+
+func TestMigrateRestoreRefusesArtifactsAboveOneUpload(t *testing.T) {
+	mock := &migrateRestoreMock{vaults: []client.BackupVault{readyVault("backups1")}, getStatuses: []string{"completed"}}
+	installMigrateRestoreMock(t, mock)
+	dir := writeMigrateRestoreFixture(t)
+	oversize := strings.Replace(migrateRestoreTestManifest, `"size_bytes": 5,`, `"size_bytes": 6442450944,`, 1)
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(oversize), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := runMigrate(t, "restore", dir, "--cluster", migrateRestoreTestCluster)
+	if exitCodeFor(err) != exitUsage || !strings.Contains(err.Error(), "db/office.dump is 6.0 GiB") || !strings.Contains(err.Error(), "multipart") {
+		t.Errorf("an artifact above one presigned upload must be refused up front, got %v", err)
+	}
+	if mock.createdWith != nil {
+		t.Error("nothing may be registered for an export that cannot be uploaded")
+	}
+}
+
+func TestMigrateRestoreStatusRejectsAStatusItDoesNotKnow(t *testing.T) {
+	mock := &migrateRestoreMock{vaults: []client.BackupVault{readyVault("backups1")}, getStatuses: []string{"archived"}}
+	installMigrateRestoreMock(t, mock)
+
+	_, _, err := runMigrate(t, "restore-status", "6f1c8e2a-0000-4000-8000-000000000001", "--wait")
+	if err == nil || !strings.Contains(err.Error(), `"archived"`) || !strings.Contains(err.Error(), "upgrade the CLI") {
+		t.Errorf("a status this CLI does not know must not be waited on forever, got %v", err)
+	}
+}
+
+func TestMigrateDataResolvesTargetsBeforeExporting(t *testing.T) {
+	fakeDockerOnPath(t)
+	installMigrateRestoreMock(t, &migrateRestoreMock{getStatuses: []string{"completed"}})
+	dir := writeMigrateFixture(t)
+	out := filepath.Join(t.TempDir(), "data")
+
+	_, _, err := runMigrate(t, "data", dir, "--out", out, "--cluster", migrateRestoreTestCluster)
+	if exitCodeFor(err) != exitUsage || !strings.Contains(err.Error(), "no ready backup vault") {
+		t.Errorf("a missing vault must fail before anything is dumped, got %v", err)
+	}
+	if _, statError := os.Stat(out); statError == nil {
+		t.Error("no dump may be taken when the restore target cannot be resolved")
 	}
 }
 

--- a/cmd/migrate_restore_test.go
+++ b/cmd/migrate_restore_test.go
@@ -1,0 +1,377 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"ankra/internal/client"
+)
+
+const migrateRestoreTestManifest = `{
+  "version": 1,
+  "module": "docker",
+  "source_dir": "/src/shop",
+  "created_at": "2026-08-29T01:02:03Z",
+  "databases": [{
+    "workload": "db", "engine": "postgres", "server_version": "17.2",
+    "target": {"namespace": "shop", "host": "db", "port": 5432, "username": "office", "password_secret": "db-secrets", "password_key": "POSTGRES_PASSWORD"},
+    "artifacts": [
+      {"path": "db/globals.sql", "kind": "globals", "format": "sql", "size_bytes": 11, "sha256": "aa"},
+      {"path": "db/office.dump", "kind": "database", "format": "pg_custom", "database": "office", "size_bytes": 5, "sha256": "bb"}
+    ]
+  }]
+}`
+
+// migrateRestoreMock scripts the platform: it records the import lifecycle
+// calls and answers GET with a sequence of statuses.
+type migrateRestoreMock struct {
+	baseMock
+	vaults       []client.BackupVault
+	createdWith  *client.CreateBackupVaultImportRequest
+	uploads      map[string]int64
+	completed    int
+	restored     int
+	getStatuses  []string
+	getCount     int
+	failExcerpt  string
+	uploadFailOn string
+}
+
+func (mock *migrateRestoreMock) ListBackupVaults() (*client.BackupVaultListResult, error) {
+	return &client.BackupVaultListResult{Items: mock.vaults}, nil
+}
+
+// CreateBackupVaultImport mints one upload per artifact the submitted
+// manifest lists, at the size it recorded - what the platform does.
+func (mock *migrateRestoreMock) CreateBackupVaultImport(vaultID string, request client.CreateBackupVaultImportRequest) (*client.CreateBackupVaultImportResult, error) {
+	mock.createdWith = &request
+	var manifest struct {
+		Databases []struct {
+			Artifacts []struct {
+				Path      string `json:"path"`
+				SizeBytes int64  `json:"size_bytes"`
+			} `json:"artifacts"`
+		} `json:"databases"`
+	}
+	if unmarshalError := json.Unmarshal(request.Manifest, &manifest); unmarshalError != nil {
+		return nil, unmarshalError
+	}
+	var uploads []client.BackupVaultImportUpload
+	for _, database := range manifest.Databases {
+		for _, artifact := range database.Artifacts {
+			uploads = append(uploads, client.BackupVaultImportUpload{
+				Path: artifact.Path, Method: "PUT", SizeBytes: artifact.SizeBytes,
+				URL: "https://vault.example.com/imports/1/" + artifact.Path + "?sig=" + artifact.Path,
+			})
+		}
+	}
+	imported := mock.importView(client.BackupVaultImportStatusUploading)
+	return &client.CreateBackupVaultImportResult{Import: imported, Uploads: uploads}, nil
+}
+
+func (mock *migrateRestoreMock) UploadPresignedObject(_ context.Context, uploadURL string, body io.Reader, size int64) error {
+	if mock.uploadFailOn != "" && strings.Contains(uploadURL, mock.uploadFailOn) {
+		return errors.New("403 SignatureDoesNotMatch")
+	}
+	content, readError := io.ReadAll(body)
+	if readError != nil {
+		return readError
+	}
+	if int64(len(content)) != size {
+		return errors.New("body does not match the declared size")
+	}
+	if mock.uploads == nil {
+		mock.uploads = map[string]int64{}
+	}
+	mock.uploads[uploadURL] = size
+	return nil
+}
+
+func (mock *migrateRestoreMock) CompleteBackupVaultImport(string, string) (*client.BackupVaultImport, error) {
+	mock.completed++
+	imported := mock.importView(client.BackupVaultImportStatusUploaded)
+	return &imported, nil
+}
+
+func (mock *migrateRestoreMock) RestoreBackupVaultImport(string, string) (*client.BackupVaultImport, error) {
+	mock.restored++
+	imported := mock.importView(client.BackupVaultImportStatusRestoring)
+	imported.Restore = &client.BackupVaultImportRestore{OperationID: "op-1", Status: "restoring",
+		Steps: []client.BackupVaultImportRestoreStep{{StepID: "step-1", Workload: "db", Status: "pending"}}}
+	return &imported, nil
+}
+
+func (mock *migrateRestoreMock) GetBackupVaultImport(string, string) (*client.BackupVaultImport, error) {
+	index := mock.getCount
+	if index >= len(mock.getStatuses) {
+		index = len(mock.getStatuses) - 1
+	}
+	mock.getCount++
+	status := mock.getStatuses[index]
+	imported := mock.importView(status)
+	stepStatus := map[string]string{"restoring": "running", "completed": "success", "failed": "failed"}[status]
+	step := client.BackupVaultImportRestoreStep{StepID: "step-1", Workload: "db", Status: stepStatus}
+	if status == "failed" {
+		step.ErrorExcerpt = mock.failExcerpt
+		excerpt := "db: " + mock.failExcerpt
+		imported.ErrorExcerpt = &excerpt
+	}
+	imported.Restore = &client.BackupVaultImportRestore{OperationID: "op-1", Status: status, Steps: []client.BackupVaultImportRestoreStep{step}}
+	return &imported, nil
+}
+
+func (mock *migrateRestoreMock) importView(status string) client.BackupVaultImport {
+	return client.BackupVaultImport{
+		ID: "6f1c8e2a-0000-4000-8000-000000000001", BackupVaultID: "vault-1", ClusterID: "cluster-1", StackName: "shop",
+		Status: status, ObjectPrefix: "imports/6f1c8e2a", Warnings: []string{},
+		Databases: []client.BackupVaultImportDatabase{{
+			Workload: "db", Engine: "postgres", ServerVersion: "17.2",
+			Target: client.BackupVaultImportTarget{Namespace: "shop", Host: "db", Port: 5432, Username: "office"},
+		}},
+	}
+}
+
+func writeMigrateRestoreFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for path, content := range map[string]string{
+		"manifest.json":  migrateRestoreTestManifest,
+		"db/globals.sql": "CREATE ROLE",
+		"db/office.dump": "PGDMP",
+	} {
+		full := filepath.Join(dir, filepath.FromSlash(path))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// installMigrateRestoreMock points the commands at the scripted platform.
+// The token satisfies the login gate without touching this machine's
+// configuration, so the tests never depend on a real session.
+func installMigrateRestoreMock(t *testing.T, mock *migrateRestoreMock) {
+	t.Helper()
+	previous := apiClient
+	apiClient = mock
+	original := migrateRestorePollInterval
+	migrateRestorePollInterval = time.Millisecond
+	t.Setenv("ANKRA_API_TOKEN", "migrate-restore-test-token")
+	t.Cleanup(func() {
+		apiClient = previous
+		migrateRestorePollInterval = original
+	})
+	resetMigrateRestoreFlags()
+}
+
+func resetMigrateRestoreFlags() {
+	migrateRestoreCluster = ""
+	migrateRestoreStack = ""
+	migrateRestoreVault = ""
+	migrateRestoreStatusVault = ""
+	for _, command := range []string{"restore", "restore-status", "data"} {
+		sub, _, _ := migrateCmd.Find([]string{command})
+		if sub == nil {
+			continue
+		}
+		_ = sub.Flags().Set("wait", "false")
+		_ = sub.Flags().Set("output", "")
+	}
+}
+
+const migrateRestoreTestCluster = "11111111-1111-4111-8111-111111111111"
+
+func readyVault(name string) client.BackupVault {
+	return client.BackupVault{ID: "22222222-2222-4222-8222-22222222222" + name[len(name)-1:], Name: name, Status: "ready"}
+}
+
+func TestMigrateRestoreCommandsRequireLogin(t *testing.T) {
+	for _, command := range []string{"restore", "restore-status", "data"} {
+		sub, _, err := migrateCmd.Find([]string{command})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !commandRequiresAuth(sub) {
+			t.Errorf("ankra migrate %s talks to the platform and must require a login", command)
+		}
+	}
+}
+
+func TestMigrateRestoreUploadsVerifiesAndFollowsTheRestore(t *testing.T) {
+	mock := &migrateRestoreMock{vaults: []client.BackupVault{readyVault("backups1")}, getStatuses: []string{"restoring", "restoring", "completed"}}
+	installMigrateRestoreMock(t, mock)
+	dir := writeMigrateRestoreFixture(t)
+
+	stdout, stderr, err := runMigrate(t, "restore", dir, "--cluster", migrateRestoreTestCluster, "--wait", "--timeout", "10s")
+	if err != nil {
+		t.Fatalf("%v\n%s", err, stderr)
+	}
+	if mock.createdWith == nil || mock.createdWith.ClusterID != migrateRestoreTestCluster || mock.createdWith.StackName != "shop" ||
+		!strings.Contains(string(mock.createdWith.Manifest), `"workload": "db"`) {
+		t.Errorf("import registered with %+v", mock.createdWith)
+	}
+	if len(mock.uploads) != 2 || mock.uploads["https://vault.example.com/imports/1/db/office.dump?sig=db/office.dump"] != 5 {
+		t.Errorf("uploads = %v", mock.uploads)
+	}
+	if mock.completed != 1 || mock.restored != 1 {
+		t.Errorf("completed=%d restored=%d, want one each", mock.completed, mock.restored)
+	}
+	if mock.getCount < 3 {
+		t.Errorf("--wait must poll until the import settles, polled %d times", mock.getCount)
+	}
+	for _, fragment := range []string{"Uploading db/office.dump (5 B)", "Verifying the upload", "Restoring 1 database server(s)", "db: running", "db: success"} {
+		if !strings.Contains(stderr, fragment) {
+			t.Errorf("progress lacks %q:\n%s", fragment, stderr)
+		}
+	}
+	if !strings.Contains(stdout, "Restore complete: 1 database server(s) loaded") || !strings.Contains(stdout, "shop/db:5432") {
+		t.Errorf("stdout:\n%s", stdout)
+	}
+}
+
+func TestMigrateRestoreWithoutWaitReportsTheImport(t *testing.T) {
+	mock := &migrateRestoreMock{vaults: []client.BackupVault{readyVault("backups1")}, getStatuses: []string{"completed"}}
+	installMigrateRestoreMock(t, mock)
+	dir := writeMigrateRestoreFixture(t)
+
+	stdout, _, err := runMigrate(t, "restore", dir, "--cluster", migrateRestoreTestCluster)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mock.getCount != 0 {
+		t.Errorf("without --wait nothing should be polled, polled %d times", mock.getCount)
+	}
+	if !strings.Contains(stdout, "Restore started (import 6f1c8e2a-0000-4000-8000-000000000001)") || !strings.Contains(stdout, "ankra migrate restore-status 6f1c8e2a-0000-4000-8000-000000000001 --wait") {
+		t.Errorf("stdout:\n%s", stdout)
+	}
+
+	stdout, _, err = runMigrate(t, "restore-status", "6f1c8e2a-0000-4000-8000-000000000001", "--wait")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "Restore complete") {
+		t.Errorf("restore-status stdout:\n%s", stdout)
+	}
+}
+
+func TestMigrateRestoreReportsAFailedRestore(t *testing.T) {
+	mock := &migrateRestoreMock{vaults: []client.BackupVault{readyVault("backups1")}, getStatuses: []string{"restoring", "failed"}, failExcerpt: "pg_restore reported errors for office"}
+	installMigrateRestoreMock(t, mock)
+	dir := writeMigrateRestoreFixture(t)
+
+	_, stderr, err := runMigrate(t, "restore", dir, "--cluster", migrateRestoreTestCluster, "--wait", "--timeout", "10s")
+	if err == nil || !strings.Contains(err.Error(), "the restore of import 6f1c8e2a-0000-4000-8000-000000000001 failed: db: pg_restore reported errors for office") {
+		t.Errorf("a failed restore must fail the command with the excerpt, got %v\n%s", err, stderr)
+	}
+	if !strings.Contains(stderr, "db: failed") {
+		t.Errorf("the step transition belongs in the progress output:\n%s", stderr)
+	}
+}
+
+func TestMigrateRestoreTimesOutWithTheWaitExitCode(t *testing.T) {
+	mock := &migrateRestoreMock{vaults: []client.BackupVault{readyVault("backups1")}, getStatuses: []string{"restoring"}}
+	installMigrateRestoreMock(t, mock)
+	dir := writeMigrateRestoreFixture(t)
+
+	_, _, err := runMigrate(t, "restore", dir, "--cluster", migrateRestoreTestCluster, "--wait", "--timeout", "30ms")
+	if exitCodeFor(err) != exitWaitTimeout {
+		t.Errorf("an expired --timeout should exit %d, got %v", exitWaitTimeout, err)
+	}
+}
+
+func TestMigrateRestoreVaultSelection(t *testing.T) {
+	dir := writeMigrateRestoreFixture(t)
+
+	installMigrateRestoreMock(t, &migrateRestoreMock{getStatuses: []string{"completed"}})
+	_, _, err := runMigrate(t, "restore", dir, "--cluster", migrateRestoreTestCluster)
+	if exitCodeFor(err) != exitUsage || !strings.Contains(err.Error(), "no ready backup vault") {
+		t.Errorf("no vault should be a usage error naming the fix, got %v", err)
+	}
+
+	installMigrateRestoreMock(t, &migrateRestoreMock{vaults: []client.BackupVault{readyVault("backups1"), readyVault("archive2")}, getStatuses: []string{"completed"}})
+	_, _, err = runMigrate(t, "restore", dir, "--cluster", migrateRestoreTestCluster)
+	if exitCodeFor(err) != exitUsage || !strings.Contains(err.Error(), "2 ready backup vaults (backups1, archive2)") {
+		t.Errorf("two vaults should ask for --vault, got %v", err)
+	}
+
+	mock := &migrateRestoreMock{vaults: []client.BackupVault{readyVault("backups1"), readyVault("archive2")}, getStatuses: []string{"completed"}}
+	installMigrateRestoreMock(t, mock)
+	if _, _, err = runMigrate(t, "restore", dir, "--cluster", migrateRestoreTestCluster, "--vault", "archive2"); err != nil {
+		t.Errorf("--vault by name should resolve: %v", err)
+	}
+}
+
+func TestMigrateRestoreRefusesAChangedArtifact(t *testing.T) {
+	mock := &migrateRestoreMock{vaults: []client.BackupVault{readyVault("backups1")}, getStatuses: []string{"completed"}}
+	installMigrateRestoreMock(t, mock)
+	dir := writeMigrateRestoreFixture(t)
+	if err := os.WriteFile(filepath.Join(dir, "db", "office.dump"), []byte("PGDMP-changed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := runMigrate(t, "restore", dir, "--cluster", migrateRestoreTestCluster)
+	if err == nil || !strings.Contains(err.Error(), "artifact db/office.dump is 13 bytes but the manifest recorded 5") {
+		t.Errorf("a changed artifact must be refused before upload, got %v", err)
+	}
+	if mock.completed != 0 {
+		t.Error("nothing may be completed when an upload was refused")
+	}
+
+	mock = &migrateRestoreMock{vaults: []client.BackupVault{readyVault("backups1")}, getStatuses: []string{"completed"}, uploadFailOn: "office.dump"}
+	installMigrateRestoreMock(t, mock)
+	dir = writeMigrateRestoreFixture(t)
+	_, _, err = runMigrate(t, "restore", dir, "--cluster", migrateRestoreTestCluster)
+	if err == nil || !strings.Contains(err.Error(), "uploading db/office.dump: 403 SignatureDoesNotMatch") {
+		t.Errorf("an upload failure must name the artifact, got %v", err)
+	}
+	if _, _, err = runMigrate(t, "restore", t.TempDir(), "--cluster", migrateRestoreTestCluster); exitCodeFor(err) != exitUsage {
+		t.Errorf("a directory without a manifest should exit %d, got %v", exitUsage, err)
+	}
+}
+
+func TestMigrateRestoreStructuredOutput(t *testing.T) {
+	mock := &migrateRestoreMock{vaults: []client.BackupVault{readyVault("backups1")}, getStatuses: []string{"completed"}}
+	installMigrateRestoreMock(t, mock)
+	dir := writeMigrateRestoreFixture(t)
+	stdout, _, err := runMigrate(t, "restore", dir, "--cluster", migrateRestoreTestCluster, "-o", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(stdout), "{") || !strings.Contains(stdout, `"status": "restoring"`) || !strings.Contains(stdout, `"object_prefix": "imports/6f1c8e2a"`) {
+		t.Errorf("json output must be the only thing on stdout:\n%s", stdout)
+	}
+}
+
+func TestMigrateDataExportsThenRestores(t *testing.T) {
+	fakeDockerOnPath(t)
+	mock := &migrateRestoreMock{vaults: []client.BackupVault{readyVault("backups1")}, getStatuses: []string{"completed"}}
+	installMigrateRestoreMock(t, mock)
+	dir := writeMigrateFixture(t)
+	out := filepath.Join(t.TempDir(), "data")
+
+	stdout, stderr, err := runMigrate(t, "data", dir, "--out", out, "--cluster", migrateRestoreTestCluster, "--wait", "--timeout", "10s")
+	if err != nil {
+		t.Fatalf("%v\n%s", err, stderr)
+	}
+	if _, statError := os.Stat(filepath.Join(out, "manifest.json")); statError != nil {
+		t.Errorf("data must leave the export behind: %v", statError)
+	}
+	if mock.createdWith == nil || !strings.Contains(string(mock.createdWith.Manifest), `"database": "office"`) || mock.createdWith.StackName != "shop" {
+		t.Errorf("the export's manifest must be what is registered, got %+v", mock.createdWith)
+	}
+	if len(mock.uploads) != 2 {
+		t.Errorf("both exported artifacts must be uploaded, got %v", mock.uploads)
+	}
+	if !strings.Contains(stderr, "Exported 1 database server(s)") || !strings.Contains(stdout, "Restore complete") {
+		t.Errorf("stdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+}

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -57,7 +57,7 @@ type APIClient interface {
 	CompleteBackupVaultImport(vaultID string, importID string) (*client.BackupVaultImport, error)
 	RestoreBackupVaultImport(vaultID string, importID string) (*client.BackupVaultImport, error)
 	GetBackupVaultImport(vaultID string, importID string) (*client.BackupVaultImport, error)
-	UploadPresignedObject(ctx context.Context, uploadURL string, body io.Reader, size int64) error
+	UploadPresignedObject(ctx context.Context, method string, uploadURL string, body io.ReadSeeker, size int64) error
 
 	ListExecutions(opts client.ListExecutionsOptions) (client.ExecutionListResponse, error)
 	GetExecution(executionID string) (client.ExecutionDetail, error)

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -53,6 +53,11 @@ type APIClient interface {
 	ProvisionBackupVault(request client.ProvisionBackupVaultRequest) (*client.BackupVault, error)
 	VerifyBackupVault(vaultID string) (*client.BackupVault, error)
 	DeleteBackupVault(vaultID string, destroyProviderResources bool) error
+	CreateBackupVaultImport(vaultID string, request client.CreateBackupVaultImportRequest) (*client.CreateBackupVaultImportResult, error)
+	CompleteBackupVaultImport(vaultID string, importID string) (*client.BackupVaultImport, error)
+	RestoreBackupVaultImport(vaultID string, importID string) (*client.BackupVaultImport, error)
+	GetBackupVaultImport(vaultID string, importID string) (*client.BackupVaultImport, error)
+	UploadPresignedObject(ctx context.Context, uploadURL string, body io.Reader, size int64) error
 
 	ListExecutions(opts client.ListExecutionsOptions) (client.ExecutionListResponse, error)
 	GetExecution(executionID string) (client.ExecutionDetail, error)

--- a/examples/modules/README.md
+++ b/examples/modules/README.md
@@ -68,6 +68,40 @@ resources:
 
 Time limits: 15s for `describe`, 30s for `detect`, 5 minutes for `convert`.
 
+### `export` (optional)
+
+A module that can also dump the data behind its source - its databases -
+lists `"capabilities": ["export"]` in its `describe` reply and answers a
+fourth verb, which backs `ankra migrate export`. Input:
+
+```json
+{"dir": "/absolute/path", "output_dir": "/absolute/output", "namespace": "shop",
+ "options": {"docker-host": "ssh://root@203.0.113.7"}}
+```
+
+Write each dump under `output_dir` and reply with what you wrote and where it
+restores to - the Service and Secret that `convert` generated for the same
+workload, so the restore needs nothing the user has to look up:
+
+```json
+{"databases": [{"workload": "db", "engine": "postgres", "server_version": "17.2",
+  "target": {"namespace": "shop", "host": "db", "port": 5432, "username": "app",
+             "password_secret": "db-secrets", "password_key": "POSTGRES_PASSWORD"},
+  "artifacts": [{"path": "db/globals.sql", "kind": "globals", "format": "sql"},
+                {"path": "db/app.dump", "kind": "database", "format": "pg_custom", "database": "app"}]}],
+ "warnings": ["dumped while the source was live"]}
+```
+
+- `engine` is `postgres` or `mysql`; `format` is `pg_custom` (a `pg_dump -Fc`
+  archive) or `sql` (plain SQL, including `pg_dumpall --globals-only` output
+  and `mysqldump` files).
+- Artifact paths are relative to `output_dir` and may not escape it. The CLI
+  measures sizes and checksums from the files itself and writes
+  `manifest.json` plus `SHA256SUMS`; do not write those names.
+- Narrate progress on stderr: it is relayed to the user live while the verb
+  runs (a dump can take minutes), and shown as the reason on failure.
+- Time limit: 6 hours.
+
 ## Rules worth knowing
 
 - **Never write to the source directory.** Convert reads; the CLI writes.

--- a/internal/client/backup_vault_imports.go
+++ b/internal/client/backup_vault_imports.go
@@ -155,32 +155,64 @@ func (c *Client) GetBackupVaultImport(vaultID string, importID string) (*BackupV
 	return &result, nil
 }
 
-// UploadPresignedObject PUTs one artifact to a presigned URL. The URL is the
-// whole credential, so no bearer token is sent; the request carries the exact
-// size because the vault rejects a chunked upload and the platform verifies
-// the object at that size afterwards. A dump can be large, so the upload
-// runs without the API client's per-request timeout and honours ctx instead.
-func (c *Client) UploadPresignedObject(ctx context.Context, uploadURL string, body io.Reader, size int64) error {
-	request, requestError := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL, body)
-	if requestError != nil {
-		return fmt.Errorf("create upload request: %w", requestError)
-	}
-	request.ContentLength = size
-	request.Header.Set("Content-Type", "application/octet-stream")
+// PresignedUploadMaximumBytes is the largest object a single presigned PUT
+// can carry on S3 and every compatible store; a bigger artifact needs a
+// multipart upload the platform does not mint yet.
+const PresignedUploadMaximumBytes = 5 << 30
 
-	var transport http.RoundTripper
-	if c.HTTP != nil {
-		transport = c.HTTP.Transport
+const presignedUploadAttempts = 3
+
+// UploadPresignedObject sends one artifact to a presigned URL. The URL is the
+// whole credential, so no bearer token and no Ankra header is sent - the
+// request goes through a plain transport, never the API client's - and the
+// body carries its exact size because the vault rejects a chunked upload and
+// the platform verifies the object at that size afterwards. A dump can be
+// large, so the upload has no per-request timeout beyond ctx; a transport
+// failure or a 5xx is retried from the start of the body, and a redirect
+// replays it, which is why the body must seek.
+func (c *Client) UploadPresignedObject(ctx context.Context, method string, uploadURL string, body io.ReadSeeker, size int64) error {
+	if method == "" {
+		method = http.MethodPut
 	}
-	uploadClient := &http.Client{Transport: transport}
-	response, doError := uploadClient.Do(request)
-	if doError != nil {
-		return fmt.Errorf("upload failed: %w", doError)
+	if size > PresignedUploadMaximumBytes {
+		return fmt.Errorf("the artifact is %d bytes; a single upload can carry at most %d", size, PresignedUploadMaximumBytes)
 	}
-	defer closeBody(response)
-	if response.StatusCode < 200 || response.StatusCode >= 300 {
+	uploadClient := &http.Client{}
+	var lastError error
+	for attempt := 1; attempt <= presignedUploadAttempts; attempt++ {
+		if _, seekError := body.Seek(0, io.SeekStart); seekError != nil {
+			return fmt.Errorf("rewind upload body: %w", seekError)
+		}
+		request, requestError := http.NewRequestWithContext(ctx, method, uploadURL, body)
+		if requestError != nil {
+			return fmt.Errorf("create upload request: %w", requestError)
+		}
+		request.ContentLength = size
+		request.Header.Set("Content-Type", "application/octet-stream")
+		request.GetBody = func() (io.ReadCloser, error) {
+			if _, seekError := body.Seek(0, io.SeekStart); seekError != nil {
+				return nil, seekError
+			}
+			return io.NopCloser(body), nil
+		}
+
+		response, doError := uploadClient.Do(request)
+		if doError != nil {
+			lastError = fmt.Errorf("upload failed: %w", doError)
+			if ctx.Err() != nil {
+				return lastError
+			}
+			continue
+		}
 		responseBody, _ := io.ReadAll(io.LimitReader(response.Body, 2048))
-		return newUnexpectedResponseError("upload", response.StatusCode, redactedBodyForError(responseBody, 500))
+		closeBody(response)
+		if response.StatusCode >= 200 && response.StatusCode < 300 {
+			return nil
+		}
+		lastError = newUnexpectedResponseError("upload", response.StatusCode, redactedBodyForError(responseBody, 500))
+		if response.StatusCode < 500 {
+			return lastError
+		}
 	}
-	return nil
+	return lastError
 }

--- a/internal/client/backup_vault_imports.go
+++ b/internal/client/backup_vault_imports.go
@@ -1,0 +1,186 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	neturl "net/url"
+)
+
+// BackupVaultImportTarget is the in-cluster server one database restores
+// into: the Service and Secret `ankra migrate convert` generated for it.
+type BackupVaultImportTarget struct {
+	Namespace      string `json:"namespace"`
+	Host           string `json:"host"`
+	Port           int    `json:"port"`
+	Username       string `json:"username,omitempty"`
+	PasswordSecret string `json:"password_secret,omitempty"`
+	PasswordKey    string `json:"password_key,omitempty"`
+}
+
+// BackupVaultImportArtifact is one uploaded dump as the export described it.
+type BackupVaultImportArtifact struct {
+	Path      string `json:"path"`
+	Kind      string `json:"kind"`
+	Format    string `json:"format"`
+	Database  string `json:"database,omitempty"`
+	SizeBytes int64  `json:"size_bytes"`
+	SHA256    string `json:"sha256"`
+}
+
+// BackupVaultImportDatabase is one database server's dumps and target.
+type BackupVaultImportDatabase struct {
+	Workload      string                      `json:"workload"`
+	Engine        string                      `json:"engine"`
+	ServerVersion string                      `json:"server_version,omitempty"`
+	Target        BackupVaultImportTarget     `json:"target"`
+	Artifacts     []BackupVaultImportArtifact `json:"artifacts"`
+}
+
+// BackupVaultImportRestoreStep is one restore job's state as the platform
+// last observed it.
+type BackupVaultImportRestoreStep struct {
+	StepID       string `json:"step_id"`
+	Workload     string `json:"workload"`
+	Status       string `json:"status"`
+	ErrorExcerpt string `json:"error_excerpt,omitempty"`
+}
+
+// BackupVaultImportRestore is the restore operation an import ran or is
+// running: one step per database server.
+type BackupVaultImportRestore struct {
+	OperationID string                         `json:"operation_id"`
+	Status      string                         `json:"status"`
+	Steps       []BackupVaultImportRestoreStep `json:"steps"`
+}
+
+// BackupVaultImport is an `ankra migrate export` directory on its way into a
+// cluster through a backup vault. Status runs uploading -> uploaded ->
+// restoring -> completed | failed.
+type BackupVaultImport struct {
+	ID            string                      `json:"id"`
+	BackupVaultID string                      `json:"backup_vault_id"`
+	ClusterID     string                      `json:"cluster_id"`
+	StackName     string                      `json:"stack_name"`
+	Status        string                      `json:"status"`
+	ObjectPrefix  string                      `json:"object_prefix"`
+	Databases     []BackupVaultImportDatabase `json:"databases"`
+	Warnings      []string                    `json:"warnings"`
+	Restore       *BackupVaultImportRestore   `json:"restore,omitempty"`
+	ErrorExcerpt  *string                     `json:"error_excerpt"`
+	CreatedAt     string                      `json:"created_at"`
+	UpdatedAt     string                      `json:"updated_at"`
+	CompletedAt   *string                     `json:"completed_at"`
+}
+
+// Import statuses on the wire.
+const (
+	BackupVaultImportStatusUploading = "uploading"
+	BackupVaultImportStatusUploaded  = "uploaded"
+	BackupVaultImportStatusRestoring = "restoring"
+	BackupVaultImportStatusCompleted = "completed"
+	BackupVaultImportStatusFailed    = "failed"
+)
+
+// BackupVaultImportUpload is one presigned PUT the CLI performs straight
+// against the vault's bucket; the platform never sees the bytes.
+type BackupVaultImportUpload struct {
+	Path      string `json:"path"`
+	Method    string `json:"method"`
+	URL       string `json:"url"`
+	ExpiresAt string `json:"expires_at"`
+	SizeBytes int64  `json:"size_bytes"`
+}
+
+// CreateBackupVaultImportRequest registers an export: the cluster its data
+// goes to and the export's manifest.json, passed through verbatim.
+type CreateBackupVaultImportRequest struct {
+	ClusterID string          `json:"cluster_id"`
+	StackName string          `json:"stack_name,omitempty"`
+	Manifest  json.RawMessage `json:"manifest"`
+}
+
+// CreateBackupVaultImportResult is the registered import plus its uploads.
+type CreateBackupVaultImportResult struct {
+	Import  BackupVaultImport         `json:"import"`
+	Uploads []BackupVaultImportUpload `json:"uploads"`
+}
+
+// CreateBackupVaultImport registers an export and returns the presigned
+// uploads for its artifacts.
+// POST /api/v1/org/backup-vaults/{vault_id}/imports
+func (c *Client) CreateBackupVaultImport(vaultID string, request CreateBackupVaultImportRequest) (*CreateBackupVaultImportResult, error) {
+	url := fmt.Sprintf("%s/api/v1/org/backup-vaults/%s/imports", c.BaseURL, neturl.PathEscape(vaultID))
+	var result CreateBackupVaultImportResult
+	if requestError := c.sendJSON(http.MethodPost, url, request, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// CompleteBackupVaultImport asks the platform to verify every artifact is in
+// the bucket at its recorded size.
+// POST /api/v1/org/backup-vaults/{vault_id}/imports/{import_id}/complete
+func (c *Client) CompleteBackupVaultImport(vaultID string, importID string) (*BackupVaultImport, error) {
+	url := fmt.Sprintf("%s/api/v1/org/backup-vaults/%s/imports/%s/complete", c.BaseURL, neturl.PathEscape(vaultID), neturl.PathEscape(importID))
+	var result BackupVaultImport
+	if requestError := c.sendJSON(http.MethodPost, url, nil, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// RestoreBackupVaultImport dispatches the in-cluster restore of an uploaded
+// import; the platform answers 202 with the import in restoring.
+// POST /api/v1/org/backup-vaults/{vault_id}/imports/{import_id}/restore
+func (c *Client) RestoreBackupVaultImport(vaultID string, importID string) (*BackupVaultImport, error) {
+	url := fmt.Sprintf("%s/api/v1/org/backup-vaults/%s/imports/%s/restore", c.BaseURL, neturl.PathEscape(vaultID), neturl.PathEscape(importID))
+	var result BackupVaultImport
+	if requestError := c.sendJSON(http.MethodPost, url, nil, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// GetBackupVaultImport reads an import with its restore's live state.
+// GET /api/v1/org/backup-vaults/{vault_id}/imports/{import_id}
+func (c *Client) GetBackupVaultImport(vaultID string, importID string) (*BackupVaultImport, error) {
+	url := fmt.Sprintf("%s/api/v1/org/backup-vaults/%s/imports/%s", c.BaseURL, neturl.PathEscape(vaultID), neturl.PathEscape(importID))
+	var result BackupVaultImport
+	if requestError := c.sendJSON(http.MethodGet, url, nil, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// UploadPresignedObject PUTs one artifact to a presigned URL. The URL is the
+// whole credential, so no bearer token is sent; the request carries the exact
+// size because the vault rejects a chunked upload and the platform verifies
+// the object at that size afterwards. A dump can be large, so the upload
+// runs without the API client's per-request timeout and honours ctx instead.
+func (c *Client) UploadPresignedObject(ctx context.Context, uploadURL string, body io.Reader, size int64) error {
+	request, requestError := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL, body)
+	if requestError != nil {
+		return fmt.Errorf("create upload request: %w", requestError)
+	}
+	request.ContentLength = size
+	request.Header.Set("Content-Type", "application/octet-stream")
+
+	var transport http.RoundTripper
+	if c.HTTP != nil {
+		transport = c.HTTP.Transport
+	}
+	uploadClient := &http.Client{Transport: transport}
+	response, doError := uploadClient.Do(request)
+	if doError != nil {
+		return fmt.Errorf("upload failed: %w", doError)
+	}
+	defer closeBody(response)
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		responseBody, _ := io.ReadAll(io.LimitReader(response.Body, 2048))
+		return newUnexpectedResponseError("upload", response.StatusCode, redactedBodyForError(responseBody, 500))
+	}
+	return nil
+}

--- a/internal/client/backup_vault_imports_test.go
+++ b/internal/client/backup_vault_imports_test.go
@@ -1,0 +1,105 @@
+package client
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestUploadPresignedObjectPutsTheBodyWithoutABearerToken(t *testing.T) {
+	var received struct {
+		method        string
+		authorization string
+		contentLength int64
+		body          string
+		query         string
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		received.method = request.Method
+		received.authorization = request.Header.Get("Authorization")
+		received.contentLength = request.ContentLength
+		received.query = request.URL.RawQuery
+		body, _ := io.ReadAll(request.Body)
+		received.body = string(body)
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	apiClient := &Client{BaseURL: server.URL, Token: "secret-token", HTTP: server.Client()}
+	uploadError := apiClient.UploadPresignedObject(context.Background(), server.URL+"/bucket/imports/1/db/office.dump?X-Amz-Signature=abc", strings.NewReader("PGDMP"), 5)
+	if uploadError != nil {
+		t.Fatal(uploadError)
+	}
+	if received.method != http.MethodPut || received.body != "PGDMP" || received.contentLength != 5 || received.query != "X-Amz-Signature=abc" {
+		t.Errorf("received = %+v", received)
+	}
+	if received.authorization != "" {
+		t.Errorf("the presigned url is the whole credential; no bearer token may be sent, got %q", received.authorization)
+	}
+}
+
+func TestUploadPresignedObjectReportsTheBucketsRefusal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusForbidden)
+		_, _ = writer.Write([]byte("<Error><Code>SignatureDoesNotMatch</Code></Error>"))
+	}))
+	defer server.Close()
+	apiClient := &Client{BaseURL: server.URL, HTTP: server.Client()}
+	uploadError := apiClient.UploadPresignedObject(context.Background(), server.URL+"/x", strings.NewReader("x"), 1)
+	if uploadError == nil || !strings.Contains(uploadError.Error(), "SignatureDoesNotMatch") {
+		t.Errorf("the bucket's reason must surface, got %v", uploadError)
+	}
+}
+
+func TestBackupVaultImportRoutes(t *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		paths = append(paths, request.Method+" "+request.URL.Path)
+		if request.Header.Get("Authorization") != "Bearer token" {
+			writer.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		switch {
+		case strings.HasSuffix(request.URL.Path, "/restore"):
+			writer.WriteHeader(http.StatusAccepted)
+			_, _ = writer.Write([]byte(`{"id":"imp-1","status":"restoring","restore":{"operation_id":"op-1","status":"restoring","steps":[]}}`))
+		case strings.HasSuffix(request.URL.Path, "/complete"):
+			writer.WriteHeader(http.StatusConflict)
+			_, _ = writer.Write([]byte(`{"detail":"The upload is incomplete: db/office.dump is missing from the vault. Upload again, then complete the import."}`))
+		case request.Method == http.MethodPost:
+			_, _ = writer.Write([]byte(`{"import":{"id":"imp-1","status":"uploading"},"uploads":[{"path":"db/office.dump","method":"PUT","url":"https://vault/x","size_bytes":5}]}`))
+		default:
+			_, _ = writer.Write([]byte(`{"id":"imp-1","status":"completed"}`))
+		}
+	}))
+	defer server.Close()
+	apiClient := &Client{BaseURL: server.URL, Token: "token", HTTP: server.Client()}
+
+	created, createError := apiClient.CreateBackupVaultImport("vault-1", CreateBackupVaultImportRequest{ClusterID: "c", Manifest: []byte(`{"version":1}`)})
+	if createError != nil || created.Import.ID != "imp-1" || len(created.Uploads) != 1 || created.Uploads[0].SizeBytes != 5 {
+		t.Errorf("create = %+v, %v", created, createError)
+	}
+	if _, completeError := apiClient.CompleteBackupVaultImport("vault-1", "imp-1"); completeError == nil || !strings.Contains(completeError.Error(), "db/office.dump is missing from the vault") {
+		t.Errorf("a 409 detail must surface verbatim, got %v", completeError)
+	}
+	restored, restoreError := apiClient.RestoreBackupVaultImport("vault-1", "imp-1")
+	if restoreError != nil || restored.Status != "restoring" || restored.Restore == nil || restored.Restore.OperationID != "op-1" {
+		t.Errorf("restore (202) = %+v, %v", restored, restoreError)
+	}
+	got, getError := apiClient.GetBackupVaultImport("vault-1", "imp-1")
+	if getError != nil || got.Status != "completed" {
+		t.Errorf("get = %+v, %v", got, getError)
+	}
+	want := []string{
+		"POST /api/v1/org/backup-vaults/vault-1/imports",
+		"POST /api/v1/org/backup-vaults/vault-1/imports/imp-1/complete",
+		"POST /api/v1/org/backup-vaults/vault-1/imports/imp-1/restore",
+		"GET /api/v1/org/backup-vaults/vault-1/imports/imp-1",
+	}
+	if strings.Join(paths, "\n") != strings.Join(want, "\n") {
+		t.Errorf("paths = %v", paths)
+	}
+}

--- a/internal/client/backup_vault_imports_test.go
+++ b/internal/client/backup_vault_imports_test.go
@@ -29,7 +29,7 @@ func TestUploadPresignedObjectPutsTheBodyWithoutABearerToken(t *testing.T) {
 	defer server.Close()
 
 	apiClient := &Client{BaseURL: server.URL, Token: "secret-token", HTTP: server.Client()}
-	uploadError := apiClient.UploadPresignedObject(context.Background(), server.URL+"/bucket/imports/1/db/office.dump?X-Amz-Signature=abc", strings.NewReader("PGDMP"), 5)
+	uploadError := apiClient.UploadPresignedObject(context.Background(), http.MethodPut, server.URL+"/bucket/imports/1/db/office.dump?X-Amz-Signature=abc", strings.NewReader("PGDMP"), 5)
 	if uploadError != nil {
 		t.Fatal(uploadError)
 	}
@@ -42,15 +42,50 @@ func TestUploadPresignedObjectPutsTheBodyWithoutABearerToken(t *testing.T) {
 }
 
 func TestUploadPresignedObjectReportsTheBucketsRefusal(t *testing.T) {
+	attempts := 0
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		attempts++
 		writer.WriteHeader(http.StatusForbidden)
 		_, _ = writer.Write([]byte("<Error><Code>SignatureDoesNotMatch</Code></Error>"))
 	}))
 	defer server.Close()
 	apiClient := &Client{BaseURL: server.URL, HTTP: server.Client()}
-	uploadError := apiClient.UploadPresignedObject(context.Background(), server.URL+"/x", strings.NewReader("x"), 1)
+	uploadError := apiClient.UploadPresignedObject(context.Background(), http.MethodPut, server.URL+"/x", strings.NewReader("x"), 1)
 	if uploadError == nil || !strings.Contains(uploadError.Error(), "SignatureDoesNotMatch") {
 		t.Errorf("the bucket's reason must surface, got %v", uploadError)
+	}
+	if attempts != 1 {
+		t.Errorf("a refusal is final; it must not be retried, got %d attempts", attempts)
+	}
+}
+
+func TestUploadPresignedObjectRetriesAServerFailureFromTheStart(t *testing.T) {
+	var bodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		content, _ := io.ReadAll(request.Body)
+		bodies = append(bodies, string(content))
+		if len(bodies) == 1 {
+			writer.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	apiClient := &Client{BaseURL: server.URL, HTTP: server.Client()}
+	uploadError := apiClient.UploadPresignedObject(context.Background(), http.MethodPut, server.URL+"/x", strings.NewReader("PGDMP"), 5)
+	if uploadError != nil {
+		t.Fatal(uploadError)
+	}
+	if len(bodies) != 2 || bodies[0] != "PGDMP" || bodies[1] != "PGDMP" {
+		t.Errorf("a 5xx must be retried with the whole body again, got %q", bodies)
+	}
+}
+
+func TestUploadPresignedObjectRefusesMoreThanOneUploadCarries(t *testing.T) {
+	apiClient := &Client{BaseURL: "http://unused.invalid"}
+	uploadError := apiClient.UploadPresignedObject(context.Background(), http.MethodPut, "http://unused.invalid/x", strings.NewReader(""), PresignedUploadMaximumBytes+1)
+	if uploadError == nil || !strings.Contains(uploadError.Error(), "at most") {
+		t.Errorf("an artifact above the single-upload limit must be refused without a request, got %v", uploadError)
 	}
 }
 

--- a/internal/migrate/docker/daemon.go
+++ b/internal/migrate/docker/daemon.go
@@ -5,15 +5,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"sort"
 	"strconv"
 	"strings"
 )
 
-// runDocker shells out to the docker CLI. Tests replace it.
-var runDocker = func(ctx context.Context, args ...string) ([]byte, error) {
-	command := exec.CommandContext(ctx, "docker", args...)
+// runDocker shells out to the docker CLI, against a remote daemon when host
+// is set. Tests replace it.
+var runDocker = func(ctx context.Context, host string, args ...string) ([]byte, error) {
+	command := dockerCommand(ctx, host, args)
 	var stderr bytes.Buffer
 	command.Stderr = &stderr
 	output, err := command.Output()
@@ -25,6 +25,8 @@ var runDocker = func(ctx context.Context, args ...string) ([]byte, error) {
 
 // DaemonOptions select which running containers to read.
 type DaemonOptions struct {
+	// Host is DOCKER_HOST for the read; empty means the local daemon.
+	Host string
 	// Project limits the read to one compose project, by label.
 	Project string
 	// Containers names specific containers; when set, Project is ignored.
@@ -90,7 +92,7 @@ func LoadDaemon(ctx context.Context, options DaemonOptions) (Project, []string, 
 		if options.Project != "" {
 			args = append(args, "--filter", "label="+labelComposeProject+"="+options.Project)
 		}
-		output, err := runDocker(ctx, args...)
+		output, err := runDocker(ctx, options.Host, args...)
 		if err != nil {
 			return Project{}, nil, err
 		}
@@ -100,7 +102,7 @@ func LoadDaemon(ctx context.Context, options DaemonOptions) (Project, []string, 
 		return Project{}, nil, fmt.Errorf("no containers found")
 	}
 
-	output, err := runDocker(ctx, append([]string{"inspect"}, ids...)...)
+	output, err := runDocker(ctx, options.Host, append([]string{"inspect"}, ids...)...)
 	if err != nil {
 		return Project{}, nil, err
 	}

--- a/internal/migrate/docker/daemon_test.go
+++ b/internal/migrate/docker/daemon_test.go
@@ -51,7 +51,7 @@ func TestLoadDaemon(t *testing.T) {
 
 	var calls []string
 	original := runDocker
-	runDocker = func(_ context.Context, args ...string) ([]byte, error) {
+	runDocker = func(_ context.Context, _ string, args ...string) ([]byte, error) {
 		calls = append(calls, strings.Join(args, " "))
 		switch args[0] {
 		case "ps":
@@ -124,7 +124,7 @@ func TestLoadDaemon(t *testing.T) {
 
 func TestLoadDaemonNoContainers(t *testing.T) {
 	original := runDocker
-	runDocker = func(_ context.Context, _ ...string) ([]byte, error) { return []byte("\n"), nil }
+	runDocker = func(_ context.Context, _ string, _ ...string) ([]byte, error) { return []byte("\n"), nil }
 	defer func() { runDocker = original }()
 	if _, _, err := LoadDaemon(context.Background(), DaemonOptions{}); err == nil {
 		t.Error("no containers should be an error, not an empty conversion")
@@ -133,7 +133,7 @@ func TestLoadDaemonNoContainers(t *testing.T) {
 
 func TestLoadDaemonExplicitContainersSkipPs(t *testing.T) {
 	original := runDocker
-	runDocker = func(_ context.Context, args ...string) ([]byte, error) {
+	runDocker = func(_ context.Context, _ string, args ...string) ([]byte, error) {
 		if args[0] == "ps" {
 			t.Fatal("ps must not run when containers are named explicitly")
 		}

--- a/internal/migrate/docker/database.go
+++ b/internal/migrate/docker/database.go
@@ -1,0 +1,71 @@
+package docker
+
+import (
+	"strings"
+
+	"ankra/internal/migrate"
+)
+
+// Image names, judged by the last path segment of the reference, that run a
+// database server. The prefixes cover the official images and the common
+// derivatives (postgis, pgvector, timescaledb, bitnami, percona); the
+// exclusions stop tooling built around a database - exporters, admin UIs,
+// connection poolers, PostgREST - from being dumped as one.
+var (
+	postgresImagePrefixes = []string{"postgres", "postgis", "pgvector", "pgvecto", "timescaledb"}
+	mysqlImagePrefixes    = []string{"mysql", "mariadb", "percona"}
+	notADatabaseFragments = []string{"exporter", "admin", "proxy", "bouncer", "rest", "backup", "operator", "client", "gui", "agent"}
+)
+
+// DatabaseEngine reports which database engine an image runs, if any.
+func DatabaseEngine(image string) (string, bool) {
+	name := imageName(image)
+	if name == "" {
+		return "", false
+	}
+	for _, fragment := range notADatabaseFragments {
+		if strings.Contains(name, fragment) {
+			return "", false
+		}
+	}
+	for _, prefix := range postgresImagePrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return migrate.EnginePostgres, true
+		}
+	}
+	for _, prefix := range mysqlImagePrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return migrate.EngineMySQL, true
+		}
+	}
+	return "", false
+}
+
+// DefaultDatabasePort is the port an engine listens on unless configured
+// otherwise: the port convert exposes on the database's Service, and the
+// one a restore connects to.
+func DefaultDatabasePort(engine string) int {
+	switch engine {
+	case migrate.EnginePostgres:
+		return 5432
+	case migrate.EngineMySQL:
+		return 3306
+	}
+	return 0
+}
+
+// imageName returns the last path segment of an image reference without its
+// tag or digest: "ghcr.io/org/pgvector:16" is "pgvector".
+func imageName(image string) string {
+	image = strings.ToLower(strings.TrimSpace(image))
+	if at := strings.Index(image, "@"); at >= 0 {
+		image = image[:at]
+	}
+	if slash := strings.LastIndex(image, "/"); slash >= 0 {
+		image = image[slash+1:]
+	}
+	if colon := strings.Index(image, ":"); colon >= 0 {
+		image = image[:colon]
+	}
+	return image
+}

--- a/internal/migrate/docker/database_test.go
+++ b/internal/migrate/docker/database_test.go
@@ -1,0 +1,43 @@
+package docker
+
+import (
+	"testing"
+
+	"ankra/internal/migrate"
+)
+
+func TestDatabaseEngine(t *testing.T) {
+	cases := map[string]string{
+		"postgres:17":                                  migrate.EnginePostgres,
+		"postgres":                                     migrate.EnginePostgres,
+		"docker.io/library/postgres:16-alpine":         migrate.EnginePostgres,
+		"pgvector/pgvector:0.8.1-pg17":                 migrate.EnginePostgres,
+		"postgis/postgis:16-3.4":                       migrate.EnginePostgres,
+		"bitnami/postgresql:16":                        migrate.EnginePostgres,
+		"timescale/timescaledb-ha:pg16":                migrate.EnginePostgres,
+		"supabase/postgres:15.1":                       migrate.EnginePostgres,
+		"localhost:5000/team/postgres@sha256:abcdef":   migrate.EnginePostgres,
+		"mysql:8.4":                                    migrate.EngineMySQL,
+		"mariadb:11":                                   migrate.EngineMySQL,
+		"bitnami/mariadb:11":                           migrate.EngineMySQL,
+		"percona/percona-server:8.0":                   migrate.EngineMySQL,
+		"nginx:1.27":                                   "",
+		"redis:7":                                      "",
+		"prom/mysqld-exporter:v0.15":                   "",
+		"postgrest/postgrest:v12":                      "",
+		"dpage/pgadmin4:8":                             "",
+		"edoburu/pgbouncer:1.22":                       "",
+		"prometheuscommunity/postgres-exporter:v0.15":  "",
+		"ghcr.io/cloudnative-pg/cloudnative-pg:1.24.0": "",
+		"": "",
+	}
+	for image, want := range cases {
+		engine, ok := DatabaseEngine(image)
+		if engine != want || ok != (want != "") {
+			t.Errorf("DatabaseEngine(%q) = %q %v, want %q", image, engine, ok, want)
+		}
+	}
+	if DefaultDatabasePort(migrate.EnginePostgres) != 5432 || DefaultDatabasePort(migrate.EngineMySQL) != 3306 || DefaultDatabasePort("other") != 0 {
+		t.Error("default ports")
+	}
+}

--- a/internal/migrate/docker/export.go
+++ b/internal/migrate/docker/export.go
@@ -86,9 +86,10 @@ func (Module) Export(ctx context.Context, request migrate.ExportRequest) (migrat
 	}
 	composeProject := options[OptionProject]
 	if composeProject == "" {
-		composeProject = project.Name
+		composeProject = composeProjectName(project.Name)
 	}
 	docker := newDockerExecutor(options[OptionDockerHost])
+	writtenFiles := map[string]bool{}
 
 	var export migrate.Export
 	var otherImages []string
@@ -107,18 +108,20 @@ func (Module) Export(ctx context.Context, request migrate.ExportRequest) (migrat
 		export.Warnings = append(export.Warnings, containerWarnings...)
 
 		job := dumpJob{
-			docker:    docker,
-			container: container,
-			workload:  workload,
-			namespace: namespace,
-			outputDir: request.OutputDir,
-			only:      splitList(options[OptionDatabasesPrefix+workload.Name]),
-			progress:  progress,
+			docker:       docker,
+			container:    container,
+			workload:     workload,
+			namespace:    namespace,
+			outputDir:    request.OutputDir,
+			only:         splitList(options[OptionDatabasesPrefix+workload.Name]),
+			progress:     progress,
+			writtenFiles: writtenFiles,
 		}
 		var database migrate.DatabaseExport
+		var databaseWarnings []string
 		switch engine {
 		case migrate.EnginePostgres:
-			database, err = dumpPostgres(ctx, job)
+			database, databaseWarnings, err = dumpPostgres(ctx, job)
 		case migrate.EngineMySQL:
 			database, err = dumpMySQL(ctx, job)
 		}
@@ -126,15 +129,34 @@ func (Module) Export(ctx context.Context, request migrate.ExportRequest) (migrat
 			return migrate.Export{}, err
 		}
 		export.Databases = append(export.Databases, database)
+		export.Warnings = append(export.Warnings, databaseWarnings...)
 	}
 
 	if len(export.Databases) == 0 {
 		return migrate.Export{}, fmt.Errorf("no database service recognised in %s (images: %s); the export knows PostgreSQL and MySQL/MariaDB images",
 			project.Name, strings.Join(otherImages, ", "))
 	}
-	export.Warnings = append(export.Warnings, "each dump is a point-in-time snapshot of a live server; rehearse with the source running, then stop its writers and export once more right before the final cutover")
+	export.Warnings = append(export.Warnings,
+		"each dump is a point-in-time snapshot of a live server; rehearse with the source running, then stop its writers and export once more right before the final cutover",
+		"the dumps hold the application's data and are written readable by you alone; delete the export directory once the restore has succeeded")
 	export.Warnings = uniqueSorted(export.Warnings)
 	return export, nil
+}
+
+// composeProjectName derives the project name compose labels containers
+// with from a directory or `name:` value, the way compose itself does:
+// lower-cased, every character outside [a-z0-9_-] dropped, and no leading
+// '-' or '_'. Without this a source directory called "Aura Office" would be
+// looked up as a project no container is labelled with.
+func composeProjectName(name string) string {
+	var builder strings.Builder
+	for _, character := range strings.ToLower(name) {
+		isLetterOrDigit := (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9')
+		if isLetterOrDigit || character == '_' || character == '-' {
+			builder.WriteRune(character)
+		}
+	}
+	return strings.TrimLeft(builder.String(), "-_")
 }
 
 // exportProject reads the source an export works from. Unlike convert, a
@@ -193,6 +215,9 @@ type dumpJob struct {
 	// server reports.
 	only     []string
 	progress io.Writer
+	// writtenFiles is shared by every job of one export so two databases
+	// whose names sanitise alike never overwrite each other.
+	writtenFiles map[string]bool
 }
 
 // inContainer builds a `docker exec` that runs program through the
@@ -221,11 +246,22 @@ func (job dumpJob) restoreTarget(engine, username, passwordKey string) migrate.R
 
 var postgresCustomMagic = []byte("PGDMP")
 
-func dumpPostgres(ctx context.Context, job dumpJob) (migrate.DatabaseExport, error) {
+// dumpPostgres dumps a PostgreSQL server: its roles (without their
+// passwords - the restore connects as the target's own user, and a dump that
+// re-set that password would lock the cluster out of its database) and every
+// database that is not a template. The `postgres` database is the server's
+// maintenance database and is left out, unless the image was told to keep
+// the application's data there - which is what POSTGRES_DB, or its default
+// of POSTGRES_USER, says.
+func dumpPostgres(ctx context.Context, job dumpJob) (migrate.DatabaseExport, []string, error) {
 	const passwordKey = "POSTGRES_PASSWORD"
 	username := "postgres"
 	if entry, ok := lookupEnv(job.workload, "POSTGRES_USER"); ok && entry.Value != "" {
 		username = entry.Value
+	}
+	applicationDatabase := username
+	if entry, ok := lookupEnv(job.workload, "POSTGRES_DB"); ok && entry.Value != "" {
+		applicationDatabase = entry.Value
 	}
 	psql := func(query string) []string {
 		return job.inContainer("PGPASSWORD", passwordKey, "psql", "-U", username, "-d", "postgres", "-tAc", query)
@@ -233,18 +269,26 @@ func dumpPostgres(ctx context.Context, job dumpJob) (migrate.DatabaseExport, err
 
 	version, err := job.docker.Output(ctx, psql("SHOW server_version")...)
 	if err != nil {
-		return migrate.DatabaseExport{}, fmt.Errorf("%s: reading the server version: %w", job.workload.Name, err)
+		return migrate.DatabaseExport{}, nil, fmt.Errorf("%s: reading the server version: %w", job.workload.Name, err)
 	}
+	var warnings []string
 	databases := job.only
 	if len(databases) == 0 {
-		output, err := job.docker.Output(ctx, psql("SELECT datname FROM pg_database WHERE NOT datistemplate AND datname <> 'postgres' ORDER BY datname")...)
+		output, err := job.docker.Output(ctx, psql("SELECT datname FROM pg_database WHERE NOT datistemplate ORDER BY datname")...)
 		if err != nil {
-			return migrate.DatabaseExport{}, fmt.Errorf("%s: listing databases: %w", job.workload.Name, err)
+			return migrate.DatabaseExport{}, nil, fmt.Errorf("%s: listing databases: %w", job.workload.Name, err)
 		}
-		databases = nonEmptyLines(string(output))
+		for _, database := range nonEmptyLines(string(output)) {
+			if database == "postgres" && applicationDatabase != "postgres" {
+				warnings = append(warnings, fmt.Sprintf("%s: the maintenance database postgres was not dumped; pass --option %s%s=postgres if the application keeps data in it",
+					job.workload.Name, OptionDatabasesPrefix, job.workload.Name))
+				continue
+			}
+			databases = append(databases, database)
+		}
 	}
 	if len(databases) == 0 {
-		return migrate.DatabaseExport{}, fmt.Errorf("%s: the server holds no database besides postgres", job.workload.Name)
+		return migrate.DatabaseExport{}, nil, fmt.Errorf("%s: the server holds no database besides postgres", job.workload.Name)
 	}
 
 	export := migrate.DatabaseExport{
@@ -256,21 +300,23 @@ func dumpPostgres(ctx context.Context, job dumpJob) (migrate.DatabaseExport, err
 	}
 
 	_, _ = fmt.Fprintf(job.progress, "%s: dumping roles and globals\n", job.workload.Name)
-	globals, err := job.writeArtifact(ctx, "globals.sql", job.inContainer("PGPASSWORD", passwordKey, "pg_dumpall", "-U", username, "--globals-only"), nil)
+	globals, err := job.writeArtifact(ctx, "globals.sql", job.inContainer("PGPASSWORD", passwordKey, "pg_dumpall", "-U", username, "--globals-only", "--no-role-passwords"), nil)
 	if err != nil {
-		return migrate.DatabaseExport{}, err
+		return migrate.DatabaseExport{}, nil, err
 	}
 	export.Artifacts = append(export.Artifacts, migrate.Artifact{Path: globals, Kind: migrate.ArtifactKindGlobals, Format: migrate.ArtifactFormatSQL})
+	warnings = append(warnings, fmt.Sprintf("%s: roles are restored without their passwords; %s keeps the password from the cluster's secret, any other role that logs in needs ALTER ROLE ... PASSWORD after the restore",
+		job.workload.Name, username))
 
 	for _, database := range databases {
 		_, _ = fmt.Fprintf(job.progress, "%s: dumping database %s\n", job.workload.Name, database)
 		dump, err := job.writeArtifact(ctx, sanitiseName(database)+".dump", job.inContainer("PGPASSWORD", passwordKey, "pg_dump", "-U", username, "-Fc", "-d", database), postgresCustomMagic)
 		if err != nil {
-			return migrate.DatabaseExport{}, err
+			return migrate.DatabaseExport{}, nil, err
 		}
 		export.Artifacts = append(export.Artifacts, migrate.Artifact{Path: dump, Kind: migrate.ArtifactKindDatabase, Format: migrate.ArtifactFormatPostgresCustom, Database: database})
 	}
-	return export, nil
+	return export, warnings, nil
 }
 
 // Schemas every MySQL/MariaDB server carries; they are not the application's
@@ -331,14 +377,15 @@ func dumpMySQL(ctx context.Context, job dumpJob) (migrate.DatabaseExport, error)
 // writeArtifact streams one docker command into <outputDir>/<workload>/<file>
 // and checks the result looks like a dump: an empty file, or a custom-format
 // archive without its magic bytes, is a failed dump even when the command
-// did not say so.
+// did not say so. The file is the application's data, so it is created
+// readable by the current user only.
 func (job dumpJob) writeArtifact(ctx context.Context, fileName string, args []string, magic []byte) (string, error) {
-	relative := path.Join(sanitiseName(job.workload.Name), fileName)
+	relative := job.uniqueArtifactPath(fileName)
 	absolute := filepath.Join(job.outputDir, filepath.FromSlash(relative))
-	if err := os.MkdirAll(filepath.Dir(absolute), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(absolute), 0o700); err != nil {
 		return "", err
 	}
-	file, err := os.Create(absolute)
+	file, err := os.OpenFile(absolute, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return "", err
 	}
@@ -354,6 +401,24 @@ func (job dumpJob) writeArtifact(ctx context.Context, fileName string, args []st
 		return "", fmt.Errorf("%s: %s: %w", job.workload.Name, relative, err)
 	}
 	return relative, nil
+}
+
+// uniqueArtifactPath is <workload>/<file>, suffixed with a counter when an
+// earlier dump of this export already took the name - two databases can
+// sanitise to the same file name, and the second must not overwrite the
+// first.
+func (job dumpJob) uniqueArtifactPath(fileName string) string {
+	directory := sanitiseName(job.workload.Name)
+	extension := path.Ext(fileName)
+	stem := strings.TrimSuffix(fileName, extension)
+	candidate := path.Join(directory, fileName)
+	for suffix := 2; job.writtenFiles[candidate]; suffix++ {
+		candidate = path.Join(directory, fmt.Sprintf("%s-%d%s", stem, suffix, extension))
+	}
+	if job.writtenFiles != nil {
+		job.writtenFiles[candidate] = true
+	}
+	return candidate
 }
 
 func checkDump(absolute string, magic []byte) error {

--- a/internal/migrate/docker/export.go
+++ b/internal/migrate/docker/export.go
@@ -1,0 +1,396 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"ankra/internal/migrate"
+)
+
+// Option names the export verb accepts through --option key=value.
+const (
+	OptionDockerHost      = "docker-host" // DOCKER_HOST for the dump; ssh://user@host reaches a remote daemon
+	OptionContainerPrefix = "container."  // container.<workload>=<name|id> dumps from a specific container
+	OptionDatabasesPrefix = "databases."  // databases.<workload>=a,b dumps only those databases
+)
+
+// dockerExecutor runs the docker CLI. Output is for short answers; Stream is
+// for dumps, which are written straight to disk and never buffered whole.
+type dockerExecutor interface {
+	Output(ctx context.Context, args ...string) ([]byte, error)
+	Stream(ctx context.Context, stdout io.Writer, args ...string) error
+}
+
+// newDockerExecutor builds the executor for one export. Tests replace it.
+var newDockerExecutor = func(host string) dockerExecutor { return dockerCLI{host: host} }
+
+// dockerCommand builds a docker invocation, against a remote daemon when
+// host is set. Reaching another machine through DOCKER_HOST=ssh://... is how
+// docker itself does it, so no ssh handling lives here.
+func dockerCommand(ctx context.Context, host string, args []string) *exec.Cmd {
+	command := exec.CommandContext(ctx, "docker", args...)
+	if host != "" {
+		command.Env = append(os.Environ(), "DOCKER_HOST="+host)
+	}
+	return command
+}
+
+// dockerCLI is the executor that runs the real docker binary.
+type dockerCLI struct{ host string }
+
+func (c dockerCLI) Output(ctx context.Context, args ...string) ([]byte, error) {
+	return runDocker(ctx, c.host, args...)
+}
+
+func (c dockerCLI) Stream(ctx context.Context, stdout io.Writer, args ...string) error {
+	command := dockerCommand(ctx, c.host, args)
+	var stderr bytes.Buffer
+	command.Stdout = stdout
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		return fmt.Errorf("docker %s: %w: %s", args[0], err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+// Export implements migrate.DataExporter. It finds every database service in
+// the source, locates its running container, and dumps each database it
+// serves through the docker CLI - which is the one tool guaranteed to be
+// present wherever a compose stack runs, and works unchanged against a remote
+// host through DOCKER_HOST.
+func (Module) Export(ctx context.Context, request migrate.ExportRequest) (migrate.Export, error) {
+	options := request.Options
+	if options == nil {
+		options = map[string]string{}
+	}
+	progress := request.Progress
+	if progress == nil {
+		progress = io.Discard
+	}
+
+	project, err := exportProject(ctx, request.Dir, options)
+	if err != nil {
+		return migrate.Export{}, err
+	}
+	namespace := request.Namespace
+	if namespace == "" {
+		namespace = sanitiseName(project.Name)
+	}
+	composeProject := options[OptionProject]
+	if composeProject == "" {
+		composeProject = project.Name
+	}
+	docker := newDockerExecutor(options[OptionDockerHost])
+
+	var export migrate.Export
+	var otherImages []string
+	for _, workload := range project.SortedWorkloads() {
+		engine, ok := DatabaseEngine(workload.Image)
+		if !ok {
+			if workload.Image != "" {
+				otherImages = append(otherImages, workload.Name+"="+workload.Image)
+			}
+			continue
+		}
+		container, containerWarnings, err := findContainer(ctx, docker, composeProject, workload.Name, options[OptionContainerPrefix+workload.Name])
+		if err != nil {
+			return migrate.Export{}, err
+		}
+		export.Warnings = append(export.Warnings, containerWarnings...)
+
+		job := dumpJob{
+			docker:    docker,
+			container: container,
+			workload:  workload,
+			namespace: namespace,
+			outputDir: request.OutputDir,
+			only:      splitList(options[OptionDatabasesPrefix+workload.Name]),
+			progress:  progress,
+		}
+		var database migrate.DatabaseExport
+		switch engine {
+		case migrate.EnginePostgres:
+			database, err = dumpPostgres(ctx, job)
+		case migrate.EngineMySQL:
+			database, err = dumpMySQL(ctx, job)
+		}
+		if err != nil {
+			return migrate.Export{}, err
+		}
+		export.Databases = append(export.Databases, database)
+	}
+
+	if len(export.Databases) == 0 {
+		return migrate.Export{}, fmt.Errorf("no database service recognised in %s (images: %s); the export knows PostgreSQL and MySQL/MariaDB images",
+			project.Name, strings.Join(otherImages, ", "))
+	}
+	export.Warnings = append(export.Warnings, "each dump is a point-in-time snapshot of a live server; rehearse with the source running, then stop its writers and export once more right before the final cutover")
+	export.Warnings = uniqueSorted(export.Warnings)
+	return export, nil
+}
+
+// exportProject reads the source an export works from. Unlike convert, a
+// project option does not switch to the daemon source: the compose file in
+// the directory stays the description, and the option names the compose
+// project the containers run under, which is what the dump has to find.
+func exportProject(ctx context.Context, dir string, options map[string]string) (Project, error) {
+	source := options[OptionSource]
+	if source == "" {
+		source = "daemon"
+		if _, ok := FindComposeFile(dir); ok {
+			source = "compose"
+		}
+	}
+	loadOptions := make(map[string]string, len(options)+1)
+	for key, value := range options {
+		loadOptions[key] = value
+	}
+	loadOptions[OptionSource] = source
+	project, _, err := loadProject(ctx, dir, loadOptions)
+	return project, err
+}
+
+// findContainer resolves a compose service to the container that runs it,
+// by the labels compose stamps, unless the user named one.
+func findContainer(ctx context.Context, docker dockerExecutor, composeProject, service, explicit string) (string, []string, error) {
+	if explicit != "" {
+		return explicit, nil, nil
+	}
+	output, err := docker.Output(ctx, "ps", "-q",
+		"--filter", "label="+labelComposeProject+"="+composeProject,
+		"--filter", "label="+labelComposeService+"="+service)
+	if err != nil {
+		return "", nil, err
+	}
+	ids := strings.Fields(string(output))
+	if len(ids) == 0 {
+		return "", nil, fmt.Errorf("no running container for service %s in compose project %s (pass --option %s=<name> if the stack runs under another project name, or --option %s%s=<container> to name the container)",
+			service, composeProject, OptionProject, OptionContainerPrefix, service)
+	}
+	var warnings []string
+	if len(ids) > 1 {
+		warnings = append(warnings, fmt.Sprintf("%s: %d containers run this service; dumped from %s", service, len(ids), ids[0]))
+	}
+	return ids[0], warnings, nil
+}
+
+// dumpJob is everything one database server's dump needs.
+type dumpJob struct {
+	docker    dockerExecutor
+	container string
+	workload  Workload
+	namespace string
+	outputDir string
+	// only restricts the dump to these databases; empty means every one the
+	// server reports.
+	only     []string
+	progress io.Writer
+}
+
+// inContainer builds a `docker exec` that runs program through the
+// container's own shell, so a password the image needs for local connections
+// comes from the container's environment and never crosses the host as a
+// command-line argument.
+func (job dumpJob) inContainer(passwordVariable, passwordKey, program string, args ...string) []string {
+	script := passwordVariable + `="$` + passwordKey + `" exec ` + program + ` "$@"`
+	return append([]string{"exec", job.container, "sh", "-c", script, "sh"}, args...)
+}
+
+// restoreTarget describes where convert put this server in the cluster.
+func (job dumpJob) restoreTarget(engine, username, passwordKey string) migrate.RestoreTarget {
+	target := migrate.RestoreTarget{
+		Namespace: job.namespace,
+		Host:      job.workload.Name,
+		Port:      DefaultDatabasePort(engine),
+		Username:  username,
+	}
+	if entry, ok := lookupEnv(job.workload, passwordKey); ok && entry.Secret {
+		target.PasswordSecret = job.workload.Name + "-secrets"
+		target.PasswordKey = passwordKey
+	}
+	return target
+}
+
+var postgresCustomMagic = []byte("PGDMP")
+
+func dumpPostgres(ctx context.Context, job dumpJob) (migrate.DatabaseExport, error) {
+	const passwordKey = "POSTGRES_PASSWORD"
+	username := "postgres"
+	if entry, ok := lookupEnv(job.workload, "POSTGRES_USER"); ok && entry.Value != "" {
+		username = entry.Value
+	}
+	psql := func(query string) []string {
+		return job.inContainer("PGPASSWORD", passwordKey, "psql", "-U", username, "-d", "postgres", "-tAc", query)
+	}
+
+	version, err := job.docker.Output(ctx, psql("SHOW server_version")...)
+	if err != nil {
+		return migrate.DatabaseExport{}, fmt.Errorf("%s: reading the server version: %w", job.workload.Name, err)
+	}
+	databases := job.only
+	if len(databases) == 0 {
+		output, err := job.docker.Output(ctx, psql("SELECT datname FROM pg_database WHERE NOT datistemplate AND datname <> 'postgres' ORDER BY datname")...)
+		if err != nil {
+			return migrate.DatabaseExport{}, fmt.Errorf("%s: listing databases: %w", job.workload.Name, err)
+		}
+		databases = nonEmptyLines(string(output))
+	}
+	if len(databases) == 0 {
+		return migrate.DatabaseExport{}, fmt.Errorf("%s: the server holds no database besides postgres", job.workload.Name)
+	}
+
+	export := migrate.DatabaseExport{
+		Workload:      job.workload.Name,
+		Engine:        migrate.EnginePostgres,
+		Image:         job.workload.Image,
+		ServerVersion: strings.TrimSpace(string(version)),
+		Target:        job.restoreTarget(migrate.EnginePostgres, username, passwordKey),
+	}
+
+	_, _ = fmt.Fprintf(job.progress, "%s: dumping roles and globals\n", job.workload.Name)
+	globals, err := job.writeArtifact(ctx, "globals.sql", job.inContainer("PGPASSWORD", passwordKey, "pg_dumpall", "-U", username, "--globals-only"), nil)
+	if err != nil {
+		return migrate.DatabaseExport{}, err
+	}
+	export.Artifacts = append(export.Artifacts, migrate.Artifact{Path: globals, Kind: migrate.ArtifactKindGlobals, Format: migrate.ArtifactFormatSQL})
+
+	for _, database := range databases {
+		_, _ = fmt.Fprintf(job.progress, "%s: dumping database %s\n", job.workload.Name, database)
+		dump, err := job.writeArtifact(ctx, sanitiseName(database)+".dump", job.inContainer("PGPASSWORD", passwordKey, "pg_dump", "-U", username, "-Fc", "-d", database), postgresCustomMagic)
+		if err != nil {
+			return migrate.DatabaseExport{}, err
+		}
+		export.Artifacts = append(export.Artifacts, migrate.Artifact{Path: dump, Kind: migrate.ArtifactKindDatabase, Format: migrate.ArtifactFormatPostgresCustom, Database: database})
+	}
+	return export, nil
+}
+
+// Schemas every MySQL/MariaDB server carries; they are not the application's
+// data and a restore must not overwrite them.
+var mysqlSystemSchemas = map[string]bool{"information_schema": true, "performance_schema": true, "mysql": true, "sys": true}
+
+func dumpMySQL(ctx context.Context, job dumpJob) (migrate.DatabaseExport, error) {
+	passwordKey := "MYSQL_ROOT_PASSWORD"
+	if _, ok := lookupEnv(job.workload, "MARIADB_ROOT_PASSWORD"); ok {
+		passwordKey = "MARIADB_ROOT_PASSWORD"
+	}
+	const username = "root"
+	client := func(query string) []string {
+		return job.inContainer("MYSQL_PWD", passwordKey, "mysql", "-u"+username, "-N", "-e", query)
+	}
+
+	version, err := job.docker.Output(ctx, client("SELECT VERSION()")...)
+	if err != nil {
+		return migrate.DatabaseExport{}, fmt.Errorf("%s: reading the server version: %w", job.workload.Name, err)
+	}
+	databases := job.only
+	if len(databases) == 0 {
+		output, err := job.docker.Output(ctx, client("SHOW DATABASES")...)
+		if err != nil {
+			return migrate.DatabaseExport{}, fmt.Errorf("%s: listing databases: %w", job.workload.Name, err)
+		}
+		for _, database := range nonEmptyLines(string(output)) {
+			if !mysqlSystemSchemas[database] {
+				databases = append(databases, database)
+			}
+		}
+	}
+	if len(databases) == 0 {
+		return migrate.DatabaseExport{}, fmt.Errorf("%s: the server holds no database besides the system schemas", job.workload.Name)
+	}
+
+	export := migrate.DatabaseExport{
+		Workload:      job.workload.Name,
+		Engine:        migrate.EngineMySQL,
+		Image:         job.workload.Image,
+		ServerVersion: strings.TrimSpace(string(version)),
+		Target:        job.restoreTarget(migrate.EngineMySQL, username, passwordKey),
+	}
+	for _, database := range databases {
+		_, _ = fmt.Fprintf(job.progress, "%s: dumping database %s\n", job.workload.Name, database)
+		// --databases makes the dump create and select its schema, so a
+		// restore is one `mysql < file` with nothing prepared by hand.
+		dump, err := job.writeArtifact(ctx, sanitiseName(database)+".sql",
+			job.inContainer("MYSQL_PWD", passwordKey, "mysqldump", "-u"+username, "--single-transaction", "--routines", "--triggers", "--events", "--databases", database), nil)
+		if err != nil {
+			return migrate.DatabaseExport{}, err
+		}
+		export.Artifacts = append(export.Artifacts, migrate.Artifact{Path: dump, Kind: migrate.ArtifactKindDatabase, Format: migrate.ArtifactFormatSQL, Database: database})
+	}
+	return export, nil
+}
+
+// writeArtifact streams one docker command into <outputDir>/<workload>/<file>
+// and checks the result looks like a dump: an empty file, or a custom-format
+// archive without its magic bytes, is a failed dump even when the command
+// did not say so.
+func (job dumpJob) writeArtifact(ctx context.Context, fileName string, args []string, magic []byte) (string, error) {
+	relative := path.Join(sanitiseName(job.workload.Name), fileName)
+	absolute := filepath.Join(job.outputDir, filepath.FromSlash(relative))
+	if err := os.MkdirAll(filepath.Dir(absolute), 0o755); err != nil {
+		return "", err
+	}
+	file, err := os.Create(absolute)
+	if err != nil {
+		return "", err
+	}
+	streamErr := job.docker.Stream(ctx, file, args...)
+	closeErr := file.Close()
+	if streamErr != nil {
+		return "", fmt.Errorf("%s: %w", job.workload.Name, streamErr)
+	}
+	if closeErr != nil {
+		return "", closeErr
+	}
+	if err := checkDump(absolute, magic); err != nil {
+		return "", fmt.Errorf("%s: %s: %w", job.workload.Name, relative, err)
+	}
+	return relative, nil
+}
+
+func checkDump(absolute string, magic []byte) error {
+	file, err := os.Open(absolute)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	header := make([]byte, 16)
+	read, err := file.Read(header)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	if read == 0 {
+		return errors.New("the dump is empty")
+	}
+	if len(magic) > 0 && !bytes.HasPrefix(header[:read], magic) {
+		return fmt.Errorf("the dump does not start with the %s archive header", string(magic))
+	}
+	return nil
+}
+
+func lookupEnv(workload Workload, name string) (EnvVar, bool) {
+	for _, entry := range workload.Env {
+		if entry.Name == name {
+			return entry, true
+		}
+	}
+	return EnvVar{}, false
+}
+
+func nonEmptyLines(text string) []string {
+	var out []string
+	for _, line := range strings.Split(text, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}

--- a/internal/migrate/docker/export_test.go
+++ b/internal/migrate/docker/export_test.go
@@ -1,0 +1,326 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"ankra/internal/migrate"
+)
+
+const exportTestCompose = `services:
+  app:
+    image: ghcr.io/org/app:1.0
+    depends_on: [postgres, mysql]
+  postgres:
+    image: pgvector/pgvector:0.8.1-pg17
+    environment:
+      POSTGRES_USER: office
+      POSTGRES_PASSWORD: secret
+    volumes: ['pgdata:/var/lib/postgresql/data']
+  mysql:
+    image: mariadb:11
+    environment:
+      MARIADB_ROOT_PASSWORD: root-secret
+volumes:
+  pgdata:
+`
+
+// cannedAnswer pairs a fragment of a docker command line with what the
+// fake daemon answers. First match wins, so fragments are distinctive.
+type cannedAnswer struct {
+	fragment string
+	answer   string
+}
+
+// fakeDocker stands in for the docker CLI: it records every call and
+// answers from a script.
+type fakeDocker struct {
+	t       *testing.T
+	host    string
+	calls   []string
+	answers []cannedAnswer
+	// failOn makes Stream fail for a command containing the fragment.
+	failOn string
+}
+
+func (f *fakeDocker) answer(args []string) (string, bool) {
+	joined := strings.Join(args, " ")
+	f.calls = append(f.calls, joined)
+	for _, canned := range f.answers {
+		if strings.Contains(joined, canned.fragment) {
+			return canned.answer, true
+		}
+	}
+	return "", false
+}
+
+func (f *fakeDocker) Output(_ context.Context, args ...string) ([]byte, error) {
+	answer, ok := f.answer(args)
+	if !ok {
+		f.t.Fatalf("unexpected docker call %q", strings.Join(args, " "))
+	}
+	return []byte(answer), nil
+}
+
+func (f *fakeDocker) Stream(_ context.Context, stdout io.Writer, args ...string) error {
+	answer, ok := f.answer(args)
+	if !ok {
+		f.t.Fatalf("unexpected docker call %q", strings.Join(args, " "))
+	}
+	if f.failOn != "" && strings.Contains(strings.Join(args, " "), f.failOn) {
+		return errors.New("exit status 1: connection refused")
+	}
+	_, err := io.WriteString(stdout, answer)
+	return err
+}
+
+// testModule is the built-in module under test; a named value keeps the
+// composite literal out of if-statement conditions.
+var testModule = Module{}
+
+func defaultAnswers() []cannedAnswer {
+	return []cannedAnswer{
+		{"label=com.docker.compose.service=postgres", "pg1\n"},
+		{"label=com.docker.compose.service=mysql", "my1\n"},
+		{"SHOW server_version", "17.2\n"},
+		{"SELECT datname", "office\npdns\n"},
+		{"pg_dumpall", "--\n-- PostgreSQL database cluster dump\nCREATE ROLE office;\n"},
+		{"pg_dump ", "PGDMP\x01\x11\x00fake archive"},
+		{"SELECT VERSION()", "11.4.2-MariaDB\n"},
+		{"SHOW DATABASES", "information_schema\nmysql\nperformance_schema\nshop\nsys\n"},
+		{"mysqldump", "-- MariaDB dump\nCREATE DATABASE shop;\n"},
+	}
+}
+
+func installFakeDocker(t *testing.T, fake *fakeDocker) {
+	t.Helper()
+	original := newDockerExecutor
+	newDockerExecutor = func(host string) dockerExecutor {
+		fake.host = host
+		return fake
+	}
+	t.Cleanup(func() { newDockerExecutor = original })
+}
+
+func writeExportFixture(t *testing.T, compose string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "shop")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "compose.yaml"), []byte(compose), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func callsContaining(calls []string, fragment string) []string {
+	var out []string
+	for _, call := range calls {
+		if strings.Contains(call, fragment) {
+			out = append(out, call)
+		}
+	}
+	return out
+}
+
+func TestExportDumpsEveryDatabaseServer(t *testing.T) {
+	fake := &fakeDocker{t: t, answers: defaultAnswers()}
+	installFakeDocker(t, fake)
+	dir := writeExportFixture(t, exportTestCompose)
+	out := t.TempDir()
+	var progress bytes.Buffer
+
+	export, err := testModule.Export(context.Background(), migrate.ExportRequest{
+		Dir: dir, OutputDir: out, Progress: &progress,
+		Options: map[string]string{OptionDockerHost: "ssh://root@203.0.113.7"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fake.host != "ssh://root@203.0.113.7" {
+		t.Errorf("docker-host option must reach the executor, got %q", fake.host)
+	}
+	if len(export.Databases) != 2 || export.Databases[0].Workload != "mysql" || export.Databases[1].Workload != "postgres" {
+		t.Fatalf("databases = %+v, want mysql then postgres (sorted)", export.Databases)
+	}
+
+	// Containers are found by the compose labels of the project the
+	// directory names.
+	if got := callsContaining(fake.calls, "ps -q"); len(got) != 2 || got[0] != "ps -q --filter label=com.docker.compose.project=shop --filter label=com.docker.compose.service=mysql" {
+		t.Errorf("container lookups = %v", got)
+	}
+
+	postgres := export.Databases[1]
+	if postgres.Engine != migrate.EnginePostgres || postgres.ServerVersion != "17.2" || postgres.Image != "pgvector/pgvector:0.8.1-pg17" {
+		t.Errorf("postgres export = %+v", postgres)
+	}
+	wantTarget := migrate.RestoreTarget{Namespace: "shop", Host: "postgres", Port: 5432, Username: "office", PasswordSecret: "postgres-secrets", PasswordKey: "POSTGRES_PASSWORD"}
+	if postgres.Target != wantTarget {
+		t.Errorf("postgres target = %+v, want %+v", postgres.Target, wantTarget)
+	}
+	if len(postgres.Artifacts) != 3 || postgres.Artifacts[0].Kind != migrate.ArtifactKindGlobals || postgres.Artifacts[1].Database != "office" || postgres.Artifacts[2].Database != "pdns" || postgres.Artifacts[2].Format != migrate.ArtifactFormatPostgresCustom {
+		t.Errorf("postgres artifacts = %+v", postgres.Artifacts)
+	}
+	// Every command runs inside the container through its own shell, with
+	// the password taken from the container's environment, so it never
+	// appears on the host's command line.
+	dumps := callsContaining(fake.calls, "pg_dump ")
+	if len(dumps) != 2 || !strings.Contains(dumps[0], `exec pg1 sh -c PGPASSWORD="$POSTGRES_PASSWORD" exec pg_dump "$@" sh -U office -Fc -d office`) {
+		t.Errorf("pg_dump calls = %v", dumps)
+	}
+	for _, call := range fake.calls {
+		if strings.Contains(call, "secret") {
+			t.Errorf("a password crossed the host command line: %q", call)
+		}
+	}
+	dump, err := os.ReadFile(filepath.Join(out, "postgres", "pdns.dump"))
+	if err != nil || !bytes.HasPrefix(dump, []byte("PGDMP")) {
+		t.Errorf("pdns.dump = %q, %v", dump, err)
+	}
+
+	mysql := export.Databases[0]
+	wantTarget = migrate.RestoreTarget{Namespace: "shop", Host: "mysql", Port: 3306, Username: "root", PasswordSecret: "mysql-secrets", PasswordKey: "MARIADB_ROOT_PASSWORD"}
+	if mysql.Target != wantTarget || mysql.ServerVersion != "11.4.2-MariaDB" {
+		t.Errorf("mysql export = %+v", mysql)
+	}
+	if len(mysql.Artifacts) != 1 || mysql.Artifacts[0].Database != "shop" || mysql.Artifacts[0].Path != "mysql/shop.sql" {
+		t.Errorf("system schemas must be skipped, got %+v", mysql.Artifacts)
+	}
+	if got := callsContaining(fake.calls, "mysqldump"); len(got) != 1 || !strings.Contains(got[0], `MYSQL_PWD="$MARIADB_ROOT_PASSWORD"`) || !strings.HasSuffix(got[0], "--databases shop") {
+		t.Errorf("mysqldump call = %v", got)
+	}
+
+	if !strings.Contains(progress.String(), "postgres: dumping database office") || !strings.Contains(progress.String(), "mysql: dumping database shop") {
+		t.Errorf("progress = %q", progress.String())
+	}
+	if !hasWarning(export.Warnings, "point-in-time snapshot") {
+		t.Errorf("the live-dump warning is missing: %v", export.Warnings)
+	}
+
+	manifest, err := migrate.FinaliseExport(out, "docker", dir, export, time.Now())
+	if err != nil {
+		t.Fatalf("the export must finalise as written: %v", err)
+	}
+	if manifest.Databases[1].Artifacts[1].SizeBytes == 0 {
+		t.Error("artifact sizes must be measured")
+	}
+}
+
+func TestExportOptionsNarrowTheDump(t *testing.T) {
+	fake := &fakeDocker{t: t, answers: defaultAnswers()}
+	installFakeDocker(t, fake)
+	dir := writeExportFixture(t, exportTestCompose)
+
+	export, err := testModule.Export(context.Background(), migrate.ExportRequest{
+		Dir: dir, OutputDir: t.TempDir(), Namespace: "avura",
+		Options: map[string]string{
+			OptionProject:                      "aura-office",
+			OptionContainerPrefix + "postgres": "postgres-main",
+			OptionDatabasesPrefix + "postgres": "office",
+			OptionContainerPrefix + "mysql":    "my-main",
+			OptionDatabasesPrefix + "mysql":    "shop",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := callsContaining(fake.calls, "ps -q"); len(got) != 0 {
+		t.Errorf("naming the container must skip the lookup, got %v", got)
+	}
+	if got := callsContaining(fake.calls, "SELECT datname"); len(got) != 0 {
+		t.Errorf("naming the databases must skip the listing, got %v", got)
+	}
+	postgres := export.Databases[1]
+	if len(postgres.Artifacts) != 2 || postgres.Artifacts[1].Database != "office" || postgres.Target.Namespace != "avura" {
+		t.Errorf("postgres export = %+v", postgres)
+	}
+	if got := callsContaining(fake.calls, "exec postgres-main"); len(got) != 3 {
+		t.Errorf("every postgres command must target the named container, got %v", got)
+	}
+}
+
+func TestExportProjectOptionFindsContainers(t *testing.T) {
+	fake := &fakeDocker{t: t, answers: defaultAnswers()}
+	installFakeDocker(t, fake)
+	dir := writeExportFixture(t, exportTestCompose)
+	if _, err := testModule.Export(context.Background(), migrate.ExportRequest{Dir: dir, OutputDir: t.TempDir(), Options: map[string]string{OptionProject: "aura-office"}}); err != nil {
+		t.Fatal(err)
+	}
+	if got := callsContaining(fake.calls, "ps -q"); len(got) != 2 || !strings.Contains(got[0], "label=com.docker.compose.project=aura-office") {
+		t.Errorf("the project option must drive the label filter, got %v", got)
+	}
+}
+
+func TestExportErrors(t *testing.T) {
+	t.Run("no running container", func(t *testing.T) {
+		fake := &fakeDocker{t: t, answers: []cannedAnswer{{"ps -q", "\n"}}}
+		installFakeDocker(t, fake)
+		_, err := testModule.Export(context.Background(), migrate.ExportRequest{Dir: writeExportFixture(t, exportTestCompose), OutputDir: t.TempDir()})
+		if err == nil || !strings.Contains(err.Error(), "no running container for service mysql") || !strings.Contains(err.Error(), "--option project=") {
+			t.Errorf("err = %v", err)
+		}
+	})
+	t.Run("garbled archive", func(t *testing.T) {
+		answers := defaultAnswers()
+		answers[5] = cannedAnswer{"pg_dump ", "pg_dump: error: connection failed\n"}
+		fake := &fakeDocker{t: t, answers: answers}
+		installFakeDocker(t, fake)
+		_, err := testModule.Export(context.Background(), migrate.ExportRequest{Dir: writeExportFixture(t, exportTestCompose), OutputDir: t.TempDir()})
+		if err == nil || !strings.Contains(err.Error(), "archive header") {
+			t.Errorf("a custom-format dump without its magic must be refused, got %v", err)
+		}
+	})
+	t.Run("empty dump", func(t *testing.T) {
+		answers := defaultAnswers()
+		answers[8] = cannedAnswer{"mysqldump", ""}
+		fake := &fakeDocker{t: t, answers: answers}
+		installFakeDocker(t, fake)
+		_, err := testModule.Export(context.Background(), migrate.ExportRequest{Dir: writeExportFixture(t, exportTestCompose), OutputDir: t.TempDir()})
+		if err == nil || !strings.Contains(err.Error(), "the dump is empty") {
+			t.Errorf("err = %v", err)
+		}
+	})
+	t.Run("dump command fails", func(t *testing.T) {
+		fake := &fakeDocker{t: t, answers: defaultAnswers(), failOn: "pg_dumpall"}
+		installFakeDocker(t, fake)
+		_, err := testModule.Export(context.Background(), migrate.ExportRequest{Dir: writeExportFixture(t, exportTestCompose), OutputDir: t.TempDir()})
+		if err == nil || !strings.Contains(err.Error(), "postgres:") || !strings.Contains(err.Error(), "connection refused") {
+			t.Errorf("the failing command's reason must surface, got %v", err)
+		}
+	})
+	t.Run("no database service", func(t *testing.T) {
+		fake := &fakeDocker{t: t}
+		installFakeDocker(t, fake)
+		_, err := testModule.Export(context.Background(), migrate.ExportRequest{Dir: writeExportFixture(t, "services:\n  web:\n    image: nginx:1.27\n"), OutputDir: t.TempDir()})
+		if err == nil || !strings.Contains(err.Error(), "no database service recognised") || !strings.Contains(err.Error(), "web=nginx:1.27") {
+			t.Errorf("err = %v", err)
+		}
+		if len(fake.calls) != 0 {
+			t.Errorf("nothing to dump must mean no docker calls, got %v", fake.calls)
+		}
+	})
+	t.Run("server without databases", func(t *testing.T) {
+		answers := defaultAnswers()
+		answers[3] = cannedAnswer{"SELECT datname", "\n"}
+		fake := &fakeDocker{t: t, answers: answers}
+		installFakeDocker(t, fake)
+		_, err := testModule.Export(context.Background(), migrate.ExportRequest{Dir: writeExportFixture(t, exportTestCompose), OutputDir: t.TempDir()})
+		if err == nil || !strings.Contains(err.Error(), "no database besides postgres") {
+			t.Errorf("err = %v", err)
+		}
+	})
+}
+
+func TestExportIsAdvertised(t *testing.T) {
+	if _, ok := migrate.ExporterFor(New()); !ok {
+		t.Error("the docker module must advertise and implement export")
+	}
+}

--- a/internal/migrate/docker/export_test.go
+++ b/internal/migrate/docker/export_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -322,5 +323,153 @@ func TestExportErrors(t *testing.T) {
 func TestExportIsAdvertised(t *testing.T) {
 	if _, ok := migrate.ExporterFor(New()); !ok {
 		t.Error("the docker module must advertise and implement export")
+	}
+}
+
+func TestExportPostgresDumpsRolesWithoutPasswords(t *testing.T) {
+	fake := &fakeDocker{t: t, answers: defaultAnswers()}
+	installFakeDocker(t, fake)
+	export, err := testModule.Export(context.Background(), migrate.ExportRequest{Dir: writeExportFixture(t, exportTestCompose), OutputDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := callsContaining(fake.calls, "pg_dumpall"); len(got) != 1 || !strings.Contains(got[0], "--globals-only --no-role-passwords") {
+		t.Errorf("the globals dump must leave role passwords out, or the restore re-sets the cluster's own user, got %v", got)
+	}
+	if !hasWarning(export.Warnings, "roles are restored without their passwords") || !hasWarning(export.Warnings, "office keeps the password") {
+		t.Errorf("the user must be told which roles need a password afterwards: %v", export.Warnings)
+	}
+}
+
+func TestExportPostgresMaintenanceDatabase(t *testing.T) {
+	withPostgres := func(answers []cannedAnswer) []cannedAnswer {
+		answers[3] = cannedAnswer{"SELECT datname", "office\npostgres\n"}
+		return answers
+	}
+	dumped := func(export migrate.Export) []string {
+		var names []string
+		for _, artifact := range export.Databases[1].Artifacts {
+			if artifact.Kind == migrate.ArtifactKindDatabase {
+				names = append(names, artifact.Database)
+			}
+		}
+		return names
+	}
+
+	t.Run("skipped with a hint when the application lives elsewhere", func(t *testing.T) {
+		fake := &fakeDocker{t: t, answers: withPostgres(defaultAnswers())}
+		installFakeDocker(t, fake)
+		export, err := testModule.Export(context.Background(), migrate.ExportRequest{Dir: writeExportFixture(t, exportTestCompose), OutputDir: t.TempDir()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := dumped(export); len(got) != 1 || got[0] != "office" {
+			t.Errorf("the maintenance database is not the application's, got %v", got)
+		}
+		if !hasWarning(export.Warnings, "--option databases.postgres=postgres") {
+			t.Errorf("skipping postgres must say how to include it: %v", export.Warnings)
+		}
+	})
+	t.Run("dumped when it is the application database", func(t *testing.T) {
+		compose := strings.Replace(exportTestCompose, "      POSTGRES_USER: office\n", "", 1)
+		fake := &fakeDocker{t: t, answers: withPostgres(defaultAnswers())}
+		installFakeDocker(t, fake)
+		export, err := testModule.Export(context.Background(), migrate.ExportRequest{Dir: writeExportFixture(t, compose), OutputDir: t.TempDir()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := dumped(export); len(got) != 2 || got[1] != "postgres" {
+			t.Errorf("without POSTGRES_USER and POSTGRES_DB the image keeps the data in postgres; it must be dumped, got %v", got)
+		}
+		if hasWarning(export.Warnings, "maintenance database postgres was not dumped") {
+			t.Errorf("no hint when postgres was dumped: %v", export.Warnings)
+		}
+	})
+	t.Run("dumped when POSTGRES_DB names it", func(t *testing.T) {
+		compose := strings.Replace(exportTestCompose, "      POSTGRES_USER: office\n", "      POSTGRES_USER: office\n      POSTGRES_DB: postgres\n", 1)
+		fake := &fakeDocker{t: t, answers: withPostgres(defaultAnswers())}
+		installFakeDocker(t, fake)
+		export, err := testModule.Export(context.Background(), migrate.ExportRequest{Dir: writeExportFixture(t, compose), OutputDir: t.TempDir()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := dumped(export); len(got) != 2 || got[1] != "postgres" {
+			t.Errorf("POSTGRES_DB=postgres makes it the application database, got %v", got)
+		}
+	})
+}
+
+func TestExportWritesTheDumpsForTheCurrentUserOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits")
+	}
+	fake := &fakeDocker{t: t, answers: defaultAnswers()}
+	installFakeDocker(t, fake)
+	out := t.TempDir()
+	export, err := testModule.Export(context.Background(), migrate.ExportRequest{Dir: writeExportFixture(t, exportTestCompose), OutputDir: out})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, database := range export.Databases {
+		directory, statError := os.Stat(filepath.Join(out, database.Workload))
+		if statError != nil {
+			t.Fatal(statError)
+		}
+		if directory.Mode().Perm() != 0o700 {
+			t.Errorf("%s: directory mode = %o, want 700", database.Workload, directory.Mode().Perm())
+		}
+		for _, artifact := range database.Artifacts {
+			file, statError := os.Stat(filepath.Join(out, filepath.FromSlash(artifact.Path)))
+			if statError != nil {
+				t.Fatal(statError)
+			}
+			if file.Mode().Perm() != 0o600 {
+				t.Errorf("%s: mode = %o, want 600", artifact.Path, file.Mode().Perm())
+			}
+		}
+	}
+	if !hasWarning(export.Warnings, "delete the export directory once the restore has succeeded") {
+		t.Errorf("the user must be told the export is their data on disk: %v", export.Warnings)
+	}
+}
+
+func TestExportKeepsDumpsApartWhenNamesSanitiseAlike(t *testing.T) {
+	answers := defaultAnswers()
+	answers[3] = cannedAnswer{"SELECT datname", "my_db\nmy-db\n"}
+	fake := &fakeDocker{t: t, answers: answers}
+	installFakeDocker(t, fake)
+	export, err := testModule.Export(context.Background(), migrate.ExportRequest{Dir: writeExportFixture(t, exportTestCompose), OutputDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	postgres := export.Databases[1]
+	if len(postgres.Artifacts) != 3 || postgres.Artifacts[1].Path != "postgres/my-db.dump" || postgres.Artifacts[2].Path != "postgres/my-db-2.dump" {
+		t.Errorf("two databases whose names sanitise alike must not overwrite each other, got %+v", postgres.Artifacts)
+	}
+	if postgres.Artifacts[1].Database != "my_db" || postgres.Artifacts[2].Database != "my-db" {
+		t.Errorf("the real database names must survive the renaming, got %+v", postgres.Artifacts)
+	}
+}
+
+func TestExportNormalisesTheComposeProjectName(t *testing.T) {
+	fake := &fakeDocker{t: t, answers: defaultAnswers()}
+	installFakeDocker(t, fake)
+	dir := filepath.Join(t.TempDir(), "Aura Office")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "compose.yaml"), []byte(exportTestCompose), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := testModule.Export(context.Background(), migrate.ExportRequest{Dir: dir, OutputDir: t.TempDir()}); err != nil {
+		t.Fatal(err)
+	}
+	if got := callsContaining(fake.calls, "ps -q"); len(got) != 2 || !strings.Contains(got[0], "label=com.docker.compose.project=auraoffice") {
+		t.Errorf("containers are labelled with compose's normalised project name, got %v", got)
+	}
+	for name, want := range map[string]string{"Aura Office": "auraoffice", "_shop.v2": "shopv2", "--Shop": "shop", "shop": "shop"} {
+		if got := composeProjectName(name); got != want {
+			t.Errorf("composeProjectName(%q) = %q, want %q", name, got, want)
+		}
 	}
 }

--- a/internal/migrate/docker/module.go
+++ b/internal/migrate/docker/module.go
@@ -43,6 +43,7 @@ func (Module) Describe() migrate.Description {
 		Protocol:     migrate.ProtocolVersion,
 		Summary:      "docker-compose files, Dockerfiles, and the running Docker daemon",
 		FilePatterns: append(append([]string(nil), ComposeFileNames...), "Dockerfile"),
+		Capabilities: []string{migrate.CapabilityExport},
 		Builtin:      true,
 	}
 }
@@ -66,57 +67,7 @@ func (Module) Convert(ctx context.Context, request migrate.ConvertRequest) (migr
 	if options == nil {
 		options = map[string]string{}
 	}
-
-	source := options[OptionSource]
-	if source == "" {
-		switch {
-		case options[OptionProject] != "" || options[OptionContainers] != "":
-			source = "daemon"
-		default:
-			if _, ok := FindComposeFile(request.Dir); ok {
-				source = "compose"
-			} else if _, ok := FindDockerfile(request.Dir); ok {
-				source = "dockerfile"
-			} else {
-				return migrate.Result{}, fmt.Errorf("no compose file or Dockerfile in %s (use --option source=daemon to read running containers)", request.Dir)
-			}
-		}
-	}
-
-	var (
-		project  Project
-		warnings []string
-		err      error
-	)
-	switch source {
-	case "compose":
-		path, ok := FindComposeFile(request.Dir)
-		if !ok {
-			return migrate.Result{}, fmt.Errorf("no compose file in %s", request.Dir)
-		}
-		project, warnings, err = LoadCompose(request.Dir, path, ComposeOptions{
-			Profiles:       splitList(options[OptionProfiles]),
-			AllProfiles:    isTrue(options[OptionAllProfiles]),
-			UseEnvironment: isTrue(options[OptionUseEnvironment]),
-		})
-	case "dockerfile":
-		path, ok := FindDockerfile(request.Dir)
-		if !ok {
-			return migrate.Result{}, fmt.Errorf("no Dockerfile in %s", request.Dir)
-		}
-		project, warnings, err = LoadDockerfile(request.Dir, path, DockerfileOptions{
-			Name:  options[OptionName],
-			Image: options[OptionImagePrefix+options[OptionName]],
-		})
-	case "daemon":
-		project, warnings, err = LoadDaemon(ctx, DaemonOptions{
-			Project:    options[OptionProject],
-			Containers: splitList(options[OptionContainers]),
-			All:        isTrue(options[OptionAll]),
-		})
-	default:
-		return migrate.Result{}, fmt.Errorf("unknown source %q: expected compose, dockerfile, or daemon", source)
-	}
+	project, warnings, err := loadProject(ctx, request.Dir, options)
 	if err != nil {
 		return migrate.Result{}, err
 	}
@@ -133,6 +84,56 @@ func (Module) Convert(ctx context.Context, request migrate.ConvertRequest) (migr
 	result := Render(project, render)
 	result.Warnings = uniqueSorted(append(warnings, result.Warnings...))
 	return result, nil
+}
+
+// loadProject reads the source Convert and Export share: the one named by
+// the source option, or the one the directory holds.
+func loadProject(ctx context.Context, dir string, options map[string]string) (Project, []string, error) {
+	source := options[OptionSource]
+	if source == "" {
+		switch {
+		case options[OptionProject] != "" || options[OptionContainers] != "":
+			source = "daemon"
+		default:
+			if _, ok := FindComposeFile(dir); ok {
+				source = "compose"
+			} else if _, ok := FindDockerfile(dir); ok {
+				source = "dockerfile"
+			} else {
+				return Project{}, nil, fmt.Errorf("no compose file or Dockerfile in %s (use --option source=daemon to read running containers)", dir)
+			}
+		}
+	}
+
+	switch source {
+	case "compose":
+		path, ok := FindComposeFile(dir)
+		if !ok {
+			return Project{}, nil, fmt.Errorf("no compose file in %s", dir)
+		}
+		return LoadCompose(dir, path, ComposeOptions{
+			Profiles:       splitList(options[OptionProfiles]),
+			AllProfiles:    isTrue(options[OptionAllProfiles]),
+			UseEnvironment: isTrue(options[OptionUseEnvironment]),
+		})
+	case "dockerfile":
+		path, ok := FindDockerfile(dir)
+		if !ok {
+			return Project{}, nil, fmt.Errorf("no Dockerfile in %s", dir)
+		}
+		return LoadDockerfile(dir, path, DockerfileOptions{
+			Name:  options[OptionName],
+			Image: options[OptionImagePrefix+options[OptionName]],
+		})
+	case "daemon":
+		return LoadDaemon(ctx, DaemonOptions{
+			Host:       options[OptionDockerHost],
+			Project:    options[OptionProject],
+			Containers: splitList(options[OptionContainers]),
+			All:        isTrue(options[OptionAll]),
+		})
+	}
+	return Project{}, nil, fmt.Errorf("unknown source %q: expected compose, dockerfile, or daemon", source)
 }
 
 func uniqueSorted(values []string) []string {

--- a/internal/migrate/docker/render.go
+++ b/internal/migrate/docker/render.go
@@ -201,6 +201,16 @@ func renderWorkload(project Project, workload Workload, options RenderOptions) (
 			warn("publishes port %d on the host; add --option ingress.%s=<host> to expose it through an Ingress", port.Host, workload.Name)
 		}
 	}
+	if len(servicePorts) == 0 {
+		if engine, ok := DatabaseEngine(workload.Image); ok {
+			// A database nobody published a port for still has to be
+			// reachable inside the cluster: the other workloads connect to
+			// it by service name, and a restore has to find it.
+			port := DefaultDatabasePort(engine)
+			containerPorts = append(containerPorts, containerPort{ContainerPort: port, Protocol: "TCP"})
+			servicePorts = append(servicePorts, servicePort{Name: fmt.Sprintf("tcp-%d", port), Port: port, TargetPort: port, Protocol: "TCP"})
+		}
+	}
 
 	container := podContainer{
 		Name:         workload.Name,

--- a/internal/migrate/docker/render_database_test.go
+++ b/internal/migrate/docker/render_database_test.go
@@ -1,0 +1,41 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRenderGivesDatabasesAServiceWithoutPublishedPorts(t *testing.T) {
+	dir := t.TempDir()
+	compose := `services:
+  db:
+    image: postgres:17
+    environment:
+      POSTGRES_PASSWORD: secret
+  cache:
+    image: redis:7
+  app:
+    image: ghcr.io/org/app:1.0
+`
+	path := filepath.Join(dir, "compose.yaml")
+	if err := os.WriteFile(path, []byte(compose), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	project, _, err := LoadCompose(dir, path, ComposeOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := Render(project, RenderOptions{ClusterName: "shop", Namespace: "shop"})
+
+	db := result.Files["manifests/db.yaml"]
+	if !strings.Contains(db, "kind: Service") || !strings.Contains(db, "port: 5432") || !strings.Contains(db, "containerPort: 5432") {
+		t.Errorf("a database with no published port must still get a Service on its default port:\n%s", db)
+	}
+	for _, name := range []string{"cache", "app"} {
+		if strings.Contains(result.Files["manifests/"+name+".yaml"], "kind: Service") {
+			t.Errorf("%s exposes nothing and must not get a Service", name)
+		}
+	}
+}

--- a/internal/migrate/export.go
+++ b/internal/migrate/export.go
@@ -1,0 +1,231 @@
+package migrate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ExportRequest is the input to the export verb: dump the data behind the
+// source in Dir into OutputDir.
+type ExportRequest struct {
+	// Dir is the directory holding the source files.
+	Dir string `json:"dir"`
+	// OutputDir is the absolute directory the module writes artifacts into.
+	// Paths in the reply are relative to it.
+	OutputDir string `json:"output_dir"`
+	// Namespace is where convert placed the workloads, so the module can say
+	// where each artifact restores to.
+	Namespace string `json:"namespace"`
+	// Options carries module-specific settings from --option key=value.
+	Options map[string]string `json:"options,omitempty"`
+	// Progress receives human-readable progress lines while a dump runs.
+	// Built-in modules write to it directly; an external module's stderr is
+	// relayed to it. It is never part of the wire format.
+	Progress io.Writer `json:"-"`
+}
+
+// Export is a module's answer to the export verb: what it dumped, grouped by
+// the database server each dump came from.
+type Export struct {
+	Databases []DatabaseExport `json:"databases"`
+	// Warnings are things a human must know before restoring: a server that
+	// was dumped while live, a database that was skipped.
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+// DatabaseExport is one database server's dumps plus where they restore to.
+type DatabaseExport struct {
+	// Workload is the source service the server ran as; convert turned it
+	// into the workload of the same name.
+	Workload string `json:"workload"`
+	// Engine is EnginePostgres or EngineMySQL.
+	Engine        string        `json:"engine"`
+	Image         string        `json:"image,omitempty"`
+	ServerVersion string        `json:"server_version,omitempty"`
+	Target        RestoreTarget `json:"target"`
+	Artifacts     []Artifact    `json:"artifacts"`
+}
+
+// RestoreTarget is the in-cluster server the dumps load into: the Service
+// convert generated for the database and the Secret holding its password.
+type RestoreTarget struct {
+	Namespace string `json:"namespace"`
+	Host      string `json:"host"`
+	Port      int    `json:"port"`
+	Username  string `json:"username,omitempty"`
+	// PasswordSecret and PasswordKey name the Secret entry the restore reads
+	// the password from. Empty when the source ran without one.
+	PasswordSecret string `json:"password_secret,omitempty"`
+	PasswordKey    string `json:"password_key,omitempty"`
+}
+
+// Artifact is one file a module wrote into the output directory.
+type Artifact struct {
+	// Path is relative to the output directory.
+	Path string `json:"path"`
+	// Kind is ArtifactKindDatabase or ArtifactKindGlobals.
+	Kind string `json:"kind"`
+	// Format is ArtifactFormatPostgresCustom or ArtifactFormatSQL.
+	Format string `json:"format"`
+	// Database is the database a Kind=database artifact holds.
+	Database string `json:"database,omitempty"`
+	// SizeBytes and SHA256 are measured from the file by the CLI, not
+	// reported by the module, so a restore can trust them.
+	SizeBytes int64  `json:"size_bytes"`
+	SHA256    string `json:"sha256"`
+}
+
+// Artifact kinds and formats.
+const (
+	ArtifactKindDatabase = "database"
+	ArtifactKindGlobals  = "globals"
+
+	ArtifactFormatPostgresCustom = "pg_custom"
+	ArtifactFormatSQL            = "sql"
+)
+
+// Database engines an export can name.
+const (
+	EnginePostgres = "postgres"
+	EngineMySQL    = "mysql"
+)
+
+// ExportManifest is the manifest.json written next to the artifacts. It is the
+// whole description of an export: a restore needs nothing else.
+type ExportManifest struct {
+	Version   int              `json:"version"`
+	Module    string           `json:"module"`
+	SourceDir string           `json:"source_dir"`
+	CreatedAt time.Time        `json:"created_at"`
+	Databases []DatabaseExport `json:"databases"`
+	Warnings  []string         `json:"warnings,omitempty"`
+}
+
+// Files an export directory always contains.
+const (
+	ExportManifestVersion   = 1
+	ExportManifestFileName  = "manifest.json"
+	ExportChecksumsFileName = "SHA256SUMS"
+)
+
+// FinaliseExport checks every artifact a module reported against the output
+// directory and measures each file's size and checksum. A module that names a
+// file it did not write, writes an empty one, or points outside the output
+// directory is rejected here, before anything is described as restorable.
+func FinaliseExport(outputDir, moduleName, sourceDir string, export Export, now time.Time) (ExportManifest, error) {
+	if len(export.Databases) == 0 {
+		return ExportManifest{}, fmt.Errorf("module returned no databases")
+	}
+	manifest := ExportManifest{
+		Version:   ExportManifestVersion,
+		Module:    moduleName,
+		SourceDir: sourceDir,
+		CreatedAt: now.UTC(),
+		Warnings:  export.Warnings,
+	}
+	seen := map[string]bool{}
+	for _, database := range export.Databases {
+		if database.Workload == "" || database.Engine == "" {
+			return ExportManifest{}, fmt.Errorf("module returned a database export without a workload or engine")
+		}
+		if len(database.Artifacts) == 0 {
+			return ExportManifest{}, fmt.Errorf("module returned no artifacts for %s", database.Workload)
+		}
+		for i := range database.Artifacts {
+			artifact := &database.Artifacts[i]
+			if err := validateArtifactPath(artifact.Path); err != nil {
+				return ExportManifest{}, err
+			}
+			if seen[artifact.Path] {
+				return ExportManifest{}, fmt.Errorf("module returned artifact %s twice", artifact.Path)
+			}
+			seen[artifact.Path] = true
+			if artifact.Kind == "" || artifact.Format == "" {
+				return ExportManifest{}, fmt.Errorf("artifact %s has no kind or format", artifact.Path)
+			}
+			if artifact.Kind == ArtifactKindDatabase && artifact.Database == "" {
+				return ExportManifest{}, fmt.Errorf("artifact %s is a database dump but names no database", artifact.Path)
+			}
+			size, sum, err := checksumFile(filepath.Join(outputDir, filepath.FromSlash(artifact.Path)))
+			if err != nil {
+				return ExportManifest{}, fmt.Errorf("artifact %s: %w", artifact.Path, err)
+			}
+			if size == 0 {
+				return ExportManifest{}, fmt.Errorf("artifact %s is empty", artifact.Path)
+			}
+			artifact.SizeBytes, artifact.SHA256 = size, sum
+		}
+		manifest.Databases = append(manifest.Databases, database)
+	}
+	return manifest, nil
+}
+
+func validateArtifactPath(path string) error {
+	switch {
+	case path == "":
+		return fmt.Errorf("module returned an artifact without a path")
+	case filepath.IsAbs(path), strings.HasPrefix(path, ".."), strings.Contains(path, "/../"), strings.Contains(path, `\`):
+		return fmt.Errorf("module returned an unsafe artifact path %q", path)
+	case path == ExportManifestFileName, path == ExportChecksumsFileName:
+		return fmt.Errorf("module returned an artifact named %s, which the CLI writes itself", path)
+	}
+	return nil
+}
+
+func checksumFile(path string) (int64, string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, "", err
+	}
+	defer func() { _ = file.Close() }()
+	digest := sha256.New()
+	size, err := io.Copy(digest, file)
+	if err != nil {
+		return 0, "", err
+	}
+	return size, hex.EncodeToString(digest.Sum(nil)), nil
+}
+
+// WriteExportManifest writes manifest.json and a SHA256SUMS file in the format
+// `sha256sum -c` reads, so an export can be verified without the CLI.
+func WriteExportManifest(outputDir string, manifest ExportManifest) error {
+	encoded, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(outputDir, ExportManifestFileName), append(encoded, '\n'), 0o644); err != nil {
+		return err
+	}
+	var lines []string
+	for _, database := range manifest.Databases {
+		for _, artifact := range database.Artifacts {
+			lines = append(lines, artifact.SHA256+"  "+artifact.Path)
+		}
+	}
+	sort.Strings(lines)
+	return os.WriteFile(filepath.Join(outputDir, ExportChecksumsFileName), []byte(strings.Join(lines, "\n")+"\n"), 0o644)
+}
+
+// ReadExportManifest reads the manifest an earlier export wrote.
+func ReadExportManifest(outputDir string) (ExportManifest, error) {
+	raw, err := os.ReadFile(filepath.Join(outputDir, ExportManifestFileName))
+	if err != nil {
+		return ExportManifest{}, err
+	}
+	var manifest ExportManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return ExportManifest{}, fmt.Errorf("reading %s: %w", ExportManifestFileName, err)
+	}
+	if manifest.Version != ExportManifestVersion {
+		return ExportManifest{}, fmt.Errorf("%s is version %d, this CLI reads version %d", ExportManifestFileName, manifest.Version, ExportManifestVersion)
+	}
+	return manifest, nil
+}

--- a/internal/migrate/export_test.go
+++ b/internal/migrate/export_test.go
@@ -1,0 +1,218 @@
+package migrate
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeArtifactFile(t *testing.T, outputDir, relative, content string) {
+	t.Helper()
+	absolute := filepath.Join(outputDir, filepath.FromSlash(relative))
+	if err := os.MkdirAll(filepath.Dir(absolute), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(absolute, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFinaliseExportMeasuresArtifacts(t *testing.T) {
+	out := t.TempDir()
+	writeArtifactFile(t, out, "db/globals.sql", "CREATE ROLE app;\n")
+	writeArtifactFile(t, out, "db/app.dump", "PGDMP\x01\x02payload")
+
+	export := Export{
+		Databases: []DatabaseExport{{
+			Workload: "db", Engine: EnginePostgres, ServerVersion: "17.2",
+			Target: RestoreTarget{Namespace: "shop", Host: "db", Port: 5432, Username: "app", PasswordSecret: "db-secrets", PasswordKey: "POSTGRES_PASSWORD"},
+			Artifacts: []Artifact{
+				{Path: "db/globals.sql", Kind: ArtifactKindGlobals, Format: ArtifactFormatSQL},
+				{Path: "db/app.dump", Kind: ArtifactKindDatabase, Format: ArtifactFormatPostgresCustom, Database: "app"},
+			},
+		}},
+		Warnings: []string{"dumped live"},
+	}
+	now := time.Date(2026, 8, 29, 1, 2, 3, 0, time.FixedZone("CEST", 2*3600))
+	manifest, err := FinaliseExport(out, "docker", "/src/shop", export, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.Version != ExportManifestVersion || manifest.Module != "docker" || manifest.SourceDir != "/src/shop" || !manifest.CreatedAt.Equal(now) || manifest.CreatedAt.Location() != time.UTC {
+		t.Errorf("manifest header = %+v", manifest)
+	}
+	if len(manifest.Warnings) != 1 || len(manifest.Databases) != 1 || len(manifest.Databases[0].Artifacts) != 2 {
+		t.Fatalf("manifest = %+v", manifest)
+	}
+	globals := manifest.Databases[0].Artifacts[0]
+	want := sha256.Sum256([]byte("CREATE ROLE app;\n"))
+	if globals.SizeBytes != int64(len("CREATE ROLE app;\n")) || globals.SHA256 != hex.EncodeToString(want[:]) {
+		t.Errorf("globals measured as %+v", globals)
+	}
+	if manifest.Databases[0].Target.PasswordSecret != "db-secrets" {
+		t.Errorf("target not carried over: %+v", manifest.Databases[0].Target)
+	}
+
+	if err := WriteExportManifest(out, manifest); err != nil {
+		t.Fatal(err)
+	}
+	sums, err := os.ReadFile(filepath.Join(out, ExportChecksumsFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(sums)), "\n")
+	if len(lines) != 2 || !strings.HasSuffix(lines[0], "  db/app.dump") || !strings.HasSuffix(lines[1], "  db/globals.sql") || !strings.HasPrefix(lines[1], globals.SHA256) {
+		t.Errorf("SHA256SUMS must list every artifact, sorted, in sha256sum format:\n%s", sums)
+	}
+	read, err := ReadExportManifest(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.Module != "docker" || len(read.Databases) != 1 || read.Databases[0].Artifacts[1].SHA256 != manifest.Databases[0].Artifacts[1].SHA256 {
+		t.Errorf("round trip lost data: %+v", read)
+	}
+}
+
+func TestFinaliseExportRejects(t *testing.T) {
+	out := t.TempDir()
+	writeArtifactFile(t, out, "db/ok.sql", "SELECT 1;\n")
+	writeArtifactFile(t, out, "db/empty.sql", "")
+
+	database := func(artifacts ...Artifact) Export {
+		return Export{Databases: []DatabaseExport{{Workload: "db", Engine: EnginePostgres, Artifacts: artifacts}}}
+	}
+	ok := Artifact{Path: "db/ok.sql", Kind: ArtifactKindGlobals, Format: ArtifactFormatSQL}
+	cases := map[string]Export{
+		"no databases":          {},
+		"no artifacts":          database(),
+		"no engine":             {Databases: []DatabaseExport{{Workload: "db", Artifacts: []Artifact{ok}}}},
+		"absolute path":         database(Artifact{Path: "/etc/passwd", Kind: ArtifactKindGlobals, Format: ArtifactFormatSQL}),
+		"parent escape":         database(Artifact{Path: "../ok.sql", Kind: ArtifactKindGlobals, Format: ArtifactFormatSQL}),
+		"nested escape":         database(Artifact{Path: "db/../../ok.sql", Kind: ArtifactKindGlobals, Format: ArtifactFormatSQL}),
+		"missing file":          database(Artifact{Path: "db/missing.sql", Kind: ArtifactKindGlobals, Format: ArtifactFormatSQL}),
+		"empty file":            database(Artifact{Path: "db/empty.sql", Kind: ArtifactKindGlobals, Format: ArtifactFormatSQL}),
+		"duplicate":             database(ok, ok),
+		"claims manifest.json":  database(Artifact{Path: ExportManifestFileName, Kind: ArtifactKindGlobals, Format: ArtifactFormatSQL}),
+		"no kind":               database(Artifact{Path: "db/ok.sql", Format: ArtifactFormatSQL}),
+		"database without name": database(Artifact{Path: "db/ok.sql", Kind: ArtifactKindDatabase, Format: ArtifactFormatSQL}),
+	}
+	for name, export := range cases {
+		if _, err := FinaliseExport(out, "docker", "/src", export, time.Now()); err == nil {
+			t.Errorf("%s: expected rejection", name)
+		}
+	}
+}
+
+func TestReadExportManifestRejectsOtherVersions(t *testing.T) {
+	out := t.TempDir()
+	if err := os.WriteFile(filepath.Join(out, ExportManifestFileName), []byte(`{"version": 99, "module": "docker"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadExportManifest(out); err == nil || !strings.Contains(err.Error(), "version 99") {
+		t.Errorf("expected a version error, got %v", err)
+	}
+	if _, err := ReadExportManifest(t.TempDir()); err == nil {
+		t.Error("a directory without a manifest must be an error")
+	}
+}
+
+// claimsExport advertises the capability without implementing the verb.
+type claimsExport struct{ fakeModule }
+
+func (m claimsExport) Describe() Description {
+	description := m.fakeModule.Describe()
+	description.Capabilities = []string{CapabilityExport}
+	return description
+}
+
+func TestExporterFor(t *testing.T) {
+	if _, ok := ExporterFor(fakeModule{name: "plain"}); ok {
+		t.Error("a module without the capability must not be offered as an exporter")
+	}
+	if _, ok := ExporterFor(claimsExport{fakeModule{name: "claims"}}); ok {
+		t.Error("advertising the capability without implementing it must not be enough")
+	}
+	if !HasCapability(Description{Capabilities: []string{"other", CapabilityExport}}, CapabilityExport) || HasCapability(Description{}, CapabilityExport) {
+		t.Error("HasCapability must find the capability among others and nowhere else")
+	}
+}
+
+// dumperModule is an external module that answers export: it writes one dump
+// under output_dir, narrates on stderr, and points the target at the
+// namespace the request named.
+const dumperModule = `#!/bin/sh
+case "$1" in
+  describe)
+    printf '%s' '{"name":"dumper","version":"0.1","protocol":1,"summary":"dumper test module","capabilities":["export"]}'
+    ;;
+  detect)
+    printf '%s' '{"confidence":0,"reason":"never"}'
+    ;;
+  export)
+    request=$(cat)
+    out=$(printf '%s' "$request" | sed -n 's/.*"output_dir":"\([^"]*\)".*/\1/p')
+    ns=$(printf '%s' "$request" | sed -n 's/.*"namespace":"\([^"]*\)".*/\1/p')
+    echo "dumping app" >&2
+    mkdir -p "$out/db" && printf 'CREATE TABLE t (id int);\n' > "$out/db/app.sql"
+    printf '{"databases":[{"workload":"db","engine":"mysql","target":{"namespace":"%s","host":"db","port":3306},"artifacts":[{"path":"db/app.sql","kind":"database","format":"sql","database":"app"}]}],"warnings":["from dumper"]}' "$ns"
+    ;;
+  *)
+    echo "unknown verb $1" >&2
+    exit 2
+    ;;
+esac
+`
+
+func TestExternalModuleExport(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script modules")
+	}
+	dir := t.TempDir()
+	writeModule(t, dir, "dumper", dumperModule, true)
+	writeModule(t, dir, "echo", echoModule, true)
+	registry := NewRegistry()
+	registry.searchDirs = func() []string { return []string{dir} }
+
+	plain, err := registry.Lookup(context.Background(), "echo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ExporterFor(plain); ok {
+		t.Error("an external module that does not list the capability must not be asked to export")
+	}
+
+	module, err := registry.Lookup(context.Background(), "dumper")
+	if err != nil {
+		t.Fatal(err)
+	}
+	exporter, ok := ExporterFor(module)
+	if !ok {
+		t.Fatal("dumper advertises export and must be offered as an exporter")
+	}
+	out := t.TempDir()
+	var progress bytes.Buffer
+	export, err := exporter.Export(context.Background(), ExportRequest{Dir: "/src", OutputDir: out, Namespace: "shop", Progress: &progress})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(export.Databases) != 1 || export.Databases[0].Target.Namespace != "shop" || export.Warnings[0] != "from dumper" {
+		t.Errorf("export = %+v", export)
+	}
+	if !strings.Contains(progress.String(), "dumping app") {
+		t.Errorf("the module's stderr must be relayed as progress, got %q", progress.String())
+	}
+	manifest, err := FinaliseExport(out, "dumper", "/src", export, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.Databases[0].Artifacts[0].SizeBytes != int64(len("CREATE TABLE t (id int);\n")) {
+		t.Errorf("artifact not measured from the file the module wrote: %+v", manifest.Databases[0].Artifacts[0])
+	}
+}

--- a/internal/migrate/external.go
+++ b/internal/migrate/external.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os/exec"
 	"strings"
 	"time"
@@ -16,21 +17,25 @@ import (
 // its output.
 const ProtocolVersion = 1
 
-// The three verbs an external module must answer. Each is invoked as
-// `ankra-module-<name> <verb>` with a JSON request on stdin and a JSON
-// response expected on stdout; anything on stderr is relayed as diagnostics.
+// The three verbs an external module must answer, and the one it may. Each
+// is invoked as `ankra-module-<name> <verb>` with a JSON request on stdin and
+// a JSON response expected on stdout; anything on stderr is relayed as
+// diagnostics.
 const (
 	VerbDescribe = "describe"
 	VerbDetect   = "detect"
 	VerbConvert  = "convert"
+	VerbExport   = "export"
 )
 
 // Time limits per verb. Describe and detect look at a directory; convert may
-// legitimately read a large tree or shell out.
+// legitimately read a large tree or shell out; export dumps databases of
+// whatever size the source holds.
 const (
 	describeTimeout = 15 * time.Second
 	detectTimeout   = 30 * time.Second
 	convertTimeout  = 5 * time.Minute
+	exportTimeout   = 6 * time.Hour
 )
 
 // detectRequest is the stdin payload for the detect verb.
@@ -50,7 +55,7 @@ func loadExternal(ctx context.Context, path string) (Module, error) {
 	defer cancel()
 
 	var description Description
-	if err := runModule(ctx, path, VerbDescribe, nil, &description); err != nil {
+	if err := runModule(ctx, path, VerbDescribe, nil, &description, nil); err != nil {
 		return nil, err
 	}
 	if description.Name == "" {
@@ -72,7 +77,7 @@ func (m *externalModule) Detect(ctx context.Context, dir string) (Detection, err
 	ctx, cancel := context.WithTimeout(ctx, detectTimeout)
 	defer cancel()
 	var detection Detection
-	err := runModule(ctx, m.path, VerbDetect, detectRequest{Dir: dir}, &detection)
+	err := runModule(ctx, m.path, VerbDetect, detectRequest{Dir: dir}, &detection, nil)
 	return detection, err
 }
 
@@ -80,13 +85,25 @@ func (m *externalModule) Convert(ctx context.Context, request ConvertRequest) (R
 	ctx, cancel := context.WithTimeout(ctx, convertTimeout)
 	defer cancel()
 	var result Result
-	err := runModule(ctx, m.path, VerbConvert, request, &result)
+	err := runModule(ctx, m.path, VerbConvert, request, &result, nil)
 	return result, err
 }
 
+// Export implements DataExporter. The module's stderr is relayed live to the
+// request's progress writer: a dump can run for minutes, and a module that
+// narrates what it is doing must be heard while it does it, not after.
+func (m *externalModule) Export(ctx context.Context, request ExportRequest) (Export, error) {
+	ctx, cancel := context.WithTimeout(ctx, exportTimeout)
+	defer cancel()
+	var export Export
+	err := runModule(ctx, m.path, VerbExport, request, &export, request.Progress)
+	return export, err
+}
+
 // runModule invokes one verb and decodes its stdout. A non-zero exit carries
-// the module's stderr, which is where a well-behaved module explains itself.
-func runModule(ctx context.Context, path, verb string, input, output interface{}) error {
+// the module's stderr, which is where a well-behaved module explains itself;
+// when progress is set, stderr is also relayed to it as it arrives.
+func runModule(ctx context.Context, path, verb string, input, output interface{}, progress io.Writer) error {
 	command := exec.CommandContext(ctx, path, verb)
 	if input != nil {
 		payload, err := json.Marshal(input)
@@ -98,6 +115,9 @@ func runModule(ctx context.Context, path, verb string, input, output interface{}
 	var stdout, stderr bytes.Buffer
 	command.Stdout = &stdout
 	command.Stderr = &stderr
+	if progress != nil {
+		command.Stderr = io.MultiWriter(&stderr, progress)
+	}
 
 	if err := command.Run(); err != nil {
 		if ctx.Err() != nil {

--- a/internal/migrate/module.go
+++ b/internal/migrate/module.go
@@ -44,10 +44,44 @@ type Description struct {
 	// FilePatterns are the globs this module looks for, shown to users so an
 	// empty detection is explainable rather than mysterious.
 	FilePatterns []string `json:"file_patterns,omitempty"`
+	// Capabilities lists the optional verbs the module answers beyond the
+	// three every module must: CapabilityExport for `ankra migrate export`.
+	Capabilities []string `json:"capabilities,omitempty"`
 	// Builtin is set by the registry, not by external modules.
 	Builtin bool `json:"builtin,omitempty"`
 	// Path is where an external module was found. Empty for built-ins.
 	Path string `json:"path,omitempty"`
+}
+
+// CapabilityExport marks a module that answers the export verb.
+const CapabilityExport = "export"
+
+// DataExporter is the optional fourth verb: dump the data a source holds -
+// its databases - so it can be loaded into the cluster once convert has
+// moved the workloads. A module advertises it through
+// Description.Capabilities; the CLI trusts the capability, not the Go type,
+// so an external module that omits it is never asked.
+type DataExporter interface {
+	Export(ctx context.Context, request ExportRequest) (Export, error)
+}
+
+// HasCapability reports whether a description advertises a capability.
+func HasCapability(description Description, capability string) bool {
+	for _, candidate := range description.Capabilities {
+		if candidate == capability {
+			return true
+		}
+	}
+	return false
+}
+
+// ExporterFor returns the module's export verb when it advertises one.
+func ExporterFor(module Module) (DataExporter, bool) {
+	if !HasCapability(module.Describe(), CapabilityExport) {
+		return nil, false
+	}
+	exporter, ok := module.(DataExporter)
+	return exporter, ok
 }
 
 // Detection is the answer to "does this directory look like yours?".

--- a/internal/skills/embedded/skills/ankra-cli/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-cli/SKILL.md
@@ -99,6 +99,26 @@ ankra cluster agent status
 A failed platform execution explains more deploy failures than pod logs do — start there. See
 `ankra-troubleshooting`.
 
+## Migrating a Docker deployment
+
+```bash
+ankra migrate convert ./app --out ./app-k8s        # compose / Dockerfile / daemon -> cluster.yaml + manifests
+ankra cluster apply ./app-k8s/cluster.yaml         # the workloads, with empty databases
+ankra migrate data ./app --cluster shop --wait     # dump every database and restore it in the cluster
+ankra migrate export ./app --out ./app-data        # the two halves of `data`, separately:
+ankra migrate restore ./app-data --cluster shop --wait
+ankra migrate restore-status <import-id> --wait    # follow a restore started without --wait
+```
+
+`export` dumps PostgreSQL and MySQL/MariaDB through the docker CLI (`--option docker-host=ssh://root@host`
+for a remote daemon, `--option project=<name>` when the compose project runs under another name);
+`restore` uploads the dumps to the organisation's backup vault with presigned URLs and the cluster's
+agent restores them inside the cluster — no kubectl, no database client, Ankra never holds the data.
+It needs a ready backup vault (`ankra backup vaults provision`; picked automatically when there is one),
+the converted stack applied, and an agent that supports data restores. Rehearse with the source running,
+then stop its writers and run `data` once more for the cutover. Modules extend the lane:
+`ankra migrate modules --help`.
+
 ## AI from the terminal
 
 ```bash


### PR DESCRIPTION
## What & why

Beads: ankra-k6ikc.1 (export) and ankra-k6ikc.3 (restore / data) — epic ankra-k6ikc, *docker compose database → Kubernetes restore through an Ankra backup vault*. Pairs with cluster (import lane) and agent#93 (`restore_import_dump` job).

`ankra migrate convert` (#174) moves the workloads of a Docker deployment but leaves every database volume empty — the avura.work migration copied its databases by hand with a 150-line script. This PR makes Ankra own that end to end:

### `ankra migrate export [dir] --out <dir>`
- **Module protocol: optional `export` verb.** `Description` gains `capabilities`; a module listing `export` answers a fourth verb. The three-verb contract is untouched so existing external modules keep working; an external module's stderr is relayed live as progress. Author doc in `examples/modules/README.md`.
- **Docker module `export`.** Recognises PostgreSQL (`postgres`, `postgis`, `pgvector`, `timescaledb`, bitnami…) and MySQL/MariaDB images (excluding exporters, admin UIs, poolers, PostgREST), finds each service's container by the compose labels, and dumps every database on the server: `pg_dumpall --globals-only` + `pg_dump -Fc` per database (verified by the `PGDMP` magic), or `mysqldump --databases --single-transaction --routines --triggers --events`. Every command runs *inside the container through its own shell*, so passwords never appear on the host command line. Remote hosts via `--option docker-host=ssh://root@host` (the daemon source honours it too); `--option project=`, `container.<w>=`, `databases.<w>=a,b` narrow the dump.
- Writes the dumps, a `manifest.json` whose `target` names the Service and Secret `convert` generated (namespace, host, port, username, `password_secret`/`password_key`), and `SHA256SUMS`. Sizes and checksums are measured by the CLI, never trusted from the module.
- **Convert fix: databases always get a Service.** A compose database with no published port (the usual shape) got no Service, so nothing in the cluster could reach it.

### `ankra migrate restore <export-dir>` / `restore-status <import-id>` / `data [dir]`
- Registers the export with the platform (`POST …/backup-vaults/{id}/imports`), **uploads each dump straight to the vault's bucket with the presigned PUT URLs** it answers (no bearer token, exact `Content-Length`, no API-client timeout), asks the platform to verify every object arrived at the recorded size, and dispatches the in-cluster restore. `--wait` polls the import and narrates each restore job's state; a failed restore fails the command with the platform's excerpt; an expired `--timeout` exits 5.
- The vault is picked automatically when the organisation has exactly one ready vault (`--vault` otherwise), the cluster defaults to the selected one, the stack name derives from the export. A changed artifact is refused before any upload.
- `data` chains export and restore: the one command that moves a Docker deployment's data once its workloads run in the cluster.
- These are the only online commands under `ankra migrate` (annotated `annotationRequiresAuth: "true"`); `convert`/`detect`/`modules`/`export` stay offline — CLAUDE.md's invariant is corrected accordingly. The `ankra-cli` skill gains the migration flow (embedded copy and monorepo source identical).

## Test plan

- `go test -race ./...` and `golangci-lint run` green (pre-commit hook).
- Export: protocol (`FinaliseExport` + every rejection, manifest round trip, capability gating, an external shell module answering `export` with live stderr), image classification (incl. false positives), docker export against a scripted docker executor (both engines, target prefill, password never on the host argv, options, garbled/empty/failed dumps), the Service fix, and the command end to end with a fake `docker` on PATH.
- Restore: command flow against a scripted `APIClient` (uploads at the manifest's sizes, verify, dispatch, `--wait` transitions, no-wait hint + `restore-status`, failed restore excerpt, `--timeout` → exit 5, vault auto-pick / two vaults / by name, changed artifact refused, upload failure named, JSON output), `data` end to end (fake docker + scripted platform), presigned PUT (no bearer, exact length, bucket refusal surfaced) and the four routes against `httptest`.

## Docs checklist

- [ ] No user-facing command/flag changes — no docs needed
- [x] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); `Short`/`Long`/`Example` on the new commands are written for docs readers
- [ ] Broader behaviour changes — docs updated in [ankra-docs](https://github.com/ankraio/ankra-docs) (link the PR): guide filed as a follow-up bead in the epic


## Review fixes (2026-08-29, `/review` pass)

- **Roles are dumped without their passwords** (`pg_dumpall --no-role-passwords`). A globals restore that re-set the target user's password to the source's hash would have locked the cluster - restore pod included - out of its own database. The export warns which other roles need `ALTER ROLE … PASSWORD` afterwards.
- **`postgres` maintenance database**: left out unless the image keeps the application's data there (`POSTGRES_DB`, defaulting to `POSTGRES_USER`), with a hint on `--option databases.<workload>=postgres` when skipped. Previously the default image config (data in `postgres`) exported nothing.
- **Compose project name normalised** the way compose does it (`"Aura Office"` → `auraoffice`), so containers are actually found; dumps written `0600` in `0700` directories with a "this is your data on disk" warning; databases whose names sanitise alike get distinct files.
- **`restore`/`data` resolve the cluster and vault before dumping**; a single artifact above 5 GiB (one presigned PUT) is refused before anything is registered; the platform-minted method is honoured; `--timeout` bounds only the `--wait`, uploads run under the command's context; a status the CLI does not know ends the wait.
- **`UploadPresignedObject`**: plain transport (no API-client headers), retries 5xx/transport failures from the start of the body via `GetBody`, never retries a refusal.
- Tests: vault-selection asserts the chosen vault id, the docker-failure test now exercises a failing dump, plus tests for every item above.
