### PR TITLE
feat(migrate): 'ankra migrate imports list' and 'imports delete' clean up a vault's dumps (ankra-k6ikc.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Added
 
+- **`ankra migrate imports list` and `ankra migrate imports delete` manage
+  the dumps a migration leaves in the backup vault.** Every restore keeps its
+  upload under `imports/<import-id>/` so the same data can be restored
+  again; the vault would otherwise hold it forever. `imports list` shows
+  what a vault holds - stack, status, databases, size - and `imports delete`
+  removes an import's dumps from the vault and forgets the import, after a
+  confirmation (`--yes` skips it). An import whose restore is running is
+  refused. A completed restore now ends by naming the delete command, and
+  deleting a vault removes the dumps of every import it held when the
+  bucket outlives the vault.
 - **A shell in any pod, from the terminal you are in.** `ankra cluster
   terminal <pod> -n <namespace>` opens an interactive shell in the pod's
   container through the platform - no kubeconfig, no port-forward - with the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,8 @@ the un-injected fallback; never bump it for a release.
   Nothing under `internal/migrate` may call the platform API: `convert`,
   `detect`, `modules` and `export` are annotated
   `annotationRequiresAuth: "false"` and work offline. The online lanes are
-  `cmd/migrate_restore.go` (`restore`, `restore-status`, `data`) and
+  `cmd/migrate_restore.go` (`restore`, `restore-status`, `data`),
+  `cmd/migrate_imports.go` (`imports list|delete`) and
   `cmd/migrate_up.go` (`up`, the one-command migration that chains convert,
   `cluster apply`, the pod wait, export and restore), annotated `"true"`,
   which drive the backup-vault import routes through `internal/client`.

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -551,6 +551,14 @@ func (m baseMock) GetBackupVaultImport(vaultID string, importID string) (*client
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) ListBackupVaultImports(string) (*client.BackupVaultImportListResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) DeleteBackupVaultImport(string, string) error {
+	return errors.New("not implemented")
+}
+
 func (m baseMock) UploadPresignedObject(ctx context.Context, method string, uploadURL string, body io.ReadSeeker, size int64) error {
 	return errors.New("not implemented")
 }

