### PR TITLE
feat(migrate): 'ankra migrate up' - one-command Docker to Kubernetes migration, production-grade export (ankra-k6ikc.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@
 
 ### Added
 
+- **`ankra migrate up` moves a Docker deployment into a cluster in one
+  command.** Where the migration used to be four commands with judgement
+  calls between them, `ankra migrate up ./app --cluster shop` now plans,
+  converts, deploys, dumps and restores, and stops before the first change
+  when something is off. The plan says exactly what will happen: every
+  database found in the running containers with its size on the source,
+  what the dumps need on disk against what is free, whether the stack
+  exists on the cluster, which backup vault carries the data, and what
+  stays behind - files in the volumes of other workloads, Redis, MongoDB,
+  search indexes - so nothing is forgotten silently. `--plan` prints that
+  and stops. Then the stack is applied under the cluster's own name, the
+  database pods are waited for, the data is exported and restored, and
+  the command ends with where the deployment runs and the URLs it answers
+  on. Run it once as a rehearsal; run it again with `--stop-source` and
+  the source's services are stopped before the final dump - that is the
+  cutover, and the command prints how to start them again. `--no-data`
+  deploys only, `--timeout` bounds each waiting step, `-o json` gives the
+  whole record.
+- **The export reads the database's real configuration, not the compose
+  file's guess.** Credentials, the application database and the root
+  account now come from the running container's environment, so a
+  `${DB_USER}` the file could not resolve, an `env_file`, or a password
+  handed over as `POSTGRES_PASSWORD_FILE` all work. A MySQL/MariaDB server
+  started without a root password (`MYSQL_RANDOM_ROOT_PASSWORD`) is dumped
+  as the application user, and a server nobody can log into is refused with
+  the reason instead of a failed dump.
 - **Scaleway clusters get the full command set.** `ankra cluster scaleway`
   now covers create (with `preflight` to prove capacity before paying for
   it), deprovision, worker counts, Kubernetes version and upgrade, the whole

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,27 +35,18 @@ the un-injected fallback; never bump it for a release.
   resource family.
 - `internal/kubeconfig` — kubeconfig read/merge/write.
 - `internal/migrate` — `ankra migrate`: the module contract (`Module`,
-  `Description`, `Detection`, `Result`), the registry that discovers
+  `Description`, `Detection`, `Result`, the optional `DataExporter`,
+  `ExportPlanner` and `SourceQuiescer`), the registry that discovers
   `ankra-module-<name>` executables, and the JSON-over-stdio protocol they
   speak. `internal/migrate/docker` is the built-in module and the reference
   implementation; `examples/modules/` holds a complete external one.
   Nothing under `internal/migrate` may call the platform API: `convert`,
   `detect`, `modules` and `export` are annotated
-  `annotationRequiresAuth: "false"` and work offline. The one online lane is
-  `cmd/migrate_restore.go` (`restore`, `restore-status`, `data`), annotated
-  `"true"`, which drives the backup-vault import routes through
-  `internal/client`.
-- `internal/migrate` — `ankra migrate`: the module contract (`Module`,
-  `Description`, `Detection`, `Result`), the registry that discovers
-  `ankra-module-<name>` executables, and the JSON-over-stdio protocol they
-  speak. `internal/migrate/docker` is the built-in module and the reference
-  implementation; `examples/modules/` holds a complete external one.
-  Nothing under `internal/migrate` may call the platform API: `convert`,
-  `detect`, `modules` and `export` are annotated
-  `annotationRequiresAuth: "false"` and work offline. The one online lane is
-  `cmd/migrate_restore.go` (`restore`, `restore-status`, `data`), annotated
-  `"true"`, which drives the backup-vault import routes through
-  `internal/client`.
+  `annotationRequiresAuth: "false"` and work offline. The online lanes are
+  `cmd/migrate_restore.go` (`restore`, `restore-status`, `data`) and
+  `cmd/migrate_up.go` (`up`, the one-command migration that chains convert,
+  `cluster apply`, the pod wait, export and restore), annotated `"true"`,
+  which drive the backup-vault import routes through `internal/client`.
 - `internal/skills` — embedded agent skills, vendored from the sibling
   `ankra-skills` repo (`make generate` / `make verify-skills`; in the split
   repo the embedded copy is canonical). `clients.go` is the table of every

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -67,11 +68,6 @@ func runApply(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("reading --dry-run: %w", err)
 	}
 
