### PR TITLE
feat(mesh): ankra cluster mesh - list, show, create, delete, join, leave, readiness (ankra-kuk7k.8)

### DIFF
--- a/cmd/cluster_mesh.go
+++ b/cmd/cluster_mesh.go
@@ -1,0 +1,190 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var clusterMeshCmd = &cobra.Command{
+	Use:   "mesh",
+	Short: "Manage Cilium cluster meshes",
+	Long: "Manage Cilium ClusterMeshes: sets of Ankra clusters whose pods and services resolve each other.\n\n" +
+		"A cluster can join a mesh only if it was created on the platform's WireGuard overlay with a unique " +
+		"network identity, so `ankra cluster mesh readiness` is the place to start - it says which of your " +
+		"clusters can mesh, and why the others cannot.",
+}
+
+var clusterMeshListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List the organisation's cluster meshes",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		meshes, listError := apiClient.ListClusterMeshes()
+		if listError != nil {
+			return fmt.Errorf("listing cluster meshes: %w", listError)
+		}
+		if handled, renderError := renderStructured(cmd, meshes); renderError != nil {
+			return renderError
+		} else if handled {
+			return nil
+		}
+		if len(meshes) == 0 {
+			fmt.Println("No cluster meshes. Create one with `ankra cluster mesh create <name>`.")
+			return nil
+		}
+		for _, mesh := range meshes {
+			fmt.Printf("%-36s  %-24s %s\n", mesh.ID, mesh.Slug, mesh.Status)
+			for _, member := range mesh.Members {
+				fmt.Printf("    %-36s  cilium-id=%-4d %-24s %s\n",
+					member.ClusterID, member.CiliumClusterID, member.CiliumClusterName, member.Status)
+			}
+		}
+		return nil
+	},
+}
+
+var clusterMeshShowCmd = &cobra.Command{
+	Use:   "show <mesh_id>",
+	Short: "Show one cluster mesh and its members",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		mesh, getError := apiClient.GetClusterMesh(args[0])
+		if getError != nil {
+			return fmt.Errorf("reading cluster mesh: %w", getError)
+		}
+		if handled, renderError := renderStructured(cmd, mesh); renderError != nil {
+			return renderError
+		} else if handled {
+			return nil
+		}
+		fmt.Printf("Mesh:   %s (%s)\nStatus: %s\n", mesh.Name, mesh.Slug, mesh.Status)
+		if len(mesh.Members) == 0 {
+			fmt.Println("Members: none yet. Add one with `ankra cluster mesh join`.")
+			return nil
+		}
+		fmt.Println("Members:")
+		for _, member := range mesh.Members {
+			fmt.Printf("  %-36s  cilium-id=%-4d %-24s %s\n",
+				member.ClusterID, member.CiliumClusterID, member.CiliumClusterName, member.Status)
+		}
+		return nil
+	},
+}
+
+var clusterMeshCreateCmd = &cobra.Command{
+	Use:   "create <name>",
+	Short: "Create an empty cluster mesh",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		mesh, createError := apiClient.CreateClusterMesh(args[0])
+		if createError != nil {
+			return fmt.Errorf("creating cluster mesh: %w", createError)
+		}
+		if handled, renderError := renderStructured(cmd, mesh); renderError != nil {
+			return renderError
+		} else if handled {
+			return nil
+		}
+		fmt.Printf("Created cluster mesh '%s' (%s).\nAdd clusters with `ankra cluster mesh join %s <cluster_id>`.\n",
+			mesh.Name, mesh.ID, mesh.ID)
+		return nil
+	},
+}
+
+var clusterMeshDeleteCmd = &cobra.Command{
+	Use:   "delete <mesh_id>",
+	Short: "Delete an empty cluster mesh",
+	Long:  "Delete a cluster mesh. The mesh must be empty; remove its members first so their Cilium configuration is torn down rather than left pointing at a mesh that no longer exists.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if deleteError := apiClient.DeleteClusterMesh(args[0]); deleteError != nil {
+			return fmt.Errorf("deleting cluster mesh: %w", deleteError)
+		}
+		fmt.Printf("Deleted cluster mesh %s.\n", args[0])
+		return nil
+	},
+}
+
+var clusterMeshJoinCmd = &cobra.Command{
+	Use:   "join <mesh_id> <cluster_id>",
+	Short: "Add a cluster to a mesh",
+	Long: "Add a cluster to a mesh. The platform mints the mesh's shared certificate authority on the first join, " +
+		"hands it to the joining cluster, and re-renders every member's peer list.\n\n" +
+		"A cluster that cannot mesh is refused with the reason; `ankra cluster mesh readiness` reports the same checks up front.",
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if joinError := apiClient.JoinClusterMesh(args[0], args[1]); joinError != nil {
+			return fmt.Errorf("joining cluster mesh: %w", joinError)
+		}
+		fmt.Printf("Cluster %s joined mesh %s.\n", args[1], args[0])
+		return nil
+	},
+}
+
+var clusterMeshLeaveCmd = &cobra.Command{
+	Use:   "leave <mesh_id> <cluster_id>",
+	Short: "Remove a cluster from a mesh",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if leaveError := apiClient.LeaveClusterMesh(args[0], args[1]); leaveError != nil {
+			return fmt.Errorf("leaving cluster mesh: %w", leaveError)
+		}
+		fmt.Printf("Cluster %s left mesh %s.\n", args[1], args[0])
+		return nil
+	},
+}
+
+var clusterMeshReadinessCmd = &cobra.Command{
+	Use:   "readiness <cluster_id> [cluster_id...]",
+	Short: "Check whether clusters can mesh together, and why not",
+	Long: "Check whether the given clusters could form one mesh. Each cluster is reported ready or not, with the " +
+		"failing checks spelled out.\n\nSome failures cannot be fixed on a running cluster: the Cilium identity and " +
+		"the overlay network mode are set when the cluster is created, so a cluster without them has to be rebuilt to mesh.",
+	Args: cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		readiness, readinessError := apiClient.CheckClusterMeshReadiness(args)
+		if readinessError != nil {
+			return fmt.Errorf("checking cluster mesh readiness: %w", readinessError)
+		}
+		if handled, renderError := renderStructured(cmd, readiness); renderError != nil {
+			return renderError
+		} else if handled {
+			return nil
+		}
+		for _, clusterID := range args {
+			result, isKnown := readiness[clusterID]
+			if !isKnown {
+				fmt.Printf("%s  unknown\n", clusterID)
+				continue
+			}
+			if result.Ready {
+				fmt.Printf("%s  ready\n", clusterID)
+				continue
+			}
+			fmt.Printf("%s  NOT ready\n", clusterID)
+			for _, item := range result.Items {
+				if item.Ready {
+					continue
+				}
+				suffix := " (cannot be fixed on a running cluster; the cluster must be recreated)"
+				if item.Remediable {
+					suffix = ""
+				}
+				fmt.Printf("    %-16s %s%s\n", item.Name, strings.TrimSpace(item.Detail), suffix)
+			}
+		}
+		return nil
+	},
+}
+
+func init() {
+	clusterMeshCmd.AddCommand(clusterMeshListCmd)
+	clusterMeshCmd.AddCommand(clusterMeshShowCmd)
+	clusterMeshCmd.AddCommand(clusterMeshCreateCmd)
+	clusterMeshCmd.AddCommand(clusterMeshDeleteCmd)
+	clusterMeshCmd.AddCommand(clusterMeshJoinCmd)
+	clusterMeshCmd.AddCommand(clusterMeshLeaveCmd)
+	clusterMeshCmd.AddCommand(clusterMeshReadinessCmd)
+	clusterCmd.AddCommand(clusterMeshCmd)
+}

