### PR TITLE
feat(cluster): ankra cluster terminal + debug create --attach (ankra-bpe51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   log, exactly like the portal's terminal. Needs `kubernetes.exec` and a
   platform that serves the bearer terminal lane (cluster-api from
   2026-08-29); an older platform answers 404 at the handshake.
+- **`ankra org terminal-session` says when a transcript was pruned.** The
+  platform now prunes recorded transcripts past a retention window (90 days
+  by default) while keeping the session facts; the facts line flags
+  `transcript pruned <time>`, and `--transcript` / `--show-input` explain
+  the prune instead of printing an empty recording.
 
 ## v0.14.0-rc5 — 2026-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Ankra CLI Changelog
 
+## Unreleased
+
+### Added
+
+- **A shell in any pod, from the terminal you are in.** `ankra cluster
+  terminal <pod> -n <namespace>` opens an interactive shell in the pod's
+  container through the platform - no kubeconfig, no port-forward - with the
+  local terminal in raw mode, so Ctrl-C and window resizes reach the remote
+  shell; leave with `exit`. A pod with one container needs nothing more, one
+  with several takes `--container`, and `--shell` picks the shell (default
+  `/bin/sh`). `ankra cluster debug create --attach` drops straight into the
+  debug pod it just created instead of printing the portal link. Every
+  session is recorded by the platform and linked from the cluster's audit
+  log, exactly like the portal's terminal. Needs `kubernetes.exec` and a
+  platform that serves the bearer terminal lane (cluster-api from
+  2026-08-29); an older platform answers 404 at the handshake.
+
 ## v0.14.0-rc5 — 2026-08-29
 
 ### Added

--- a/cmd/cluster_debug.go
+++ b/cmd/cluster_debug.go
@@ -103,9 +103,14 @@ Examples:
 		noMounts, _ := cmd.Flags().GetBool("no-mounts")
 		noEnvironment, _ := cmd.Flags().GetBool("no-env")
 		ttl, _ := cmd.Flags().GetDuration("ttl")
+		attach, _ := cmd.Flags().GetBool("attach")
+		shell, _ := cmd.Flags().GetString("shell")
 
 		if namespace == "" {
 			return withExitCode(exitUsage, errors.New("--namespace (-n) is required"))
+		}
+		if attach && cmd.Flags().Changed("output") {
+			return withExitCode(exitUsage, errors.New("--attach opens an interactive terminal and cannot be combined with -o"))
 		}
 		if fromPod == "" && container != "" {
 			return withExitCode(exitUsage, errors.New("--container only means something with --from-pod"))
@@ -137,7 +142,20 @@ Examples:
 			return renderError
 		}
 		renderDebugPodCreated(cmd, cluster.ID, created)
-		return nil
+		if !attach {
+			return nil
+		}
+		if !created.Ready {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "The pod is not running yet; open it once it is with:\n  ankra cluster terminal %s -n %s -c %s\n",
+				created.PodName, created.Namespace, created.ContainerName)
+			return nil
+		}
+		return runPodTerminal(cmd, cluster.ID, client.PodTerminalRequest{
+			Namespace:     created.Namespace,
+			PodName:       created.PodName,
+			ContainerName: created.ContainerName,
+			Shell:         shell,
+		})
 	},
 }
 
