### PR TITLE
release: cut v0.14.0-rc6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Ankra CLI Changelog
 
-## Unreleased
+## v0.14.0-rc6 — 2026-08-29
 
 ### Added
 


### PR DESCRIPTION
Promotes `## Unreleased` to `## v0.14.0-rc6 — 2026-08-29`.

Above v0.14.0-rc5 on master: #192 - `ankra cluster terminal` (interactive shell in any pod through the platform's bearer terminal lane, cluster#2140) and `ankra cluster debug create --attach`; `ankra org terminal-session` says when a transcript was pruned by retention (cluster#2143).

Release commit touches CHANGELOG.md only; the tag is pushed after the squash-merge. Notes extractor dry-run matches the heading.