--- a/cmd/cluster_mesh_test.go
+++ b/cmd/cluster_mesh_test.go
@@ -1,0 +1,175 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type clusterMeshMock struct {
+	baseMock
+	meshes    []client.ClusterMesh
+	readiness map[string]client.ClusterMeshReadiness
+
+	createdNames []string
+	joins        [][2]string
+	leaves       [][2]string
+	deleted      []string
+	readinessFor [][]string
+
+	joinError error
+}
+
+func (m *clusterMeshMock) ListClusterMeshes() ([]client.ClusterMesh, error) {
+	return m.meshes, nil
+}
+
+func (m *clusterMeshMock) GetClusterMesh(meshID string) (*client.ClusterMesh, error) {
+	for _, mesh := range m.meshes {
+		if mesh.ID == meshID {
+			return &mesh, nil
+		}
+	}
+	return nil, errors.New("cluster mesh not found")
+}
+
+func (m *clusterMeshMock) CreateClusterMesh(name string) (*client.ClusterMesh, error) {
+	m.createdNames = append(m.createdNames, name)
+	return &client.ClusterMesh{ID: "mesh-1", Slug: "production-eu", Name: name, Status: "pending"}, nil
+}
+
+func (m *clusterMeshMock) DeleteClusterMesh(meshID string) error {
+	m.deleted = append(m.deleted, meshID)
+	return nil
+}
+
+func (m *clusterMeshMock) JoinClusterMesh(meshID string, clusterID string) error {
+	if m.joinError != nil {
+		return m.joinError
+	}
+	m.joins = append(m.joins, [2]string{meshID, clusterID})
+	return nil
+}
+
+func (m *clusterMeshMock) LeaveClusterMesh(meshID string, clusterID string) error {
+	m.leaves = append(m.leaves, [2]string{meshID, clusterID})
+	return nil
+}
+
+func (m *clusterMeshMock) CheckClusterMeshReadiness(clusterIDs []string) (map[string]client.ClusterMeshReadiness, error) {
+	m.readinessFor = append(m.readinessFor, clusterIDs)
+	return m.readiness, nil
+}
+
+func executeMeshCommand(t *testing.T, args ...string) error {
+	t.Helper()
+	t.Cleanup(func() { rootCmd.SetIn(nil) })
+	rootCmd.SetOut(new(strings.Builder))
+	rootCmd.SetErr(new(strings.Builder))
+	rootCmd.SetArgs(args)
+	return rootCmd.Execute()
+}
+
+func TestClusterMeshCreatePassesTheName(t *testing.T) {
+	mock := &clusterMeshMock{}
+	setMockClient(t, mock)
+
+	if err := executeMeshCommand(t, "cluster", "mesh", "create", "Production EU"); err != nil {
+		t.Fatalf("create returned %v", err)
+	}
+	if len(mock.createdNames) != 1 || mock.createdNames[0] != "Production EU" {
+		t.Fatalf("expected the name to reach the API, got %v", mock.createdNames)
+	}
+}
+
+func TestClusterMeshJoinPassesMeshAndCluster(t *testing.T) {
+	mock := &clusterMeshMock{}
+	setMockClient(t, mock)
+
+	if err := executeMeshCommand(t, "cluster", "mesh", "join", "mesh-1", "cluster-9"); err != nil {
+		t.Fatalf("join returned %v", err)
+	}
+	if len(mock.joins) != 1 || mock.joins[0] != [2]string{"mesh-1", "cluster-9"} {
+		t.Fatalf("expected one join of cluster-9 into mesh-1, got %v", mock.joins)
+	}
+}
+
+// A refusal from the platform carries the operator-facing reason, so the CLI
+// must surface it rather than replacing it with a generic failure.
+func TestClusterMeshJoinSurfacesTheRefusalReason(t *testing.T) {
+	mock := &clusterMeshMock{
+		joinError: errors.New("cluster c1 cannot join the mesh: the cluster's nodes are not on the platform WireGuard overlay"),
+	}
+	setMockClient(t, mock)
+
+	err := executeMeshCommand(t, "cluster", "mesh", "join", "mesh-1", "c1")
+	if err == nil {
+		t.Fatal("expected the refusal to fail the command")
+	}
+	if !strings.Contains(err.Error(), "not on the platform WireGuard overlay") {
+		t.Fatalf("the reason must reach the operator, got %v", err)
+	}
+}
+
+func TestClusterMeshLeavePassesMeshAndCluster(t *testing.T) {
+	mock := &clusterMeshMock{}
+	setMockClient(t, mock)
+
+	if err := executeMeshCommand(t, "cluster", "mesh", "leave", "mesh-1", "cluster-9"); err != nil {
+		t.Fatalf("leave returned %v", err)
+	}
+	if len(mock.leaves) != 1 || mock.leaves[0] != [2]string{"mesh-1", "cluster-9"} {
+		t.Fatalf("expected one leave, got %v", mock.leaves)
+	}
+}
+
+func TestClusterMeshReadinessPassesEveryCluster(t *testing.T) {
+	mock := &clusterMeshMock{
+		readiness: map[string]client.ClusterMeshReadiness{
+			"c1": {Ready: true},
+			"c2": {Ready: false, Items: []client.ClusterMeshReadinessItem{
+				{Name: "transport", Ready: false, Detail: "not on the overlay", Remediable: false},
+			}},
+		},
+	}
+	setMockClient(t, mock)
+
+	if err := executeMeshCommand(t, "cluster", "mesh", "readiness", "c1", "c2"); err != nil {
+		t.Fatalf("readiness returned %v", err)
+	}
+	if len(mock.readinessFor) != 1 || len(mock.readinessFor[0]) != 2 {
+		t.Fatalf("expected both clusters in one call, got %v", mock.readinessFor)
+	}
+}
+
+func TestClusterMeshReadinessNeedsAtLeastOneCluster(t *testing.T) {
+	mock := &clusterMeshMock{}
+	setMockClient(t, mock)
+
+	if err := executeMeshCommand(t, "cluster", "mesh", "readiness"); err == nil {
+		t.Fatal("readiness with no clusters should be rejected by the argument check")
+	}
+}
+
+func TestClusterMeshShowRejectsAnUnknownMesh(t *testing.T) {
+	mock := &clusterMeshMock{}
+	setMockClient(t, mock)
+
+	if err := executeMeshCommand(t, "cluster", "mesh", "show", "missing"); err == nil {
+		t.Fatal("an unknown mesh should fail the command")
+	}
+}
+
+func TestClusterMeshDeletePassesTheMesh(t *testing.T) {
+	mock := &clusterMeshMock{}
+	setMockClient(t, mock)
+
+	if err := executeMeshCommand(t, "cluster", "mesh", "delete", "mesh-1"); err != nil {
+		t.Fatalf("delete returned %v", err)
+	}
+	if len(mock.deleted) != 1 || mock.deleted[0] != "mesh-1" {
+		t.Fatalf("expected one delete of mesh-1, got %v", mock.deleted)
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1412,6 +1412,34 @@ func (m baseMock) ListKubeadmVersions() (*client.ListVersionsResult, error) {
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) ListClusterMeshes() ([]client.ClusterMesh, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetClusterMesh(string) (*client.ClusterMesh, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) CreateClusterMesh(string) (*client.ClusterMesh, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) DeleteClusterMesh(string) error {
+	return errors.New("not implemented")
+}
+
+func (m baseMock) JoinClusterMesh(string, string) error {
+	return errors.New("not implemented")
+}
+
+func (m baseMock) LeaveClusterMesh(string, string) error {
+	return errors.New("not implemented")
+}
+
+func (m baseMock) CheckClusterMeshReadiness([]string) (map[string]client.ClusterMeshReadiness, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) CreatePlayground(string) (*client.CreatePlaygroundResult, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -398,6 +398,14 @@ type APIClient interface {
 	ListHetznerServerTypes(credentialID, location string) ([]client.HetznerServerType, error)
 	ListK3sVersions() (*client.ListVersionsResult, error)
 	ListKubeadmVersions() (*client.ListVersionsResult, error)
+
+	ListClusterMeshes() ([]client.ClusterMesh, error)
+	GetClusterMesh(meshID string) (*client.ClusterMesh, error)
+	CreateClusterMesh(name string) (*client.ClusterMesh, error)
+	DeleteClusterMesh(meshID string) error
+	JoinClusterMesh(meshID string, clusterID string) error
+	LeaveClusterMesh(meshID string, clusterID string) error
+	CheckClusterMeshReadiness(clusterIDs []string) (map[string]client.ClusterMeshReadiness, error)
 	CreatePlayground(planID string) (*client.CreatePlaygroundResult, error)
 	ListPlaygroundPlans() (*client.PlaygroundPlanCatalog, error)
 	ResizePlayground(clusterID string, planID string) (*client.ResizePlaygroundResult, error)

--- a/internal/client/clustermesh.go
+++ b/internal/client/clustermesh.go
@@ -1,0 +1,105 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+)
+
+const clusterMeshAPIPath = "/api/v1/org/cluster-meshes"
+
+// ClusterMeshMember is one cluster in a mesh.
+type ClusterMeshMember struct {
+	ClusterID         string `json:"cluster_id"`
+	CiliumClusterID   int    `json:"cilium_cluster_id"`
+	CiliumClusterName string `json:"cilium_cluster_name"`
+	Status            string `json:"status"`
+}
+
+// ClusterMesh is a mesh and the clusters in it.
+type ClusterMesh struct {
+	ID      string              `json:"id"`
+	Slug    string              `json:"slug"`
+	Name    string              `json:"name"`
+	Status  string              `json:"status"`
+	Members []ClusterMeshMember `json:"members"`
+}
+
+// ClusterMeshReadinessItem is one checked precondition for joining a mesh.
+type ClusterMeshReadinessItem struct {
+	Name       string `json:"name"`
+	Ready      bool   `json:"ready"`
+	Detail     string `json:"detail"`
+	Remediable bool   `json:"remediable"`
+}
+
+// ClusterMeshReadiness is one cluster's answer to "could this mesh?".
+type ClusterMeshReadiness struct {
+	Ready bool                       `json:"ready"`
+	Items []ClusterMeshReadinessItem `json:"items"`
+}
+
+// ListClusterMeshes returns every mesh of the organisation with its members.
+func (c *Client) ListClusterMeshes() ([]ClusterMesh, error) {
+	var response struct {
+		ClusterMeshes []ClusterMesh `json:"cluster_meshes"`
+	}
+	if err := c.sendJSON(http.MethodGet, c.BaseURL+clusterMeshAPIPath, nil, &response); err != nil {
+		return nil, err
+	}
+	return response.ClusterMeshes, nil
+}
+
+// GetClusterMesh returns one mesh.
+func (c *Client) GetClusterMesh(meshID string) (*ClusterMesh, error) {
+	var response struct {
+		ClusterMesh ClusterMesh `json:"cluster_mesh"`
+	}
+	url := fmt.Sprintf("%s%s/%s", c.BaseURL, clusterMeshAPIPath, meshID)
+	if err := c.sendJSON(http.MethodGet, url, nil, &response); err != nil {
+		return nil, err
+	}
+	return &response.ClusterMesh, nil
+}
+
+// CreateClusterMesh declares a new, empty mesh.
+func (c *Client) CreateClusterMesh(name string) (*ClusterMesh, error) {
+	var response struct {
+		ClusterMesh ClusterMesh `json:"cluster_mesh"`
+	}
+	body := map[string]any{"name": name}
+	if err := c.sendJSON(http.MethodPost, c.BaseURL+clusterMeshAPIPath, body, &response); err != nil {
+		return nil, err
+	}
+	return &response.ClusterMesh, nil
+}
+
+// DeleteClusterMesh removes an empty mesh.
+func (c *Client) DeleteClusterMesh(meshID string) error {
+	url := fmt.Sprintf("%s%s/%s", c.BaseURL, clusterMeshAPIPath, meshID)
+	return c.sendJSON(http.MethodDelete, url, nil, nil)
+}
+
+// JoinClusterMesh admits a cluster to a mesh.
+func (c *Client) JoinClusterMesh(meshID string, clusterID string) error {
+	url := fmt.Sprintf("%s%s/%s/members", c.BaseURL, clusterMeshAPIPath, meshID)
+	return c.sendJSON(http.MethodPost, url, map[string]any{"cluster_id": clusterID}, nil)
+}
+
+// LeaveClusterMesh removes a cluster from a mesh.
+func (c *Client) LeaveClusterMesh(meshID string, clusterID string) error {
+	url := fmt.Sprintf("%s%s/%s/members/%s", c.BaseURL, clusterMeshAPIPath, meshID, clusterID)
+	return c.sendJSON(http.MethodDelete, url, nil, nil)
+}
+
+// CheckClusterMeshReadiness answers, per cluster, whether the given set could
+// mesh together and why not.
+func (c *Client) CheckClusterMeshReadiness(clusterIDs []string) (map[string]ClusterMeshReadiness, error) {
+	var response struct {
+		Readiness map[string]ClusterMeshReadiness `json:"readiness"`
+	}
+	body := map[string]any{"cluster_ids": clusterIDs}
+	if err := c.sendJSON(http.MethodPost, c.BaseURL+clusterMeshAPIPath+"/readiness", body, &response); err != nil {
+		return nil, err
+	}
+	return response.Readiness, nil
+}


### PR DESCRIPTION
Bead: ankra-kuk7k.8

`ankra cluster mesh` — the CLI for Cilium ClusterMeshes. Drives the routes in **ankraio/cluster#2104**; the agent handlers are **ankraio/agent#91**.

```
ankra cluster mesh readiness <cluster_id>...   # start here
ankra cluster mesh create <name>
ankra cluster mesh join <mesh_id> <cluster_id>
ankra cluster mesh list | show <mesh_id>
ankra cluster mesh leave <mesh_id> <cluster_id>
ankra cluster mesh delete <mesh_id>
```

## Why `readiness` is the front door

Whether a cluster can mesh is decided **when it is created** — it needs a unique Cilium identity and the platform's WireGuard overlay, neither of which can be retrofitted. So the useful question isn't "did my join fail", it's "which of my clusters can mesh at all".

`readiness` prints the failing checks per cluster and marks the ones that **cannot be fixed on a running cluster**, because for those the honest answer is "rebuild it" — and an operator should learn that before they try to join, not after.

A refusal from the platform carries the operator-facing reason, so `join` surfaces it rather than replacing it with a generic failure. There's a test for that, since that reason is the entire value of the pre-flight the platform runs.

## Notes

- The client methods target the `/api/v1` twins, the surface the CLI is allowed to use. The cluster PR mounts every mesh route on both prefixes and has a test that fails if one ever loses its twin.
- The seven new `APIClient` methods are stubbed on `baseMock` so existing command tests keep compiling.

## Gates

`go build`, `go vet`, `go test ./...` (6 packages), `golangci-lint` (**0 issues**), `make verify-skills`.

## One thing worth noting for review

`gofmt -w internal/client/` reformatted four files I never touched (`baseurl.go`, `control_plane.go`, `credentials.go`, `helpers_test.go`) — they are not gofmt-clean on `master`. I reverted those so this PR carries only the mesh change, but that formatting drift on master is real and someone may want to fix it deliberately in its own commit.