--- a/cmd/migrate_imports.go
+++ b/cmd/migrate_imports.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+
+	"ankra/internal/client"
+)
+
+// The imports a migration leaves in a backup vault are the dumps it
+// uploaded: kept so a restore can be run again, removed when they are no
+// longer wanted. These verbs list and delete them.
+
+var (
+	migrateImportsListVault   string
+	migrateImportsDeleteVault string
+	migrateImportsDeleteYes   bool
+)
+
+var migrateImportsCmd = &cobra.Command{
+	Use:   "imports",
+	Short: "List and delete the exports uploaded to a backup vault by 'ankra migrate restore'",
+	Long: `Every 'ankra migrate restore' (and 'up', and 'data') uploads the export's
+dumps into the organisation's backup vault under imports/<import-id>/ and
+keeps them there, so the same upload can be restored again. These verbs
+show what a vault holds and remove an import - its dumps in the vault and
+the record - once it is no longer needed.`,
+	Annotations: map[string]string{annotationRequiresAuth: "true"},
+}
+
+var migrateImportsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List the imports a backup vault holds",
+	Example: `  ankra migrate imports list
+  ankra migrate imports list --vault backups -o json`,
+	Args:        cobra.NoArgs,
+	Annotations: map[string]string{annotationRequiresAuth: "true"},
+	RunE:        runMigrateImportsList,
+}
+
+var migrateImportsDeleteCmd = &cobra.Command{
+	Use:   "delete <import-id>",
+	Short: "Remove an import's dumps from the vault and forget the import",
+	Long: `Delete the dumps an import uploaded into the backup vault and hide the
+import. An import whose restore is still running is refused: its job is
+reading those dumps. Objects the vault cannot be asked to remove are noted
+in the audit record; the import is gone either way.`,
+	Example: `  ankra migrate imports delete 6f1c8e2a-... --yes
+  ankra migrate imports delete 6f1c8e2a-... --vault backups`,
+	Args:        cobra.ExactArgs(1),
+	Annotations: map[string]string{annotationRequiresAuth: "true"},
+	RunE:        runMigrateImportsDelete,
+}
+
+func init() {
+	migrateImportsListCmd.Flags().StringVar(&migrateImportsListVault, "vault", "", "Backup vault, by name or id (default: the organisation's only ready vault)")
+	registerStructuredOutputFlags(migrateImportsListCmd)
+	migrateImportsCmd.AddCommand(migrateImportsListCmd)
+
+	migrateImportsDeleteCmd.Flags().StringVar(&migrateImportsDeleteVault, "vault", "", "Backup vault the import went through, by name or id (default: the organisation's only ready vault)")
+	migrateImportsDeleteCmd.Flags().BoolVarP(&migrateImportsDeleteYes, "yes", "y", false, "Skip the confirmation prompt")
+	migrateImportsCmd.AddCommand(migrateImportsDeleteCmd)
+
+	migrateCmd.AddCommand(migrateImportsCmd)
+}
+
+func runMigrateImportsList(cmd *cobra.Command, _ []string) error {
+	vaultID, err := resolveImportVaultID(migrateImportsListVault)
+	if err != nil {
+		return err
+	}
+	listing, err := apiClient.ListBackupVaultImports(vaultID)
+	if err != nil {
+		return backupLaneError("listing the imports", err)
+	}
+	if handled, err := renderStructured(cmd, listing); handled || err != nil {
+		return err
+	}
+	if len(listing.Imports) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "The vault holds no imports.")
+		return nil
+	}
+	writer := table.NewWriter()
+	writer.SetOutputMirror(cmd.OutOrStdout())
+	writer.SetStyle(table.StyleRounded)
+	writer.AppendHeader(table.Row{"IMPORT", "STACK", "STATUS", "DATABASES", "SIZE", "CREATED"})
+	for _, imported := range listing.Imports {
+		workloads := make([]string, 0, len(imported.Databases))
+		var totalBytes int64
+		for _, database := range imported.Databases {
+			workloads = append(workloads, database.Workload)
+			for _, artifact := range database.Artifacts {
+				totalBytes += artifact.SizeBytes
+			}
+		}
+		writer.AppendRow(table.Row{imported.ID, imported.StackName, imported.Status, strings.Join(workloads, ", "), formatByteSize(totalBytes), imported.CreatedAt})
+	}
+	writer.Render()
+	return nil
+}
+
+func runMigrateImportsDelete(cmd *cobra.Command, args []string) error {
+	importID := args[0]
+	vaultID, err := resolveImportVaultID(migrateImportsDeleteVault)
+	if err != nil {
+		return err
+	}
+	imported, err := apiClient.GetBackupVaultImport(vaultID, importID)
+	if err != nil {
+		return backupLaneError("reading the import", err)
+	}
+	if imported.Status == client.BackupVaultImportStatusRestoring {
+		return withExitCode(exitUsage, fmt.Errorf("import %s is being restored right now; wait for it to finish (ankra migrate restore-status %s --wait) before deleting it", importID, importID))
+	}
+	message := fmt.Sprintf("Delete import %s (stack %s, %d database server(s)) and its dumps from the vault? [y/N] ", importID, imported.StackName, len(imported.Databases))
+	if confirmError := confirmPrompt(cmd.InOrStdin(), cmd.ErrOrStderr(), message, migrateImportsDeleteYes); confirmError != nil {
+		return confirmError
+	}
+	if deleteError := apiClient.DeleteBackupVaultImport(vaultID, importID); deleteError != nil {
+		return backupLaneError("deleting the import", deleteError)
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Import %s deleted; its dumps are removed from the vault.\n", importID)
+	return nil
+}

--- a/cmd/migrate_imports_test.go
+++ b/cmd/migrate_imports_test.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+// migrateImportsMock scripts the vault's import listing and deletion on top
+// of the restore mock, which already answers the vault lookup and GET.
+type migrateImportsMock struct {
+	migrateRestoreMock
+	listed  []client.BackupVaultImport
+	deleted []string
+}
+
+func (mock *migrateImportsMock) ListBackupVaultImports(string) (*client.BackupVaultImportListResult, error) {
+	return &client.BackupVaultImportListResult{Imports: mock.listed}, nil
+}
+
+func (mock *migrateImportsMock) DeleteBackupVaultImport(_ string, importID string) error {
+	if strings.HasSuffix(importID, "-refused") {
+		return errors.New("409 Conflict: The restore of this import is already running.")
+	}
+	mock.deleted = append(mock.deleted, importID)
+	return nil
+}
+
+func installMigrateImportsMock(t *testing.T, mock *migrateImportsMock) {
+	t.Helper()
+	installMigrateRestoreMock(t, &mock.migrateRestoreMock)
+	apiClient = mock
+	migrateImportsListVault = ""
+	migrateImportsDeleteVault = ""
+	migrateImportsDeleteYes = false
+	_ = migrateImportsListCmd.Flags().Set("output", "")
+}
+
+func TestMigrateImportsListShowsWhatTheVaultHolds(t *testing.T) {
+	mock := &migrateImportsMock{migrateRestoreMock: migrateRestoreMock{vaults: []client.BackupVault{readyVault("backups1")}}}
+	installMigrateImportsMock(t, mock)
+	mock.listed = []client.BackupVaultImport{{
+		ID: "6f1c8e2a-0000-4000-8000-000000000001", StackName: "shop", Status: "completed", CreatedAt: "2026-08-29T10:00:00Z",
+		Databases: []client.BackupVaultImportDatabase{{Workload: "db", Artifacts: []client.BackupVaultImportArtifact{{SizeBytes: 5 << 20}, {SizeBytes: 3 << 20}}}},
+	}}
+
+	stdout, _, err := runMigrate(t, "imports", "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"6f1c8e2a-0000-4000-8000-000000000001", "shop", "completed", "db", "8.0 MiB"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("listing must show %q:\n%s", want, stdout)
+		}
+	}
+
+	mock.listed = nil
+	stdout, _, err = runMigrate(t, "imports", "list")
+	if err != nil || !strings.Contains(stdout, "holds no imports") {
+		t.Errorf("an empty vault must say so, got %v:\n%s", err, stdout)
+	}
+
+	installMigrateImportsMock(t, &migrateImportsMock{})
+	_, _, err = runMigrate(t, "imports", "list")
+	if exitCodeFor(err) != exitUsage || !strings.Contains(err.Error(), "no ready backup vault") {
+		t.Errorf("no vault is a usage error, got %v", err)
+	}
+}
+
+func TestMigrateImportsDeleteConfirmsAndRefusesARunningRestore(t *testing.T) {
+	mock := &migrateImportsMock{migrateRestoreMock: migrateRestoreMock{vaults: []client.BackupVault{readyVault("backups1")}, getStatuses: []string{"completed"}}}
+	installMigrateImportsMock(t, mock)
+
+	rootCmd.SetIn(strings.NewReader("n\n"))
+	t.Cleanup(func() { rootCmd.SetIn(nil) })
+	_, _, err := runMigrate(t, "imports", "delete", "6f1c8e2a-0000-4000-8000-000000000001")
+	if exitCodeFor(err) != exitCancelled || len(mock.deleted) != 0 {
+		t.Fatalf("a declined prompt must exit %d and delete nothing, got %v (deleted %v)", exitCancelled, err, mock.deleted)
+	}
+
+	stdout, _, err := runMigrate(t, "imports", "delete", "6f1c8e2a-0000-4000-8000-000000000001", "--yes")
+	if err != nil || len(mock.deleted) != 1 || mock.deleted[0] != "6f1c8e2a-0000-4000-8000-000000000001" || !strings.Contains(stdout, "deleted; its dumps are removed") {
+		t.Errorf("--yes must delete: err=%v deleted=%v\n%s", err, mock.deleted, stdout)
+	}
+
+	mock.getStatuses = []string{"restoring"}
+	mock.getCount = 0
+	_, _, err = runMigrate(t, "imports", "delete", "6f1c8e2a-0000-4000-8000-000000000002", "--yes")
+	if exitCodeFor(err) != exitUsage || !strings.Contains(err.Error(), "being restored right now") || len(mock.deleted) != 1 {
+		t.Errorf("a restoring import is refused before the platform is asked, got %v", err)
+	}
+
+	mock.getStatuses = []string{"completed"}
+	mock.getCount = 0
+	_, _, err = runMigrate(t, "imports", "delete", "6f1c8e2a-0000-4000-8000-00000-refused", "--yes")
+	if err == nil || !strings.Contains(err.Error(), "already running") {
+		t.Errorf("the platform's refusal must surface, got %v", err)
+	}
+}