@@ -264,6 +282,8 @@ func init() {
 	clusterDebugCreateCmd.Flags().Bool("no-mounts", false, "Do not mirror the target's volumes and volume mounts")
 	clusterDebugCreateCmd.Flags().Bool("no-env", false, "Do not mirror the target's environment variables")
 	clusterDebugCreateCmd.Flags().Duration("ttl", debugPodDefaultTTL, "How long the pod lives before the kubelet ends it (1m-8h)")
+	clusterDebugCreateCmd.Flags().BoolP("attach", "a", false, "Open a shell in the debug pod as soon as it runs (see \"cluster terminal\")")
+	clusterDebugCreateCmd.Flags().String("shell", podTerminalDefaultShell, "Shell to start with --attach")
 
 	clusterDebugListCmd.Flags().StringP("namespace", "n", "", "Only list debug pods in this namespace")
 

--- a/cmd/cluster_debug_test.go
+++ b/cmd/cluster_debug_test.go
@@ -68,7 +68,7 @@ func debugStringPointer(value string) *string { return &value }
 func resetDebugFlagsNow() {
 	for name, value := range map[string]string{
 		"namespace": "", "from-pod": "", "container": "", "image": "",
-		"no-mounts": "false", "no-env": "false", "ttl": debugPodDefaultTTL.String(),
+		"no-mounts": "false", "no-env": "false", "ttl": debugPodDefaultTTL.String(), "attach": "false", "shell": podTerminalDefaultShell,
 	} {
 		_ = clusterDebugCreateCmd.Flags().Set(name, value)
 	}

--- a/cmd/cluster_terminal.go
+++ b/cmd/cluster_terminal.go
@@ -1,0 +1,251 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"ankra/internal/client"
+)
+
+const (
+	podTerminalPingInterval   = 30 * time.Second
+	podTerminalResizeInterval = 250 * time.Millisecond
+	podTerminalDefaultShell   = "/bin/sh"
+	podTerminalDefaultCols    = 80
+	podTerminalDefaultRows    = 24
+)
+
+var clusterTerminalCmd = &cobra.Command{
+	Use:   "terminal <pod>",
+	Short: "Open an interactive shell in a pod's container",
+	Long: `Open an interactive shell in a container of the named pod, through the
+platform - no kubeconfig and no port-forward. The local terminal is put in
+raw mode, so every keystroke (Ctrl-C included) reaches the remote shell;
+leave with exit or Ctrl-D. Window resizes follow the local terminal.
+
+Every session is recorded by the platform and linked from the cluster's
+audit log as an open_pod_terminal event; "ankra org terminal-session"
+replays it. Needs kubernetes.exec on the cluster.
+
+With one container the shell opens there; a pod with several needs
+--container. Input that is not a terminal (a pipe) is forwarded as typed
+and should end with exit, since the remote shell cannot see the pipe close.`,
+	Example: `  ankra cluster terminal api-6d8f9c7b5-x2kq9 -n payments
+  ankra cluster terminal api-6d8f9c7b5-x2kq9 -n payments -c sidecar --shell /bin/bash`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		namespace, _ := cmd.Flags().GetString("namespace")
+		container, _ := cmd.Flags().GetString("container")
+		shell, _ := cmd.Flags().GetString("shell")
+		if namespace == "" {
+			return withExitCode(exitUsage, errors.New("--namespace (-n) is required"))
+		}
+		cluster, err := resolveActiveCluster(cmd)
+		if err != nil {
+			return err
+		}
+		if container == "" {
+			container, err = defaultPodContainer(cluster.ID, namespace, args[0])
+			if err != nil {
+				return err
+			}
+		}
+		return runPodTerminal(cmd, cluster.ID, client.PodTerminalRequest{
+			Namespace:     namespace,
+			PodName:       args[0],
+			ContainerName: container,
+			Shell:         shell,
+		})
+	},
+}
+
+// defaultPodContainer picks the container a terminal opens in when the
+// operator named none: the pod's only container. Several containers is a
+// choice the operator has to make, and the refusal lists them.
+func defaultPodContainer(clusterID string, namespace string, podName string) (string, error) {
+	response, requestError := apiClient.GetResources(clusterID, client.GetResourcesRequest{
+		ResourceRequests: []client.ResourceRequestItem{{Kind: "Pod", Version: "v1", Namespace: namespace, Name: podName}},
+	})
+	if requestError != nil {
+		return "", requestError
+	}
+	if len(response.ResourceResponses) == 0 || len(response.ResourceResponses[0].Items) == 0 {
+		return "", withExitCode(exitNotFound, fmt.Errorf("pod %q not found in namespace %q", podName, namespace))
+	}
+	pod, isObject := response.ResourceResponses[0].Items[0].(map[string]interface{})
+	if !isObject {
+		return "", fmt.Errorf("unexpected pod payload for %q", podName)
+	}
+	names := terminalContainerNames(pod)
+	switch len(names) {
+	case 0:
+		return "", fmt.Errorf("pod %q reports no containers", podName)
+	case 1:
+		return names[0], nil
+	default:
+		return "", withExitCode(exitUsage, fmt.Errorf("pod %q has several containers (%s); pick one with --container",
+			podName, strings.Join(names, ", ")))
+	}
+}
+
+// terminalContainerNames lists the pod's regular containers - the ones a
+// shell can run in. Init and ephemeral containers are left out on purpose:
+// they are what podContainerNames (logs) enumerates, and a pod with one app
+// container and one init container still has exactly one place to open a
+// shell.
+func terminalContainerNames(pod map[string]interface{}) []string {
+	names := []string{}
+	spec, hasSpec := getNestedMap(pod, "spec")
+	if !hasSpec {
+		return names
+	}
+	containers, isList := spec["containers"].([]interface{})
+	if !isList {
+		return names
+	}
+	for _, rawContainer := range containers {
+		container, isMap := rawContainer.(map[string]interface{})
+		if !isMap {
+			continue
+		}
+		if name, hasName := container["name"].(string); hasName && name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// runPodTerminal bridges the local terminal and the platform relay until the
+// remote shell exits or the relay ends the session. A refused credential
+// exits 6; the relay's other refusals arrive as the client's typed errors
+// and keep their usual exit codes.
+func runPodTerminal(cmd *cobra.Command, clusterID string, request client.PodTerminalRequest) error {
+	input := cmd.InOrStdin()
+	output := cmd.OutOrStdout()
+	errorOutput := cmd.ErrOrStderr()
+	if request.Shell == "" {
+		request.Shell = podTerminalDefaultShell
+	}
+
+	inputFile, isInputFile := input.(*os.File)
+	isInteractive := isInputFile && term.IsTerminal(int(inputFile.Fd()))
+	request.Cols, request.Rows = podTerminalDefaultCols, podTerminalDefaultRows
+	sizeDescriptor := -1
+	if outputFile, isOutputFile := output.(*os.File); isOutputFile && term.IsTerminal(int(outputFile.Fd())) {
+		sizeDescriptor = int(outputFile.Fd())
+		if cols, rows, sizeError := term.GetSize(sizeDescriptor); sizeError == nil && cols > 0 && rows > 0 {
+			request.Cols, request.Rows = cols, rows
+		}
+	}
+
+	_, _ = fmt.Fprintf(errorOutput, "Opening %s in %s/%s - the session is recorded to the audit log; leave with exit.\n",
+		request.Shell, request.PodName, request.ContainerName)
+
+	parentContext := cmd.Context()
+	if parentContext == nil {
+		parentContext = context.Background()
+	}
+	ctx, cancel := context.WithCancel(parentContext)
+	defer cancel()
+
+	session, openError := apiClient.OpenPodTerminal(ctx, clusterID, request)
+	if openError != nil {
+		return openError
+	}
+	defer func() { _ = session.Close() }()
+
+	if isInteractive {
+		previousState, rawError := term.MakeRaw(int(inputFile.Fd()))
+		if rawError != nil {
+			return fmt.Errorf("putting the terminal in raw mode: %w", rawError)
+		}
+		defer func() { _ = term.Restore(int(inputFile.Fd()), previousState) }()
+	}
+
+	go forwardTerminalInput(ctx, input, session)
+	go keepTerminalAlive(ctx, session, sizeDescriptor, request.Cols, request.Rows)
+
+	for frame := range session.Frames() {
+		switch frame.Type {
+		case "stdout", "stderr":
+			payload, decodeError := frame.Payload()
+			if decodeError != nil {
+				continue
+			}
+			_, _ = output.Write(payload)
+		case "error":
+			_, _ = fmt.Fprintf(errorOutput, "\r\n%s\r\n", frame.Message)
+		}
+	}
+	cancel()
+
+	closeError := session.Err()
+	var closed *client.PodTerminalClosedError
+	if errors.As(closeError, &closed) && closed.IsAuthentication() {
+		return withExitCode(exitAuth, closeError)
+	}
+	return closeError
+}
+
+// forwardTerminalInput copies what is typed (or piped) to the remote shell
+// until the input ends or the session does.
+func forwardTerminalInput(ctx context.Context, input io.Reader, session client.PodTerminal) {
+	buffer := make([]byte, 4096)
+	for {
+		count, readError := input.Read(buffer)
+		if count > 0 {
+			if sendError := session.SendInput(buffer[:count]); sendError != nil {
+				return
+			}
+		}
+		if readError != nil || ctx.Err() != nil {
+			return
+		}
+	}
+}
+
+// keepTerminalAlive pings the relay on the portal's cadence and follows the
+// local window size, sending a resize only when it changed.
+func keepTerminalAlive(ctx context.Context, session client.PodTerminal, sizeDescriptor int, cols int, rows int) {
+	pingTicker := time.NewTicker(podTerminalPingInterval)
+	defer pingTicker.Stop()
+	resizeTicker := time.NewTicker(podTerminalResizeInterval)
+	defer resizeTicker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-pingTicker.C:
+			if pingError := session.Ping(); pingError != nil {
+				return
+			}
+		case <-resizeTicker.C:
+			if sizeDescriptor < 0 {
+				continue
+			}
+			newCols, newRows, sizeError := term.GetSize(sizeDescriptor)
+			if sizeError != nil || (newCols == cols && newRows == rows) {
+				continue
+			}
+			cols, rows = newCols, newRows
+			if resizeError := session.Resize(cols, rows); resizeError != nil {
+				return
+			}
+		}
+	}
+}
+
+func init() {
+	clusterTerminalCmd.Flags().StringP("namespace", "n", "", "Namespace of the pod (required)")
+	clusterTerminalCmd.Flags().StringP("container", "c", "", "Container to open the shell in (default: the pod's only container)")
+	clusterTerminalCmd.Flags().String("shell", podTerminalDefaultShell, "Shell to start in the container")
+	clusterCmd.AddCommand(clusterTerminalCmd)
+}

