### PR TITLE
feat(cluster): ankra cluster debug + ankra org terminal-session (ankra-loyfi)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 ### Added
 
+- **Debug pods that impersonate a workload.** `ankra cluster debug create
+  --namespace <ns> --from-pod <pod>` spins up a pod that mirrors the named
+  pod - its service account, node, volumes and volume mounts, environment
+  variables and `envFrom` sources, tolerations and security context - under
+  an image chosen for its tools (netshoot by default; `--image` takes any
+  reference, `debug images` lists the tag-pinned catalogue). Without
+  `--from-pod` it is a plain shell in a namespace. `--container` picks which
+  container to mirror, `--no-mounts` / `--no-env` leave those out, `--ttl`
+  sets the lifetime (1m-8h, default 1h) the kubelet enforces on its own. The
+  command prints the portal link to the new pod's terminal; `debug list` and
+  `debug delete` manage what is running. Needs `kubernetes.write` and
+  `kubernetes.exec`, and cluster agent 2.1.1074 or newer.
+- **Recorded terminal sessions are readable.** Every pod terminal session is
+  now recorded by the platform; `ankra org terminal-session <session-id>`
+  prints a session's facts and, with `--transcript`, replays the recorded
+  output as text (`--show-input` lists what was typed). The session id is
+  the `terminal_session_id` on an `open_pod_terminal` audit row. Needs
+  `audit.read`.
 - **The Security Center is readable from the terminal.** `ankra security
   overview` prints the fleet's actionable totals, scanner coverage, the
   remediation candidates, and - first - how many vulnerabilities CISA lists