--- a/cmd/migrate_restore.go
+++ b/cmd/migrate_restore.go
@@ -436,6 +436,7 @@ func printMigrateRestoreOutcome(cmd *cobra.Command, imported *client.BackupVault
 	switch imported.Status {
 	case client.BackupVaultImportStatusCompleted:
 		_, _ = fmt.Fprintf(out, "Restore complete: %d database server(s) loaded (import %s).\n", len(imported.Databases), imported.ID)
+		_, _ = fmt.Fprintf(out, "The dumps stay in the vault so the import can be restored again; remove them with:\n  ankra migrate imports delete %s\n", imported.ID)
 	case client.BackupVaultImportStatusRestoring:
 		_, _ = fmt.Fprintf(out, "Restore still running (import %s).\n", imported.ID)
 	default:

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -57,6 +57,8 @@ type APIClient interface {
 	CompleteBackupVaultImport(vaultID string, importID string) (*client.BackupVaultImport, error)
 	RestoreBackupVaultImport(vaultID string, importID string) (*client.BackupVaultImport, error)
 	GetBackupVaultImport(vaultID string, importID string) (*client.BackupVaultImport, error)
+	ListBackupVaultImports(vaultID string) (*client.BackupVaultImportListResult, error)
+	DeleteBackupVaultImport(vaultID string, importID string) error
 	UploadPresignedObject(ctx context.Context, method string, uploadURL string, body io.ReadSeeker, size int64) error
 
 	ListExecutions(opts client.ListExecutionsOptions) (client.ExecutionListResponse, error)

--- a/internal/client/backup_vault_imports.go
+++ b/internal/client/backup_vault_imports.go
@@ -155,6 +155,31 @@ func (c *Client) GetBackupVaultImport(vaultID string, importID string) (*BackupV
 	return &result, nil
 }
 
+// BackupVaultImportListResult is a vault's imports, newest first.
+type BackupVaultImportListResult struct {
+	Imports []BackupVaultImport `json:"imports"`
+}
+
+// ListBackupVaultImports reads a vault's imports without their live restore
+// detail.
+// GET /api/v1/org/backup-vaults/{vault_id}/imports
+func (c *Client) ListBackupVaultImports(vaultID string) (*BackupVaultImportListResult, error) {
+	url := fmt.Sprintf("%s/api/v1/org/backup-vaults/%s/imports", c.BaseURL, neturl.PathEscape(vaultID))
+	var result BackupVaultImportListResult
+	if requestError := c.sendJSON(http.MethodGet, url, nil, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// DeleteBackupVaultImport removes an import's dumps from the vault and hides
+// the import; the platform answers 409 while its restore is running.
+// DELETE /api/v1/org/backup-vaults/{vault_id}/imports/{import_id}
+func (c *Client) DeleteBackupVaultImport(vaultID string, importID string) error {
+	url := fmt.Sprintf("%s/api/v1/org/backup-vaults/%s/imports/%s", c.BaseURL, neturl.PathEscape(vaultID), neturl.PathEscape(importID))
+	return c.sendJSON(http.MethodDelete, url, nil, nil)
+}
+
 // PresignedUploadMaximumBytes is the largest object a single presigned PUT
 // can carry on S3 and every compatible store; a bigger artifact needs a
 // multipart upload the platform does not mint yet.

--- a/internal/skills/embedded/skills/ankra-cli/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-cli/SKILL.md
@@ -111,6 +111,8 @@ ankra migrate data ./app --cluster shop --wait     # dump every database and res
 ankra migrate export ./app --out ./app-data        # the two halves of `data`, separately:
 ankra migrate restore ./app-data --cluster shop --wait
 ankra migrate restore-status <import-id> --wait    # follow a restore started without --wait
+ankra migrate imports list                         # the dumps a vault still holds (restore again, or clean up)
+ankra migrate imports delete <import-id> --yes     # remove an import's dumps from the vault
 ```
 
 `up` plans before it touches anything (databases and their sizes from the running containers, free


### PR DESCRIPTION
## What & why

Bead: ankra-k6ikc.6 (CLI half; platform half is the cluster PR "delete an import's dumps, and sweep them when a customer vault goes").

Every restore keeps its upload under `imports/<import-id>/` in the backup vault so the same data can be restored again, and nothing removed it.

- `ankra migrate imports list [--vault]`: what a vault holds (import, stack, status, databases, total size, created), `-o json|yaml`.
- `ankra migrate imports delete <import-id> [--vault] [--yes]`: confirms, refuses an import that is being restored before asking the platform (and surfaces the platform's 409 if it raced), then `DELETE /api/v1/org/backup-vaults/{vault}/imports/{id}`.
- A completed `restore` now ends by naming the delete command.
- Client: `ListBackupVaultImports`, `DeleteBackupVaultImport`; `APIClient` + `baseMock` updated. Docs: both skill copies (identical), CHANGELOG, CLAUDE.md lane list.

## Test plan

- Pre-commit hook (tests + golangci-lint) green.
- `cmd/migrate_imports_test.go`: listing shows stack/status/databases/size and says when empty; no vault is a usage error; a declined prompt deletes nothing (exit 4); `--yes` deletes; a restoring import is refused locally; the platform's refusal surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhfwAPcMpkMEbZs1jyfTxs