--- a/cmd/cluster_terminal_test.go
+++ b/cmd/cluster_terminal_test.go
@@ -1,0 +1,303 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"ankra/internal/client"
+)
+
+type fakePodTerminal struct {
+	frames     chan client.PodTerminalFrame
+	closeError error
+	inputLock  sync.Mutex
+	inputs     []string
+}
+
+func newFakePodTerminal(closeError error, frames ...client.PodTerminalFrame) *fakePodTerminal {
+	channel := make(chan client.PodTerminalFrame, len(frames))
+	for _, frame := range frames {
+		channel <- frame
+	}
+	close(channel)
+	return &fakePodTerminal{frames: channel, closeError: closeError}
+}
+
+func (f *fakePodTerminal) Frames() <-chan client.PodTerminalFrame { return f.frames }
+func (f *fakePodTerminal) SendInput(data []byte) error {
+	f.inputLock.Lock()
+	defer f.inputLock.Unlock()
+	f.inputs = append(f.inputs, string(data))
+	return nil
+}
+func (f *fakePodTerminal) Resize(int, int) error { return nil }
+func (f *fakePodTerminal) Ping() error           { return nil }
+func (f *fakePodTerminal) Close() error          { return nil }
+func (f *fakePodTerminal) Err() error            { return f.closeError }
+func (f *fakePodTerminal) typed() string {
+	f.inputLock.Lock()
+	defer f.inputLock.Unlock()
+	return strings.Join(f.inputs, "")
+}
+
+type terminalMock struct {
+	baseMock
+	podItems       []any
+	terminal       *fakePodTerminal
+	openError      error
+	openRequest    *client.PodTerminalRequest
+	createResponse *client.DebugPodResponse
+}
+
+func (m *terminalMock) GetResources(clusterID string, request client.GetResourcesRequest) (*client.GetResourcesResponse, error) {
+	return &client.GetResourcesResponse{ResourceResponses: []client.ResourceResponseItem{
+		{Status: "success", Kind: "Pod", Items: m.podItems},
+	}}, nil
+}
+
+func (m *terminalMock) OpenPodTerminal(ctx context.Context, clusterID string, request client.PodTerminalRequest) (client.PodTerminal, error) {
+	m.openRequest = &request
+	if m.openError != nil {
+		return nil, m.openError
+	}
+	return m.terminal, nil
+}
+
+func (m *terminalMock) CreateDebugPod(clusterID string, request client.CreateDebugPodRequest) (*client.DebugPodResponse, error) {
+	return m.createResponse, nil
+}
+
+func stdoutFrame(text string) client.PodTerminalFrame {
+	return client.PodTerminalFrame{Type: "stdout", Data: base64.StdEncoding.EncodeToString([]byte(text))}
+}
+
+func podWithContainers(names ...string) any {
+	containers := make([]any, 0, len(names))
+	for _, name := range names {
+		containers = append(containers, map[string]any{"name": name})
+	}
+	return map[string]any{"kind": "Pod", "spec": map[string]any{"containers": containers}}
+}
+
+func helloTerminal() *fakePodTerminal {
+	return newFakePodTerminal(nil,
+		client.PodTerminalFrame{Type: "connecting"},
+		client.PodTerminalFrame{Type: "connected"},
+		stdoutFrame("hello from the pod\n"),
+		client.PodTerminalFrame{Type: "end"})
+}
+
+func resetTerminalFlags(t *testing.T) {
+	t.Helper()
+	reset := func() {
+		_ = clusterTerminalCmd.Flags().Set("namespace", "")
+		_ = clusterTerminalCmd.Flags().Set("container", "")
+		_ = clusterTerminalCmd.Flags().Set("shell", podTerminalDefaultShell)
+		rootCmd.SetIn(nil)
+	}
+	reset()
+	t.Cleanup(reset)
+}
+
+func waitForTyped(t *testing.T, terminal *fakePodTerminal, expected string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(terminal.typed(), expected) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("typed input never reached the session: %q", terminal.typed())
+}
+
+func TestClusterTerminalBridgesInputAndOutput(t *testing.T) {
+	terminal := helloTerminal()
+	mock := &terminalMock{terminal: terminal}
+	setMockClient(t, mock)
+	resetTerminalFlags(t)
+	writeSelectedClusterJSON(t)
+	rootCmd.SetIn(bytes.NewBufferString("id\n"))
+
+	output, err := executeCommand("cluster", "terminal", "web-1", "-n", "default", "-c", "app", "--shell", "/bin/bash")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.openRequest == nil {
+		t.Fatal("no terminal was opened")
+	}
+	request := *mock.openRequest
+	if request.Namespace != "default" || request.PodName != "web-1" || request.ContainerName != "app" || request.Shell != "/bin/bash" {
+		t.Errorf("request not carried: %+v", request)
+	}
+	if request.Cols != podTerminalDefaultCols || request.Rows != podTerminalDefaultRows {
+		t.Errorf("a non-terminal output falls back to %dx%d, got %dx%d", podTerminalDefaultCols, podTerminalDefaultRows, request.Cols, request.Rows)
+	}
+	if !strings.Contains(output, "hello from the pod") {
+		t.Errorf("remote output was not written:\n%s", output)
+	}
+	if !strings.Contains(output, "recorded to the audit log") {
+		t.Errorf("the recording notice is missing:\n%s", output)
+	}
+	waitForTyped(t, terminal, "id\n")
+}
+
+func TestClusterTerminalDefaultsToTheOnlyContainer(t *testing.T) {
+	mock := &terminalMock{terminal: helloTerminal(), podItems: []any{podWithContainers("app")}}
+	setMockClient(t, mock)
+	resetTerminalFlags(t)
+	writeSelectedClusterJSON(t)
+
+	if _, err := executeCommand("cluster", "terminal", "web-1", "-n", "default"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.openRequest == nil || mock.openRequest.ContainerName != "app" {
+		t.Fatalf("the only container was not chosen: %+v", mock.openRequest)
+	}
+	if mock.openRequest.Shell != podTerminalDefaultShell {
+		t.Errorf("shell defaults to %s, got %q", podTerminalDefaultShell, mock.openRequest.Shell)
+	}
+}
+
+func TestClusterTerminalRefusesToGuessBetweenContainers(t *testing.T) {
+	mock := &terminalMock{terminal: helloTerminal(), podItems: []any{podWithContainers("app", "sidecar")}}
+	setMockClient(t, mock)
+	resetTerminalFlags(t)
+	writeSelectedClusterJSON(t)
+
+	_, err := executeCommand("cluster", "terminal", "web-1", "-n", "default")
+	if err == nil || exitCodeFor(err) != exitUsage {
+		t.Fatalf("expected a usage error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "app, sidecar") || !strings.Contains(err.Error(), "--container") {
+		t.Errorf("the refusal should list the containers: %v", err)
+	}
+	if mock.openRequest != nil {
+		t.Error("a terminal was opened despite the refusal")
+	}
+}
+
+func TestClusterTerminalReportsAMissingPod(t *testing.T) {
+	mock := &terminalMock{terminal: helloTerminal()}
+	setMockClient(t, mock)
+	resetTerminalFlags(t)
+	writeSelectedClusterJSON(t)
+
+	_, err := executeCommand("cluster", "terminal", "ghost", "-n", "default")
+	if err == nil || exitCodeFor(err) != exitNotFound {
+		t.Fatalf("expected the not-found exit code, got %v", err)
+	}
+}
+
+func TestClusterTerminalRequiresANamespace(t *testing.T) {
+	mock := &terminalMock{terminal: helloTerminal()}
+	setMockClient(t, mock)
+	resetTerminalFlags(t)
+	writeSelectedClusterJSON(t)
+
+	_, err := executeCommand("cluster", "terminal", "web-1")
+	if err == nil || exitCodeFor(err) != exitUsage {
+		t.Fatalf("expected a usage error, got %v", err)
+	}
+}
+
+func TestClusterTerminalSurfacesThePermissionRefusal(t *testing.T) {
+	terminal := newFakePodTerminal(&client.PermissionDeniedError{Permission: "kubernetes.exec"},
+		client.PodTerminalFrame{Type: "error", Message: "Permission denied"})
+	mock := &terminalMock{terminal: terminal}
+	setMockClient(t, mock)
+	resetTerminalFlags(t)
+	writeSelectedClusterJSON(t)
+
+	output, err := executeCommand("cluster", "terminal", "web-1", "-n", "default", "-c", "app")
+	if err == nil || exitCodeFor(err) != exitForbidden {
+		t.Fatalf("expected the RBAC exit code, got %v", err)
+	}
+	if !strings.Contains(output, "Permission denied") {
+		t.Errorf("the relay's error frame was not shown:\n%s", output)
+	}
+}
+
+func TestClusterTerminalRefusedTokenExitsAuth(t *testing.T) {
+	terminal := newFakePodTerminal(&client.PodTerminalClosedError{Code: 4001, Message: "Authentication required"},
+		client.PodTerminalFrame{Type: "error", Message: "Authentication required"})
+	mock := &terminalMock{terminal: terminal}
+	setMockClient(t, mock)
+	resetTerminalFlags(t)
+	writeSelectedClusterJSON(t)
+
+	_, err := executeCommand("cluster", "terminal", "web-1", "-n", "default", "-c", "app")
+	if err == nil || exitCodeFor(err) != exitAuth {
+		t.Fatalf("expected the auth exit code, got %v", err)
+	}
+}
+
+func TestClusterDebugCreateAttachOpensTheDebugContainer(t *testing.T) {
+	terminal := helloTerminal()
+	mock := &terminalMock{terminal: terminal, createResponse: createdDebugPod()}
+	setMockClient(t, mock)
+	resetDebugCreateFlags(t)
+	resetTerminalFlags(t)
+	writeSelectedClusterJSON(t)
+
+	output, err := executeCommand("cluster", "debug", "create", "-n", "payments", "--attach", "--shell", "/bin/bash")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.openRequest == nil {
+		t.Fatal("no terminal was opened after the create")
+	}
+	request := *mock.openRequest
+	if request.Namespace != "payments" || request.PodName != "debug-api-7f3a" || request.ContainerName != "debug" || request.Shell != "/bin/bash" {
+		t.Errorf("the debug container was not attached: %+v", request)
+	}
+	plain := stripANSICodes(output)
+	for _, expected := range []string{"debug-api-7f3a", "hello from the pod"} {
+		if !strings.Contains(plain, expected) {
+			t.Errorf("output lacks %q:\n%s", expected, plain)
+		}
+	}
+}
+
+func TestClusterDebugCreateAttachWaitsForARunningPod(t *testing.T) {
+	notReady := createdDebugPod()
+	notReady.Ready = false
+	notReady.Phase = "Pending"
+	mock := &terminalMock{terminal: helloTerminal(), createResponse: notReady}
+	setMockClient(t, mock)
+	resetDebugCreateFlags(t)
+	resetTerminalFlags(t)
+	writeSelectedClusterJSON(t)
+
+	output, err := executeCommand("cluster", "debug", "create", "-n", "payments", "--attach")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.openRequest != nil {
+		t.Error("a terminal was opened on a pod that is not running")
+	}
+	if !strings.Contains(output, "ankra cluster terminal debug-api-7f3a -n payments -c debug") {
+		t.Errorf("the hint to attach later is missing:\n%s", output)
+	}
+}
+
+func TestClusterDebugCreateAttachRefusesStructuredOutput(t *testing.T) {
+	mock := &terminalMock{terminal: helloTerminal(), createResponse: createdDebugPod()}
+	setMockClient(t, mock)
+	resetDebugCreateFlags(t)
+	resetTerminalFlags(t)
+	writeSelectedClusterJSON(t)
+
+	_, err := executeCommand("cluster", "debug", "create", "-n", "payments", "--attach", "-o", "json")
+	if err == nil || exitCodeFor(err) != exitUsage {
+		t.Fatalf("expected a usage error, got %v", err)
+	}
+	if mock.openRequest != nil {
+		t.Error("a terminal was opened despite the refusal")
+	}
+}

--- a/cmd/cluster_terminal_test.go
+++ b/cmd/cluster_terminal_test.go
@@ -47,11 +47,13 @@ func (f *fakePodTerminal) typed() string {
 
 type terminalMock struct {
 	baseMock
-	podItems       []any
-	terminal       *fakePodTerminal
-	openError      error
-	openRequest    *client.PodTerminalRequest
-	createResponse *client.DebugPodResponse
+	podItems        []any
+	terminal        *fakePodTerminal
+	openError       error
+	openRequest     *client.PodTerminalRequest
+	createResponse  *client.DebugPodResponse
+	session         *client.TerminalSession
+	transcriptCalls int
 }
 
 func (m *terminalMock) GetResources(clusterID string, request client.GetResourcesRequest) (*client.GetResourcesResponse, error) {
@@ -70,6 +72,43 @@ func (m *terminalMock) OpenPodTerminal(ctx context.Context, clusterID string, re
 
 func (m *terminalMock) CreateDebugPod(clusterID string, request client.CreateDebugPodRequest) (*client.DebugPodResponse, error) {
 	return m.createResponse, nil
+}
+
+func (m *terminalMock) GetTerminalSession(sessionID string) (*client.TerminalSession, error) {
+	return m.session, nil
+}
+
+func (m *terminalMock) GetTerminalTranscript(sessionID string, afterSequence int, limit int) (*client.TerminalTranscriptPage, error) {
+	m.transcriptCalls++
+	return &client.TerminalTranscriptPage{SessionID: sessionID}, nil
+}
+
+func TestOrgTerminalSessionSaysTheTranscriptWasPruned(t *testing.T) {
+	prunedAt := "2026-11-27T06:00:00Z"
+	mock := &terminalMock{session: &client.TerminalSession{
+		ID: "11111111-2222-4333-8444-555555555555", UserEmail: "ops@example.com",
+		Namespace: "payments", PodName: "api-6d8f9c7b5-x2kq9", ContainerName: "api", Shell: "/bin/sh",
+		StartedAt: "2026-08-28T22:00:00Z", RecordedBytes: 4096, TranscriptPrunedAt: &prunedAt,
+	}}
+	setMockClient(t, mock)
+	t.Cleanup(func() {
+		_ = orgTerminalSessionCmd.Flags().Set("transcript", "false")
+		_ = orgTerminalSessionCmd.Flags().Set("show-input", "false")
+	})
+
+	output, err := executeCommand("org", "terminal-session", "11111111-2222-4333-8444-555555555555", "--transcript", "--show-input")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(output, "transcript pruned "+prunedAt) {
+		t.Errorf("the facts should flag the pruned transcript:\n%s", output)
+	}
+	if !strings.Contains(output, "pruned on "+prunedAt+" under the retention policy") {
+		t.Errorf("the pruned notice is missing:\n%s", output)
+	}
+	if strings.Contains(output, "--- recorded output ---") || mock.transcriptCalls != 0 {
+		t.Errorf("a pruned transcript must not be fetched or replayed (calls=%d):\n%s", mock.transcriptCalls, output)
+	}
 }
 
 func stdoutFrame(text string) client.PodTerminalFrame {

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -3736,3 +3736,7 @@ func (m baseMock) GetTerminalSession(sessionID string) (*client.TerminalSession,
 func (m baseMock) GetTerminalTranscript(sessionID string, afterSequence int, limit int) (*client.TerminalTranscriptPage, error) {
 	return &client.TerminalTranscriptPage{}, nil
 }
+
+func (m baseMock) OpenPodTerminal(ctx context.Context, clusterID string, request client.PodTerminalRequest) (client.PodTerminal, error) {
+	return nil, errors.New("not implemented")
+}

--- a/cmd/org_terminal_session.go
+++ b/cmd/org_terminal_session.go
@@ -43,7 +43,8 @@ Examples:
 			return err
 		}
 		var chunks []client.TerminalTranscriptChunk
-		if withTranscript || showInput {
+		isPruned := session.TranscriptPrunedAt != nil
+		if (withTranscript || showInput) && !isPruned {
 			chunks, err = collectTerminalTranscript(args[0])
 			if err != nil {
 				return err
@@ -58,6 +59,10 @@ Examples:
 
 		out := cmd.OutOrStdout()
 		renderTerminalSessionFacts(out, session)
+		if isPruned && (withTranscript || showInput) {
+			_, _ = fmt.Fprintf(out, "\nThe transcript was pruned on %s under the retention policy; only the session facts remain.\n", *session.TranscriptPrunedAt)
+			return nil
+		}
 		if withTranscript {
 			_, _ = fmt.Fprintln(out, "\n--- recorded output ---")
 			for _, chunk := range chunks {
@@ -111,6 +116,9 @@ func renderTerminalSessionFacts(out io.Writer, session *client.TerminalSession) 
 	}
 	if session.RecordingDegraded {
 		flags = append(flags, "recording degraded")
+	}
+	if session.TranscriptPrunedAt != nil {
+		flags = append(flags, "transcript pruned "+*session.TranscriptPrunedAt)
 	}
 	_, _ = fmt.Fprintf(out, "Session:    %s\n", session.ID)
 	_, _ = fmt.Fprintf(out, "User:       %s\n", session.UserEmail)

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -328,6 +328,7 @@ type APIClient interface {
 	DeleteDebugPod(clusterID string, namespace string, podName string) (*client.DeleteDebugPodResponse, error)
 	GetTerminalSession(sessionID string) (*client.TerminalSession, error)
 	GetTerminalTranscript(sessionID string, afterSequence int, limit int) (*client.TerminalTranscriptPage, error)
+	OpenPodTerminal(ctx context.Context, clusterID string, request client.PodTerminalRequest) (client.PodTerminal, error)
 	ListHelmReleases(clusterID string, opts *client.HelmReleasesOptions) (*client.HelmReleasesResponse, error)
 	UninstallHelmRelease(clusterID, releaseName, namespace string) (*client.UninstallHelmReleaseResponse, error)
 	QueryPrometheusInstant(clusterID, query string, timeoutSeconds int) (*client.PrometheusQueryResult, error)

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,14 @@ toolchain go1.26.6
 
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+	github.com/coder/websocket v1.8.13
 	github.com/dustin/go-humanize v1.0.1
 	github.com/jedib0t/go-pretty/v6 v6.6.7
 	github.com/manifoldco/promptui v0.9.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
+	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -28,6 +30,6 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/sys v0.44.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5O
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/coder/websocket v1.8.13 h1:f3QZdXy7uGVz+4uCJy2nTZyM0yTBj8yANEHhqlXZ9FE=
+github.com/coder/websocket v1.8.13/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -61,8 +63,10 @@ github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSW
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
+golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
 golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=
 golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/client/debugpods.go
+++ b/internal/client/debugpods.go
@@ -202,6 +202,9 @@ type TerminalSession struct {
 	RecordedBytes     int64   `json:"recorded_bytes"`
 	IsTruncated       bool    `json:"is_truncated"`
 	RecordingDegraded bool    `json:"recording_degraded"`
+	// TranscriptPrunedAt is set once the platform's retention removed the
+	// recorded bytes; the facts stay, the transcript is gone.
+	TranscriptPrunedAt *string `json:"transcript_pruned_at"`
 }
 
 type TerminalTranscriptChunk struct {

--- a/internal/client/terminal.go
+++ b/internal/client/terminal.go
@@ -1,0 +1,283 @@
+package client
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/coder/websocket"
+)
+
+// PodTerminalRequest names the container a terminal is opened in and the
+// window it starts with.
+type PodTerminalRequest struct {
+	Namespace     string
+	PodName       string
+	ContainerName string
+	Shell         string
+	Cols          int
+	Rows          int
+}
+
+// PodTerminalFrame is one message from the platform's terminal relay. Type
+// is one of connecting, connected, stdout, stderr, pong, error or end; Data
+// carries the base64 payload of a stdout/stderr frame and Message the text
+// of an error frame.
+type PodTerminalFrame struct {
+	Type    string `json:"type"`
+	Data    string `json:"data,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// Payload decodes the bytes a stdout or stderr frame carries; every other
+// frame carries none.
+func (frame PodTerminalFrame) Payload() ([]byte, error) {
+	if frame.Data == "" {
+		return nil, nil
+	}
+	return base64.StdEncoding.DecodeString(frame.Data)
+}
+
+// PodTerminal is an open terminal session on a pod. Frames delivers what
+// the relay sends until the session ends, at which point the channel is
+// closed and Err reports why.
+type PodTerminal interface {
+	Frames() <-chan PodTerminalFrame
+	SendInput(data []byte) error
+	Resize(cols int, rows int) error
+	Ping() error
+	Close() error
+	Err() error
+}
+
+// PodTerminalClosedError is a session the relay ended with a close code the
+// CLI has no better name for: 4001 (the token was refused) or an unexpected
+// code. Message carries the relay's last error frame, when it sent one.
+type PodTerminalClosedError struct {
+	Code    int
+	Reason  string
+	Message string
+}
+
+func (e *PodTerminalClosedError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Reason != "" {
+		return e.Reason
+	}
+	return fmt.Sprintf("the terminal session was closed (code %d)", e.Code)
+}
+
+// IsAuthentication reports whether the relay refused the credential.
+func (e *PodTerminalClosedError) IsAuthentication() bool {
+	return e.Code == podTerminalCloseAuthenticationRequired
+}
+
+// The relay's close codes (cluster-api terminalapi).
+const (
+	podTerminalCloseAuthenticationRequired = 4001
+	podTerminalCloseClusterUnavailable     = 4002
+	podTerminalCloseNoAgent                = 4003
+	podTerminalCloseSandbox                = 4004
+	podTerminalClosePermissionDenied       = 4403
+)
+
+const podTerminalReadLimitBytes = 4 << 20
+
+// OpenPodTerminal opens a websocket terminal on the named container through
+// the platform relay (the bearer twin of the portal's terminal route).
+// Every session is recorded and audited by the platform. The returned
+// session lives until ctx is cancelled, Close is called, or the relay ends
+// it.
+func (c *Client) OpenPodTerminal(ctx context.Context, clusterID string, request PodTerminalRequest) (PodTerminal, error) {
+	if request.Namespace == "" || request.PodName == "" || request.ContainerName == "" {
+		return nil, errors.New("a namespace, pod and container are required to open a terminal")
+	}
+	endpoint, parseError := url.Parse(c.BaseURL)
+	if parseError != nil {
+		return nil, fmt.Errorf("invalid API base URL %q: %w", c.BaseURL, parseError)
+	}
+	switch endpoint.Scheme {
+	case "https":
+		endpoint.Scheme = "wss"
+	case "http":
+		endpoint.Scheme = "ws"
+	default:
+		return nil, fmt.Errorf("unsupported API base URL scheme %q", endpoint.Scheme)
+	}
+	endpoint.Path = strings.TrimRight(endpoint.Path, "/") + "/api/v1/clusters/" + url.PathEscape(clusterID) + "/kubernetes/pod/terminal"
+	query := url.Values{}
+	query.Set("namespace", request.Namespace)
+	query.Set("pod_name", request.PodName)
+	query.Set("container_name", request.ContainerName)
+	if request.Shell != "" {
+		query.Set("shell", request.Shell)
+	}
+	if request.Cols > 0 {
+		query.Set("cols", strconv.Itoa(request.Cols))
+	}
+	if request.Rows > 0 {
+		query.Set("rows", strconv.Itoa(request.Rows))
+	}
+	endpoint.RawQuery = query.Encode()
+
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer "+c.Token)
+	if c.orgOverride != "" {
+		headers.Set(orgOverrideHeader, c.orgOverride)
+	}
+	connection, response, dialError := websocket.Dial(ctx, endpoint.String(), &websocket.DialOptions{
+		HTTPHeader: headers,
+		HTTPClient: &http.Client{Transport: &http.Transport{Proxy: http.ProxyFromEnvironment}},
+	})
+	if dialError != nil {
+		if response != nil {
+			return nil, &UnexpectedResponseError{
+				StatusCode: response.StatusCode,
+				message:    fmt.Sprintf("the terminal handshake was refused with HTTP %d", response.StatusCode),
+			}
+		}
+		return nil, fmt.Errorf("connecting to the pod terminal: %w", dialError)
+	}
+	connection.SetReadLimit(podTerminalReadLimitBytes)
+
+	sessionContext, cancel := context.WithCancel(ctx)
+	session := &podTerminalConnection{
+		connection: connection,
+		frames:     make(chan PodTerminalFrame, 64),
+		cancel:     cancel,
+		done:       make(chan struct{}),
+	}
+	go session.readLoop(sessionContext)
+	return session, nil
+}
+
+type podTerminalConnection struct {
+	connection *websocket.Conn
+	frames     chan PodTerminalFrame
+	cancel     context.CancelFunc
+	done       chan struct{}
+
+	writeLock sync.Mutex
+	closeOnce sync.Once
+
+	stateLock        sync.Mutex
+	lastErrorMessage string
+	sawEnd           bool
+	closeError       error
+}
+
+func (session *podTerminalConnection) Frames() <-chan PodTerminalFrame {
+	return session.frames
+}
+
+func (session *podTerminalConnection) readLoop(ctx context.Context) {
+	defer close(session.frames)
+	for {
+		messageType, payload, readError := session.connection.Read(ctx)
+		if readError != nil {
+			session.settle(ctx, readError)
+			return
+		}
+		if messageType != websocket.MessageText {
+			continue
+		}
+		var frame PodTerminalFrame
+		if unmarshalError := json.Unmarshal(payload, &frame); unmarshalError != nil {
+			continue
+		}
+		session.stateLock.Lock()
+		switch frame.Type {
+		case "error":
+			session.lastErrorMessage = frame.Message
+		case "end":
+			session.sawEnd = true
+		}
+		session.stateLock.Unlock()
+		select {
+		case session.frames <- frame:
+		case <-session.done:
+			return
+		case <-ctx.Done():
+			session.settle(ctx, ctx.Err())
+			return
+		}
+	}
+}
+
+// settle records why the session ended. A normal close, a close after the
+// relay's own end frame, and a close the CLI asked for all count as a clean
+// end; the relay's numbered refusals become the client's typed errors so
+// the command layer maps them the way it maps the HTTP twins.
+func (session *podTerminalConnection) settle(ctx context.Context, readError error) {
+	session.stateLock.Lock()
+	defer session.stateLock.Unlock()
+	closeStatus := websocket.CloseStatus(readError)
+	var closeError websocket.CloseError
+	reason := ""
+	if errors.As(readError, &closeError) {
+		reason = closeError.Reason
+	}
+	switch {
+	case closeStatus == websocket.StatusNormalClosure, session.sawEnd, ctx.Err() != nil && closeStatus == -1:
+		session.closeError = nil
+	case closeStatus == -1:
+		session.closeError = fmt.Errorf("the terminal connection dropped: %w", readError)
+	case closeStatus == podTerminalClosePermissionDenied:
+		session.closeError = &PermissionDeniedError{Permission: "kubernetes.exec"}
+	case closeStatus == podTerminalCloseClusterUnavailable:
+		session.closeError = &ClusterUnavailableError{ErrorCode: "CLUSTER_OFFLINE", Detail: session.lastErrorMessage}
+	case closeStatus == podTerminalCloseNoAgent:
+		session.closeError = &ClusterUnavailableError{ErrorCode: "NO_AGENT", Detail: session.lastErrorMessage}
+	case closeStatus == podTerminalCloseSandbox:
+		session.closeError = &ClusterUnavailableError{ErrorCode: "SANDBOX_MODE", Detail: session.lastErrorMessage}
+	default:
+		session.closeError = &PodTerminalClosedError{Code: int(closeStatus), Reason: reason, Message: session.lastErrorMessage}
+	}
+}
+
+func (session *podTerminalConnection) Err() error {
+	session.stateLock.Lock()
+	defer session.stateLock.Unlock()
+	return session.closeError
+}
+
+func (session *podTerminalConnection) writeFrame(frame map[string]any) error {
+	payload, marshalError := json.Marshal(frame)
+	if marshalError != nil {
+		return marshalError
+	}
+	session.writeLock.Lock()
+	defer session.writeLock.Unlock()
+	return session.connection.Write(context.Background(), websocket.MessageText, payload)
+}
+
+func (session *podTerminalConnection) SendInput(data []byte) error {
+	return session.writeFrame(map[string]any{"type": "stdin", "data": base64.StdEncoding.EncodeToString(data)})
+}
+
+func (session *podTerminalConnection) Resize(cols int, rows int) error {
+	return session.writeFrame(map[string]any{"type": "resize", "cols": cols, "rows": rows})
+}
+
+func (session *podTerminalConnection) Ping() error {
+	return session.writeFrame(map[string]any{"type": "ping"})
+}
+
+func (session *podTerminalConnection) Close() error {
+	var closeError error
+	session.closeOnce.Do(func() {
+		close(session.done)
+		closeError = session.connection.Close(websocket.StatusNormalClosure, "")
+		session.cancel()
+	})
+	return closeError
+}

--- a/internal/client/terminal_test.go
+++ b/internal/client/terminal_test.go
@@ -1,0 +1,255 @@
+package client
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+type terminalRelayBehaviour func(ctx context.Context, connection *websocket.Conn, request *http.Request)
+
+func newTerminalRelay(t *testing.T, behaviour terminalRelayBehaviour) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		connection, acceptError := websocket.Accept(writer, request, nil)
+		if acceptError != nil {
+			return
+		}
+		behaviour(request.Context(), connection, request)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func relayFrame(ctx context.Context, connection *websocket.Conn, frame map[string]any) {
+	payload, _ := json.Marshal(frame)
+	_ = connection.Write(ctx, websocket.MessageText, payload)
+}
+
+func encodeTerminalData(text string) string {
+	return base64.StdEncoding.EncodeToString([]byte(text))
+}
+
+func nextFrame(t *testing.T, session PodTerminal) PodTerminalFrame {
+	t.Helper()
+	select {
+	case frame, isOpen := <-session.Frames():
+		if !isOpen {
+			t.Fatalf("the session ended early: %v", session.Err())
+		}
+		return frame
+	case <-time.After(5 * time.Second):
+		t.Fatal("no frame within 5s")
+	}
+	return PodTerminalFrame{}
+}
+
+func TestOpenPodTerminalRoundTrip(t *testing.T) {
+	var seenRequest *http.Request
+	server := newTerminalRelay(t, func(ctx context.Context, connection *websocket.Conn, request *http.Request) {
+		seenRequest = request
+		relayFrame(ctx, connection, map[string]any{"type": "connecting"})
+		relayFrame(ctx, connection, map[string]any{"type": "connected"})
+		for {
+			_, payload, readError := connection.Read(ctx)
+			if readError != nil {
+				return
+			}
+			var frame map[string]any
+			if unmarshalError := json.Unmarshal(payload, &frame); unmarshalError != nil {
+				return
+			}
+			switch frame["type"] {
+			case "stdin":
+				data, _ := base64.StdEncoding.DecodeString(frame["data"].(string))
+				if string(data) == "exit\n" {
+					relayFrame(ctx, connection, map[string]any{"type": "end"})
+					_ = connection.Close(websocket.StatusNormalClosure, "")
+					return
+				}
+				relayFrame(ctx, connection, map[string]any{"type": "stdout", "data": encodeTerminalData("echo:" + string(data))})
+			case "ping":
+				relayFrame(ctx, connection, map[string]any{"type": "pong"})
+			case "resize":
+				relayFrame(ctx, connection, map[string]any{"type": "stdout",
+					"data": encodeTerminalData(fmt.Sprintf("resize:%vx%v", frame["cols"], frame["rows"]))})
+			}
+		}
+	})
+	apiClient := New("secret-token", server.URL)
+	apiClient.SetOrganisationOverride("11111111-2222-4333-8444-555555555555")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, openError := apiClient.OpenPodTerminal(ctx, "cluster-1", PodTerminalRequest{
+		Namespace: "default", PodName: "web-1", ContainerName: "app", Shell: "/bin/bash", Cols: 120, Rows: 40,
+	})
+	if openError != nil {
+		t.Fatalf("open: %v", openError)
+	}
+	defer func() { _ = session.Close() }()
+
+	if frame := nextFrame(t, session); frame.Type != "connecting" {
+		t.Fatalf("first frame = %+v", frame)
+	}
+	if frame := nextFrame(t, session); frame.Type != "connected" {
+		t.Fatalf("second frame = %+v", frame)
+	}
+	if sendError := session.SendInput([]byte("pwd\n")); sendError != nil {
+		t.Fatal(sendError)
+	}
+	echoed := nextFrame(t, session)
+	payload, decodeError := echoed.Payload()
+	if decodeError != nil || echoed.Type != "stdout" || string(payload) != "echo:pwd\n" {
+		t.Fatalf("stdout frame = %+v (%v)", echoed, decodeError)
+	}
+	if pingError := session.Ping(); pingError != nil {
+		t.Fatal(pingError)
+	}
+	if frame := nextFrame(t, session); frame.Type != "pong" {
+		t.Fatalf("pong frame = %+v", frame)
+	}
+	if resizeError := session.Resize(100, 30); resizeError != nil {
+		t.Fatal(resizeError)
+	}
+	resized := nextFrame(t, session)
+	payload, _ = resized.Payload()
+	if string(payload) != "resize:100x30" {
+		t.Fatalf("resize echo = %q", payload)
+	}
+	if sendError := session.SendInput([]byte("exit\n")); sendError != nil {
+		t.Fatal(sendError)
+	}
+	if frame := nextFrame(t, session); frame.Type != "end" {
+		t.Fatalf("end frame = %+v", frame)
+	}
+	for range session.Frames() {
+	}
+	if closeError := session.Err(); closeError != nil {
+		t.Fatalf("a session the relay ended normally reports %v", closeError)
+	}
+
+	if seenRequest == nil {
+		t.Fatal("the relay never saw the handshake")
+	}
+	if seenRequest.Header.Get("Authorization") != "Bearer secret-token" {
+		t.Errorf("authorization = %q", seenRequest.Header.Get("Authorization"))
+	}
+	if seenRequest.Header.Get(orgOverrideHeader) != "11111111-2222-4333-8444-555555555555" {
+		t.Errorf("organisation override was not sent: %q", seenRequest.Header.Get(orgOverrideHeader))
+	}
+	if seenRequest.URL.Path != "/api/v1/clusters/cluster-1/kubernetes/pod/terminal" {
+		t.Errorf("path = %q", seenRequest.URL.Path)
+	}
+	query, _ := url.ParseQuery(seenRequest.URL.RawQuery)
+	for key, expected := range map[string]string{
+		"namespace": "default", "pod_name": "web-1", "container_name": "app", "shell": "/bin/bash", "cols": "120", "rows": "40",
+	} {
+		if query.Get(key) != expected {
+			t.Errorf("query %s = %q, want %q", key, query.Get(key), expected)
+		}
+	}
+}
+
+func TestOpenPodTerminalMapsTheRelaysRefusals(t *testing.T) {
+	cases := []struct {
+		name    string
+		code    websocket.StatusCode
+		message string
+		check   func(t *testing.T, closeError error)
+	}{
+		{
+			name: "4403 is the exec permission", code: 4403, message: "Permission denied",
+			check: func(t *testing.T, closeError error) {
+				var denied *PermissionDeniedError
+				if !errors.As(closeError, &denied) || denied.Permission != "kubernetes.exec" {
+					t.Fatalf("got %v", closeError)
+				}
+			},
+		},
+		{
+			name: "4002 is the cluster offline envelope", code: 4002, message: "Cluster is offline",
+			check: func(t *testing.T, closeError error) {
+				var unavailable *ClusterUnavailableError
+				if !errors.As(closeError, &unavailable) || unavailable.ErrorCode != "CLUSTER_OFFLINE" || unavailable.Detail != "Cluster is offline" {
+					t.Fatalf("got %v", closeError)
+				}
+			},
+		},
+		{
+			name: "4003 is the no-agent envelope", code: 4003, message: "No agent connected",
+			check: func(t *testing.T, closeError error) {
+				var unavailable *ClusterUnavailableError
+				if !errors.As(closeError, &unavailable) || unavailable.ErrorCode != "NO_AGENT" {
+					t.Fatalf("got %v", closeError)
+				}
+			},
+		},
+		{
+			name: "4001 is a refused credential", code: 4001, message: "Authentication required",
+			check: func(t *testing.T, closeError error) {
+				var closed *PodTerminalClosedError
+				if !errors.As(closeError, &closed) || !closed.IsAuthentication() || closed.Error() != "Authentication required" {
+					t.Fatalf("got %v", closeError)
+				}
+			},
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			server := newTerminalRelay(t, func(ctx context.Context, connection *websocket.Conn, request *http.Request) {
+				relayFrame(ctx, connection, map[string]any{"type": "error", "message": testCase.message})
+				_ = connection.Close(testCase.code, testCase.message)
+			})
+			apiClient := New("secret-token", server.URL)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			session, openError := apiClient.OpenPodTerminal(ctx, "cluster-1", PodTerminalRequest{Namespace: "default", PodName: "web-1", ContainerName: "app"})
+			if openError != nil {
+				t.Fatalf("open: %v", openError)
+			}
+			defer func() { _ = session.Close() }()
+			sawErrorFrame := false
+			for frame := range session.Frames() {
+				if frame.Type == "error" && frame.Message == testCase.message {
+					sawErrorFrame = true
+				}
+			}
+			if !sawErrorFrame {
+				t.Error("the error frame was not delivered before the close")
+			}
+			testCase.check(t, session.Err())
+		})
+	}
+}
+
+func TestOpenPodTerminalRefusedHandshake(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusBadRequest)
+	}))
+	t.Cleanup(server.Close)
+	apiClient := New("secret-token", server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, openError := apiClient.OpenPodTerminal(ctx, "cluster-1", PodTerminalRequest{Namespace: "default", PodName: "web-1", ContainerName: "app"})
+	var unexpected *UnexpectedResponseError
+	if !errors.As(openError, &unexpected) || unexpected.StatusCode != http.StatusBadRequest {
+		t.Fatalf("got %v", openError)
+	}
+}
+
+func TestOpenPodTerminalRequiresTheTarget(t *testing.T) {
+	apiClient := New("secret-token", "https://api.example.test")
+	if _, openError := apiClient.OpenPodTerminal(context.Background(), "cluster-1", PodTerminalRequest{Namespace: "default"}); openError == nil {
+		t.Fatal("a request without a pod and container must be refused before dialing")
+	}
+}


### PR DESCRIPTION
Bead: ankra-bpe51 (follow-up of epic ankra-loyfi). Platform side: ankraio/cluster PR "bearer twin of the pod terminal websocket" (same bead) - the CLI dials `/api/v1/clusters/{id}/kubernetes/pod/terminal` with its bearer token; an older platform answers 404 at the handshake, surfaced as the usual unexpected-response error.

## Commands

- `ankra cluster terminal <pod> -n <ns> [-c <container>] [--shell /bin/sh]` - an interactive shell in the pod through the platform relay. Raw-mode local TTY (Ctrl-C reaches the remote shell), window resizes followed by polling the local size, keepalive pings on the portal's 30s cadence. One container needs nothing more; several are refused with the list (exit 2) rather than guessed - init and ephemeral containers do not count as places to shell into. Piped input is forwarded as typed.
- `ankra cluster debug create --attach [--shell]` - drops into the debug pod it just created (container `debug`); a pod that is not running yet gets the `cluster terminal` hint instead, and `--attach` with `-o` is a usage error.

## Client

`internal/client/terminal.go`: `OpenPodTerminal` (github.com/coder/websocket, the relay's own library) with the JSON frame protocol the portal speaks (`stdin`/`resize`/`ping` out, base64 `stdout`/`stderr` in). The relay's close codes become the client's typed errors - 4403 → `PermissionDeniedError` (exit 7), 4002/4003/4004 → `ClusterUnavailableError` with the frozen codes, 4001 → `PodTerminalClosedError.IsAuthentication` (exit 6) - so the command layer maps them the way it maps the HTTP twins. Added to `APIClient` and `baseMock` per the three-place invariant.

## Verification

- `go build`, `go test -race ./internal/client/ ./cmd/`, `golangci-lint run` - green.
- `internal/client/terminal_test.go`: a coder/websocket relay in-process asserts the bearer header, the organisation override header, the `/api/v1` path and every query field, then the stdin echo, ping/pong, resize and the normal end; the four close codes map to the typed errors; a refused handshake is an `UnexpectedResponseError`.
- `cmd/cluster_terminal_test.go`: input/output bridging with a fake session, the only-container default, the several-containers refusal, missing pod (exit 3), permission refusal (exit 7), refused token (exit 6), and `debug create --attach` opening the `debug` container, waiting for a running pod, and refusing `-o`.

Docs: ankraio/ankra-docs PR to follow (debug-pods + pod-terminal pages).
