### PR TITLE
fix(migrate): 'up' runs again into its own output directory; convert's next step needs -f (ankra-k6ikc.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## v0.14.0-rc6 — 2026-08-29
 
+### Fixed
+
+- **`ankra migrate up` runs again into the same output directory.** The
+  rehearsal left `stack/` and `data/` behind and the cutover run refused the
+  directory as "not empty" unless `--force` was passed. A directory that
+  holds nothing but an earlier run's output is now reused; `--force` is only
+  for one that holds other files. `ankra migrate convert` also printed
+  `ankra cluster apply <file>` as the next step, which that command does not
+  accept - it is `ankra cluster apply -f <file>`.
+
 ### Added
 
 - **A shell in any pod, from the terminal you are in.** `ankra cluster

--- a/cmd/migrate_convert.go
+++ b/cmd/migrate_convert.go
@@ -53,7 +53,7 @@ plain text - and each one names the fix.
 
 Then review the output and apply it:
 
-  ankra cluster apply <out>/cluster.yaml`,
+  ankra cluster apply -f <out>/cluster.yaml`,
 	Example: `  ankra migrate convert
   ankra migrate convert ./app --out ./app-k8s --option profiles=app
   ankra migrate convert --option source=daemon --option project=aura-office
@@ -132,7 +132,7 @@ func runMigrateConvert(cmd *cobra.Command, args []string) error {
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Converted %s with the %s module.\n", dir, summary.Module)
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Wrote %d file(s) to %s\n", len(summary.Files), summary.Out)
 	printMigrateWarnings(cmd, summary.Warnings)
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nReview the output, then apply it:\n  ankra cluster apply %s\n", filepath.Join(summary.Out, "cluster.yaml"))
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nReview the output, then apply it:\n  ankra cluster apply -f %s\n", filepath.Join(summary.Out, "cluster.yaml"))
 	return nil
 }
 

--- a/cmd/migrate_up.go
+++ b/cmd/migrate_up.go
@@ -59,9 +59,10 @@ into a cluster that Ankra runs, end to end:
   5. Restore. Upload the dumps through the backup vault and load them
               into the cluster, as 'ankra migrate restore' does, and wait.
 
-The command is safe to run more than once: the stack is re-applied, the
-databases are dumped and restored again. Rehearse while the source runs,
-then run it once more with --stop-source when you are ready to switch.
+The command is safe to run more than once, into the same output directory:
+the stack is re-applied, the databases are dumped and restored again.
+Rehearse while the source runs, then run it once more with --stop-source
+when you are ready to switch.
 --timeout bounds each waiting step (deploy, readiness, restore).
 
 Not carried: files kept in the volumes of non-database workloads, and data