--- a/cmd/cluster_debug.go
+++ b/cmd/cluster_debug.go
@@ -1,0 +1,280 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+)
+
+// ankra cluster debug: a pod Ankra creates in a namespace that impersonates
+// another pod - same service account, node, volumes and mounts, environment -
+// under an image chosen for its tools, so a distroless or crash-looping
+// workload can be inspected without an ephemeral container mutating it. The
+// platform builds the mirror and records every terminal session into it.
+
+const (
+	debugPodDefaultTTL = time.Hour
+	debugPodMinimumTTL = time.Minute
+	debugPodMaximumTTL = 8 * time.Hour
+)
+
+var clusterDebugCmd = &cobra.Command{
+	Use:   "debug",
+	Short: "Spin up, list and remove debug pods",
+	Long: `Debug pods are pods Ankra creates on your behalf, in any namespace of the
+active cluster, from an image chosen for its tools rather than for the
+workload. Point one at an existing pod with --from-pod and it impersonates
+that pod: the same service account, node, volumes and volume mounts,
+environment variables and envFrom sources, tolerations and security
+context - under an image that actually has curl, dig, psql or strace in it.
+The workload itself is never touched.
+
+Labels are never copied, so a debug pod never sits behind the workload's
+Service. Every debug pod carries a lifetime the kubelet enforces on its own,
+and every terminal session into one is recorded to the audit log.`,
+	Annotations: map[string]string{"group": "kubernetes"},
+}
+
+var clusterDebugImagesCmd = &cobra.Command{
+	Use:   "images",
+	Short: "List the debug image catalogue",
+	Long: `List the tag-pinned images the platform offers for debug pods. Any image
+reference is accepted by "debug create --image"; the catalogue is the set
+that ships with tools and is known to pull.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cluster, err := resolveActiveCluster(cmd)
+		if err != nil {
+			return err
+		}
+		catalogue, err := apiClient.ListDebugPodImages(cluster.ID)
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, catalogue.Images); handled || renderError != nil {
+			return renderError
+		}
+		renderer := table.NewWriter()
+		renderer.SetOutputMirror(cmd.OutOrStdout())
+		renderer.AppendHeader(table.Row{"NAME", "IMAGE", "DEFAULT", "DESCRIPTION"})
+		for _, image := range catalogue.Images {
+			isDefault := ""
+			if image.IsDefault {
+				isDefault = "yes"
+			}
+			renderer.AppendRow(table.Row{image.Name, image.Image, isDefault, image.Description})
+		}
+		renderer.SetStyle(table.StyleLight)
+		renderer.Render()
+		return nil
+	},
+}
+
+var clusterDebugCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a debug pod, optionally impersonating an existing pod",
+	Long: `Create a debug pod in a namespace of the active cluster and wait for it to
+start. With --from-pod the pod impersonates the named pod - its service
+account, node, volumes and mounts, environment - so what the workload's
+container sees, the debug pod sees. Without --from-pod it is a plain pod of
+the chosen image with no service-account token.
+
+The command prints the portal link to the new pod's terminal; every session
+opened there is recorded to the audit log. Creating a debug pod needs the
+kubernetes.write and kubernetes.exec permissions.
+
+Examples:
+  ankra cluster debug create -n payments --from-pod api-6d8f9c7b5-x2kq9
+  ankra cluster debug create -n payments --from-pod api-6d8f9c7b5-x2kq9 --container sidecar --no-env
+  ankra cluster debug create -n payments --image docker.io/library/alpine:3.21 --ttl 2h
+  ankra cluster debug create -n payments --from-pod api-6d8f9c7b5-x2kq9 -o json`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		namespace, _ := cmd.Flags().GetString("namespace")
+		fromPod, _ := cmd.Flags().GetString("from-pod")
+		container, _ := cmd.Flags().GetString("container")
+		image, _ := cmd.Flags().GetString("image")
+		noMounts, _ := cmd.Flags().GetBool("no-mounts")
+		noEnvironment, _ := cmd.Flags().GetBool("no-env")
+		ttl, _ := cmd.Flags().GetDuration("ttl")
+
+		if namespace == "" {
+			return withExitCode(exitUsage, errors.New("--namespace (-n) is required"))
+		}
+		if fromPod == "" && container != "" {
+			return withExitCode(exitUsage, errors.New("--container only means something with --from-pod"))
+		}
+		if fromPod == "" && (noMounts || noEnvironment) {
+			return withExitCode(exitUsage, errors.New("--no-mounts and --no-env only mean something with --from-pod: nothing is mirrored without one"))
+		}
+		if ttl < debugPodMinimumTTL || ttl > debugPodMaximumTTL {
+			return withExitCode(exitUsage, fmt.Errorf("--ttl must be between %s and %s", debugPodMinimumTTL, debugPodMaximumTTL))
+		}
+
+		cluster, err := resolveActiveCluster(cmd)
+		if err != nil {
+			return err
+		}
+		created, err := apiClient.CreateDebugPod(cluster.ID, client.CreateDebugPodRequest{
+			Namespace:           namespace,
+			TargetPodName:       fromPod,
+			TargetContainerName: container,
+			Image:               image,
+			MirrorVolumeMounts:  !noMounts,
+			MirrorEnvironment:   !noEnvironment,
+			TTLSeconds:          int(ttl / time.Second),
+		})
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, created); handled || renderError != nil {
+			return renderError
+		}
+		renderDebugPodCreated(cmd, cluster.ID, created)
+		return nil
+	},
+}
+
+func renderDebugPodCreated(cmd *cobra.Command, clusterID string, created *client.DebugPodResponse) {
+	out := cmd.OutOrStdout()
+	state := "created"
+	if created.Ready {
+		state = "running"
+	}
+	_, _ = fmt.Fprintf(out, "%s Debug pod %s %s in %s\n",
+		text.FgGreen.Sprint("✓"), text.Bold.Sprint(created.PodName), state, created.Namespace)
+	_, _ = fmt.Fprintf(out, "  Image:     %s\n", created.Image)
+	if created.NodeName != "" {
+		_, _ = fmt.Fprintf(out, "  Node:      %s\n", created.NodeName)
+	}
+	if created.TargetPodName != nil {
+		targetContainer := ""
+		if created.TargetContainerName != nil {
+			targetContainer = " (container " + *created.TargetContainerName + ")"
+		}
+		_, _ = fmt.Fprintf(out, "  Mirrors:   %s%s\n", *created.TargetPodName, targetContainer)
+		_, _ = fmt.Fprintf(out, "  Mirrored:  %d volume mount(s), %d env var(s), %d envFrom source(s)\n",
+			len(created.MirroredVolumeMounts), created.MirroredEnvironmentVariables, created.MirroredEnvironmentSources)
+	}
+	_, _ = fmt.Fprintf(out, "  Expires:   %s\n", created.ExpiresAt)
+	for _, warning := range created.Warnings {
+		_, _ = fmt.Fprintf(out, "  %s %s\n", text.FgYellow.Sprint("!"), warning)
+	}
+	_, _ = fmt.Fprintf(out, "\nOpen a terminal in the portal (every session is recorded to the audit log):\n  %s\n",
+		debugPodTerminalPath(clusterID, created.Namespace, created.PodName))
+}
+
+// debugPodTerminalPath is the portal page the CLI hands over to, as a path
+// under the portal's own host: an interactive terminal from the CLI itself
+// is a later piece.
+func debugPodTerminalPath(clusterID string, namespace string, podName string) string {
+	return "/organisation/clusters/cluster/imported/" + clusterID +
+		"/kubernetes/workloads/pods/" + namespace + "/" + podName + "?activeTab=terminal"
+}
+
+var clusterDebugListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List the debug pods on the active cluster",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		namespace, _ := cmd.Flags().GetString("namespace")
+		cluster, err := resolveActiveCluster(cmd)
+		if err != nil {
+			return err
+		}
+		listing, err := apiClient.ListDebugPods(cluster.ID, namespace)
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, listing.DebugPods); handled || renderError != nil {
+			return renderError
+		}
+		if len(listing.DebugPods) == 0 {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No debug pods on this cluster.")
+			return nil
+		}
+		renderer := table.NewWriter()
+		renderer.SetOutputMirror(cmd.OutOrStdout())
+		renderer.AppendHeader(table.Row{"NAMESPACE", "NAME", "PHASE", "MIRRORS", "IMAGE", "REQUESTED BY", "EXPIRES"})
+		for _, pod := range listing.DebugPods {
+			mirrors := "-"
+			if pod.TargetPodName != nil {
+				mirrors = *pod.TargetPodName
+			}
+			expires := pod.ExpiresAt
+			if pod.IsExpired {
+				expires = text.FgYellow.Sprint(expires + " (expired)")
+			}
+			renderer.AppendRow(table.Row{pod.Namespace, pod.PodName, pod.Phase, mirrors, pod.Image, pod.RequestedBy, expires})
+		}
+		renderer.SetStyle(table.StyleLight)
+		renderer.Render()
+		return nil
+	},
+}
+
+var clusterDebugDeleteCmd = &cobra.Command{
+	Use:   "delete <pod_name>",
+	Short: "Delete a debug pod",
+	Long: `Delete a debug pod before its lifetime ends. Only a pod carrying the
+ankra.io/debug-pod label can be deleted this way; a workload pod answers
+not found.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		namespace, _ := cmd.Flags().GetString("namespace")
+		yes, _ := cmd.Flags().GetBool("yes")
+		if namespace == "" {
+			return withExitCode(exitUsage, errors.New("--namespace (-n) is required"))
+		}
+		cluster, err := resolveActiveCluster(cmd)
+		if err != nil {
+			return err
+		}
+		if confirmError := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Delete debug pod %s in %s? [y/N]: ", args[0], namespace), yes); confirmError != nil {
+			return confirmError
+		}
+		outcome, err := apiClient.DeleteDebugPod(cluster.ID, namespace, args[0])
+		if err != nil {
+			return err
+		}
+		if handled, renderError := renderStructured(cmd, outcome); handled || renderError != nil {
+			return renderError
+		}
+		if outcome.Status == "not_found" {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Debug pod %s was already gone from %s.\n", args[0], namespace)
+			return nil
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s Deleted debug pod %s in %s\n", text.FgGreen.Sprint("✓"), args[0], namespace)
+		return nil
+	},
+}
+
+func init() {
+	clusterDebugCreateCmd.Flags().StringP("namespace", "n", "", "Namespace to create the debug pod in (required)")
+	clusterDebugCreateCmd.Flags().String("from-pod", "", "Pod to impersonate: its service account, node, volumes, mounts and environment are mirrored")
+	clusterDebugCreateCmd.Flags().StringP("container", "c", "", "Container of --from-pod whose mounts and environment to mirror (default: the first)")
+	clusterDebugCreateCmd.Flags().String("image", "", "Debug image (default: the catalogue's default; see \"debug images\")")
+	clusterDebugCreateCmd.Flags().Bool("no-mounts", false, "Do not mirror the target's volumes and volume mounts")
+	clusterDebugCreateCmd.Flags().Bool("no-env", false, "Do not mirror the target's environment variables")
+	clusterDebugCreateCmd.Flags().Duration("ttl", debugPodDefaultTTL, "How long the pod lives before the kubelet ends it (1m-8h)")
+
+	clusterDebugListCmd.Flags().StringP("namespace", "n", "", "Only list debug pods in this namespace")
+
+	clusterDebugDeleteCmd.Flags().StringP("namespace", "n", "", "Namespace of the debug pod (required)")
+	clusterDebugDeleteCmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
+
+	registerStructuredOutputFlags(clusterDebugImagesCmd, clusterDebugCreateCmd, clusterDebugListCmd, clusterDebugDeleteCmd)
+
+	clusterDebugCmd.AddCommand(clusterDebugImagesCmd)
+	clusterDebugCmd.AddCommand(clusterDebugCreateCmd)
+	clusterDebugCmd.AddCommand(clusterDebugListCmd)
+	clusterDebugCmd.AddCommand(clusterDebugDeleteCmd)
+	clusterCmd.AddCommand(clusterDebugCmd)
+}