-	importRequest, err := buildImportRequest(filePath)
-	if err != nil {
-		return fmt.Errorf("invalid ImportCluster in %q:\n  %w", filePath, err)
-	}
-
 	allowRepoint, err := cmd.Flags().GetBool("allow-repoint")
 	if err != nil {
 		return fmt.Errorf("reading --allow-repoint: %w", err)
@@ -83,11 +79,9 @@ func runApply(cmd *cobra.Command, _ []string) error {
 	if allowRepointDestroyingData && !allowRepoint {
 		return errors.New("--allow-repoint-destroying-data requires --allow-repoint")
 	}
-	importRequest.AllowRepoint = allowRepoint
-	importRequest.AllowRepointDestroyingData = allowRepointDestroyingData
-
-	if err := validateResourceGraph(importRequest); err != nil {
-		return fmt.Errorf("invalid ImportCluster in %q:\n  %w", filePath, err)
+	importRequest, err := loadImportCluster(filePath, allowRepoint, allowRepointDestroyingData)
+	if err != nil {
+		return err
 	}
 
 	if dryRun {
@@ -105,9 +99,9 @@ func runApply(cmd *cobra.Command, _ []string) error {
 	}
 	defer cancelRequestContext()
 
-	importResponse, submitted, err := apiClient.ApplyCluster(requestContext, importRequest, wait)
+	importResponse, submitted, err := applyImportCluster(requestContext, importRequest, wait)
 	if err != nil {
-		return asyncWriteError("applying cluster", wait, err)
+		return err
 	}
 	if submitted {
 		if rendered, err := renderStructured(cmd, newAsyncSubmittedResult("Cluster apply")); rendered || err != nil {
@@ -154,6 +148,32 @@ func runApply(cmd *cobra.Command, _ []string) error {
 	fmt.Printf("\nView it in the UI:\n  %s/organisation/clusters/cluster/imported/%s/overview\n",
 		strings.TrimRight(baseURL, "/"), importResponse.ClusterId)
 	return nil
+}
+
+// loadImportCluster reads and validates an ImportCluster file into the
+// request the platform accepts, with the repoint permissions set.
+func loadImportCluster(filePath string, allowRepoint bool, allowRepointDestroyingData bool) (client.CreateImportClusterRequest, error) {
+	importRequest, err := buildImportRequest(filePath)
+	if err != nil {
+		return client.CreateImportClusterRequest{}, fmt.Errorf("invalid ImportCluster in %q:\n  %w", filePath, err)
+	}
+	importRequest.AllowRepoint = allowRepoint
+	importRequest.AllowRepointDestroyingData = allowRepointDestroyingData
+	if err := validateResourceGraph(importRequest); err != nil {
+		return client.CreateImportClusterRequest{}, fmt.Errorf("invalid ImportCluster in %q:\n  %w", filePath, err)
+	}
+	return importRequest, nil
+}
+
+// applyImportCluster sends the request; submitted is true when the platform
+// accepted the write without waiting for it. Errors carry the wait exit code
+// when the --wait deadline expired.
+func applyImportCluster(ctx context.Context, importRequest client.CreateImportClusterRequest, wait bool) (*client.ImportResponse, bool, error) {
+	importResponse, submitted, err := apiClient.ApplyCluster(ctx, importRequest, wait)
+	if err != nil {
+		return nil, false, asyncWriteError("applying cluster", wait, err)
+	}
+	return importResponse, submitted, nil
 }
 
 func buildImportRequest(path string) (client.CreateImportClusterRequest, error) {

--- a/cmd/diskfree_unix.go
+++ b/cmd/diskfree_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package cmd
+
+import "syscall"
+
+// freeDiskBytes reports how much the filesystem holding path can still take,
+// or ok=false when it cannot tell.
+func freeDiskBytes(path string) (int64, bool) {
+	var stat syscall.Statfs_t
+	if statError := syscall.Statfs(path, &stat); statError != nil {
+		return 0, false
+	}
+	return int64(stat.Bavail) * int64(stat.Bsize), true
+}

--- a/cmd/diskfree_windows.go
+++ b/cmd/diskfree_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package cmd
+
+// freeDiskBytes is not measured on Windows; the caller treats the space as
+// unknown rather than as plentiful.
+func freeDiskBytes(string) (int64, bool) {
+	return 0, false
+}

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -16,18 +16,26 @@ import (
 // platform API, so none of them require a login.
 var migrateCmd = &cobra.Command{
 	Use:   "migrate",
-	Short: "Convert an existing deployment (docker-compose, Dockerfile, running containers) into Ankra cluster and stack definitions",
-	Long: `Convert an existing deployment into an ImportCluster manifest plus the
-Kubernetes manifests its stack refers to, ready for 'ankra cluster apply'.
+	Short: "Move an existing deployment (docker-compose, Dockerfile, running containers) into a cluster Ankra runs",
+	Long: `Move an existing deployment into a cluster that Ankra runs.
 
-Conversion is done by modules. The 'docker' module is built in and reads
-docker-compose files, bare Dockerfiles, and the running Docker daemon. Anyone
-can add a module for another format by putting an executable named
-'ankra-module-<name>' on PATH or in ~/.ankra/modules - see
-'ankra migrate modules --help' for the contract.
+'ankra migrate up <dir> --cluster <name>' does the whole journey in one
+command: it plans (what will move, how big it is, what stays behind),
+converts the deployment into a stack, deploys the stack, dumps every
+database from the source and restores it in the cluster. Run it once as a
+rehearsal, then again with --stop-source for the cutover.
 
-Nothing here talks to the platform: the commands read local files, write a
-directory, and leave applying it to you.`,
+The steps are also separate commands, for when you want to look at each
+result: 'convert' writes the stack, 'ankra cluster apply' deploys it,
+'export' dumps the data, 'restore' loads it, 'data' does export and
+restore together. 'convert', 'detect', 'export' and 'modules' work offline;
+'up', 'restore', 'restore-status' and 'data' talk to the platform.
+
+Conversion and export are done by modules. The 'docker' module is built in
+and reads docker-compose files, bare Dockerfiles, and the running Docker
+daemon. Anyone can add a module for another format by putting an executable
+named 'ankra-module-<name>' on PATH or in ~/.ankra/modules - see
+'ankra migrate modules --help' for the contract.`,
 	Annotations: map[string]string{annotationRequiresAuth: "false"},
 }
 

--- a/cmd/migrate_convert.go
+++ b/cmd/migrate_convert.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -87,17 +88,14 @@ func runMigrateConvert(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
 	options, err := parseMigrateOptions(migrateConvertOptions)
 	if err != nil {
 		return err
 	}
-
 	module, err := selectMigrateModule(cmd, newMigrateRegistry(), dir, migrateConvertModule)
 	if err != nil {
 		return err
 	}
-
 	clusterName := migrateConvertClusterName
 	if clusterName == "" {
 		clusterName = migrateResourceName(filepath.Base(dir))
@@ -107,22 +105,69 @@ func runMigrateConvert(cmd *cobra.Command, args []string) error {
 		namespace = clusterName
 	}
 
-	result, err := module.Convert(cmd.Context(), migrate.ConvertRequest{
-		Dir:         dir,
-		ClusterName: clusterName,
-		Namespace:   namespace,
-		Options:     options,
+	summary, clusterYAML, err := performMigrateConvert(dir, migrateConvertRequest{
+		Module: module, ClusterName: clusterName, Namespace: namespace, Options: options,
+		Out: migrateConvertOut, Force: migrateConvertForce, DryRun: migrateConvertDryRun,
 	})
 	if err != nil {
-		return fmt.Errorf("%s: %w", module.Describe().Name, err)
-	}
-	if err := migrate.Validate(result); err != nil {
-		return fmt.Errorf("%s: %w", module.Describe().Name, err)
+		return err
 	}
 
+	if migrateConvertDryRun {
+		if handled, err := renderStructured(cmd, summary); handled || err != nil {
+			return err
+		}
+		_, _ = fmt.Fprint(cmd.OutOrStdout(), string(clusterYAML))
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "\nWould write %d file(s) to %s:\n", len(summary.Files), migrateConvertOut)
+		for _, file := range summary.Files {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  %s\n", file)
+		}
+		printMigrateWarnings(cmd, summary.Warnings)
+		return nil
+	}
+
+	if handled, err := renderStructured(cmd, summary); handled || err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Converted %s with the %s module.\n", dir, summary.Module)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Wrote %d file(s) to %s\n", len(summary.Files), summary.Out)
+	printMigrateWarnings(cmd, summary.Warnings)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nReview the output, then apply it:\n  ankra cluster apply %s\n", filepath.Join(summary.Out, "cluster.yaml"))
+	return nil
+}
+
+// migrateConvertRequest is one conversion: the module, the names the output
+// carries, and where it goes. DryRun renders without writing.
+type migrateConvertRequest struct {
+	Module      migrate.Module
+	ClusterName string
+	Namespace   string
+	Options     map[string]string
+	Out         string
+	Force       bool
+	DryRun      bool
+}
+
+// performMigrateConvert runs the module, validates its result, and writes
+// cluster.yaml plus every file it produced under Out unless DryRun. It
+// returns the summary (Out set when written) and the rendered cluster.yaml.
+func performMigrateConvert(dir string, request migrateConvertRequest) (migrateConvertSummary, []byte, error) {
+	module := request.Module
+	result, err := module.Convert(context.Background(), migrate.ConvertRequest{
+		Dir:         dir,
+		ClusterName: request.ClusterName,
+		Namespace:   request.Namespace,
+		Options:     request.Options,
+	})
+	if err != nil {
+		return migrateConvertSummary{}, nil, fmt.Errorf("%s: %w", module.Describe().Name, err)
+	}
+	if err := migrate.Validate(result); err != nil {
+		return migrateConvertSummary{}, nil, fmt.Errorf("%s: %w", module.Describe().Name, err)
+	}
 	clusterYAML, err := yaml.Marshal(result.Cluster)
 	if err != nil {
-		return err
+		return migrateConvertSummary{}, nil, err
 	}
 
 	files := make([]string, 0, len(result.Files)+1)
@@ -131,57 +176,37 @@ func runMigrateConvert(cmd *cobra.Command, args []string) error {
 	}
 	sort.Strings(files)
 	files = append([]string{"cluster.yaml"}, files...)
-
 	summary := migrateConvertSummary{
 		Module:   module.Describe().Name,
 		Cluster:  result.Cluster,
 		Files:    files,
 		Warnings: result.Warnings,
 	}
-
-	if migrateConvertDryRun {
-		if handled, err := renderStructured(cmd, summary); handled || err != nil {
-			return err
-		}
-		_, _ = fmt.Fprint(cmd.OutOrStdout(), string(clusterYAML))
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "\nWould write %d file(s) to %s:\n", len(files), migrateConvertOut)
-		for _, file := range files {
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  %s\n", file)
-		}
-		printMigrateWarnings(cmd, result.Warnings)
-		return nil
+	if request.DryRun {
+		return summary, clusterYAML, nil
 	}
 
-	out, err := filepath.Abs(migrateConvertOut)
+	out, err := filepath.Abs(request.Out)
 	if err != nil {
-		return withExitCode(exitUsage, err)
+		return migrateConvertSummary{}, nil, withExitCode(exitUsage, err)
 	}
-	if err := ensureMigrateOutDir(out, migrateConvertForce); err != nil {
-		return err
+	if err := ensureMigrateOutDir(out, request.Force); err != nil {
+		return migrateConvertSummary{}, nil, err
 	}
 	if err := os.WriteFile(filepath.Join(out, "cluster.yaml"), clusterYAML, 0o644); err != nil {
-		return err
+		return migrateConvertSummary{}, nil, err
 	}
 	for file, content := range result.Files {
 		path := filepath.Join(out, filepath.FromSlash(file))
 		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			return err
+			return migrateConvertSummary{}, nil, err
 		}
 		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-			return err
+			return migrateConvertSummary{}, nil, err
 		}
 	}
 	summary.Out = out
-
-	if handled, err := renderStructured(cmd, summary); handled || err != nil {
-		return err
-	}
-
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Converted %s with the %s module.\n", dir, summary.Module)
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Wrote %d file(s) to %s\n", len(files), out)
-	printMigrateWarnings(cmd, result.Warnings)
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nReview the output, then apply it:\n  ankra cluster apply %s\n", filepath.Join(out, "cluster.yaml"))
-	return nil
+	return summary, clusterYAML, nil
 }
 
 func printMigrateWarnings(cmd *cobra.Command, warnings []string) {

--- a/cmd/migrate_export_test.go
+++ b/cmd/migrate_export_test.go
@@ -12,9 +12,12 @@ import (
 // migrateTestCompose fixture: one postgres service holding one database.
 const fakeDockerScript = `#!/bin/sh
 case "$*" in
+  *"inspect --format"*) printf 'POSTGRES_USER=postgres\nPOSTGRES_PASSWORD=secret\n' ;;
+  *"compose.service=web"*) echo web1 ;;
   *"ps -q"*) echo abc123 ;;
+  *"stop "*) echo "docker $*" >> "${FAKE_DOCKER_LOG:-/dev/null}" ;;
   *"SHOW server_version"*) echo 17.2 ;;
-  *"SELECT datname"*) echo office ;;
+  *"SELECT datname"*) echo "office|${FAKE_DB_SIZE:-8388608}" ;;
   *pg_dumpall*) printf -- '-- globals\n' ;;
   *"-d boom"*) echo 'pg_dump: error: connection to server failed: FATAL: database "boom" does not exist' >&2; exit 1 ;;
   *"pg_dump "*) printf 'PGDMP\001\002fake' ;;

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -72,7 +72,19 @@ func resetMigrateFlags() {
 	migrateConvertOptions = nil
 	migrateConvertForce = false
 	migrateConvertDryRun = false
-	for _, command := range []string{"convert", "detect", "modules"} {
+	migrateUpModule = ""
+	migrateUpOut = "ankra-migration"
+	migrateUpNamespace = ""
+	migrateUpStack = ""
+	migrateUpCluster = ""
+	migrateUpVault = ""
+	migrateUpOptions = nil
+	migrateUpForce = false
+	migrateUpNoData = false
+	migrateUpStopSource = false
+	migrateUpYes = false
+	migrateUpPlanOnly = false
+	for _, command := range []string{"convert", "detect", "modules", "up"} {
 		sub, _, _ := migrateCmd.Find([]string{command})
 		if sub != nil && sub.Flags().Lookup("output") != nil {
 			_ = sub.Flags().Set("output", "")

--- a/cmd/migrate_up.go
+++ b/cmd/migrate_up.go
@@ -1,0 +1,568 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"ankra/internal/client"
+	"ankra/internal/migrate"
+)
+
+// 'ankra migrate up' is the one-command migration: everything the separate
+// verbs do, in the order a careful operator would run them, with every
+// check that can be made up front made before anything is written.
+
+var (
+	migrateUpModule     string
+	migrateUpOut        string
+	migrateUpNamespace  string
+	migrateUpStack      string
+	migrateUpCluster    string
+	migrateUpVault      string
+	migrateUpOptions    []string
+	migrateUpForce      bool
+	migrateUpNoData     bool
+	migrateUpStopSource bool
+	migrateUpYes        bool
+	migrateUpPlanOnly   bool
+)
+
+// migrateUpPodPollInterval is how often the database workloads are checked
+// for readiness; tests shorten it.
+var migrateUpPodPollInterval = 5 * time.Second
+
+var migrateUpCmd = &cobra.Command{
+	Use:   "up [dir]",
+	Short: "Move a deployment into a cluster - convert, deploy and carry its data over - in one command",
+	Long: `Move the deployment described in a directory (default: the current one)
+into a cluster that Ankra runs, end to end:
+
+  1. Plan.    Detect the source, find every database it runs and its size,
+              resolve the cluster, the stack and the backup vault, and say
+              what the migration will and will not carry. Nothing is
+              touched until the plan checks out; --plan stops here.
+  2. Convert. Turn the deployment into a stack (cluster.yaml plus the
+              manifests) under <out>/stack, as 'ankra migrate convert' does.
+  3. Deploy.  Apply the stack to the cluster and wait for its database
+              workloads to be running.
+  4. Export.  Dump every database from the source, as 'ankra migrate
+              export' does, into <out>/data. With --stop-source the
+              source's other services are stopped first, so the dump is
+              the last word on the data: that is the cutover.
+  5. Restore. Upload the dumps through the backup vault and load them
+              into the cluster, as 'ankra migrate restore' does, and wait.
+
+The command is safe to run more than once: the stack is re-applied, the
+databases are dumped and restored again. Rehearse while the source runs,
+then run it once more with --stop-source when you are ready to switch.
+--timeout bounds each waiting step (deploy, readiness, restore).
+
+Not carried: files kept in the volumes of non-database workloads, and data
+in engines the export does not dump (Redis, MongoDB, search indexes). The
+plan names every such item so nothing is left behind unnoticed.`,
+	Example: `  ankra migrate up ./app --cluster shop --plan
+  ankra migrate up ./app --cluster shop --option ingress.app=shop.example.com --option cluster-issuer=letsencrypt-prod
+  ankra migrate up ./app --cluster shop --stop-source --yes
+  ankra migrate up ./app --cluster shop --option docker-host=ssh://root@203.0.113.7`,
+	Args:        cobra.MaximumNArgs(1),
+	Annotations: map[string]string{annotationRequiresAuth: "true"},
+	RunE:        runMigrateUp,
+}
+
+func init() {
+	migrateUpCmd.Flags().StringVar(&migrateUpCluster, "cluster", "", "Cluster to migrate into, by name or id (default: the selected cluster)")
+	migrateUpCmd.Flags().StringVar(&migrateUpVault, "vault", "", "Backup vault the data goes through, by name or id (default: the organisation's only ready vault)")
+	migrateUpCmd.Flags().StringVar(&migrateUpModule, "module", "", "Module to use (default: the most confident detection)")
+	migrateUpCmd.Flags().StringVar(&migrateUpOut, "out", "ankra-migration", "Output directory: <out>/stack for the conversion, <out>/data for the dumps")
+	migrateUpCmd.Flags().StringVar(&migrateUpStack, "stack", "", "Name of the stack on the cluster (default: the directory name)")
+	migrateUpCmd.Flags().StringVar(&migrateUpNamespace, "namespace", "", "Namespace the workloads run in (default: the stack name)")
+	migrateUpCmd.Flags().StringArrayVar(&migrateUpOptions, "option", nil, "Module option as key=value (repeatable); convert and export options both apply")
+	migrateUpCmd.Flags().BoolVar(&migrateUpForce, "force", false, "Overwrite an output directory that is not empty")
+	migrateUpCmd.Flags().BoolVar(&migrateUpNoData, "no-data", false, "Deploy the workloads only; carry no data over")
+	migrateUpCmd.Flags().BoolVar(&migrateUpStopSource, "stop-source", false, "Stop the source's non-database services before the export, so the dump is final (the cutover)")
+	migrateUpCmd.Flags().BoolVarP(&migrateUpYes, "yes", "y", false, "Skip the confirmation prompt")
+	migrateUpCmd.Flags().BoolVar(&migrateUpPlanOnly, "plan", false, "Print the plan and stop; change nothing")
+	registerAsyncWriteFlags(migrateUpCmd)
+	_ = migrateUpCmd.Flags().MarkHidden("wait")
+	registerStructuredOutputFlags(migrateUpCmd)
+	migrateCmd.AddCommand(migrateUpCmd)
+}
+
+// migrateUpPlan is everything the command established before changing
+// anything.
+type migrateUpPlan struct {
+	Module      string              `json:"module" yaml:"module"`
+	Dir         string              `json:"dir" yaml:"dir"`
+	Out         string              `json:"out" yaml:"out"`
+	ClusterID   string              `json:"cluster_id" yaml:"cluster_id"`
+	ClusterName string              `json:"cluster_name" yaml:"cluster_name"`
+	Stack       string              `json:"stack" yaml:"stack"`
+	StackExists bool                `json:"stack_exists" yaml:"stack_exists"`
+	Namespace   string              `json:"namespace" yaml:"namespace"`
+	VaultID     string              `json:"vault_id,omitempty" yaml:"vault_id,omitempty"`
+	Data        *migrate.ExportPlan `json:"data,omitempty" yaml:"data,omitempty"`
+	// EstimatedBytes is the source's own size of everything the export
+	// carries; the dumps compress, so it is a ceiling.
+	EstimatedBytes int64 `json:"estimated_bytes" yaml:"estimated_bytes"`
+	// FreeBytes is the space left where the dumps go; zero when unknown.
+	FreeBytes int64    `json:"free_bytes" yaml:"free_bytes"`
+	Warnings  []string `json:"warnings,omitempty" yaml:"warnings,omitempty"`
+}
+
+// migrateUpSummary is the structured shape of a completed migration.
+type migrateUpSummary struct {
+	Plan    migrateUpPlan             `json:"plan" yaml:"plan"`
+	Convert migrateConvertSummary     `json:"convert" yaml:"convert"`
+	Quiesce *migrate.Quiesce          `json:"quiesce,omitempty" yaml:"quiesce,omitempty"`
+	Import  *client.BackupVaultImport `json:"import,omitempty" yaml:"import,omitempty"`
+	URLs    []string                  `json:"urls,omitempty" yaml:"urls,omitempty"`
+}
+
+func runMigrateUp(cmd *cobra.Command, args []string) error {
+	_ = cmd.Flags().Set("wait", "true")
+	dir, err := migrateSourceDir(args)
+	if err != nil {
+		return err
+	}
+	options, err := parseMigrateOptions(migrateUpOptions)
+	if err != nil {
+		return err
+	}
+	module, err := selectMigrateModule(cmd, newMigrateRegistry(), dir, migrateUpModule)
+	if err != nil {
+		return err
+	}
+	_, hasExport := migrate.ExporterFor(module)
+	carryData := !migrateUpNoData && hasExport
+	if migrateUpStopSource && !carryData {
+		return withExitCode(exitUsage, errors.New("--stop-source only makes sense when data is carried over"))
+	}
+	quiescer, canQuiesce := module.(migrate.SourceQuiescer)
+	if migrateUpStopSource && !canQuiesce {
+		return withExitCode(exitUsage, fmt.Errorf("the %s module cannot stop the source's services; stop them yourself, then run without --stop-source", module.Describe().Name))
+	}
+
+	plan, err := planMigrateUp(cmd, dir, module, options, carryData)
+	if err != nil {
+		return err
+	}
+	if migrateUpPlanOnly {
+		if handled, err := renderStructured(cmd, plan); handled || err != nil {
+			return err
+		}
+		printMigrateUpPlan(cmd, plan, carryData)
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Plan only; nothing was changed. Run again without --plan to migrate.")
+		return nil
+	}
+	if !structuredOutputRequested(cmd) {
+		printMigrateUpPlan(cmd, plan, carryData)
+	}
+	if confirmError := confirmMigrateUp(cmd, plan, carryData); confirmError != nil {
+		return confirmError
+	}
+
+	progress := cmd.ErrOrStderr()
+	_, _ = fmt.Fprintf(progress, "\n==> Converting %s\n", dir)
+	convertSummary, _, err := performMigrateConvert(dir, migrateConvertRequest{
+		Module: module, ClusterName: plan.ClusterName, Namespace: plan.Namespace, Options: options,
+		Out: filepath.Join(plan.Out, "stack"), Force: true,
+	})
+	if err != nil {
+		return err
+	}
+	if len(convertSummary.Cluster.Spec.Stacks) > 0 {
+		plan.Stack = convertSummary.Cluster.Spec.Stacks[0].Name
+	}
+	_, _ = fmt.Fprintf(progress, "Wrote %d file(s) to %s\n", len(convertSummary.Files), convertSummary.Out)
+	printMigrateWarnings(cmd, convertSummary.Warnings)
+
+	_, _ = fmt.Fprintf(progress, "\n==> Deploying stack %s to cluster %s\n", plan.Stack, plan.ClusterName)
+	if applyError := deployMigrateUpStack(cmd, filepath.Join(convertSummary.Out, "cluster.yaml")); applyError != nil {
+		return applyError
+	}
+
+	summary := migrateUpSummary{Plan: plan, Convert: convertSummary, URLs: migrateUpURLs(options)}
+	if carryData {
+		workloads := make([]string, 0, len(plan.Data.Databases))
+		for _, server := range plan.Data.Databases {
+			workloads = append(workloads, server.Workload)
+		}
+		_, _ = fmt.Fprintf(progress, "\n==> Waiting for %s to run in namespace %s\n", strings.Join(workloads, ", "), plan.Namespace)
+		if waitError := waitForMigrateUpWorkloads(cmd, plan.ClusterID, plan.Namespace, workloads); waitError != nil {
+			return waitError
+		}
+
+		exportRequest := migrate.ExportRequest{Dir: dir, Namespace: plan.Namespace, Options: options}
+		if migrateUpStopSource {
+			_, _ = fmt.Fprintln(progress, "\n==> Stopping the source's services")
+			quiesce, quiesceError := quiescer.QuiesceSource(cmd.Context(), exportRequest)
+			if quiesceError != nil {
+				return quiesceError
+			}
+			summary.Quiesce = &quiesce
+			if len(quiesce.Stopped) == 0 {
+				_, _ = fmt.Fprintln(progress, "No running service besides the databases; nothing to stop.")
+			} else {
+				_, _ = fmt.Fprintf(progress, "Stopped %s. To bring them back: %s\n", strings.Join(quiesce.Stopped, ", "), quiesce.Resume)
+			}
+		}
+
+		_, _ = fmt.Fprintf(progress, "\n==> Exporting the data of %s\n", dir)
+		exported, exportError := performMigrateExport(cmd, dir, migrateExportRequest{
+			Module: module.Describe().Name, Out: filepath.Join(plan.Out, "data"), Namespace: plan.Namespace,
+			Options: migrateUpOptions, Force: true,
+		})
+		if exportError != nil {
+			return exportError
+		}
+		_, _ = fmt.Fprintf(progress, "Exported %d database server(s) to %s\n", len(exported.Manifest.Databases), exported.Out)
+
+		_, _ = fmt.Fprintf(progress, "\n==> Restoring into cluster %s\n", plan.ClusterName)
+		imported, restoreError := performMigrateRestore(cmd, exported.Out, migrateRestoreTargets{
+			clusterID: plan.ClusterID, clusterName: plan.ClusterName, vaultID: plan.VaultID, stackName: plan.Stack,
+		}, true)
+		if restoreError != nil {
+			return restoreError
+		}
+		summary.Import = imported
+	}
+
+	if handled, err := renderStructured(cmd, summary); handled || err != nil {
+		return err
+	}
+	printMigrateUpOutcome(cmd, summary, carryData)
+	return nil
+}
+
+// planMigrateUp establishes everything the migration needs before it
+// changes anything: the source's databases and their sizes, the space to
+// dump them into, and the cluster, stack and vault they go to.
+func planMigrateUp(cmd *cobra.Command, dir string, module migrate.Module, options map[string]string, carryData bool) (migrateUpPlan, error) {
+	out, err := filepath.Abs(migrateUpOut)
+	if err != nil {
+		return migrateUpPlan{}, withExitCode(exitUsage, err)
+	}
+	stackName := migrateUpStack
+	if stackName == "" {
+		stackName = migrateResourceName(filepath.Base(dir))
+	}
+	namespace := migrateUpNamespace
+	if namespace == "" {
+		namespace = stackName
+	}
+	plan := migrateUpPlan{Module: module.Describe().Name, Dir: dir, Out: out, Stack: stackName, Namespace: namespace}
+
+	clusterID, clusterName, err := resolveClusterForCmd(migrateUpCluster)
+	if err != nil {
+		return migrateUpPlan{}, err
+	}
+	if isUUIDLike(clusterName) {
+		clusterName, err = clusterNameForID(clusterID)
+		if err != nil {
+			return migrateUpPlan{}, err
+		}
+	}
+	plan.ClusterID, plan.ClusterName = clusterID, clusterName
+	stacks, err := apiClient.ListClusterStacks(clusterID)
+	if err != nil {
+		return migrateUpPlan{}, fmt.Errorf("listing the stacks of cluster %s: %w", clusterName, err)
+	}
+	for _, stack := range stacks {
+		plan.StackExists = plan.StackExists || stack.Name == stackName
+	}
+
+	if carryData {
+		vaultID, vaultError := resolveImportVaultID(migrateUpVault)
+		if vaultError != nil {
+			return migrateUpPlan{}, vaultError
+		}
+		plan.VaultID = vaultID
+		if planner, ok := module.(migrate.ExportPlanner); ok {
+			exportPlan, planError := planner.PlanExport(cmd.Context(), migrate.ExportRequest{Dir: dir, Namespace: namespace, Options: options})
+			if planError != nil {
+				return migrateUpPlan{}, planError
+			}
+			plan.Data = &exportPlan
+			for _, server := range exportPlan.Databases {
+				plan.EstimatedBytes += server.EstimatedBytes()
+				for _, database := range server.Databases {
+					if database.SizeBytes > client.PresignedUploadMaximumBytes {
+						plan.Warnings = append(plan.Warnings, fmt.Sprintf("%s: database %s is %s on the source; a dump above %s cannot be uploaded in one piece and would be refused",
+							server.Workload, database.Name, formatByteSize(database.SizeBytes), formatByteSize(client.PresignedUploadMaximumBytes)))
+					}
+				}
+			}
+			plan.Warnings = append(plan.Warnings, exportPlan.Warnings...)
+		} else {
+			plan.Warnings = append(plan.Warnings, fmt.Sprintf("the %s module does not describe its export up front; sizes are unknown until the dump runs", module.Describe().Name))
+		}
+		if free, ok := freeDiskBytes(nearestExistingDir(out)); ok {
+			plan.FreeBytes = free
+			if plan.EstimatedBytes > free {
+				return migrateUpPlan{}, withExitCode(exitUsage, fmt.Errorf("the source holds about %s of data but only %s is free at %s; pass --out to a larger volume",
+					formatByteSize(plan.EstimatedBytes), formatByteSize(free), out))
+			}
+		}
+	}
+	// The output directory is the first thing the migration changes, so it
+	// is created only once every check above has passed.
+	if !migrateUpPlanOnly {
+		if outError := ensureMigrateOutDir(out, migrateUpForce); outError != nil {
+			return migrateUpPlan{}, outError
+		}
+	}
+	return plan, nil
+}
+
+// nearestExistingDir walks up from path to the first directory that exists,
+// which is where a not-yet-created output directory would take its space.
+func nearestExistingDir(path string) string {
+	for current := path; ; current = filepath.Dir(current) {
+		if _, statError := os.Stat(current); statError == nil {
+			return current
+		}
+		if filepath.Dir(current) == current {
+			return current
+		}
+	}
+}
+
+func isUUIDLike(value string) bool {
+	return len(value) == 36 && strings.Count(value, "-") == 4
+}
+
+// clusterNameForID finds the name of a cluster given by id: the stack is
+// applied under the cluster's name, so an id on the command line is not
+// enough.
+func clusterNameForID(clusterID string) (string, error) {
+	const pageSize = 100
+	for page := 1; page <= 50; page++ {
+		response, listError := apiClient.ListClusters(page, pageSize)
+		if listError != nil {
+			return "", fmt.Errorf("listing clusters: %w", listError)
+		}
+		for _, cluster := range response.Result {
+			if cluster.ID == clusterID {
+				return cluster.Name, nil
+			}
+		}
+		if len(response.Result) < pageSize {
+			break
+		}
+	}
+	return "", withExitCode(exitNotFound, fmt.Errorf("no cluster with id %s in this organisation", clusterID))
+}
+
+func printMigrateUpPlan(cmd *cobra.Command, plan migrateUpPlan, carryData bool) {
+	out := cmd.ErrOrStderr()
+	_, _ = fmt.Fprintf(out, "Migration plan for %s (%s module)\n", plan.Dir, plan.Module)
+	stackState := "new"
+	if plan.StackExists {
+		stackState = "exists, will be updated"
+	}
+	_, _ = fmt.Fprintf(out, "  cluster    %s\n", plan.ClusterName)
+	_, _ = fmt.Fprintf(out, "  stack      %s (%s), namespace %s\n", plan.Stack, stackState, plan.Namespace)
+	_, _ = fmt.Fprintf(out, "  output     %s\n", plan.Out)
+	if !carryData {
+		_, _ = fmt.Fprintln(out, "  data       not carried (--no-data, or the module cannot export)")
+	} else if plan.Data != nil {
+		for _, server := range plan.Data.Databases {
+			names := make([]string, 0, len(server.Databases))
+			for _, database := range server.Databases {
+				if database.SizeBytes > 0 {
+					names = append(names, fmt.Sprintf("%s (%s)", database.Name, formatByteSize(database.SizeBytes)))
+				} else {
+					names = append(names, database.Name)
+				}
+			}
+			version := server.ServerVersion
+			if version != "" {
+				version = " " + version
+			}
+			_, _ = fmt.Fprintf(out, "  data       %s: %s%s as %s - %s\n", server.Workload, server.Engine, version, server.Username, strings.Join(names, ", "))
+		}
+		free := "free space unknown"
+		if plan.FreeBytes > 0 {
+			free = formatByteSize(plan.FreeBytes) + " free"
+		}
+		_, _ = fmt.Fprintf(out, "  disk       about %s to dump, %s at %s\n", formatByteSize(plan.EstimatedBytes), free, plan.Out)
+		if len(plan.Data.NotCarried) > 0 {
+			_, _ = fmt.Fprintln(out, "  not carried:")
+			for _, item := range plan.Data.NotCarried {
+				_, _ = fmt.Fprintf(out, "    - %s\n", item)
+			}
+		}
+	}
+	if len(plan.Warnings) > 0 {
+		_, _ = fmt.Fprintln(out, "  warnings:")
+		for _, warning := range plan.Warnings {
+			_, _ = fmt.Fprintf(out, "    - %s\n", warning)
+		}
+	}
+}
+
+// confirmMigrateUp asks before the first change, naming what stopping the
+// source will do when that was asked for.
+func confirmMigrateUp(cmd *cobra.Command, plan migrateUpPlan, carryData bool) error {
+	message := fmt.Sprintf("\nMigrate %s into cluster %s as stack %s", plan.Dir, plan.ClusterName, plan.Stack)
+	if carryData {
+		message += " and carry its data over"
+	}
+	if migrateUpStopSource {
+		message += "; the source's non-database services will be STOPPED before the final export"
+	}
+	return confirmPrompt(cmd.InOrStdin(), cmd.ErrOrStderr(), message+"? [y/N] ", migrateUpYes)
+}
+
+// deployMigrateUpStack applies the converted cluster.yaml and waits for the
+// write; a refused configuration is reported the way 'ankra cluster apply'
+// reports it.
+func deployMigrateUpStack(cmd *cobra.Command, clusterFile string) error {
+	importRequest, err := loadImportCluster(clusterFile, false, false)
+	if err != nil {
+		return err
+	}
+	requestContext, cancel, err := asyncWriteRequestContext(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	response, _, err := applyImportCluster(requestContext, importRequest, true)
+	if err != nil {
+		return err
+	}
+	if len(response.Errors) > 0 {
+		var lines []string
+		for _, resourceError := range response.Errors {
+			for _, detail := range resourceError.Errors {
+				lines = append(lines, fmt.Sprintf("%s %q: %s: %s", resourceError.Kind, resourceError.Name, detail.Key, detail.Message))
+			}
+		}
+		return fmt.Errorf("the platform refused the stack:\n  %s", strings.Join(lines, "\n  "))
+	}
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Stack applied to cluster %s; the agent is deploying it.\n", response.Name)
+	return nil
+}
+
+// waitForMigrateUpWorkloads polls the cluster until every named workload
+// has a running, ready pod in the namespace: the restore connects to them,
+// so a database still pulling its image must not be handed a dump.
+func waitForMigrateUpWorkloads(cmd *cobra.Command, clusterID string, namespace string, workloads []string) error {
+	waitContext, cancel, err := asyncWriteRequestContext(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	progress := cmd.ErrOrStderr()
+	lastState := map[string]string{}
+	for {
+		pending := 0
+		for _, workload := range workloads {
+			state, isReady, readError := migrateUpWorkloadState(clusterID, namespace, workload)
+			if readError != nil {
+				return readError
+			}
+			if lastState[workload] != state {
+				lastState[workload] = state
+				_, _ = fmt.Fprintf(progress, "  %s: %s\n", workload, state)
+			}
+			if !isReady {
+				pending++
+			}
+		}
+		if pending == 0 {
+			return nil
+		}
+		select {
+		case <-waitContext.Done():
+			return asyncWriteError("waiting for the database workloads", true, waitContext.Err())
+		case <-time.After(migrateUpPodPollInterval):
+		}
+	}
+}
+
+// migrateUpWorkloadState reads the pods of one workload and folds them into
+// a state line; ready means at least one pod is running with every
+// container ready.
+func migrateUpWorkloadState(clusterID string, namespace string, workload string) (string, bool, error) {
+	response, listError := apiClient.ListPods(clusterID, &client.ListPodsOptions{Namespace: namespace, NameContains: workload, PageSize: 100})
+	if listError != nil {
+		return "", false, fmt.Errorf("listing the pods of %s: %w", workload, listError)
+	}
+	var states []string
+	for _, pod := range response.Pods {
+		if pod.Name != workload && !strings.HasPrefix(pod.Name, workload+"-") {
+			continue
+		}
+		if pod.Phase == "Running" && podIsReady(pod.Ready) {
+			return "running", true, nil
+		}
+		states = append(states, pod.Phase+" "+pod.Ready)
+	}
+	if len(states) == 0 {
+		return "no pod yet", false, nil
+	}
+	sort.Strings(states)
+	return strings.Join(states, ", "), false, nil
+}
+
+// podIsReady reads the "ready/total" column: every container ready, and at
+// least one.
+func podIsReady(ready string) bool {
+	readyCount, total, found := strings.Cut(ready, "/")
+	return found && readyCount == total && readyCount != "0" && readyCount != ""
+}
+
+// migrateUpURLs lists the hosts the conversion exposed, from the ingress
+// options, as URLs.
+func migrateUpURLs(options map[string]string) []string {
+	scheme := "http://"
+	if options["cluster-issuer"] != "" {
+		scheme = "https://"
+	}
+	var urls []string
+	for key, value := range options {
+		if strings.HasPrefix(key, "ingress.") && value != "" {
+			urls = append(urls, scheme+value)
+		}
+	}
+	sort.Strings(urls)
+	return urls
+}
+
+func printMigrateUpOutcome(cmd *cobra.Command, summary migrateUpSummary, carryData bool) {
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "\n%s is running on cluster %s as stack %s (namespace %s).\n", summary.Plan.Dir, summary.Plan.ClusterName, summary.Plan.Stack, summary.Plan.Namespace)
+	if carryData && summary.Import != nil {
+		_, _ = fmt.Fprintf(out, "Data: %d database server(s) restored (import %s).\n", len(summary.Import.Databases), summary.Import.ID)
+	}
+	if len(summary.URLs) > 0 {
+		_, _ = fmt.Fprintf(out, "Reachable at: %s - point the DNS records at the cluster's ingress.\n", strings.Join(summary.URLs, ", "))
+	}
+	if summary.Plan.Data != nil && len(summary.Plan.Data.NotCarried) > 0 {
+		_, _ = fmt.Fprintln(out, "Still on the source (not carried):")
+		for _, item := range summary.Plan.Data.NotCarried {
+			_, _ = fmt.Fprintf(out, "  - %s\n", item)
+		}
+	}
+	switch {
+	case summary.Quiesce != nil && len(summary.Quiesce.Stopped) > 0:
+		_, _ = fmt.Fprintf(out, "The source's services are stopped; this was the cutover. To bring them back: %s\n", summary.Quiesce.Resume)
+	case carryData:
+		_, _ = fmt.Fprintln(out, "This was a rehearsal: the source kept running. When you are ready to switch, run the same command with --stop-source for the final sync.")
+	}
+}
+
+// structuredOutputRequested reports whether -o json|yaml is in effect, so
+// human progress that would pollute the document is skipped.
+func structuredOutputRequested(cmd *cobra.Command) bool {
+	format, _ := cmd.Flags().GetString("output")
+	return format != ""
+}

--- a/cmd/migrate_up_test.go
+++ b/cmd/migrate_up_test.go
@@ -1,0 +1,245 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+// migrateUpMock scripts the platform for 'ankra migrate up': the cluster
+// listing, the stack apply, the pods of the deployed workloads, and the
+// import lifecycle the restore drives.
+type migrateUpMock struct {
+	migrateRestoreMock
+	clusterName   string
+	stacks        []string
+	applied       []client.CreateImportClusterRequest
+	podPolls      int
+	podReadyAfter int
+}
+
+func (mock *migrateUpMock) ListClusters(int, int) (*client.ClusterListResponse, error) {
+	return &client.ClusterListResponse{Result: []client.ClusterListItem{{ID: migrateRestoreTestCluster, Name: mock.clusterName}}}, nil
+}
+
+func (mock *migrateUpMock) ListClusterStacks(string) ([]client.ClusterStackListItem, error) {
+	items := make([]client.ClusterStackListItem, 0, len(mock.stacks))
+	for _, name := range mock.stacks {
+		items = append(items, client.ClusterStackListItem{Name: name})
+	}
+	return items, nil
+}
+
+func (mock *migrateUpMock) ApplyCluster(_ context.Context, request client.CreateImportClusterRequest, _ bool) (*client.ImportResponse, bool, error) {
+	mock.applied = append(mock.applied, request)
+	return &client.ImportResponse{Name: request.Name, ClusterId: migrateRestoreTestCluster}, false, nil
+}
+
+func (mock *migrateUpMock) ListPods(_ string, options *client.ListPodsOptions) (*client.ListPodsResponse, error) {
+	mock.podPolls++
+	namespace := options.Namespace
+	if mock.podPolls <= mock.podReadyAfter {
+		return &client.ListPodsResponse{Pods: []client.PodSummary{{Name: "db-0", Namespace: &namespace, Phase: "Pending", Ready: "0/1"}}}, nil
+	}
+	return &client.ListPodsResponse{Pods: []client.PodSummary{
+		{Name: "dbadmin-7c9-x", Namespace: &namespace, Phase: "Running", Ready: "1/1"},
+		{Name: "db-0", Namespace: &namespace, Phase: "Running", Ready: "1/1"},
+	}}, nil
+}
+
+func installMigrateUpMock(t *testing.T, mock *migrateUpMock) {
+	t.Helper()
+	installMigrateRestoreMock(t, &mock.migrateRestoreMock)
+	apiClient = mock
+	original := migrateUpPodPollInterval
+	migrateUpPodPollInterval = 0
+	t.Cleanup(func() { migrateUpPodPollInterval = original })
+}
+
+func newMigrateUpMock() *migrateUpMock {
+	return &migrateUpMock{
+		migrateRestoreMock: migrateRestoreMock{vaults: []client.BackupVault{readyVault("backups1")}, getStatuses: []string{"completed"}},
+		clusterName:        "shop-cluster",
+		podReadyAfter:      2,
+	}
+}
+
+func TestMigrateUpPlanChangesNothing(t *testing.T) {
+	fakeDockerOnPath(t)
+	mock := newMigrateUpMock()
+	installMigrateUpMock(t, mock)
+	dir := writeMigrateFixture(t)
+	out := filepath.Join(t.TempDir(), "migration")
+
+	stdout, stderr, err := runMigrate(t, "up", dir, "--out", out, "--cluster", migrateRestoreTestCluster, "--plan")
+	if err != nil {
+		t.Fatalf("%v\n%s", err, stderr)
+	}
+	for _, want := range []string{
+		"Migration plan for " + dir + " (docker module)",
+		"cluster    shop-cluster",
+		"stack      shop (new), namespace shop",
+		"db: postgres 17.2 as postgres - office (8.0 MiB)",
+		"about 8.0 MiB to dump",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("the plan must say %q:\n%s", want, stderr)
+		}
+	}
+	if !strings.Contains(stdout, "Plan only; nothing was changed") {
+		t.Errorf("stdout:\n%s", stdout)
+	}
+	if _, statError := os.Stat(out); statError == nil {
+		t.Error("--plan must not create the output directory")
+	}
+	if len(mock.applied) != 0 || mock.createdWith != nil || mock.podPolls != 0 {
+		t.Errorf("--plan must not touch the platform: applied=%d imports=%v polls=%d", len(mock.applied), mock.createdWith != nil, mock.podPolls)
+	}
+}
+
+func TestMigrateUpMigratesEndToEnd(t *testing.T) {
+	fakeDockerOnPath(t)
+	mock := newMigrateUpMock()
+	mock.stacks = []string{"other"}
+	installMigrateUpMock(t, mock)
+	dir := writeMigrateFixture(t)
+	out := filepath.Join(t.TempDir(), "migration")
+
+	stdout, stderr, err := runMigrate(t, "up", dir, "--out", out, "--cluster", migrateRestoreTestCluster, "--yes", "--option", "ingress.web=shop.example.com")
+	if err != nil {
+		t.Fatalf("%v\n%s", err, stderr)
+	}
+	if len(mock.applied) != 1 || mock.applied[0].Name != "shop-cluster" {
+		t.Fatalf("the stack must be applied under the target cluster's own name, got %+v", mock.applied)
+	}
+	if stacks := mock.applied[0].Spec.Stacks; len(stacks) != 1 || stacks[0].Name != "shop" || len(stacks[0].Manifests) == 0 {
+		t.Errorf("applied stacks = %+v", stacks)
+	}
+	if mock.podPolls < 3 {
+		t.Errorf("the database pod must be waited for until it is ready, got %d polls", mock.podPolls)
+	}
+	for _, file := range []string{"stack/cluster.yaml", "data/manifest.json", "data/db/office.dump"} {
+		if _, statError := os.Stat(filepath.Join(out, filepath.FromSlash(file))); statError != nil {
+			t.Errorf("%s missing: %v", file, statError)
+		}
+	}
+	if mock.createdWith == nil || mock.createdWith.StackName != "shop" || len(mock.uploads) != 2 || mock.restored != 1 {
+		t.Errorf("the export must be registered as stack shop, uploaded and restored: created=%+v uploads=%d restored=%d", mock.createdWith, len(mock.uploads), mock.restored)
+	}
+	for _, want := range []string{"==> Deploying stack shop to cluster shop-cluster", "db: Pending 0/1", "db: running", "==> Exporting", "==> Restoring"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("progress must say %q:\n%s", want, stderr)
+		}
+	}
+	for _, want := range []string{
+		dir + " is running on cluster shop-cluster as stack shop (namespace shop).",
+		"Data: 1 database server(s) restored",
+		"Reachable at: http://shop.example.com",
+		"This was a rehearsal",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("stdout must say %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestMigrateUpStopSourceIsTheCutover(t *testing.T) {
+	fakeDockerOnPath(t)
+	dockerLog := filepath.Join(t.TempDir(), "docker.log")
+	t.Setenv("FAKE_DOCKER_LOG", dockerLog)
+	mock := newMigrateUpMock()
+	installMigrateUpMock(t, mock)
+	dir := writeMigrateFixture(t)
+
+	// Declining the prompt changes nothing, on either side.
+	rootCmd.SetIn(strings.NewReader("n\n"))
+	t.Cleanup(func() { rootCmd.SetIn(nil) })
+	_, _, err := runMigrate(t, "up", dir, "--out", filepath.Join(t.TempDir(), "m1"), "--cluster", migrateRestoreTestCluster, "--stop-source")
+	if exitCodeFor(err) != exitCancelled || len(mock.applied) != 0 {
+		t.Fatalf("a declined prompt must exit %d with nothing applied, got %v (applied %d)", exitCancelled, err, len(mock.applied))
+	}
+	if _, statError := os.Stat(dockerLog); statError == nil {
+		t.Fatal("nothing may be stopped before the confirmation")
+	}
+
+	stdout, stderr, err := runMigrate(t, "up", dir, "--out", filepath.Join(t.TempDir(), "m2"), "--cluster", migrateRestoreTestCluster, "--stop-source", "--yes")
+	if err != nil {
+		t.Fatalf("%v\n%s", err, stderr)
+	}
+	stopped, _ := os.ReadFile(dockerLog)
+	if !strings.Contains(string(stopped), "docker stop web1") || strings.Contains(string(stopped), "abc123") {
+		t.Errorf("the web service must be stopped and the database left running, got %q", stopped)
+	}
+	if !strings.Contains(stderr, "Stopped web. To bring them back: docker start web1") {
+		t.Errorf("stderr:\n%s", stderr)
+	}
+	if !strings.Contains(stdout, "this was the cutover") || !strings.Contains(stdout, "docker start web1") || strings.Contains(stdout, "rehearsal") {
+		t.Errorf("stdout:\n%s", stdout)
+	}
+}
+
+func TestMigrateUpRefusesBeforeTouchingAnythingWhenTheVaultIsMissing(t *testing.T) {
+	fakeDockerOnPath(t)
+	mock := newMigrateUpMock()
+	mock.vaults = nil
+	installMigrateUpMock(t, mock)
+	dir := writeMigrateFixture(t)
+	out := filepath.Join(t.TempDir(), "migration")
+
+	_, _, err := runMigrate(t, "up", dir, "--out", out, "--cluster", migrateRestoreTestCluster, "--yes")
+	if exitCodeFor(err) != exitUsage || !strings.Contains(err.Error(), "no ready backup vault") {
+		t.Errorf("a missing vault must fail the plan, got %v", err)
+	}
+	if _, statError := os.Stat(out); statError == nil {
+		t.Error("a failed plan must leave no output directory")
+	}
+	if len(mock.applied) != 0 {
+		t.Error("a failed plan must not deploy")
+	}
+}
+
+func TestMigrateUpWarnsAboutADatabaseAboveOneUpload(t *testing.T) {
+	fakeDockerOnPath(t)
+	t.Setenv("FAKE_DB_SIZE", "6442450944")
+	installMigrateUpMock(t, newMigrateUpMock())
+	dir := writeMigrateFixture(t)
+
+	_, stderr, err := runMigrate(t, "up", dir, "--out", filepath.Join(t.TempDir(), "m"), "--cluster", migrateRestoreTestCluster, "--plan")
+	if err != nil {
+		t.Fatalf("%v\n%s", err, stderr)
+	}
+	if !strings.Contains(stderr, "db: database office is 6.0 GiB on the source; a dump above 5.0 GiB cannot be uploaded in one piece") {
+		t.Errorf("the plan must warn about the upload limit:\n%s", stderr)
+	}
+}
+
+func TestMigrateUpNoDataDeploysOnly(t *testing.T) {
+	fakeDockerOnPath(t)
+	mock := newMigrateUpMock()
+	mock.vaults = nil
+	installMigrateUpMock(t, mock)
+	dir := writeMigrateFixture(t)
+	out := filepath.Join(t.TempDir(), "migration")
+
+	stdout, stderr, err := runMigrate(t, "up", dir, "--out", out, "--cluster", migrateRestoreTestCluster, "--no-data", "--yes")
+	if err != nil {
+		t.Fatalf("%v\n%s", err, stderr)
+	}
+	if len(mock.applied) != 1 || mock.podPolls != 0 || mock.createdWith != nil {
+		t.Errorf("--no-data must deploy and nothing else: applied=%d polls=%d import=%v", len(mock.applied), mock.podPolls, mock.createdWith != nil)
+	}
+	if _, statError := os.Stat(filepath.Join(out, "data")); statError == nil {
+		t.Error("--no-data must not dump")
+	}
+	if !strings.Contains(stdout, "is running on cluster shop-cluster") || strings.Contains(stdout, "rehearsal") {
+		t.Errorf("stdout:\n%s", stdout)
+	}
+	_, _, err = runMigrate(t, "up", dir, "--out", filepath.Join(t.TempDir(), "m2"), "--cluster", migrateRestoreTestCluster, "--no-data", "--stop-source", "--yes")
+	if exitCodeFor(err) != exitUsage {
+		t.Errorf("--stop-source without data is a usage error, got %v", err)
+	}
+}

--- a/internal/migrate/docker/export.go
+++ b/internal/migrate/docker/export.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"ankra/internal/migrate"
@@ -66,19 +67,87 @@ func (c dockerCLI) Stream(ctx context.Context, stdout io.Writer, args ...string)
 // serves through the docker CLI - which is the one tool guaranteed to be
 // present wherever a compose stack runs, and works unchanged against a remote
 // host through DOCKER_HOST.
-func (Module) Export(ctx context.Context, request migrate.ExportRequest) (migrate.Export, error) {
-	options := request.Options
-	if options == nil {
-		options = map[string]string{}
-	}
+func (module Module) Export(ctx context.Context, request migrate.ExportRequest) (migrate.Export, error) {
 	progress := request.Progress
 	if progress == nil {
 		progress = io.Discard
 	}
-
-	project, err := exportProject(ctx, request.Dir, options)
+	source, err := module.discoverSource(ctx, request)
 	if err != nil {
 		return migrate.Export{}, err
+	}
+
+	var export migrate.Export
+	export.Warnings = append(export.Warnings, source.warnings...)
+	writtenFiles := map[string]bool{}
+	for _, server := range source.servers {
+		job := dumpJob{
+			docker:       source.docker,
+			server:       server,
+			namespace:    source.namespace,
+			outputDir:    request.OutputDir,
+			only:         splitList(source.options[OptionDatabasesPrefix+server.workload.Name]),
+			progress:     progress,
+			writtenFiles: writtenFiles,
+		}
+		var database migrate.DatabaseExport
+		var databaseWarnings []string
+		switch server.engine {
+		case migrate.EnginePostgres:
+			database, databaseWarnings, err = dumpPostgres(ctx, job)
+		case migrate.EngineMySQL:
+			database, databaseWarnings, err = dumpMySQL(ctx, job)
+		}
+		if err != nil {
+			return migrate.Export{}, err
+		}
+		export.Databases = append(export.Databases, database)
+		export.Warnings = append(export.Warnings, databaseWarnings...)
+	}
+
+	export.Warnings = append(export.Warnings,
+		"each dump is a point-in-time snapshot of a live server; rehearse with the source running, then stop its writers and export once more right before the final cutover",
+		"the dumps hold the application's data and are written readable by you alone; delete the export directory once the restore has succeeded")
+	export.Warnings = uniqueSorted(export.Warnings)
+	return export, nil
+}
+
+// exportSource is the source as an export or a plan sees it: the compose
+// project, the docker executor reaching its daemon, and every database
+// service resolved to its running container.
+type exportSource struct {
+	project   Project
+	options   map[string]string
+	namespace string
+	docker    dockerExecutor
+	servers   []databaseServer
+	// others are the non-database workloads, for what the export leaves
+	// behind.
+	others   []Workload
+	warnings []string
+}
+
+// databaseServer is one database service resolved to its container. The
+// environment is the container's own, read from the daemon: it is what the
+// server was actually started with, which a compose file with an
+// unresolved ${VAR} or an env_file cannot tell.
+type databaseServer struct {
+	workload    Workload
+	engine      string
+	container   string
+	environment map[string]string
+}
+
+// discoverSource loads the project, finds the container behind every
+// database service and reads its environment. Nothing is dumped.
+func (Module) discoverSource(ctx context.Context, request migrate.ExportRequest) (exportSource, error) {
+	options := request.Options
+	if options == nil {
+		options = map[string]string{}
+	}
+	project, err := exportProject(ctx, request.Dir, options)
+	if err != nil {
+		return exportSource{}, err
 	}
 	namespace := request.Namespace
 	if namespace == "" {
@@ -88,75 +157,41 @@ func (Module) Export(ctx context.Context, request migrate.ExportRequest) (migrat
 	if composeProject == "" {
 		composeProject = composeProjectName(project.Name)
 	}
-	docker := newDockerExecutor(options[OptionDockerHost])
-	writtenFiles := map[string]bool{}
+	source := exportSource{
+		project:   project,
+		options:   options,
+		namespace: namespace,
+		docker:    newDockerExecutor(options[OptionDockerHost]),
+	}
 
-	var export migrate.Export
 	var otherImages []string
 	for _, workload := range project.SortedWorkloads() {
 		engine, ok := DatabaseEngine(workload.Image)
 		if !ok {
+			source.others = append(source.others, workload)
 			if workload.Image != "" {
 				otherImages = append(otherImages, workload.Name+"="+workload.Image)
 			}
 			continue
 		}
-		container, containerWarnings, err := findContainer(ctx, docker, composeProject, workload.Name, options[OptionContainerPrefix+workload.Name])
+		container, containerWarnings, err := findContainer(ctx, source.docker, composeProject, workload.Name, options[OptionContainerPrefix+workload.Name])
 		if err != nil {
-			return migrate.Export{}, err
+			return exportSource{}, err
 		}
-		export.Warnings = append(export.Warnings, containerWarnings...)
-
-		job := dumpJob{
-			docker:       docker,
-			container:    container,
-			workload:     workload,
-			namespace:    namespace,
-			outputDir:    request.OutputDir,
-			only:         splitList(options[OptionDatabasesPrefix+workload.Name]),
-			progress:     progress,
-			writtenFiles: writtenFiles,
-		}
-		var database migrate.DatabaseExport
-		var databaseWarnings []string
-		switch engine {
-		case migrate.EnginePostgres:
-			database, databaseWarnings, err = dumpPostgres(ctx, job)
-		case migrate.EngineMySQL:
-			database, err = dumpMySQL(ctx, job)
-		}
+		source.warnings = append(source.warnings, containerWarnings...)
+		environment, err := containerEnvironment(ctx, source.docker, container)
 		if err != nil {
-			return migrate.Export{}, err
+			return exportSource{}, fmt.Errorf("%s: reading the container's environment: %w", workload.Name, err)
 		}
-		export.Databases = append(export.Databases, database)
-		export.Warnings = append(export.Warnings, databaseWarnings...)
+		source.servers = append(source.servers, databaseServer{
+			workload: workload, engine: engine, container: container, environment: environment,
+		})
 	}
-
-	if len(export.Databases) == 0 {
-		return migrate.Export{}, fmt.Errorf("no database service recognised in %s (images: %s); the export knows PostgreSQL and MySQL/MariaDB images",
+	if len(source.servers) == 0 {
+		return exportSource{}, fmt.Errorf("no database service recognised in %s (images: %s); the export knows PostgreSQL and MySQL/MariaDB images",
 			project.Name, strings.Join(otherImages, ", "))
 	}
-	export.Warnings = append(export.Warnings,
-		"each dump is a point-in-time snapshot of a live server; rehearse with the source running, then stop its writers and export once more right before the final cutover",
-		"the dumps hold the application's data and are written readable by you alone; delete the export directory once the restore has succeeded")
-	export.Warnings = uniqueSorted(export.Warnings)
-	return export, nil
-}
-
-// composeProjectName derives the project name compose labels containers
-// with from a directory or `name:` value, the way compose itself does:
-// lower-cased, every character outside [a-z0-9_-] dropped, and no leading
-// '-' or '_'. Without this a source directory called "Aura Office" would be
-// looked up as a project no container is labelled with.
-func composeProjectName(name string) string {
-	var builder strings.Builder
-	for _, character := range strings.ToLower(name) {
-		isLetterOrDigit := (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9')
-		if isLetterOrDigit || character == '_' || character == '-' {
-			builder.WriteRune(character)
-		}
-	}
-	return strings.TrimLeft(builder.String(), "-_")
+	return source, nil
 }
 
 // exportProject reads the source an export works from. Unlike convert, a
@@ -199,16 +234,45 @@ func findContainer(ctx context.Context, docker dockerExecutor, composeProject, s
 	}
 	var warnings []string
 	if len(ids) > 1 {
-		warnings = append(warnings, fmt.Sprintf("%s: %d containers run this service; dumped from %s", service, len(ids), ids[0]))
+		warnings = append(warnings, fmt.Sprintf("service %s runs %d containers; dumping from %s", service, len(ids), ids[0]))
 	}
 	return ids[0], warnings, nil
+}
+
+// containerEnvironment reads the environment a container was started with.
+func containerEnvironment(ctx context.Context, docker dockerExecutor, container string) (map[string]string, error) {
+	output, err := docker.Output(ctx, "inspect", "--format", "{{range .Config.Env}}{{println .}}{{end}}", container)
+	if err != nil {
+		return nil, err
+	}
+	environment := map[string]string{}
+	for _, line := range nonEmptyLines(string(output)) {
+		name, value, _ := strings.Cut(line, "=")
+		environment[name] = value
+	}
+	return environment, nil
+}
+
+// composeProjectName derives the project name compose labels containers
+// with from a directory or `name:` value, the way compose itself does:
+// lower-cased, every character outside [a-z0-9_-] dropped, and no leading
+// '-' or '_'. Without this a source directory called "Aura Office" would be
+// looked up as a project no container is labelled with.
+func composeProjectName(name string) string {
+	var builder strings.Builder
+	for _, character := range strings.ToLower(name) {
+		isLetterOrDigit := (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9')
+		if isLetterOrDigit || character == '_' || character == '-' {
+			builder.WriteRune(character)
+		}
+	}
+	return strings.TrimLeft(builder.String(), "-_")
 }
 
 // dumpJob is everything one database server's dump needs.
 type dumpJob struct {
 	docker    dockerExecutor
-	container string
-	workload  Workload
+	server    databaseServer
 	namespace string
 	outputDir string
 	// only restricts the dump to these databases; empty means every one the
@@ -220,25 +284,56 @@ type dumpJob struct {
 	writtenFiles map[string]bool
 }
 
+// value is a setting of the server, from the container's environment first
+// and the compose description second, so what the server was really started
+// with wins over what the file says.
+func (server databaseServer) value(name string) string {
+	if value, ok := server.environment[name]; ok && value != "" {
+		return value
+	}
+	if entry, ok := lookupEnv(server.workload, name); ok && !entry.Unresolved {
+		return entry.Value
+	}
+	return ""
+}
+
+// has reports whether the server carries the variable at all, as a value or
+// as the _FILE indirection the official images accept for secrets.
+func (server databaseServer) has(name string) bool {
+	if _, ok := server.environment[name]; ok {
+		return true
+	}
+	if _, ok := server.environment[name+"_FILE"]; ok {
+		return true
+	}
+	if _, ok := lookupEnv(server.workload, name); ok {
+		return true
+	}
+	_, ok := lookupEnv(server.workload, name+"_FILE")
+	return ok
+}
+
 // inContainer builds a `docker exec` that runs program through the
 // container's own shell, so a password the image needs for local connections
-// comes from the container's environment and never crosses the host as a
-// command-line argument.
+// comes from the container's environment - or from the file its _FILE
+// variant points at, as the official images allow - and never crosses the
+// host as a command-line argument.
 func (job dumpJob) inContainer(passwordVariable, passwordKey, program string, args ...string) []string {
-	script := passwordVariable + `="$` + passwordKey + `" exec ` + program + ` "$@"`
-	return append([]string{"exec", job.container, "sh", "-c", script, "sh"}, args...)
+	script := `value="$` + passwordKey + `"; if [ -z "$value" ] && [ -n "${` + passwordKey + `_FILE:-}" ]; then value="$(cat "$` + passwordKey + `_FILE")"; fi; ` +
+		passwordVariable + `="$value" exec ` + program + ` "$@"`
+	return append([]string{"exec", job.server.container, "sh", "-c", script, "sh"}, args...)
 }
 
 // restoreTarget describes where convert put this server in the cluster.
 func (job dumpJob) restoreTarget(engine, username, passwordKey string) migrate.RestoreTarget {
 	target := migrate.RestoreTarget{
 		Namespace: job.namespace,
-		Host:      job.workload.Name,
+		Host:      job.server.workload.Name,
 		Port:      DefaultDatabasePort(engine),
 		Username:  username,
 	}
-	if entry, ok := lookupEnv(job.workload, passwordKey); ok && entry.Secret {
-		target.PasswordSecret = job.workload.Name + "-secrets"
+	if entry, ok := lookupEnv(job.server.workload, passwordKey); ok && entry.Secret {
+		target.PasswordSecret = job.server.workload.Name + "-secrets"
 		target.PasswordKey = passwordKey
 	}
 	return target
@@ -246,70 +341,119 @@ func (job dumpJob) restoreTarget(engine, username, passwordKey string) migrate.R
 
 var postgresCustomMagic = []byte("PGDMP")
 
+// databaseSize is one database and its size as the server reports it.
+type databaseSize struct {
+	name      string
+	sizeBytes int64
+}
+
+// parseDatabaseSizes reads "name<sep>bytes" lines; a line without a size is
+// a database of unknown size, never a rejected one.
+func parseDatabaseSizes(text string, separator string) []databaseSize {
+	var databases []databaseSize
+	for _, line := range nonEmptyLines(text) {
+		name, size, _ := strings.Cut(line, separator)
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		bytes, _ := strconv.ParseInt(strings.TrimSpace(size), 10, 64)
+		databases = append(databases, databaseSize{name: name, sizeBytes: bytes})
+	}
+	return databases
+}
+
+// postgresCredentials is the superuser the image was configured with; the
+// official image creates it and, unless POSTGRES_DB says otherwise, a
+// database of the same name for the application.
+func postgresCredentials(server databaseServer) (username string, applicationDatabase string) {
+	username = server.value("POSTGRES_USER")
+	if username == "" {
+		username = "postgres"
+	}
+	applicationDatabase = server.value("POSTGRES_DB")
+	if applicationDatabase == "" {
+		applicationDatabase = username
+	}
+	return username, applicationDatabase
+}
+
+func postgresClient(job dumpJob, username string) func(query string) []string {
+	return func(query string) []string {
+		return job.inContainer("PGPASSWORD", "POSTGRES_PASSWORD", "psql", "-U", username, "-d", "postgres", "-tAc", query)
+	}
+}
+
+// listPostgresDatabases asks the server for every non-template database and
+// its size; the maintenance database `postgres` is left out unless it is
+// the application's, and the caller is told when that happens.
+func listPostgresDatabases(ctx context.Context, docker dockerExecutor, psql func(string) []string, applicationDatabase string, workload string) ([]databaseSize, []string, error) {
+	output, err := docker.Output(ctx, psql("SELECT datname, pg_database_size(datname) FROM pg_database WHERE NOT datistemplate ORDER BY datname")...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%s: listing databases: %w", workload, err)
+	}
+	var databases []databaseSize
+	var warnings []string
+	for _, database := range parseDatabaseSizes(string(output), "|") {
+		if database.name == "postgres" && applicationDatabase != "postgres" {
+			warnings = append(warnings, fmt.Sprintf("%s: the maintenance database postgres was not dumped; pass --option %s%s=postgres if the application keeps data in it",
+				workload, OptionDatabasesPrefix, workload))
+			continue
+		}
+		databases = append(databases, database)
+	}
+	return databases, warnings, nil
+}
+
 // dumpPostgres dumps a PostgreSQL server: its roles (without their
 // passwords - the restore connects as the target's own user, and a dump that
 // re-set that password would lock the cluster out of its database) and every
-// database that is not a template. The `postgres` database is the server's
-// maintenance database and is left out, unless the image was told to keep
-// the application's data there - which is what POSTGRES_DB, or its default
-// of POSTGRES_USER, says.
+// database that is not a template.
 func dumpPostgres(ctx context.Context, job dumpJob) (migrate.DatabaseExport, []string, error) {
 	const passwordKey = "POSTGRES_PASSWORD"
-	username := "postgres"
-	if entry, ok := lookupEnv(job.workload, "POSTGRES_USER"); ok && entry.Value != "" {
-		username = entry.Value
-	}
-	applicationDatabase := username
-	if entry, ok := lookupEnv(job.workload, "POSTGRES_DB"); ok && entry.Value != "" {
-		applicationDatabase = entry.Value
-	}
-	psql := func(query string) []string {
-		return job.inContainer("PGPASSWORD", passwordKey, "psql", "-U", username, "-d", "postgres", "-tAc", query)
-	}
+	workload := job.server.workload.Name
+	username, applicationDatabase := postgresCredentials(job.server)
+	psql := postgresClient(job, username)
 
 	version, err := job.docker.Output(ctx, psql("SHOW server_version")...)
 	if err != nil {
-		return migrate.DatabaseExport{}, nil, fmt.Errorf("%s: reading the server version: %w", job.workload.Name, err)
+		return migrate.DatabaseExport{}, nil, fmt.Errorf("%s: reading the server version: %w", workload, err)
 	}
 	var warnings []string
 	databases := job.only
 	if len(databases) == 0 {
-		output, err := job.docker.Output(ctx, psql("SELECT datname FROM pg_database WHERE NOT datistemplate ORDER BY datname")...)
-		if err != nil {
-			return migrate.DatabaseExport{}, nil, fmt.Errorf("%s: listing databases: %w", job.workload.Name, err)
+		listed, listWarnings, listError := listPostgresDatabases(ctx, job.docker, psql, applicationDatabase, workload)
+		if listError != nil {
+			return migrate.DatabaseExport{}, nil, listError
 		}
-		for _, database := range nonEmptyLines(string(output)) {
-			if database == "postgres" && applicationDatabase != "postgres" {
-				warnings = append(warnings, fmt.Sprintf("%s: the maintenance database postgres was not dumped; pass --option %s%s=postgres if the application keeps data in it",
-					job.workload.Name, OptionDatabasesPrefix, job.workload.Name))
-				continue
-			}
-			databases = append(databases, database)
+		warnings = append(warnings, listWarnings...)
+		for _, database := range listed {
+			databases = append(databases, database.name)
 		}
 	}
 	if len(databases) == 0 {
-		return migrate.DatabaseExport{}, nil, fmt.Errorf("%s: the server holds no database besides postgres", job.workload.Name)
+		return migrate.DatabaseExport{}, nil, fmt.Errorf("%s: the server holds no database besides postgres", workload)
 	}
 
 	export := migrate.DatabaseExport{
-		Workload:      job.workload.Name,
+		Workload:      workload,
 		Engine:        migrate.EnginePostgres,
-		Image:         job.workload.Image,
+		Image:         job.server.workload.Image,
 		ServerVersion: strings.TrimSpace(string(version)),
 		Target:        job.restoreTarget(migrate.EnginePostgres, username, passwordKey),
 	}
 
-	_, _ = fmt.Fprintf(job.progress, "%s: dumping roles and globals\n", job.workload.Name)
+	_, _ = fmt.Fprintf(job.progress, "%s: dumping roles and globals\n", workload)
 	globals, err := job.writeArtifact(ctx, "globals.sql", job.inContainer("PGPASSWORD", passwordKey, "pg_dumpall", "-U", username, "--globals-only", "--no-role-passwords"), nil)
 	if err != nil {
 		return migrate.DatabaseExport{}, nil, err
 	}
 	export.Artifacts = append(export.Artifacts, migrate.Artifact{Path: globals, Kind: migrate.ArtifactKindGlobals, Format: migrate.ArtifactFormatSQL})
 	warnings = append(warnings, fmt.Sprintf("%s: roles are restored without their passwords; %s keeps the password from the cluster's secret, any other role that logs in needs ALTER ROLE ... PASSWORD after the restore",
-		job.workload.Name, username))
+		workload, username))
 
 	for _, database := range databases {
-		_, _ = fmt.Fprintf(job.progress, "%s: dumping database %s\n", job.workload.Name, database)
+		_, _ = fmt.Fprintf(job.progress, "%s: dumping database %s\n", workload, database)
 		dump, err := job.writeArtifact(ctx, sanitiseName(database)+".dump", job.inContainer("PGPASSWORD", passwordKey, "pg_dump", "-U", username, "-Fc", "-d", database), postgresCustomMagic)
 		if err != nil {
 			return migrate.DatabaseExport{}, nil, err
@@ -323,55 +467,102 @@ func dumpPostgres(ctx context.Context, job dumpJob) (migrate.DatabaseExport, []s
 // data and a restore must not overwrite them.
 var mysqlSystemSchemas = map[string]bool{"information_schema": true, "performance_schema": true, "mysql": true, "sys": true}
 
-func dumpMySQL(ctx context.Context, job dumpJob) (migrate.DatabaseExport, error) {
-	passwordKey := "MYSQL_ROOT_PASSWORD"
-	if _, ok := lookupEnv(job.workload, "MARIADB_ROOT_PASSWORD"); ok {
-		passwordKey = "MARIADB_ROOT_PASSWORD"
+// mysqlCredentials picks the account the dump connects as: root when the
+// image was given a root password, else the application user the image
+// created, which can read its own database. An image started with a random
+// root password and no application user leaves nothing to dump with.
+func mysqlCredentials(server databaseServer) (username string, passwordKey string, warning string, err error) {
+	for _, rootKey := range []string{"MYSQL_ROOT_PASSWORD", "MARIADB_ROOT_PASSWORD"} {
+		if server.has(rootKey) {
+			return "root", rootKey, "", nil
+		}
 	}
-	const username = "root"
-	client := func(query string) []string {
+	for _, emptyKey := range []string{"MYSQL_ALLOW_EMPTY_PASSWORD", "MARIADB_ALLOW_EMPTY_ROOT_PASSWORD"} {
+		if server.value(emptyKey) != "" {
+			return "root", "MYSQL_ROOT_PASSWORD", "", nil
+		}
+	}
+	for _, pair := range [][2]string{{"MYSQL_USER", "MYSQL_PASSWORD"}, {"MARIADB_USER", "MARIADB_PASSWORD"}} {
+		if user := server.value(pair[0]); user != "" && server.has(pair[1]) {
+			return user, pair[1], fmt.Sprintf("%s: no root password is configured, so the dump runs as %s and carries only the databases that user can read",
+				server.workload.Name, user), nil
+		}
+	}
+	return "", "", "", fmt.Errorf("%s: no account to dump with - the container has neither MYSQL_ROOT_PASSWORD nor MYSQL_USER/MYSQL_PASSWORD (a MYSQL_RANDOM_ROOT_PASSWORD server needs an application user)",
+		server.workload.Name)
+}
+
+func mysqlClient(job dumpJob, username string, passwordKey string) func(query string) []string {
+	return func(query string) []string {
 		return job.inContainer("MYSQL_PWD", passwordKey, "mysql", "-u"+username, "-N", "-e", query)
 	}
+}
+
+// listMySQLDatabases asks the server for every schema the account can see
+// and its size, minus the server's own.
+func listMySQLDatabases(ctx context.Context, docker dockerExecutor, client func(string) []string, workload string) ([]databaseSize, error) {
+	output, err := docker.Output(ctx, client("SELECT s.schema_name, COALESCE(SUM(t.data_length + t.index_length), 0) FROM information_schema.schemata s LEFT JOIN information_schema.tables t ON t.table_schema = s.schema_name GROUP BY s.schema_name ORDER BY s.schema_name")...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: listing databases: %w", workload, err)
+	}
+	var databases []databaseSize
+	for _, database := range parseDatabaseSizes(string(output), "\t") {
+		if !mysqlSystemSchemas[database.name] {
+			databases = append(databases, database)
+		}
+	}
+	return databases, nil
+}
+
+func dumpMySQL(ctx context.Context, job dumpJob) (migrate.DatabaseExport, []string, error) {
+	workload := job.server.workload.Name
+	username, passwordKey, credentialWarning, err := mysqlCredentials(job.server)
+	if err != nil {
+		return migrate.DatabaseExport{}, nil, err
+	}
+	var warnings []string
+	if credentialWarning != "" {
+		warnings = append(warnings, credentialWarning)
+	}
+	client := mysqlClient(job, username, passwordKey)
 
 	version, err := job.docker.Output(ctx, client("SELECT VERSION()")...)
 	if err != nil {
-		return migrate.DatabaseExport{}, fmt.Errorf("%s: reading the server version: %w", job.workload.Name, err)
+		return migrate.DatabaseExport{}, nil, fmt.Errorf("%s: reading the server version: %w", workload, err)
 	}
 	databases := job.only
 	if len(databases) == 0 {
-		output, err := job.docker.Output(ctx, client("SHOW DATABASES")...)
-		if err != nil {
-			return migrate.DatabaseExport{}, fmt.Errorf("%s: listing databases: %w", job.workload.Name, err)
+		listed, listError := listMySQLDatabases(ctx, job.docker, client, workload)
+		if listError != nil {
+			return migrate.DatabaseExport{}, nil, listError
 		}
-		for _, database := range nonEmptyLines(string(output)) {
-			if !mysqlSystemSchemas[database] {
-				databases = append(databases, database)
-			}
+		for _, database := range listed {
+			databases = append(databases, database.name)
 		}
 	}
 	if len(databases) == 0 {
-		return migrate.DatabaseExport{}, fmt.Errorf("%s: the server holds no database besides the system schemas", job.workload.Name)
+		return migrate.DatabaseExport{}, nil, fmt.Errorf("%s: the server holds no database besides the system schemas", workload)
 	}
 
 	export := migrate.DatabaseExport{
-		Workload:      job.workload.Name,
+		Workload:      workload,
 		Engine:        migrate.EngineMySQL,
-		Image:         job.workload.Image,
+		Image:         job.server.workload.Image,
 		ServerVersion: strings.TrimSpace(string(version)),
 		Target:        job.restoreTarget(migrate.EngineMySQL, username, passwordKey),
 	}
 	for _, database := range databases {
-		_, _ = fmt.Fprintf(job.progress, "%s: dumping database %s\n", job.workload.Name, database)
+		_, _ = fmt.Fprintf(job.progress, "%s: dumping database %s\n", workload, database)
 		// --databases makes the dump create and select its schema, so a
 		// restore is one `mysql < file` with nothing prepared by hand.
 		dump, err := job.writeArtifact(ctx, sanitiseName(database)+".sql",
 			job.inContainer("MYSQL_PWD", passwordKey, "mysqldump", "-u"+username, "--single-transaction", "--routines", "--triggers", "--events", "--databases", database), nil)
 		if err != nil {
-			return migrate.DatabaseExport{}, err
+			return migrate.DatabaseExport{}, nil, err
 		}
 		export.Artifacts = append(export.Artifacts, migrate.Artifact{Path: dump, Kind: migrate.ArtifactKindDatabase, Format: migrate.ArtifactFormatSQL, Database: database})
 	}
-	return export, nil
+	return export, warnings, nil
 }
 
 // writeArtifact streams one docker command into <outputDir>/<workload>/<file>
@@ -392,13 +583,13 @@ func (job dumpJob) writeArtifact(ctx context.Context, fileName string, args []st
 	streamErr := job.docker.Stream(ctx, file, args...)
 	closeErr := file.Close()
 	if streamErr != nil {
-		return "", fmt.Errorf("%s: %w", job.workload.Name, streamErr)
+		return "", fmt.Errorf("%s: %w", job.server.workload.Name, streamErr)
 	}
 	if closeErr != nil {
 		return "", closeErr
 	}
 	if err := checkDump(absolute, magic); err != nil {
-		return "", fmt.Errorf("%s: %s: %w", job.workload.Name, relative, err)
+		return "", fmt.Errorf("%s: %s: %w", job.server.workload.Name, relative, err)
 	}
 	return relative, nil
 }
@@ -408,7 +599,7 @@ func (job dumpJob) writeArtifact(ctx context.Context, fileName string, args []st
 // sanitise to the same file name, and the second must not overwrite the
 // first.
 func (job dumpJob) uniqueArtifactPath(fileName string) string {
-	directory := sanitiseName(job.workload.Name)
+	directory := sanitiseName(job.server.workload.Name)
 	extension := path.Ext(fileName)
 	stem := strings.TrimSuffix(fileName, extension)
 	candidate := path.Join(directory, fileName)

--- a/internal/migrate/docker/export_test.go
+++ b/internal/migrate/docker/export_test.go
@@ -91,12 +91,13 @@ func defaultAnswers() []cannedAnswer {
 		{"label=com.docker.compose.service=postgres", "pg1\n"},
 		{"label=com.docker.compose.service=mysql", "my1\n"},
 		{"SHOW server_version", "17.2\n"},
-		{"SELECT datname", "office\npdns\n"},
+		{"SELECT datname", "office|8388608\npdns|1048576\n"},
 		{"pg_dumpall", "--\n-- PostgreSQL database cluster dump\nCREATE ROLE office;\n"},
 		{"pg_dump ", "PGDMP\x01\x11\x00fake archive"},
 		{"SELECT VERSION()", "11.4.2-MariaDB\n"},
-		{"SHOW DATABASES", "information_schema\nmysql\nperformance_schema\nshop\nsys\n"},
+		{"information_schema.schemata", "information_schema\t0\nmysql\t4096\nperformance_schema\t0\nshop\t2097152\nsys\t0\n"},
 		{"mysqldump", "-- MariaDB dump\nCREATE DATABASE shop;\n"},
+		{"inspect --format", ""},
 	}
 }
 
@@ -174,8 +175,11 @@ func TestExportDumpsEveryDatabaseServer(t *testing.T) {
 	// the password taken from the container's environment, so it never
 	// appears on the host's command line.
 	dumps := callsContaining(fake.calls, "pg_dump ")
-	if len(dumps) != 2 || !strings.Contains(dumps[0], `exec pg1 sh -c PGPASSWORD="$POSTGRES_PASSWORD" exec pg_dump "$@" sh -U office -Fc -d office`) {
+	if len(dumps) != 2 || !strings.HasPrefix(dumps[0], `exec pg1 sh -c value="$POSTGRES_PASSWORD";`) || !strings.Contains(dumps[0], `PGPASSWORD="$value" exec pg_dump "$@" sh -U office -Fc -d office`) {
 		t.Errorf("pg_dump calls = %v", dumps)
+	}
+	if !strings.Contains(dumps[0], `cat "$POSTGRES_PASSWORD_FILE"`) {
+		t.Errorf("the _FILE secret indirection the official images accept must be honoured: %s", dumps[0])
 	}
 	for _, call := range fake.calls {
 		if strings.Contains(call, "secret") {
@@ -195,7 +199,7 @@ func TestExportDumpsEveryDatabaseServer(t *testing.T) {
 	if len(mysql.Artifacts) != 1 || mysql.Artifacts[0].Database != "shop" || mysql.Artifacts[0].Path != "mysql/shop.sql" {
 		t.Errorf("system schemas must be skipped, got %+v", mysql.Artifacts)
 	}
-	if got := callsContaining(fake.calls, "mysqldump"); len(got) != 1 || !strings.Contains(got[0], `MYSQL_PWD="$MARIADB_ROOT_PASSWORD"`) || !strings.HasSuffix(got[0], "--databases shop") {
+	if got := callsContaining(fake.calls, "mysqldump"); len(got) != 1 || !strings.Contains(got[0], `value="$MARIADB_ROOT_PASSWORD"`) || !strings.Contains(got[0], `MYSQL_PWD="$value" exec mysqldump`) || !strings.HasSuffix(got[0], "--databases shop") {
 		t.Errorf("mysqldump call = %v", got)
 	}
 
@@ -470,6 +474,149 @@ func TestExportNormalisesTheComposeProjectName(t *testing.T) {
 	for name, want := range map[string]string{"Aura Office": "auraoffice", "_shop.v2": "shopv2", "--Shop": "shop", "shop": "shop"} {
 		if got := composeProjectName(name); got != want {
 			t.Errorf("composeProjectName(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestExportReadsCredentialsFromTheRunningContainer(t *testing.T) {
+	// The compose file says POSTGRES_USER=office, but the container was
+	// started with another user and an explicit database: what the server
+	// runs with is what the dump must use.
+	answers := defaultAnswers()
+	answers[9] = cannedAnswer{"inspect --format", "PATH=/usr/bin\nPOSTGRES_USER=shopadmin\nPOSTGRES_DB=shopdata\nPOSTGRES_PASSWORD=secret\n"}
+	answers[3] = cannedAnswer{"SELECT datname", "postgres|100\nshopdata|2048\n"}
+	fake := &fakeDocker{t: t, answers: answers}
+	installFakeDocker(t, fake)
+	export, err := testModule.Export(context.Background(), migrate.ExportRequest{Dir: writeExportFixture(t, exportTestCompose), OutputDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	postgres := export.Databases[1]
+	if postgres.Target.Username != "shopadmin" {
+		t.Errorf("the container's POSTGRES_USER must win over the compose file, got %+v", postgres.Target)
+	}
+	if got := callsContaining(fake.calls, "pg_dump "); len(got) != 1 || !strings.Contains(got[0], "-U shopadmin -Fc -d shopdata") {
+		t.Errorf("pg_dump calls = %v", got)
+	}
+	if got := callsContaining(fake.calls, "inspect --format"); len(got) != 2 || !strings.HasSuffix(got[0], " pg1") && !strings.HasSuffix(got[1], " pg1") {
+		t.Errorf("every database container's environment must be read, got %v", got)
+	}
+}
+
+func TestExportMySQLFallsBackToTheApplicationUser(t *testing.T) {
+	compose := strings.Replace(exportTestCompose, "      MARIADB_ROOT_PASSWORD: root-secret\n", "      MARIADB_USER: shop\n      MARIADB_PASSWORD: shop-secret\n      MARIADB_RANDOM_ROOT_PASSWORD: '1'\n", 1)
+	fake := &fakeDocker{t: t, answers: defaultAnswers()}
+	installFakeDocker(t, fake)
+	export, err := testModule.Export(context.Background(), migrate.ExportRequest{Dir: writeExportFixture(t, compose), OutputDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mysql := export.Databases[0]
+	if mysql.Target.Username != "shop" || mysql.Target.PasswordKey != "MARIADB_PASSWORD" || mysql.Target.PasswordSecret != "mysql-secrets" {
+		t.Errorf("without a root password the application user is the account, got %+v", mysql.Target)
+	}
+	if got := callsContaining(fake.calls, "mysqldump"); len(got) != 1 || !strings.Contains(got[0], `value="$MARIADB_PASSWORD"`) || !strings.Contains(got[0], "-ushop ") {
+		t.Errorf("mysqldump call = %v", got)
+	}
+	if !hasWarning(export.Warnings, "the dump runs as shop") {
+		t.Errorf("dumping as a non-root user must be said: %v", export.Warnings)
+	}
+
+	noAccount := strings.Replace(exportTestCompose, "      MARIADB_ROOT_PASSWORD: root-secret\n", "      MARIADB_RANDOM_ROOT_PASSWORD: '1'\n", 1)
+	installFakeDocker(t, &fakeDocker{t: t, answers: defaultAnswers()})
+	_, err = testModule.Export(context.Background(), migrate.ExportRequest{Dir: writeExportFixture(t, noAccount), OutputDir: t.TempDir()})
+	if err == nil || !strings.Contains(err.Error(), "no account to dump with") {
+		t.Errorf("a server nobody can log into must be refused with the reason, got %v", err)
+	}
+}
+
+// exportPlanCompose adds workloads whose data a database dump does not
+// carry: files in a volume, a cache, a search index.
+var exportPlanCompose = strings.Replace(exportTestCompose, "volumes:\n  pgdata:\n", `  uploads:
+    image: ghcr.io/org/app:1.0
+    volumes: ['uploads:/var/www/uploads', './config.yml:/etc/app/config.yml:ro']
+  cache:
+    image: redis:7
+  search:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.0
+volumes:
+  pgdata:
+  uploads:
+`, 1)
+
+func TestPlanExportDescribesTheDumpWithoutRunningIt(t *testing.T) {
+	fake := &fakeDocker{t: t, answers: defaultAnswers()}
+	installFakeDocker(t, fake)
+	plan, err := testModule.PlanExport(context.Background(), migrate.ExportRequest{Dir: writeExportFixture(t, exportPlanCompose)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Databases) != 2 || plan.Databases[1].Workload != "postgres" || plan.Databases[1].ServerVersion != "17.2" || plan.Databases[1].Username != "office" {
+		t.Fatalf("planned servers = %+v", plan.Databases)
+	}
+	postgres := plan.Databases[1]
+	if len(postgres.Databases) != 2 || postgres.Databases[0] != (migrate.PlannedDatabase{Name: "office", SizeBytes: 8388608}) || postgres.EstimatedBytes() != 8388608+1048576 {
+		t.Errorf("postgres plan = %+v", postgres.Databases)
+	}
+	if mysql := plan.Databases[0]; len(mysql.Databases) != 1 || mysql.Databases[0] != (migrate.PlannedDatabase{Name: "shop", SizeBytes: 2097152}) {
+		t.Errorf("mysql plan = %+v", mysql.Databases)
+	}
+	for _, call := range fake.calls {
+		if strings.Contains(call, "pg_dump") || strings.Contains(call, "mysqldump") {
+			t.Errorf("a plan must not dump anything, got %q", call)
+		}
+	}
+	joined := strings.Join(plan.NotCarried, "\n")
+	for _, want := range []string{"uploads keeps files in /var/www/uploads", "cache runs a Redis dataset (redis)", "search runs an Elasticsearch index"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("not carried must mention %q, got:\n%s", want, joined)
+		}
+	}
+	if strings.Contains(joined, "config.yml") {
+		t.Errorf("a read-only bind file is configuration, not data: %s", joined)
+	}
+	if !hasWarning(plan.Warnings, "maintenance database postgres") == strings.Contains(strings.Join(fake.calls, " "), "postgres|") {
+		t.Errorf("the plan must carry the listing's warnings: %v", plan.Warnings)
+	}
+}
+
+func TestPlanExportHonoursTheDatabaseSelection(t *testing.T) {
+	fake := &fakeDocker{t: t, answers: defaultAnswers()}
+	installFakeDocker(t, fake)
+	plan, err := testModule.PlanExport(context.Background(), migrate.ExportRequest{Dir: writeExportFixture(t, exportTestCompose), Options: map[string]string{OptionDatabasesPrefix + "postgres": "pdns,archive"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	postgres := plan.Databases[1]
+	if len(postgres.Databases) != 2 || postgres.Databases[0].Name != "pdns" || postgres.Databases[0].SizeBytes != 1048576 || postgres.Databases[1].Name != "archive" || postgres.Databases[1].SizeBytes != 0 {
+		t.Errorf("a selected database keeps its size when the server knows it and is listed unsized otherwise, got %+v", postgres.Databases)
+	}
+}
+
+func TestQuiesceSourceStopsEverythingButTheDatabases(t *testing.T) {
+	answers := defaultAnswers()
+	answers = append(answers,
+		cannedAnswer{"label=com.docker.compose.service=app", "app1\n"},
+		cannedAnswer{"label=com.docker.compose.service=uploads", "up1\nup2\n"},
+		cannedAnswer{"label=com.docker.compose.service=cache", "\n"},
+		cannedAnswer{"label=com.docker.compose.service=search", "\n"},
+		cannedAnswer{"stop ", ""},
+	)
+	fake := &fakeDocker{t: t, answers: answers}
+	installFakeDocker(t, fake)
+	quiesce, err := testModule.QuiesceSource(context.Background(), migrate.ExportRequest{Dir: writeExportFixture(t, exportPlanCompose)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(quiesce.Stopped, ",") != "app,uploads" || quiesce.Resume != "docker start app1 up1 up2" {
+		t.Errorf("quiesce = %+v", quiesce)
+	}
+	if got := callsContaining(fake.calls, "stop "); len(got) != 1 || got[0] != "stop app1 up1 up2" {
+		t.Errorf("stop calls = %v", got)
+	}
+	for _, call := range callsContaining(fake.calls, "stop ") {
+		if strings.Contains(call, "pg1") || strings.Contains(call, "my1") {
+			t.Errorf("the databases must keep running for the dump: %s", call)
 		}
 	}
 }

--- a/internal/migrate/docker/plan.go
+++ b/internal/migrate/docker/plan.go
@@ -1,0 +1,194 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"ankra/internal/migrate"
+)
+
+// dataImages are images that hold data this module knows it does not dump.
+// Naming them is the difference between "migrated" and "migrated, except
+// the search index".
+var dataImages = map[string]string{
+	"mongo":         "a MongoDB database",
+	"mongodb":       "a MongoDB database",
+	"redis":         "a Redis dataset",
+	"valkey":        "a Valkey dataset",
+	"elasticsearch": "an Elasticsearch index",
+	"opensearch":    "an OpenSearch index",
+	"rabbitmq":      "RabbitMQ queues",
+	"minio":         "MinIO object storage",
+	"clickhouse":    "a ClickHouse database",
+	"influxdb":      "an InfluxDB database",
+	"neo4j":         "a Neo4j graph",
+	"cassandra":     "a Cassandra keyspace",
+	"couchdb":       "a CouchDB database",
+}
+
+// PlanExport implements migrate.ExportPlanner: it resolves every database
+// service to its container, asks each server what it holds and how big it
+// is, and lists the data the source keeps that the export will not carry.
+// Nothing is written.
+func (module Module) PlanExport(ctx context.Context, request migrate.ExportRequest) (migrate.ExportPlan, error) {
+	source, err := module.discoverSource(ctx, request)
+	if err != nil {
+		return migrate.ExportPlan{}, err
+	}
+	plan := migrate.ExportPlan{Warnings: append([]string(nil), source.warnings...)}
+	for _, server := range source.servers {
+		job := dumpJob{docker: source.docker, server: server, only: splitList(source.options[OptionDatabasesPrefix+server.workload.Name])}
+		planned, warnings, err := planServer(ctx, job)
+		if err != nil {
+			return migrate.ExportPlan{}, err
+		}
+		plan.Databases = append(plan.Databases, planned)
+		plan.Warnings = append(plan.Warnings, warnings...)
+	}
+	plan.NotCarried = notCarried(source)
+	plan.Warnings = uniqueSorted(plan.Warnings)
+	return plan, nil
+}
+
+// planServer reads one server's version and databases with their sizes.
+func planServer(ctx context.Context, job dumpJob) (migrate.PlannedDatabaseServer, []string, error) {
+	workload := job.server.workload.Name
+	planned := migrate.PlannedDatabaseServer{Workload: workload, Engine: job.server.engine, Container: job.server.container}
+	var warnings []string
+	var client func(string) []string
+	var listed []databaseSize
+	switch job.server.engine {
+	case migrate.EnginePostgres:
+		username, applicationDatabase := postgresCredentials(job.server)
+		planned.Username = username
+		client = postgresClient(job, username)
+		version, err := job.docker.Output(ctx, client("SHOW server_version")...)
+		if err != nil {
+			return migrate.PlannedDatabaseServer{}, nil, fmt.Errorf("%s: reading the server version: %w", workload, err)
+		}
+		planned.ServerVersion = strings.TrimSpace(string(version))
+		databases, listWarnings, err := listPostgresDatabases(ctx, job.docker, client, applicationDatabase, workload)
+		if err != nil {
+			return migrate.PlannedDatabaseServer{}, nil, err
+		}
+		listed, warnings = databases, listWarnings
+	case migrate.EngineMySQL:
+		username, passwordKey, credentialWarning, err := mysqlCredentials(job.server)
+		if err != nil {
+			return migrate.PlannedDatabaseServer{}, nil, err
+		}
+		if credentialWarning != "" {
+			warnings = append(warnings, credentialWarning)
+		}
+		planned.Username = username
+		client = mysqlClient(job, username, passwordKey)
+		version, err := job.docker.Output(ctx, client("SELECT VERSION()")...)
+		if err != nil {
+			return migrate.PlannedDatabaseServer{}, nil, fmt.Errorf("%s: reading the server version: %w", workload, err)
+		}
+		planned.ServerVersion = strings.TrimSpace(string(version))
+		listed, err = listMySQLDatabases(ctx, job.docker, client, workload)
+		if err != nil {
+			return migrate.PlannedDatabaseServer{}, nil, err
+		}
+	}
+	only := map[string]bool{}
+	for _, name := range job.only {
+		only[name] = true
+	}
+	for _, database := range listed {
+		if len(only) > 0 && !only[database.name] {
+			continue
+		}
+		planned.Databases = append(planned.Databases, migrate.PlannedDatabase{Name: database.name, SizeBytes: database.sizeBytes})
+	}
+	for name := range only {
+		isListed := false
+		for _, database := range planned.Databases {
+			isListed = isListed || database.Name == name
+		}
+		if !isListed {
+			planned.Databases = append(planned.Databases, migrate.PlannedDatabase{Name: name})
+		}
+	}
+	if len(planned.Databases) == 0 {
+		return migrate.PlannedDatabaseServer{}, nil, fmt.Errorf("%s: the server holds no database to carry", workload)
+	}
+	return planned, warnings, nil
+}
+
+// notCarried lists what the source holds beyond its database servers:
+// files in the volumes of the other workloads, and data engines this
+// module does not dump.
+func notCarried(source exportSource) []string {
+	var items []string
+	for _, workload := range source.others {
+		if description, ok := dataImage(workload.Image); ok {
+			items = append(items, fmt.Sprintf("%s runs %s (%s), which this export does not dump", workload.Name, description, imageName(workload.Image)))
+		}
+		var mounts []string
+		for _, volume := range workload.Volumes {
+			if volume.ReadOnly || volume.BindFile {
+				continue
+			}
+			mounts = append(mounts, volume.Target)
+		}
+		if len(mounts) > 0 {
+			sort.Strings(mounts)
+			items = append(items, fmt.Sprintf("%s keeps files in %s; volumes are not carried by this export - copy them into the cluster's PersistentVolumeClaim yourself", workload.Name, strings.Join(mounts, ", ")))
+		}
+	}
+	return items
+}
+
+// dataImage recognises an image that holds application data of a kind this
+// module does not dump.
+func dataImage(image string) (string, bool) {
+	name := imageName(image)
+	if slash := strings.LastIndex(name, "/"); slash >= 0 {
+		name = name[slash+1:]
+	}
+	description, ok := dataImages[name]
+	return description, ok
+}
+
+// QuiesceSource implements migrate.SourceQuiescer: it stops every container
+// of the compose project that is not a database server, so the export that
+// follows is the last word on the data. The databases keep running - the
+// dump needs them - and the command to bring the rest back is returned.
+func (module Module) QuiesceSource(ctx context.Context, request migrate.ExportRequest) (migrate.Quiesce, error) {
+	source, err := module.discoverSource(ctx, request)
+	if err != nil {
+		return migrate.Quiesce{}, err
+	}
+	composeProject := source.options[OptionProject]
+	if composeProject == "" {
+		composeProject = composeProjectName(source.project.Name)
+	}
+	var quiesce migrate.Quiesce
+	var containers []string
+	for _, workload := range source.others {
+		output, err := source.docker.Output(ctx, "ps", "-q",
+			"--filter", "label="+labelComposeProject+"="+composeProject,
+			"--filter", "label="+labelComposeService+"="+workload.Name)
+		if err != nil {
+			return migrate.Quiesce{}, err
+		}
+		ids := strings.Fields(string(output))
+		if len(ids) == 0 {
+			continue
+		}
+		containers = append(containers, ids...)
+		quiesce.Stopped = append(quiesce.Stopped, workload.Name)
+	}
+	if len(containers) == 0 {
+		return quiesce, nil
+	}
+	if _, err := source.docker.Output(ctx, append([]string{"stop"}, containers...)...); err != nil {
+		return migrate.Quiesce{}, fmt.Errorf("stopping the source's writers: %w", err)
+	}
+	quiesce.Resume = "docker start " + strings.Join(containers, " ")
+	return quiesce, nil
+}

--- a/internal/migrate/export.go
+++ b/internal/migrate/export.go
@@ -1,6 +1,7 @@
 package migrate
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -228,4 +229,65 @@ func ReadExportManifest(outputDir string) (ExportManifest, error) {
 		return ExportManifest{}, fmt.Errorf("%s is version %d, this CLI reads version %d", ExportManifestFileName, manifest.Version, ExportManifestVersion)
 	}
 	return manifest, nil
+}
+
+// ExportPlan is what an export would do, worked out without dumping
+// anything: which servers and databases it will carry, how big they are on
+// the source, and what the source holds that it will leave behind. A caller
+// can refuse early, size the work, and tell the user the truth before a
+// single byte moves.
+type ExportPlan struct {
+	Databases []PlannedDatabaseServer `json:"databases"`
+	// NotCarried names data the source holds that this export leaves behind:
+	// files in volumes, engines it does not dump. Each item says why.
+	NotCarried []string `json:"not_carried,omitempty"`
+	// Warnings are conditions the export will proceed under.
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+// PlannedDatabaseServer is one database service the export will dump.
+type PlannedDatabaseServer struct {
+	Workload      string            `json:"workload"`
+	Engine        string            `json:"engine"`
+	Container     string            `json:"container"`
+	ServerVersion string            `json:"server_version,omitempty"`
+	Username      string            `json:"username"`
+	Databases     []PlannedDatabase `json:"databases"`
+}
+
+// PlannedDatabase is one database and its size on the source server, as the
+// server reports it: an upper bound for the dump, which compresses.
+type PlannedDatabase struct {
+	Name      string `json:"name"`
+	SizeBytes int64  `json:"size_bytes"`
+}
+
+// EstimatedBytes is the sum of the server's databases as it reports them.
+func (server PlannedDatabaseServer) EstimatedBytes() int64 {
+	var total int64
+	for _, database := range server.Databases {
+		total += database.SizeBytes
+	}
+	return total
+}
+
+// ExportPlanner is the optional capability of a DataExporter that can
+// describe an export before running it. Built-in modules implement it; an
+// external module without it is simply exported without a preflight.
+type ExportPlanner interface {
+	PlanExport(ctx context.Context, request ExportRequest) (ExportPlan, error)
+}
+
+// Quiesce is what stopping the source's writers did: which services were
+// stopped, and the command that starts them again.
+type Quiesce struct {
+	Stopped []string `json:"stopped"`
+	Resume  string   `json:"resume,omitempty"`
+}
+
+// SourceQuiescer is the optional capability of a DataExporter that can stop
+// the source's writers - every service that is not a database - so the final
+// export is consistent with what the workloads last wrote.
+type SourceQuiescer interface {
+	QuiesceSource(ctx context.Context, request ExportRequest) (Quiesce, error)
 }

--- a/internal/skills/embedded/skills/ankra-cli/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-cli/SKILL.md
@@ -102,22 +102,27 @@ A failed platform execution explains more deploy failures than pod logs do — s
 ## Migrating a Docker deployment
 
 ```bash
-ankra migrate convert ./app --out ./app-k8s        # compose / Dockerfile / daemon -> cluster.yaml + manifests
-ankra cluster apply ./app-k8s/cluster.yaml         # the workloads, with empty databases
+ankra migrate up ./app --cluster shop --plan       # what will move, how big, what stays behind; changes nothing
+ankra migrate up ./app --cluster shop              # convert + deploy + dump + restore, one command (rehearsal)
+ankra migrate up ./app --cluster shop --stop-source --yes   # the cutover: stop the source's services, final sync
+ankra migrate convert ./app --out ./app-k8s        # the steps separately: compose / Dockerfile / daemon -> stack
+ankra cluster apply -f ./app-k8s/cluster.yaml      # the workloads, with empty databases
 ankra migrate data ./app --cluster shop --wait     # dump every database and restore it in the cluster
 ankra migrate export ./app --out ./app-data        # the two halves of `data`, separately:
 ankra migrate restore ./app-data --cluster shop --wait
 ankra migrate restore-status <import-id> --wait    # follow a restore started without --wait
 ```
 
-`export` dumps PostgreSQL and MySQL/MariaDB through the docker CLI (`--option docker-host=ssh://root@host`
-for a remote daemon, `--option project=<name>` when the compose project runs under another name);
-`restore` uploads the dumps to the organisation's backup vault with presigned URLs and the cluster's
-agent restores them inside the cluster — no kubectl, no database client, Ankra never holds the data.
-It needs a ready backup vault (`ankra backup vaults provision`; picked automatically when there is one),
-the converted stack applied, and an agent that supports data restores. Rehearse with the source running,
-then stop its writers and run `data` once more for the cutover. Modules extend the lane:
-`ankra migrate modules --help`.
+`up` plans before it touches anything (databases and their sizes from the running containers, free
+disk, cluster, stack, vault; `--plan` stops there), applies the stack under the cluster's name, waits
+for the database pods, then dumps and restores. It is safe to re-run. `export` dumps PostgreSQL and
+MySQL/MariaDB through the docker CLI with the credentials the container actually runs with
+(`--option docker-host=ssh://root@host` for a remote daemon, `--option project=<name>` when the compose
+project runs under another name); `restore` uploads the dumps to the organisation's backup vault with
+presigned URLs and the cluster's agent restores them inside the cluster — no kubectl, no database
+client, Ankra never holds the data. Needs a ready backup vault (`ankra backup vaults provision`; picked
+automatically when there is one) and an agent that supports data restores. Not carried, and named in
+the plan: files in the volumes of non-database workloads, Redis/MongoDB/search data.
 
 ## AI from the terminal
 


### PR DESCRIPTION
## What & why

Bead: ankra-k6ikc.8 (epic ankra-k6ikc). Follows #188. The ask: make the migrate module production-grade and make a Docker → Kubernetes move in Ankra feel like one command.

### `ankra migrate up <dir> --cluster <name>`

1. **Plan** (`--plan` stops here, nothing written): the module, the cluster (resolved by name or id; the stack is applied under the cluster's *name*, so an id on the command line updates the right cluster), whether the stack already exists, the backup vault, every database server with its databases **and sizes as the servers report them** (read from the running containers), the estimated dump size against free disk where `--out` lands (refuses when it does not fit), a warning for any database above the 5 GiB single-upload limit, and a **not carried** list: files in the volumes of non-database workloads, and data images the export does not dump (Redis, MongoDB, Elasticsearch/OpenSearch, RabbitMQ, MinIO, ClickHouse, InfluxDB, Neo4j, Cassandra, CouchDB).
2. Confirm (`--yes` skips; `--stop-source` is named in the prompt).
3. **Convert** into `<out>/stack` under the cluster's name and the target namespace.
4. **Deploy**: `cluster apply` with wait; refused configurations are reported per resource.
5. **Wait** for each database workload to have a running, ready pod (`ListPods`, name-prefix matched, `--timeout` bounded, progress on state change).
6. **Export** into `<out>/data`; with `--stop-source`, the source's non-database containers are stopped first and the resume command printed (the cutover).
7. **Restore** through the vault with `--wait`.
8. Summary: where it runs, the import, URLs from `ingress.<workload>` options, what is still on the source, and whether this was a rehearsal or the cutover. `-o json` gives the whole record; `--no-data` deploys only.

Reuses `performMigrateConvert` (extracted from `convert`) and `loadImportCluster`/`applyImportCluster` (extracted from `cluster apply`, behaviour unchanged).

### Docker module

- **Credentials from the container, not the file**: `POSTGRES_USER`/`POSTGRES_DB`/`MYSQL_*` are read from `docker inspect` of the running container (compose value as fallback), so unresolved `${VAR}`, `env_file` and the official images' `*_FILE` secret indirection all work (`inContainer` reads the `_FILE` when the variable is empty).
- **MySQL/MariaDB account fallback**: root when a root password (or `ALLOW_EMPTY_PASSWORD`) is configured, else the application user (`MYSQL_USER`/`MYSQL_PASSWORD`, MariaDB twins) with a warning, else a refusal that names the fix (`MYSQL_RANDOM_ROOT_PASSWORD` servers).
- **Size-aware listing**: `pg_database_size` / `information_schema` sums power the plan; the maintenance-database rule and the selection option are shared between plan and export.
- New optional capabilities `migrate.ExportPlanner` (`PlanExport`) and `migrate.SourceQuiescer` (`QuiesceSource`), implemented by the docker module; external modules without them are exported without a preflight, and `--stop-source` is refused for them with the reason.

Docs: root `migrate` help, both `ankra-cli` skill copies (identical), CLAUDE.md layout bullet (deduplicated), CHANGELOG.

## Test plan

- `go test ./...` green; pre-commit hook (tests + `golangci-lint`, 0 issues) green.
- `cmd/migrate_up_test.go`: `--plan` changes nothing (no output dir, no API writes, plan lines); end-to-end (apply under the cluster's name with the converted stack, pods polled until ready, dumps written, import registered as the stack, 2 uploads, restore driven, summary + rehearsal hint); `--stop-source` (declined prompt = exit 4 with nothing touched; accepted = `docker stop web1` recorded, database left running, cutover summary with the resume command); missing vault fails the plan before any output; a 6 GiB database warns; `--no-data` deploys only and refuses `--stop-source`.
- Docker module tests: credentials from the container win over the compose file; MySQL falls back to the application user and refuses a server nobody can log into; `PlanExport` reports sizes and not-carried items without dumping; selection keeps known sizes; `QuiesceSource` stops every non-database container and no database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhfwAPcMpkMEbZs1jyfTxs