@@ -84,7 +85,7 @@ func init() {
 	migrateUpCmd.Flags().StringVar(&migrateUpStack, "stack", "", "Name of the stack on the cluster (default: the directory name)")
 	migrateUpCmd.Flags().StringVar(&migrateUpNamespace, "namespace", "", "Namespace the workloads run in (default: the stack name)")
 	migrateUpCmd.Flags().StringArrayVar(&migrateUpOptions, "option", nil, "Module option as key=value (repeatable); convert and export options both apply")
-	migrateUpCmd.Flags().BoolVar(&migrateUpForce, "force", false, "Overwrite an output directory that is not empty")
+	migrateUpCmd.Flags().BoolVar(&migrateUpForce, "force", false, "Overwrite an output directory that holds files no earlier run of this command wrote")
 	migrateUpCmd.Flags().BoolVar(&migrateUpNoData, "no-data", false, "Deploy the workloads only; carry no data over")
 	migrateUpCmd.Flags().BoolVar(&migrateUpStopSource, "stop-source", false, "Stop the source's non-database services before the export, so the dump is final (the cutover)")
 	migrateUpCmd.Flags().BoolVarP(&migrateUpYes, "yes", "y", false, "Skip the confirmation prompt")
@@ -314,11 +315,35 @@ func planMigrateUp(cmd *cobra.Command, dir string, module migrate.Module, option
 	// The output directory is the first thing the migration changes, so it
 	// is created only once every check above has passed.
 	if !migrateUpPlanOnly {
-		if outError := ensureMigrateOutDir(out, migrateUpForce); outError != nil {
+		if outError := ensureMigrateUpOutDir(out, migrateUpForce); outError != nil {
 			return migrateUpPlan{}, outError
 		}
 	}
 	return plan, nil
+}
+
+// ensureMigrateUpOutDir accepts an output directory that is empty, absent,
+// or holds nothing but an earlier run's stack/ and data/ - a rehearsal
+// followed by the cutover is the normal use, and must not need --force.
+// Anything else in it belongs to someone, and --force is the permission to
+// overwrite.
+func ensureMigrateUpOutDir(out string, force bool) error {
+	entries, readError := os.ReadDir(out)
+	switch {
+	case os.IsNotExist(readError):
+		return os.MkdirAll(out, 0o755)
+	case readError != nil:
+		return readError
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && (entry.Name() == "stack" || entry.Name() == "data") {
+			continue
+		}
+		if !force {
+			return withExitCode(exitUsage, fmt.Errorf("%s holds %s, which no earlier run of this command wrote; pass --force to overwrite it or --out for another directory", out, entry.Name()))
+		}
+	}
+	return nil
 }
 
 // nearestExistingDir walks up from path to the first directory that exists,

--- a/cmd/migrate_up_test.go
+++ b/cmd/migrate_up_test.go
@@ -243,3 +243,33 @@ func TestMigrateUpNoDataDeploysOnly(t *testing.T) {
 		t.Errorf("--stop-source without data is a usage error, got %v", err)
 	}
 }
+
+func TestMigrateUpRunsAgainIntoTheSameDirectory(t *testing.T) {
+	fakeDockerOnPath(t)
+	mock := newMigrateUpMock()
+	installMigrateUpMock(t, mock)
+	dir := writeMigrateFixture(t)
+	out := filepath.Join(t.TempDir(), "migration")
+
+	if _, stderr, err := runMigrate(t, "up", dir, "--out", out, "--cluster", migrateRestoreTestCluster, "--yes"); err != nil {
+		t.Fatalf("first run: %v\n%s", err, stderr)
+	}
+	mock.podPolls = 0
+	if _, stderr, err := runMigrate(t, "up", dir, "--out", out, "--cluster", migrateRestoreTestCluster, "--yes"); err != nil {
+		t.Fatalf("the rehearsal's output directory must be reusable for the cutover without --force: %v\n%s", err, stderr)
+	}
+	if len(mock.applied) != 2 {
+		t.Errorf("both runs must deploy, got %d", len(mock.applied))
+	}
+
+	if writeError := os.WriteFile(filepath.Join(out, "notes.txt"), []byte("mine"), 0o644); writeError != nil {
+		t.Fatal(writeError)
+	}
+	_, _, err := runMigrate(t, "up", dir, "--out", out, "--cluster", migrateRestoreTestCluster, "--yes")
+	if exitCodeFor(err) != exitUsage || !strings.Contains(err.Error(), "holds notes.txt") {
+		t.Errorf("a directory with someone else's files needs --force, got %v", err)
+	}
+	if _, _, err = runMigrate(t, "up", dir, "--out", out, "--cluster", migrateRestoreTestCluster, "--yes", "--force"); err != nil {
+		t.Errorf("--force overwrites: %v", err)
+	}
+}


### PR DESCRIPTION
## What & why

Bead: ankra-k6ikc.8 (follow-up; found while writing the docs guide against source).

- `ankra migrate up` is built around running twice (rehearse, then `--stop-source` for the cutover), but the second run refused `--out` as "not empty" because the first run had left `stack/` and `data/` there. A directory that holds nothing but an earlier run's output is now reused; `--force` is only for a directory holding other files, and the error names the file that is in the way.
- `ankra migrate convert` printed `ankra cluster apply <out>/cluster.yaml` as the next step; that command takes no positional argument and requires `-f`. Help text and the printed hint now say `-f`.

## Test plan

- Pre-commit hook (tests + golangci-lint) green.
- `TestMigrateUpRunsAgainIntoTheSameDirectory`: two runs into one `--out` both deploy; a foreign file makes it a usage error naming the file; `--force` overwrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhfwAPcMpkMEbZs1jyfTxs