--- a/cmd/cluster_debug_test.go
+++ b/cmd/cluster_debug_test.go
@@ -1,0 +1,250 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type debugPodMock struct {
+	baseMock
+	createRequest  *client.CreateDebugPodRequest
+	createResponse *client.DebugPodResponse
+	createError    error
+	listed         []client.DebugPodSummary
+	deleted        []string
+	session        *client.TerminalSession
+	transcript     []client.TerminalTranscriptChunk
+}
+
+func (m *debugPodMock) ListDebugPodImages(clusterID string) (*client.DebugPodImagesResponse, error) {
+	return &client.DebugPodImagesResponse{Images: []client.DebugPodImage{
+		{Image: "docker.io/nicolaka/netshoot:v0.13", Name: "netshoot", Description: "Network toolkit.", IsDefault: true},
+		{Image: "docker.io/library/busybox:1.37", Name: "busybox", Description: "Minimal shell."},
+	}}, nil
+}
+
+func (m *debugPodMock) CreateDebugPod(clusterID string, request client.CreateDebugPodRequest) (*client.DebugPodResponse, error) {
+	m.createRequest = &request
+	if m.createError != nil {
+		return nil, m.createError
+	}
+	return m.createResponse, nil
+}
+
+func (m *debugPodMock) ListDebugPods(clusterID string, namespace string) (*client.ListDebugPodsResponse, error) {
+	return &client.ListDebugPodsResponse{DebugPods: m.listed}, nil
+}
+
+func (m *debugPodMock) DeleteDebugPod(clusterID string, namespace string, podName string) (*client.DeleteDebugPodResponse, error) {
+	m.deleted = append(m.deleted, namespace+"/"+podName)
+	return &client.DeleteDebugPodResponse{Status: "success"}, nil
+}
+
+func (m *debugPodMock) GetTerminalSession(sessionID string) (*client.TerminalSession, error) {
+	return m.session, nil
+}
+
+func (m *debugPodMock) GetTerminalTranscript(sessionID string, afterSequence int, limit int) (*client.TerminalTranscriptPage, error) {
+	page := &client.TerminalTranscriptPage{SessionID: sessionID}
+	for _, chunk := range m.transcript {
+		if chunk.Sequence > afterSequence && len(page.Chunks) < 2 {
+			page.Chunks = append(page.Chunks, chunk)
+			page.NextAfter = chunk.Sequence
+		}
+	}
+	page.HasMore = len(page.Chunks) == 2 && page.NextAfter < m.transcript[len(m.transcript)-1].Sequence
+	return page, nil
+}
+
+func debugStringPointer(value string) *string { return &value }
+
+// Cobra flags are package-level state, so a value set by one invocation
+// would leak into the next; every test resets the debug flags on cleanup,
+// and a test that invokes the command more than once resets in between.
+func resetDebugFlagsNow() {
+	for name, value := range map[string]string{
+		"namespace": "", "from-pod": "", "container": "", "image": "",
+		"no-mounts": "false", "no-env": "false", "ttl": debugPodDefaultTTL.String(),
+	} {
+		_ = clusterDebugCreateCmd.Flags().Set(name, value)
+	}
+	_ = clusterDebugListCmd.Flags().Set("namespace", "")
+	_ = clusterDebugDeleteCmd.Flags().Set("namespace", "")
+	_ = clusterDebugDeleteCmd.Flags().Set("yes", "false")
+}
+
+func resetDebugCreateFlags(t *testing.T) {
+	t.Helper()
+	t.Cleanup(resetDebugFlagsNow)
+}
+
+func createdDebugPod() *client.DebugPodResponse {
+	return &client.DebugPodResponse{
+		PodName:                      "debug-api-7f3a",
+		Namespace:                    "payments",
+		ContainerName:                "debug",
+		Image:                        "docker.io/nicolaka/netshoot:v0.13",
+		NodeName:                     "worker-2",
+		Phase:                        "Running",
+		Ready:                        true,
+		ExpiresAt:                    "2026-08-28T23:00:00Z",
+		TargetPodName:                debugStringPointer("api-6d8f9c7b5-x2kq9"),
+		TargetContainerName:          debugStringPointer("api"),
+		MirroredVolumes:              []string{"data"},
+		MirroredVolumeMounts:         []string{"/var/lib/api"},
+		MirroredEnvironmentVariables: 2,
+		MirroredEnvironmentSources:   1,
+		Warnings:                     []string{"volume scratch is an emptyDir: the debug pod gets a fresh, empty one, not the target's contents"},
+		RequestedBy:                  "ops@example.com",
+	}
+}
+
+func TestClusterDebugCreateImpersonatesAPod(t *testing.T) {
+	mock := &debugPodMock{createResponse: createdDebugPod()}
+	setMockClient(t, mock)
+	resetDebugCreateFlags(t)
+	writeSelectedClusterJSON(t)
+
+	output, err := executeCommand("cluster", "debug", "create", "-n", "payments",
+		"--from-pod", "api-6d8f9c7b5-x2kq9", "--container", "api", "--no-env", "--ttl", "30m")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.createRequest == nil {
+		t.Fatal("the API was never called")
+	}
+	request := *mock.createRequest
+	if request.Namespace != "payments" || request.TargetPodName != "api-6d8f9c7b5-x2kq9" || request.TargetContainerName != "api" {
+		t.Errorf("target not carried: %+v", request)
+	}
+	if !request.MirrorVolumeMounts || request.MirrorEnvironment {
+		t.Errorf("--no-env turns environment mirroring off and leaves mounts on: %+v", request)
+	}
+	if request.TTLSeconds != 1800 {
+		t.Errorf("--ttl 30m is 1800 seconds: %d", request.TTLSeconds)
+	}
+	plain := stripANSICodes(output)
+	for _, expected := range []string{"debug-api-7f3a", "running", "Mirrors:   api-6d8f9c7b5-x2kq9 (container api)", "1 volume mount(s), 2 env var(s), 1 envFrom source(s)", "emptyDir", "activeTab=terminal"} {
+		if !strings.Contains(plain, expected) {
+			t.Errorf("output lacks %q:\n%s", expected, plain)
+		}
+	}
+}
+
+func TestClusterDebugCreateRefusesMirrorFlagsWithoutATarget(t *testing.T) {
+	mock := &debugPodMock{createResponse: createdDebugPod()}
+	setMockClient(t, mock)
+	resetDebugCreateFlags(t)
+	writeSelectedClusterJSON(t)
+
+	_, err := executeCommand("cluster", "debug", "create", "-n", "payments", "--no-env")
+	if exitCodeFor(err) != exitUsage {
+		t.Fatalf("expected a usage error, got %v", err)
+	}
+	if mock.createRequest != nil {
+		t.Fatal("a usage error must not reach the API")
+	}
+	resetDebugFlagsNow()
+	_, err = executeCommand("cluster", "debug", "create", "--from-pod", "api")
+	if exitCodeFor(err) != exitUsage {
+		t.Fatalf("a missing namespace is a usage error, got %v", err)
+	}
+	resetDebugFlagsNow()
+	_, err = executeCommand("cluster", "debug", "create", "-n", "payments", "--ttl", "9h")
+	if exitCodeFor(err) != exitUsage {
+		t.Fatalf("a ttl over eight hours is a usage error, got %v", err)
+	}
+}
+
+func TestClusterDebugCreatePropagatesTheRefusal(t *testing.T) {
+	mock := &debugPodMock{createError: &client.ClusterUnavailableError{ErrorCode: "AGENT_TIMEOUT", Detail: "Agent timeout while creating the debug pod"}}
+	setMockClient(t, mock)
+	resetDebugCreateFlags(t)
+	writeSelectedClusterJSON(t)
+
+	_, err := executeCommand("cluster", "debug", "create", "-n", "payments")
+	var unavailable *client.ClusterUnavailableError
+	if !errors.As(err, &unavailable) || unavailable.ErrorCode != "AGENT_TIMEOUT" {
+		t.Fatalf("the cluster error must surface typed, with its code: %v", err)
+	}
+}
+
+func TestClusterDebugListAndImages(t *testing.T) {
+	mock := &debugPodMock{listed: []client.DebugPodSummary{{
+		PodName: "debug-api-7f3a", Namespace: "payments", Phase: "Running", Image: "busybox:1.37",
+		TargetPodName: debugStringPointer("api-6d8f9c7b5-x2kq9"), RequestedBy: "ops@example.com",
+		ExpiresAt: "2026-08-28T23:00:00Z", IsExpired: true,
+	}}}
+	setMockClient(t, mock)
+	resetDebugCreateFlags(t)
+	writeSelectedClusterJSON(t)
+
+	output, err := executeCommand("cluster", "debug", "list")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	plain := stripANSICodes(output)
+	if !strings.Contains(plain, "debug-api-7f3a") || !strings.Contains(plain, "api-6d8f9c7b5-x2kq9") || !strings.Contains(plain, "(expired)") {
+		t.Errorf("listing lacks the debug pod facts:\n%s", plain)
+	}
+
+	output, err = executeCommand("cluster", "debug", "images", "-o", "json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(output, `"is_default": true`) || !strings.Contains(output, "netshoot") {
+		t.Errorf("json catalogue lacks the default: %s", output)
+	}
+}
+
+func TestClusterDebugDeleteConfirmsFirst(t *testing.T) {
+	mock := &debugPodMock{}
+	setMockClient(t, mock)
+	resetDebugCreateFlags(t)
+	writeSelectedClusterJSON(t)
+
+	output, err := executeCommand("cluster", "debug", "delete", "debug-api-7f3a", "-n", "payments", "--yes")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mock.deleted) != 1 || mock.deleted[0] != "payments/debug-api-7f3a" {
+		t.Errorf("delete not issued: %v", mock.deleted)
+	}
+	if !strings.Contains(stripANSICodes(output), "Deleted debug pod debug-api-7f3a") {
+		t.Errorf("output = %s", output)
+	}
+}
+
+func TestOrgTerminalSessionPrintsTheRecording(t *testing.T) {
+	endedAt := "2026-08-28T22:01:30Z"
+	endReason := "agent_ended"
+	mock := &debugPodMock{
+		session: &client.TerminalSession{
+			ID: "11111111-2222-4333-8444-555555555555", UserEmail: "ops@example.com",
+			Namespace: "payments", PodName: "debug-api-7f3a", ContainerName: "debug", Shell: "/bin/sh",
+			StartedAt: "2026-08-28T22:00:00Z", EndedAt: &endedAt, EndReason: &endReason,
+			RecordedBytes: 42, IsTruncated: true,
+		},
+		transcript: []client.TerminalTranscriptChunk{
+			{Sequence: 1, Direction: "input", Data: base64.StdEncoding.EncodeToString([]byte("env\x7f\n"))},
+			{Sequence: 2, Direction: "output", Data: base64.StdEncoding.EncodeToString([]byte("DATABASE_URL=postgres://x\r\n"))},
+			{Sequence: 3, Direction: "input", Data: base64.StdEncoding.EncodeToString([]byte("exit\n"))},
+		},
+	}
+	setMockClient(t, mock)
+	resetDebugCreateFlags(t)
+
+	output, err := executeCommand("org", "terminal-session", "11111111-2222-4333-8444-555555555555", "--transcript", "--show-input")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, expected := range []string{"ops@example.com", "payments/debug-api-7f3a (debug), shell /bin/sh", "(agent_ended)", "42 bytes [truncated]", "DATABASE_URL=postgres://x", "env⌫⏎\nexit⏎"} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("output lacks %q:\n%s", expected, output)
+		}
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -3712,3 +3712,27 @@ func (baseMock) ListAzureCredentials() ([]client.AzureCredentialListItem, error)
 func (baseMock) CreateAzureCredential(client.CreateAzureCredentialRequest) (*client.CreateAzureCredentialResponse, error) {
 	return &client.CreateAzureCredentialResponse{Success: true}, nil
 }
+
+func (m baseMock) ListDebugPodImages(clusterID string) (*client.DebugPodImagesResponse, error) {
+	return &client.DebugPodImagesResponse{}, nil
+}
+
+func (m baseMock) CreateDebugPod(clusterID string, request client.CreateDebugPodRequest) (*client.DebugPodResponse, error) {
+	return &client.DebugPodResponse{}, nil
+}
+
+func (m baseMock) ListDebugPods(clusterID string, namespace string) (*client.ListDebugPodsResponse, error) {
+	return &client.ListDebugPodsResponse{}, nil
+}
+
+func (m baseMock) DeleteDebugPod(clusterID string, namespace string, podName string) (*client.DeleteDebugPodResponse, error) {
+	return &client.DeleteDebugPodResponse{Status: "success"}, nil
+}
+
+func (m baseMock) GetTerminalSession(sessionID string) (*client.TerminalSession, error) {
+	return &client.TerminalSession{}, nil
+}
+
+func (m baseMock) GetTerminalTranscript(sessionID string, afterSequence int, limit int) (*client.TerminalTranscriptPage, error) {
+	return &client.TerminalTranscriptPage{}, nil
+}

--- a/cmd/org_terminal_session.go
+++ b/cmd/org_terminal_session.go
@@ -1,0 +1,161 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// ankra org terminal-session: a recorded pod-terminal session, read behind
+// audit.read. The session id comes from an open_pod_terminal audit row
+// (details.terminal_session_id).
+
+const terminalTranscriptPageLimit = 500
+
+var orgTerminalSessionCmd = &cobra.Command{
+	Use:   "terminal-session <session_id>",
+	Short: "Read a recorded pod-terminal session from the audit log",
+	Long: `Every pod terminal session opened through Ankra is recorded. The
+open_pod_terminal audit row carries the session id in its details; this
+command prints the session's facts and, with --transcript, replays the
+recorded output as text (everything the container printed, in order).
+--show-input lists what was typed as well, with control characters named.
+
+Needs the audit.read permission. A recording contains whatever the shell
+printed, secrets included.
+
+Examples:
+  ankra org terminal-session 11111111-2222-4333-8444-555555555555
+  ankra org terminal-session 11111111-2222-4333-8444-555555555555 --transcript
+  ankra org terminal-session 11111111-2222-4333-8444-555555555555 --transcript -o json`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		withTranscript, _ := cmd.Flags().GetBool("transcript")
+		showInput, _ := cmd.Flags().GetBool("show-input")
+
+		session, err := apiClient.GetTerminalSession(args[0])
+		if err != nil {
+			return err
+		}
+		var chunks []client.TerminalTranscriptChunk
+		if withTranscript || showInput {
+			chunks, err = collectTerminalTranscript(args[0])
+			if err != nil {
+				return err
+			}
+		}
+		if handled, renderError := renderStructured(cmd, map[string]any{
+			"session":    session,
+			"transcript": chunks,
+		}); handled || renderError != nil {
+			return renderError
+		}
+
+		out := cmd.OutOrStdout()
+		renderTerminalSessionFacts(out, session)
+		if withTranscript {
+			_, _ = fmt.Fprintln(out, "\n--- recorded output ---")
+			for _, chunk := range chunks {
+				if chunk.Direction != "output" {
+					continue
+				}
+				decoded, decodeError := base64.StdEncoding.DecodeString(chunk.Data)
+				if decodeError != nil {
+					continue
+				}
+				_, _ = out.Write(decoded)
+			}
+			_, _ = fmt.Fprintln(out, "\n--- end of recording ---")
+		}
+		if showInput {
+			_, _ = fmt.Fprintln(out, "\n--- typed input ---")
+			_, _ = fmt.Fprint(out, describeTypedInput(chunks))
+			_, _ = fmt.Fprintln(out, "--- end of input ---")
+		}
+		return nil
+	},
+}
+
+func collectTerminalTranscript(sessionID string) ([]client.TerminalTranscriptChunk, error) {
+	chunks := []client.TerminalTranscriptChunk{}
+	afterSequence := 0
+	for {
+		page, err := apiClient.GetTerminalTranscript(sessionID, afterSequence, terminalTranscriptPageLimit)
+		if err != nil {
+			return nil, err
+		}
+		chunks = append(chunks, page.Chunks...)
+		if !page.HasMore || len(page.Chunks) == 0 {
+			return chunks, nil
+		}
+		afterSequence = page.NextAfter
+	}
+}
+
+func renderTerminalSessionFacts(out io.Writer, session *client.TerminalSession) {
+	ended := "still open"
+	if session.EndedAt != nil {
+		ended = *session.EndedAt
+		if session.EndReason != nil {
+			ended += " (" + *session.EndReason + ")"
+		}
+	}
+	flags := []string{}
+	if session.IsTruncated {
+		flags = append(flags, "truncated")
+	}
+	if session.RecordingDegraded {
+		flags = append(flags, "recording degraded")
+	}
+	_, _ = fmt.Fprintf(out, "Session:    %s\n", session.ID)
+	_, _ = fmt.Fprintf(out, "User:       %s\n", session.UserEmail)
+	_, _ = fmt.Fprintf(out, "Container:  %s/%s (%s), shell %s\n", session.Namespace, session.PodName, session.ContainerName, session.Shell)
+	_, _ = fmt.Fprintf(out, "Cluster:    %s\n", session.ClusterID)
+	_, _ = fmt.Fprintf(out, "Started:    %s\n", session.StartedAt)
+	_, _ = fmt.Fprintf(out, "Ended:      %s\n", ended)
+	_, _ = fmt.Fprintf(out, "Recorded:   %d bytes", session.RecordedBytes)
+	if len(flags) > 0 {
+		_, _ = fmt.Fprintf(out, " [%s]", strings.Join(flags, ", "))
+	}
+	_, _ = fmt.Fprintln(out)
+}
+
+// describeTypedInput renders the input chunks as text with control
+// characters named, so an edited command reads differently from a typed one.
+func describeTypedInput(chunks []client.TerminalTranscriptChunk) string {
+	var described strings.Builder
+	for _, chunk := range chunks {
+		if chunk.Direction != "input" {
+			continue
+		}
+		decoded, decodeError := base64.StdEncoding.DecodeString(chunk.Data)
+		if decodeError != nil {
+			continue
+		}
+		for _, character := range string(decoded) {
+			switch {
+			case character == '\r' || character == '\n':
+				described.WriteString("⏎\n")
+			case character == 0x7f:
+				described.WriteString("⌫")
+			case character < 0x20:
+				described.WriteString("^" + string(rune(character+0x40)))
+			default:
+				described.WriteRune(character)
+			}
+		}
+	}
+	return described.String()
+}
+
+func init() {
+	orgTerminalSessionCmd.Flags().Bool("transcript", false, "Print the recorded output")
+	orgTerminalSessionCmd.Flags().Bool("show-input", false, "List what was typed, with control characters named")
+	registerStructuredOutputFlags(orgTerminalSessionCmd)
+	orgCmd.AddCommand(orgTerminalSessionCmd)
+}

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -322,6 +322,12 @@ type APIClient interface {
 	ListPods(clusterID string, opts *client.ListPodsOptions) (*client.ListPodsResponse, error)
 	GetResources(clusterID string, req client.GetResourcesRequest) (*client.GetResourcesResponse, error)
 	StreamPodLogs(ctx context.Context, clusterID string, opts client.PodLogOptions, writer io.Writer) error
+	ListDebugPodImages(clusterID string) (*client.DebugPodImagesResponse, error)
+	CreateDebugPod(clusterID string, request client.CreateDebugPodRequest) (*client.DebugPodResponse, error)
+	ListDebugPods(clusterID string, namespace string) (*client.ListDebugPodsResponse, error)
+	DeleteDebugPod(clusterID string, namespace string, podName string) (*client.DeleteDebugPodResponse, error)
+	GetTerminalSession(sessionID string) (*client.TerminalSession, error)
+	GetTerminalTranscript(sessionID string, afterSequence int, limit int) (*client.TerminalTranscriptPage, error)
 	ListHelmReleases(clusterID string, opts *client.HelmReleasesOptions) (*client.HelmReleasesResponse, error)
 	UninstallHelmRelease(clusterID, releaseName, namespace string) (*client.UninstallHelmReleaseResponse, error)
 	QueryPrometheusInstant(clusterID, query string, timeoutSeconds int) (*client.PrometheusQueryResult, error)

--- a/internal/client/debugpods.go
+++ b/internal/client/debugpods.go
@@ -1,0 +1,253 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// Debug pods: a pod Ankra creates in a namespace that impersonates another
+// pod - same service account, node, volumes and mounts, environment - under
+// an image chosen for its tools. The platform builds the mirror; these calls
+// ride the bearer twins of the portal's debug-pod routes.
+
+type DebugPodImage struct {
+	Image       string `json:"image"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	IsDefault   bool   `json:"is_default"`
+}
+
+type DebugPodImagesResponse struct {
+	Images []DebugPodImage `json:"images"`
+}
+
+type CreateDebugPodRequest struct {
+	Namespace           string   `json:"namespace"`
+	TargetPodName       string   `json:"target_pod_name,omitempty"`
+	TargetContainerName string   `json:"target_container_name,omitempty"`
+	Image               string   `json:"image,omitempty"`
+	Command             []string `json:"command,omitempty"`
+	MirrorVolumeMounts  bool     `json:"mirror_volume_mounts"`
+	MirrorEnvironment   bool     `json:"mirror_environment"`
+	TTLSeconds          int      `json:"ttl_seconds"`
+}
+
+type DebugPodResponse struct {
+	PodName                      string   `json:"pod_name"`
+	Namespace                    string   `json:"namespace"`
+	ContainerName                string   `json:"container_name"`
+	Image                        string   `json:"image"`
+	NodeName                     string   `json:"node_name"`
+	Phase                        string   `json:"phase"`
+	Ready                        bool     `json:"ready"`
+	ExpiresAt                    string   `json:"expires_at"`
+	TargetPodName                *string  `json:"target_pod_name"`
+	TargetContainerName          *string  `json:"target_container_name"`
+	ServiceAccountName           *string  `json:"service_account_name"`
+	MirroredVolumes              []string `json:"mirrored_volumes"`
+	MirroredVolumeMounts         []string `json:"mirrored_volume_mounts"`
+	MirroredEnvironmentVariables int      `json:"mirrored_environment_variables"`
+	MirroredEnvironmentSources   int      `json:"mirrored_environment_sources"`
+	Warnings                     []string `json:"warnings"`
+	RequestedBy                  string   `json:"requested_by"`
+}
+
+type DebugPodSummary struct {
+	PodName             string  `json:"pod_name"`
+	Namespace           string  `json:"namespace"`
+	Phase               string  `json:"phase"`
+	NodeName            string  `json:"node_name"`
+	Image               string  `json:"image"`
+	TargetPodName       *string `json:"target_pod_name"`
+	TargetContainerName *string `json:"target_container_name"`
+	RequestedBy         string  `json:"requested_by"`
+	CreatedAt           string  `json:"created_at"`
+	ExpiresAt           string  `json:"expires_at"`
+	IsExpired           bool    `json:"is_expired"`
+}
+
+type ListDebugPodsResponse struct {
+	DebugPods []DebugPodSummary `json:"debug_pods"`
+}
+
+type DeleteDebugPodResponse struct {
+	Status  string  `json:"status"`
+	Message *string `json:"message"`
+}
+
+func (c *Client) debugPodsEndpoint(clusterID string) string {
+	return fmt.Sprintf("%s/api/v1/clusters/%s/kubernetes/debug-pods", c.BaseURL, url.PathEscape(clusterID))
+}
+
+// ListDebugPodImages reads the platform's tag-pinned image catalogue.
+func (c *Client) ListDebugPodImages(clusterID string) (*DebugPodImagesResponse, error) {
+	var response DebugPodImagesResponse
+	if err := c.getJSON(c.debugPodsEndpoint(clusterID)+"/images", &response); err != nil {
+		return nil, fmt.Errorf("listing debug pod images: %w", err)
+	}
+	return &response, nil
+}
+
+// CreateDebugPod creates the pod and waits for it to start. A refusal -
+// the platform's, the agent's, or an agent too old to build one - carries
+// its reason in the error; a cluster that is offline or agentless surfaces
+// as ClusterUnavailableError like the other kubernetes calls.
+func (c *Client) CreateDebugPod(clusterID string, request CreateDebugPodRequest) (*DebugPodResponse, error) {
+	var response DebugPodResponse
+	if err := c.sendKubernetesJSON(http.MethodPost, c.debugPodsEndpoint(clusterID), request, &response); err != nil {
+		return nil, fmt.Errorf("creating debug pod: %w", err)
+	}
+	return &response, nil
+}
+
+// ListDebugPods lists the cluster's debug pods, optionally within one namespace.
+func (c *Client) ListDebugPods(clusterID string, namespace string) (*ListDebugPodsResponse, error) {
+	endpoint := c.debugPodsEndpoint(clusterID)
+	if namespace != "" {
+		endpoint += "?namespace=" + url.QueryEscape(namespace)
+	}
+	var response ListDebugPodsResponse
+	if err := c.getJSON(endpoint, &response); err != nil {
+		return nil, fmt.Errorf("listing debug pods: %w", err)
+	}
+	return &response, nil
+}
+
+// DeleteDebugPod deletes a debug pod; a pod without the debug label answers 404.
+func (c *Client) DeleteDebugPod(clusterID string, namespace string, podName string) (*DeleteDebugPodResponse, error) {
+	endpoint := c.debugPodsEndpoint(clusterID) + "/" + url.PathEscape(namespace) + "/" + url.PathEscape(podName)
+	var response DeleteDebugPodResponse
+	if err := c.sendKubernetesJSON(http.MethodDelete, endpoint, nil, &response); err != nil {
+		return nil, fmt.Errorf("deleting debug pod: %w", err)
+	}
+	return &response, nil
+}
+
+// sendKubernetesJSON issues an authenticated JSON request on the kubernetes
+// lane: a 503 CLUSTER_OFFLINE / NO_AGENT / AGENT_TIMEOUT envelope becomes
+// ClusterUnavailableError so the command prints the shared advice, an RBAC
+// 403 becomes PermissionDeniedError, and any other refusal surfaces the
+// backend's detail string.
+func (c *Client) sendKubernetesJSON(method string, endpoint string, payload any, target any) error {
+	var bodyReader *bytes.Reader
+	if payload != nil {
+		encoded, marshalError := json.Marshal(payload)
+		if marshalError != nil {
+			return fmt.Errorf("marshal request: %w", marshalError)
+		}
+		bodyReader = bytes.NewReader(encoded)
+	} else {
+		bodyReader = bytes.NewReader(nil)
+	}
+	request, requestError := http.NewRequest(method, endpoint, bodyReader)
+	if requestError != nil {
+		return fmt.Errorf("create request: %w", requestError)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "Bearer "+c.Token)
+
+	response, doError := c.HTTP.Do(request)
+	if doError != nil {
+		return fmt.Errorf("request failed: %w", doError)
+	}
+	defer closeBody(response)
+
+	body, readError := readResponseBody(response)
+	if readError != nil {
+		return fmt.Errorf("read response: %w", readError)
+	}
+	switch {
+	case response.StatusCode == http.StatusUnauthorized:
+		return ErrUnauthorized
+	case response.StatusCode == http.StatusServiceUnavailable:
+		return parseClusterError(body)
+	case response.StatusCode < 200 || response.StatusCode >= 300:
+		if denied := PermissionDeniedFromResponse(response.StatusCode, body); denied != nil {
+			return denied
+		}
+		if detail := detailFromBody(body); detail != "" {
+			return newUnexpectedResponseErrorWithMessage(response.StatusCode, detail)
+		}
+		return newUnexpectedResponseError("request failed", response.StatusCode, redactedBodyForError(body, 500))
+	}
+	if target == nil {
+		return nil
+	}
+	if unmarshalError := json.Unmarshal(body, target); unmarshalError != nil {
+		return fmt.Errorf("parse response: %w", unmarshalError)
+	}
+	return nil
+}
+
+// Recorded terminal sessions: what crossed the relay while a pod terminal
+// was open, read behind audit.read.
+
+type TerminalSession struct {
+	ID                string  `json:"id"`
+	OrganisationID    string  `json:"organisation_id"`
+	ClusterID         string  `json:"cluster_id"`
+	AuditLogID        *string `json:"audit_log_id"`
+	UserEmail         string  `json:"user_email"`
+	Namespace         string  `json:"namespace"`
+	PodName           string  `json:"pod_name"`
+	ContainerName     string  `json:"container_name"`
+	Shell             string  `json:"shell"`
+	StartedAt         string  `json:"started_at"`
+	EndedAt           *string `json:"ended_at"`
+	EndReason         *string `json:"end_reason"`
+	RecordedBytes     int64   `json:"recorded_bytes"`
+	IsTruncated       bool    `json:"is_truncated"`
+	RecordingDegraded bool    `json:"recording_degraded"`
+}
+
+type TerminalTranscriptChunk struct {
+	Sequence   int    `json:"sequence"`
+	Direction  string `json:"direction"`
+	RecordedAt string `json:"recorded_at"`
+	Data       string `json:"data"`
+}
+
+type TerminalTranscriptPage struct {
+	SessionID string                    `json:"session_id"`
+	Chunks    []TerminalTranscriptChunk `json:"chunks"`
+	NextAfter int                       `json:"next_after"`
+	HasMore   bool                      `json:"has_more"`
+}
+
+func (c *Client) terminalSessionEndpoint(sessionID string) string {
+	return c.BaseURL + "/api/v1/org/organisation/terminal-sessions/" + url.PathEscape(sessionID)
+}
+
+// GetTerminalSession reads one recorded session's facts.
+func (c *Client) GetTerminalSession(sessionID string) (*TerminalSession, error) {
+	var session TerminalSession
+	if err := c.getJSON(c.terminalSessionEndpoint(sessionID), &session); err != nil {
+		return nil, fmt.Errorf("getting terminal session: %w", err)
+	}
+	return &session, nil
+}
+
+// GetTerminalTranscript reads one page of a session's transcript, keyset on
+// the chunk sequence.
+func (c *Client) GetTerminalTranscript(sessionID string, afterSequence int, limit int) (*TerminalTranscriptPage, error) {
+	query := url.Values{}
+	if afterSequence > 0 {
+		query.Set("after", strconv.Itoa(afterSequence))
+	}
+	if limit > 0 {
+		query.Set("limit", strconv.Itoa(limit))
+	}
+	endpoint := c.terminalSessionEndpoint(sessionID) + "/transcript"
+	if encoded := query.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+	var page TerminalTranscriptPage
+	if err := c.getJSON(endpoint, &page); err != nil {
+		return nil, fmt.Errorf("getting terminal transcript: %w", err)
+	}
+	return &page, nil
+}


### PR DESCRIPTION
Bead: ankra-loyfi (CLI lane of the debug-pods epic). Backend: ankraio/cluster#2124; agent: ankraio/agent#92 (released as 2.1.1074); portal: ankraio/portal#1700; docs: ankraio/ankra-docs#230.

## Commands

- `ankra cluster debug create -n <ns> [--from-pod <pod>] [--container <c>] [--image <ref>] [--no-mounts] [--no-env] [--ttl 1h]` — creates a debug pod and waits for it to start. With `--from-pod` it impersonates that pod (service account, node, volumes and mounts, env/envFrom, tolerations, security context); without, a plain pod of the image with no service-account token. Prints what was mirrored, the agent's warnings, the expiry, and the portal path to the pod's terminal (an interactive terminal from the CLI itself is a later piece — the CLI has no websocket or raw-TTY dependency today). `--container`, `--no-mounts` and `--no-env` are refused without `--from-pod` (exit 2), `--ttl` is bounded to 1m–8h.
- `ankra cluster debug list [-n <ns>]` — every debug pod on the cluster, with what it mirrors, who asked, and its expiry (marked when past).
- `ankra cluster debug delete <pod> -n <ns> [-y]` — confirms first (exit 4 on decline); a pod without the debug label answers not found.
- `ankra cluster debug images` — the tag-pinned catalogue with its default.
- `ankra org terminal-session <session-id> [--transcript] [--show-input]` — a recorded pod-terminal session's facts (user, container, shell, started/ended, bytes, truncated/degraded), the recorded output replayed as text, and the typed input with control characters named. The session id is `terminal_session_id` on an `open_pod_terminal` audit row. Needs `audit.read`.

All take `-o json|yaml`.

## Client

`internal/client/debugpods.go`: the six calls on the `/api/v1` twins, with the kubernetes degraded-state envelope (`CLUSTER_OFFLINE` / `NO_AGENT` / `AGENT_TIMEOUT` → `ClusterUnavailableError`), RBAC 403 → `PermissionDeniedError` (exit 7), and any other refusal's `detail` surfaced (a 409 `AGENT_OUTDATED` names the agent upgrade). Added to the `APIClient` interface and `baseMock` per the three-place invariant.

## Verification

- `go build`, `go vet`, `go test -race ./...`, `golangci-lint run` — green.
- `cmd/cluster_debug_test.go`: impersonating create carries the target, container and switches and prints the mirror facts + terminal path; mirror flags without a target, a missing namespace and a ttl over 8h are usage errors that never reach the API; a cluster-unavailable error surfaces typed with its code; list marks expired pods; `images -o json` carries the default; delete confirms and issues the call; `org terminal-session --transcript --show-input` prints the facts, the output and the named-control-character input.
- CHANGELOG `## Unreleased` carries both entries.
