### PR TITLE
feat(migrate): dumps above 1 GiB are uploaded in parts; the 5 GiB ceiling is gone (ankra-k6ikc.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- **Dumps above 1 GiB are uploaded in parts, and the 5 GiB ceiling is
+  gone.** `ankra migrate restore`, `data` and `up` now send a large dump
+  as a multipart upload the platform starts for them: 64 MiB parts, each
+  retried on its own when the link hiccups, completed by the CLI and
+  aborted if it cannot finish, so the vault never keeps half an upload. An
+  artifact may be up to 625 GiB (10,000 parts of 64 MiB). The progress line says how
+  many parts a dump has.
 - **`ankra migrate imports list` and `ankra migrate imports delete` manage
   the dumps a migration leaves in the backup vault.** Every restore keeps its
   upload under `imports/<import-id>/` so the same data can be restored

--- a/cmd/diskfree_unix.go
+++ b/cmd/diskfree_unix.go
@@ -4,9 +4,9 @@ package cmd
 
 import "syscall"
 
-// freeDiskBytes reports how much the filesystem holding path can still take,
+// statfsFreeBytes reports how much the filesystem holding path can still take,
 // or ok=false when it cannot tell.
-func freeDiskBytes(path string) (int64, bool) {
+func statfsFreeBytes(path string) (int64, bool) {
 	var stat syscall.Statfs_t
 	if statError := syscall.Statfs(path, &stat); statError != nil {
 		return 0, false

--- a/cmd/diskfree_windows.go
+++ b/cmd/diskfree_windows.go
@@ -2,8 +2,8 @@
 
 package cmd
 
-// freeDiskBytes is not measured on Windows; the caller treats the space as
+// statfsFreeBytes is not measured on Windows; the caller treats the space as
 // unknown rather than as plentiful.
-func freeDiskBytes(string) (int64, bool) {
+func statfsFreeBytes(string) (int64, bool) {
 	return 0, false
 }

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -559,7 +559,7 @@ func (m baseMock) DeleteBackupVaultImport(string, string) error {
 	return errors.New("not implemented")
 }
 
-func (m baseMock) UploadPresignedObject(ctx context.Context, method string, uploadURL string, body io.ReadSeeker, size int64) error {
+func (m baseMock) UploadPresignedObject(context.Context, client.BackupVaultImportUpload, client.UploadBody, int64) error {
 	return errors.New("not implemented")
 }
 

--- a/cmd/migrate_restore.go
+++ b/cmd/migrate_restore.go
@@ -259,9 +259,9 @@ func performMigrateRestore(cmd *cobra.Command, exportDir string, targets migrate
 	}
 	for _, database := range manifest.Databases {
 		for _, artifact := range database.Artifacts {
-			if artifact.SizeBytes > client.PresignedUploadMaximumBytes {
-				return nil, withExitCode(exitUsage, fmt.Errorf("artifact %s is %s; a single upload carries at most %s, and multipart uploads are not supported yet",
-					artifact.Path, formatByteSize(artifact.SizeBytes), formatByteSize(client.PresignedUploadMaximumBytes)))
+			if artifact.SizeBytes > client.ImportArtifactMaximumBytes {
+				return nil, withExitCode(exitUsage, fmt.Errorf("artifact %s is %s; an upload carries at most %s",
+					artifact.Path, formatByteSize(artifact.SizeBytes), formatByteSize(client.ImportArtifactMaximumBytes)))
 			}
 		}
 	}
@@ -284,7 +284,11 @@ func performMigrateRestore(cmd *cobra.Command, exportDir string, targets migrate
 		if info.Size() != upload.SizeBytes {
 			return nil, fmt.Errorf("artifact %s is %d bytes but the manifest recorded %d; run `ankra migrate export` again", upload.Path, info.Size(), upload.SizeBytes)
 		}
-		_, _ = fmt.Fprintf(progress, "Uploading %s (%s)\n", upload.Path, formatByteSize(info.Size()))
+		if upload.Method == client.BackupVaultImportUploadMethodMultipart {
+			_, _ = fmt.Fprintf(progress, "Uploading %s (%s, %d parts)\n", upload.Path, formatByteSize(info.Size()), len(upload.Parts))
+		} else {
+			_, _ = fmt.Fprintf(progress, "Uploading %s (%s)\n", upload.Path, formatByteSize(info.Size()))
+		}
 		if uploadError := uploadMigrateArtifact(cmd.Context(), localPath, upload, info.Size()); uploadError != nil {
 			return nil, fmt.Errorf("uploading %s: %w", upload.Path, uploadError)
 		}
@@ -312,7 +316,7 @@ func uploadMigrateArtifact(ctx context.Context, localPath string, upload client.
 		return openError
 	}
 	defer func() { _ = file.Close() }()
-	return apiClient.UploadPresignedObject(ctx, upload.Method, upload.URL, file, size)
+	return apiClient.UploadPresignedObject(ctx, upload, file, size)
 }
 
 // exportSourceDir is where the export was taken from, when the manifest

--- a/cmd/migrate_restore_test.go
+++ b/cmd/migrate_restore_test.go
@@ -39,6 +39,8 @@ type migrateRestoreMock struct {
 	vaultIDs     []string
 	createdWith  *client.CreateBackupVaultImportRequest
 	uploads      map[string]int64
+	multipartFor string
+	uploaded     []client.BackupVaultImportUpload
 	completed    int
 	restored     int
 	getStatuses  []string
@@ -70,19 +72,38 @@ func (mock *migrateRestoreMock) CreateBackupVaultImport(vaultID string, request 
 	var uploads []client.BackupVaultImportUpload
 	for _, database := range manifest.Databases {
 		for _, artifact := range database.Artifacts {
-			uploads = append(uploads, client.BackupVaultImportUpload{
+			upload := client.BackupVaultImportUpload{
 				Path: artifact.Path, Method: "PUT", SizeBytes: artifact.SizeBytes,
 				URL: "https://vault.example.com/imports/1/" + artifact.Path + "?sig=" + artifact.Path,
-			})
+			}
+			if mock.multipartFor == artifact.Path {
+				upload = client.BackupVaultImportUpload{
+					Path: artifact.Path, Method: client.BackupVaultImportUploadMethodMultipart, SizeBytes: artifact.SizeBytes,
+					UploadID: "up-1", PartSizeBytes: 2,
+					Parts: []client.BackupVaultImportUploadPart{
+						{PartNumber: 1, URL: "https://vault.example.com/imports/1/" + artifact.Path + "?partNumber=1&uploadId=up-1"},
+						{PartNumber: 2, URL: "https://vault.example.com/imports/1/" + artifact.Path + "?partNumber=2&uploadId=up-1"},
+						{PartNumber: 3, URL: "https://vault.example.com/imports/1/" + artifact.Path + "?partNumber=3&uploadId=up-1"},
+					},
+					CompleteURL: "https://vault.example.com/imports/1/" + artifact.Path + "?uploadId=up-1",
+					AbortURL:    "https://vault.example.com/imports/1/" + artifact.Path + "?uploadId=up-1&abort",
+				}
+			}
+			uploads = append(uploads, upload)
 		}
 	}
 	imported := mock.importView(client.BackupVaultImportStatusUploading)
 	return &client.CreateBackupVaultImportResult{Import: imported, Uploads: uploads}, nil
 }
 
-func (mock *migrateRestoreMock) UploadPresignedObject(_ context.Context, method string, uploadURL string, body io.ReadSeeker, size int64) error {
-	if method != http.MethodPut {
-		return fmt.Errorf("the platform minted a %s upload; the CLI must use it as given", method)
+func (mock *migrateRestoreMock) UploadPresignedObject(_ context.Context, upload client.BackupVaultImportUpload, body client.UploadBody, size int64) error {
+	mock.uploaded = append(mock.uploaded, upload)
+	if upload.Method != http.MethodPut && upload.Method != client.BackupVaultImportUploadMethodMultipart {
+		return fmt.Errorf("the platform minted a %s upload; the CLI must use it as given", upload.Method)
+	}
+	uploadURL := upload.URL
+	if upload.Method == client.BackupVaultImportUploadMethodMultipart {
+		uploadURL = upload.CompleteURL
 	}
 	if mock.uploadFailOn != "" && strings.Contains(uploadURL, mock.uploadFailOn) {
 		return errors.New("403 SignatureDoesNotMatch")
@@ -331,13 +352,13 @@ func TestMigrateRestoreRefusesArtifactsAboveOneUpload(t *testing.T) {
 	mock := &migrateRestoreMock{vaults: []client.BackupVault{readyVault("backups1")}, getStatuses: []string{"completed"}}
 	installMigrateRestoreMock(t, mock)
 	dir := writeMigrateRestoreFixture(t)
-	oversize := strings.Replace(migrateRestoreTestManifest, `"size_bytes": 5,`, `"size_bytes": 6442450944,`, 1)
+	oversize := strings.Replace(migrateRestoreTestManifest, `"size_bytes": 5,`, `"size_bytes": 671088640001,`, 1)
 	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(oversize), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	_, _, err := runMigrate(t, "restore", dir, "--cluster", migrateRestoreTestCluster)
-	if exitCodeFor(err) != exitUsage || !strings.Contains(err.Error(), "db/office.dump is 6.0 GiB") || !strings.Contains(err.Error(), "multipart") {
+	if exitCodeFor(err) != exitUsage || !strings.Contains(err.Error(), "db/office.dump is 625.0 GiB") || !strings.Contains(err.Error(), "an upload carries at most 625.0 GiB") {
 		t.Errorf("an artifact above one presigned upload must be refused up front, got %v", err)
 	}
 	if mock.createdWith != nil {
@@ -432,5 +453,28 @@ func TestMigrateDataExportsThenRestores(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "Exported 1 database server(s)") || !strings.Contains(stdout, "Restore complete") {
 		t.Errorf("stdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+}
+
+func TestMigrateRestorePassesAMultipartUploadThrough(t *testing.T) {
+	mock := &migrateRestoreMock{vaults: []client.BackupVault{readyVault("backups1")}, getStatuses: []string{"completed"}, multipartFor: "db/office.dump"}
+	installMigrateRestoreMock(t, mock)
+	dir := writeMigrateRestoreFixture(t)
+
+	_, stderr, err := runMigrate(t, "restore", dir, "--cluster", migrateRestoreTestCluster)
+	if err != nil {
+		t.Fatalf("%v\n%s", err, stderr)
+	}
+	if !strings.Contains(stderr, "Uploading db/office.dump (5 B, 3 parts)") {
+		t.Errorf("a multipart upload says how many parts it has:\n%s", stderr)
+	}
+	var multipart *client.BackupVaultImportUpload
+	for index := range mock.uploaded {
+		if mock.uploaded[index].Method == client.BackupVaultImportUploadMethodMultipart {
+			multipart = &mock.uploaded[index]
+		}
+	}
+	if multipart == nil || multipart.UploadID != "up-1" || len(multipart.Parts) != 3 || multipart.CompleteURL == "" || multipart.AbortURL == "" {
+		t.Errorf("the upload must reach the client as the platform described it, got %+v", mock.uploaded)
 	}
 }

--- a/cmd/migrate_up.go
+++ b/cmd/migrate_up.go
@@ -38,6 +38,10 @@ var (
 // for readiness; tests shorten it.
 var migrateUpPodPollInterval = 5 * time.Second
 
+// freeDiskBytes measures the space left where the dumps go; tests replace
+// it so a plan's verdict does not depend on the machine running them.
+var freeDiskBytes = statfsFreeBytes
+
 var migrateUpCmd = &cobra.Command{
 	Use:   "up [dir]",
 	Short: "Move a deployment into a cluster - convert, deploy and carry its data over - in one command",
@@ -293,9 +297,9 @@ func planMigrateUp(cmd *cobra.Command, dir string, module migrate.Module, option
 			for _, server := range exportPlan.Databases {
 				plan.EstimatedBytes += server.EstimatedBytes()
 				for _, database := range server.Databases {
-					if database.SizeBytes > client.PresignedUploadMaximumBytes {
-						plan.Warnings = append(plan.Warnings, fmt.Sprintf("%s: database %s is %s on the source; a dump above %s cannot be uploaded in one piece and would be refused",
-							server.Workload, database.Name, formatByteSize(database.SizeBytes), formatByteSize(client.PresignedUploadMaximumBytes)))
+					if database.SizeBytes > client.ImportArtifactMaximumBytes {
+						plan.Warnings = append(plan.Warnings, fmt.Sprintf("%s: database %s is %s on the source; a dump above %s cannot be uploaded and would be refused",
+							server.Workload, database.Name, formatByteSize(database.SizeBytes), formatByteSize(client.ImportArtifactMaximumBytes)))
 					}
 				}
 			}

--- a/cmd/migrate_up_test.go
+++ b/cmd/migrate_up_test.go
@@ -204,7 +204,10 @@ func TestMigrateUpRefusesBeforeTouchingAnythingWhenTheVaultIsMissing(t *testing.
 
 func TestMigrateUpWarnsAboutADatabaseAboveOneUpload(t *testing.T) {
 	fakeDockerOnPath(t)
-	t.Setenv("FAKE_DB_SIZE", "6442450944")
+	t.Setenv("FAKE_DB_SIZE", "671088640001")
+	originalFree := freeDiskBytes
+	freeDiskBytes = func(string) (int64, bool) { return 1 << 50, true }
+	t.Cleanup(func() { freeDiskBytes = originalFree })
 	installMigrateUpMock(t, newMigrateUpMock())
 	dir := writeMigrateFixture(t)
 
@@ -212,7 +215,7 @@ func TestMigrateUpWarnsAboutADatabaseAboveOneUpload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v\n%s", err, stderr)
 	}
-	if !strings.Contains(stderr, "db: database office is 6.0 GiB on the source; a dump above 5.0 GiB cannot be uploaded in one piece") {
+	if !strings.Contains(stderr, "db: database office is 625.0 GiB on the source; a dump above 625.0 GiB cannot be uploaded") {
 		t.Errorf("the plan must warn about the upload limit:\n%s", stderr)
 	}
 }
@@ -241,5 +244,23 @@ func TestMigrateUpNoDataDeploysOnly(t *testing.T) {
 	_, _, err = runMigrate(t, "up", dir, "--out", filepath.Join(t.TempDir(), "m2"), "--cluster", migrateRestoreTestCluster, "--no-data", "--stop-source", "--yes")
 	if exitCodeFor(err) != exitUsage {
 		t.Errorf("--stop-source without data is a usage error, got %v", err)
+	}
+}
+
+func TestMigrateUpRefusesWhenTheDumpsDoNotFit(t *testing.T) {
+	fakeDockerOnPath(t)
+	originalFree := freeDiskBytes
+	freeDiskBytes = func(string) (int64, bool) { return 1 << 20, true }
+	t.Cleanup(func() { freeDiskBytes = originalFree })
+	installMigrateUpMock(t, newMigrateUpMock())
+	dir := writeMigrateFixture(t)
+	out := filepath.Join(t.TempDir(), "m")
+
+	_, _, err := runMigrate(t, "up", dir, "--out", out, "--cluster", migrateRestoreTestCluster, "--yes")
+	if exitCodeFor(err) != exitUsage || !strings.Contains(err.Error(), "only 1.0 MiB is free") {
+		t.Errorf("dumps that do not fit must stop the plan, got %v", err)
+	}
+	if _, statError := os.Stat(out); statError == nil {
+		t.Error("a refused plan must leave no output directory")
 	}
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -59,7 +59,7 @@ type APIClient interface {
 	GetBackupVaultImport(vaultID string, importID string) (*client.BackupVaultImport, error)
 	ListBackupVaultImports(vaultID string) (*client.BackupVaultImportListResult, error)
 	DeleteBackupVaultImport(vaultID string, importID string) error
-	UploadPresignedObject(ctx context.Context, method string, uploadURL string, body io.ReadSeeker, size int64) error
+	UploadPresignedObject(ctx context.Context, upload client.BackupVaultImportUpload, body client.UploadBody, size int64) error
 
 	ListExecutions(opts client.ListExecutionsOptions) (client.ExecutionListResponse, error)
 	GetExecution(executionID string) (client.ExecutionDetail, error)

--- a/internal/client/backup_vault_imports.go
+++ b/internal/client/backup_vault_imports.go
@@ -1,8 +1,11 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -84,15 +87,35 @@ const (
 	BackupVaultImportStatusFailed    = "failed"
 )
 
-// BackupVaultImportUpload is one presigned PUT the CLI performs straight
-// against the vault's bucket; the platform never sees the bytes.
+// BackupVaultImportUpload is one upload the CLI performs straight against
+// the vault's bucket; the platform never sees the bytes. Method PUT carries
+// one presigned URL for the whole object; Method multipart carries one
+// presigned PUT per part of PartSizeBytes (the last one shorter) and the
+// presigned calls that complete or abort the upload.
 type BackupVaultImportUpload struct {
-	Path      string `json:"path"`
-	Method    string `json:"method"`
-	URL       string `json:"url"`
-	ExpiresAt string `json:"expires_at"`
-	SizeBytes int64  `json:"size_bytes"`
+	Path          string                        `json:"path"`
+	Method        string                        `json:"method"`
+	URL           string                        `json:"url,omitempty"`
+	ExpiresAt     string                        `json:"expires_at"`
+	SizeBytes     int64                         `json:"size_bytes"`
+	UploadID      string                        `json:"upload_id,omitempty"`
+	PartSizeBytes int64                         `json:"part_size_bytes,omitempty"`
+	Parts         []BackupVaultImportUploadPart `json:"parts,omitempty"`
+	CompleteURL   string                        `json:"complete_url,omitempty"`
+	AbortURL      string                        `json:"abort_url,omitempty"`
 }
+
+// BackupVaultImportUploadPart is one presigned PUT of a multipart upload.
+type BackupVaultImportUploadPart struct {
+	PartNumber int    `json:"part_number"`
+	URL        string `json:"url"`
+}
+
+// Upload methods the platform mints.
+const (
+	BackupVaultImportUploadMethodPut       = "PUT"
+	BackupVaultImportUploadMethodMultipart = "multipart"
+)
 
 // CreateBackupVaultImportRequest registers an export: the cluster its data
 // goes to and the export's manifest.json, passed through verbatim.
@@ -180,37 +203,56 @@ func (c *Client) DeleteBackupVaultImport(vaultID string, importID string) error 
 	return c.sendJSON(http.MethodDelete, url, nil, nil)
 }
 
-// PresignedUploadMaximumBytes is the largest object a single presigned PUT
-// can carry on S3 and every compatible store; a bigger artifact needs a
-// multipart upload the platform does not mint yet.
-const PresignedUploadMaximumBytes = 5 << 30
+// ImportArtifactMaximumBytes is the largest artifact an import accepts: the
+// 10,000 parts of 64 MiB a multipart upload can carry. It mirrors the
+// platform's limit so the CLI can refuse before registering anything.
+const ImportArtifactMaximumBytes = int64(64<<20) * 10000
 
 const presignedUploadAttempts = 3
 
-// UploadPresignedObject sends one artifact to a presigned URL. The URL is the
-// whole credential, so no bearer token and no Ankra header is sent - the
-// request goes through a plain transport, never the API client's - and the
-// body carries its exact size because the vault rejects a chunked upload and
-// the platform verifies the object at that size afterwards. A dump can be
-// large, so the upload has no per-request timeout beyond ctx; a transport
-// failure or a 5xx is retried from the start of the body, and a redirect
-// replays it, which is why the body must seek.
-func (c *Client) UploadPresignedObject(ctx context.Context, method string, uploadURL string, body io.ReadSeeker, size int64) error {
+// UploadBody is what an upload reads from: seekable, so a failed attempt
+// restarts from the beginning, and addressable, so a multipart upload can
+// send each part from its own offset. A file is both.
+type UploadBody interface {
+	io.ReadSeeker
+	io.ReaderAt
+}
+
+// UploadPresignedObject sends one artifact to the vault as the platform
+// described the upload: a single PUT, or a multipart upload part by part.
+// The URLs are the whole credential, so no bearer token and no Ankra header
+// is sent - the requests go through a plain transport, never the API
+// client's. Every request carries its exact length because the vault
+// rejects a chunked upload and the platform verifies the object's size
+// afterwards. A transport failure or a 5xx is retried from the start of the
+// body (or the part), which is why the body must seek; a refusal is final.
+func (c *Client) UploadPresignedObject(ctx context.Context, upload BackupVaultImportUpload, body UploadBody, size int64) error {
+	if size > ImportArtifactMaximumBytes {
+		return fmt.Errorf("the artifact is %d bytes; an upload can carry at most %d", size, ImportArtifactMaximumBytes)
+	}
+	uploadClient := &http.Client{}
+	if upload.Method == BackupVaultImportUploadMethodMultipart {
+		return uploadMultipart(ctx, uploadClient, upload, body, size)
+	}
+	method := upload.Method
 	if method == "" {
 		method = http.MethodPut
 	}
-	if size > PresignedUploadMaximumBytes {
-		return fmt.Errorf("the artifact is %d bytes; a single upload can carry at most %d", size, PresignedUploadMaximumBytes)
-	}
-	uploadClient := &http.Client{}
+	_, putError := putPresigned(ctx, uploadClient, method, upload.URL, body, size)
+	return putError
+}
+
+// putPresigned sends body to one presigned URL with retries and returns the
+// ETag the store answered with, which a multipart completion needs.
+func putPresigned(ctx context.Context, uploadClient *http.Client, method string, uploadURL string, body io.ReadSeeker, size int64) (string, error) {
 	var lastError error
 	for attempt := 1; attempt <= presignedUploadAttempts; attempt++ {
 		if _, seekError := body.Seek(0, io.SeekStart); seekError != nil {
-			return fmt.Errorf("rewind upload body: %w", seekError)
+			return "", fmt.Errorf("rewind upload body: %w", seekError)
 		}
 		request, requestError := http.NewRequestWithContext(ctx, method, uploadURL, body)
 		if requestError != nil {
-			return fmt.Errorf("create upload request: %w", requestError)
+			return "", fmt.Errorf("create upload request: %w", requestError)
 		}
 		request.ContentLength = size
 		request.Header.Set("Content-Type", "application/octet-stream")
@@ -225,19 +267,113 @@ func (c *Client) UploadPresignedObject(ctx context.Context, method string, uploa
 		if doError != nil {
 			lastError = fmt.Errorf("upload failed: %w", doError)
 			if ctx.Err() != nil {
-				return lastError
+				return "", lastError
 			}
 			continue
 		}
 		responseBody, _ := io.ReadAll(io.LimitReader(response.Body, 2048))
 		closeBody(response)
 		if response.StatusCode >= 200 && response.StatusCode < 300 {
-			return nil
+			return response.Header.Get("ETag"), nil
 		}
 		lastError = newUnexpectedResponseError("upload", response.StatusCode, redactedBodyForError(responseBody, 500))
 		if response.StatusCode < 500 {
-			return lastError
+			return "", lastError
+		}
+	}
+	return "", lastError
+}
+
+// uploadMultipart sends the body part by part to the presigned part URLs,
+// then completes the upload with the ETags the store handed back. Any
+// failure aborts the upload so the store does not keep the parts.
+func uploadMultipart(ctx context.Context, uploadClient *http.Client, upload BackupVaultImportUpload, body UploadBody, size int64) error {
+	if upload.PartSizeBytes <= 0 || len(upload.Parts) == 0 || upload.CompleteURL == "" {
+		return errors.New("the platform described a multipart upload without parts or a completion")
+	}
+	expectedParts := int((size + upload.PartSizeBytes - 1) / upload.PartSizeBytes)
+	if expectedParts != len(upload.Parts) {
+		return fmt.Errorf("the platform minted %d part(s) for an artifact that needs %d; run `ankra migrate export` again", len(upload.Parts), expectedParts)
+	}
+	completed := make([]multipartCompletedPart, 0, len(upload.Parts))
+	for index, part := range upload.Parts {
+		offset := int64(index) * upload.PartSizeBytes
+		length := min(upload.PartSizeBytes, size-offset)
+		section := io.NewSectionReader(body, offset, length)
+		etag, putError := putPresigned(ctx, uploadClient, http.MethodPut, part.URL, section, length)
+		if putError != nil {
+			abortMultipart(ctx, uploadClient, upload.AbortURL)
+			return fmt.Errorf("part %d of %d: %w", part.PartNumber, len(upload.Parts), putError)
+		}
+		completed = append(completed, multipartCompletedPart{PartNumber: part.PartNumber, ETag: etag})
+	}
+	if completeError := completeMultipart(ctx, uploadClient, upload.CompleteURL, completed); completeError != nil {
+		abortMultipart(ctx, uploadClient, upload.AbortURL)
+		return completeError
+	}
+	return nil
+}
+
+type multipartCompletedPart struct {
+	PartNumber int    `xml:"PartNumber"`
+	ETag       string `xml:"ETag"`
+}
+
+type completeMultipartUploadRequest struct {
+	XMLName xml.Name                 `xml:"CompleteMultipartUpload"`
+	Parts   []multipartCompletedPart `xml:"Part"`
+}
+
+// completeMultipart posts the part list to the presigned completion. S3 may
+// answer 200 with an error document when the assembly fails after the
+// headers went out, so the body is read for one.
+func completeMultipart(ctx context.Context, uploadClient *http.Client, completeURL string, parts []multipartCompletedPart) error {
+	document, marshalError := xml.Marshal(completeMultipartUploadRequest{Parts: parts})
+	if marshalError != nil {
+		return fmt.Errorf("render the completion: %w", marshalError)
+	}
+	var lastError error
+	for attempt := 1; attempt <= presignedUploadAttempts; attempt++ {
+		request, requestError := http.NewRequestWithContext(ctx, http.MethodPost, completeURL, bytes.NewReader(document))
+		if requestError != nil {
+			return fmt.Errorf("create completion request: %w", requestError)
+		}
+		request.ContentLength = int64(len(document))
+		request.Header.Set("Content-Type", "application/xml")
+		response, doError := uploadClient.Do(request)
+		if doError != nil {
+			lastError = fmt.Errorf("completing the upload failed: %w", doError)
+			if ctx.Err() != nil {
+				return lastError
+			}
+			continue
+		}
+		responseBody, _ := io.ReadAll(io.LimitReader(response.Body, 64<<10))
+		closeBody(response)
+		switch {
+		case response.StatusCode >= 200 && response.StatusCode < 300 && !bytes.Contains(responseBody, []byte("<Error>")):
+			return nil
+		case response.StatusCode >= 500 || bytes.Contains(responseBody, []byte("<Error>")) && response.StatusCode < 300:
+			lastError = newUnexpectedResponseError("completing the upload", response.StatusCode, redactedBodyForError(responseBody, 500))
+		default:
+			return newUnexpectedResponseError("completing the upload", response.StatusCode, redactedBodyForError(responseBody, 500))
 		}
 	}
 	return lastError
+}
+
+// abortMultipart tells the store to drop the parts of an upload that will
+// never complete, best effort: the platform's completion check would have
+// refused the object anyway, this just stops the parts costing storage.
+func abortMultipart(ctx context.Context, uploadClient *http.Client, abortURL string) {
+	if abortURL == "" {
+		return
+	}
+	request, requestError := http.NewRequestWithContext(ctx, http.MethodDelete, abortURL, nil)
+	if requestError != nil {
+		return
+	}
+	if response, doError := uploadClient.Do(request); doError == nil {
+		closeBody(response)
+	}
 }

--- a/internal/client/backup_vault_imports_test.go
+++ b/internal/client/backup_vault_imports_test.go
@@ -2,10 +2,12 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -29,7 +31,7 @@ func TestUploadPresignedObjectPutsTheBodyWithoutABearerToken(t *testing.T) {
 	defer server.Close()
 
 	apiClient := &Client{BaseURL: server.URL, Token: "secret-token", HTTP: server.Client()}
-	uploadError := apiClient.UploadPresignedObject(context.Background(), http.MethodPut, server.URL+"/bucket/imports/1/db/office.dump?X-Amz-Signature=abc", strings.NewReader("PGDMP"), 5)
+	uploadError := apiClient.UploadPresignedObject(context.Background(), BackupVaultImportUpload{Method: http.MethodPut, URL: server.URL + "/bucket/imports/1/db/office.dump?X-Amz-Signature=abc"}, strings.NewReader("PGDMP"), 5)
 	if uploadError != nil {
 		t.Fatal(uploadError)
 	}
@@ -50,7 +52,7 @@ func TestUploadPresignedObjectReportsTheBucketsRefusal(t *testing.T) {
 	}))
 	defer server.Close()
 	apiClient := &Client{BaseURL: server.URL, HTTP: server.Client()}
-	uploadError := apiClient.UploadPresignedObject(context.Background(), http.MethodPut, server.URL+"/x", strings.NewReader("x"), 1)
+	uploadError := apiClient.UploadPresignedObject(context.Background(), BackupVaultImportUpload{Method: http.MethodPut, URL: server.URL + "/x"}, strings.NewReader("x"), 1)
 	if uploadError == nil || !strings.Contains(uploadError.Error(), "SignatureDoesNotMatch") {
 		t.Errorf("the bucket's reason must surface, got %v", uploadError)
 	}
@@ -72,7 +74,7 @@ func TestUploadPresignedObjectRetriesAServerFailureFromTheStart(t *testing.T) {
 	}))
 	defer server.Close()
 	apiClient := &Client{BaseURL: server.URL, HTTP: server.Client()}
-	uploadError := apiClient.UploadPresignedObject(context.Background(), http.MethodPut, server.URL+"/x", strings.NewReader("PGDMP"), 5)
+	uploadError := apiClient.UploadPresignedObject(context.Background(), BackupVaultImportUpload{Method: http.MethodPut, URL: server.URL + "/x"}, strings.NewReader("PGDMP"), 5)
 	if uploadError != nil {
 		t.Fatal(uploadError)
 	}
@@ -83,7 +85,7 @@ func TestUploadPresignedObjectRetriesAServerFailureFromTheStart(t *testing.T) {
 
 func TestUploadPresignedObjectRefusesMoreThanOneUploadCarries(t *testing.T) {
 	apiClient := &Client{BaseURL: "http://unused.invalid"}
-	uploadError := apiClient.UploadPresignedObject(context.Background(), http.MethodPut, "http://unused.invalid/x", strings.NewReader(""), PresignedUploadMaximumBytes+1)
+	uploadError := apiClient.UploadPresignedObject(context.Background(), BackupVaultImportUpload{Method: http.MethodPut, URL: "http://unused.invalid/x"}, strings.NewReader(""), ImportArtifactMaximumBytes+1)
 	if uploadError == nil || !strings.Contains(uploadError.Error(), "at most") {
 		t.Errorf("an artifact above the single-upload limit must be refused without a request, got %v", uploadError)
 	}
@@ -136,5 +138,116 @@ func TestBackupVaultImportRoutes(t *testing.T) {
 	}
 	if strings.Join(paths, "\n") != strings.Join(want, "\n") {
 		t.Errorf("paths = %v", paths)
+	}
+}
+
+// multipartFake is an object store that accepts part PUTs, hands back
+// ETags, and records the completion or abort it received.
+type multipartFake struct {
+	mutex        sync.Mutex
+	parts        map[string]string
+	completed    string
+	aborted      bool
+	failPart     string
+	completeBody string
+}
+
+func newMultipartFake(t *testing.T) (*multipartFake, *httptest.Server) {
+	t.Helper()
+	fake := &multipartFake{parts: map[string]string{}}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		fake.mutex.Lock()
+		defer fake.mutex.Unlock()
+		query := request.URL.Query()
+		switch {
+		case request.Method == http.MethodPut && query.Get("partNumber") != "":
+			content, _ := io.ReadAll(request.Body)
+			if query.Get("partNumber") == fake.failPart {
+				writer.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			fake.parts[query.Get("partNumber")] = string(content)
+			writer.Header().Set("ETag", `"etag-`+query.Get("partNumber")+`"`)
+			writer.WriteHeader(http.StatusOK)
+		case request.Method == http.MethodPost && query.Get("uploadId") != "":
+			content, _ := io.ReadAll(request.Body)
+			fake.completed = string(content)
+			if fake.completeBody != "" {
+				writer.WriteHeader(http.StatusOK)
+				_, _ = writer.Write([]byte(fake.completeBody))
+				return
+			}
+			writer.WriteHeader(http.StatusOK)
+			_, _ = writer.Write([]byte("<CompleteMultipartUploadResult><ETag>\"final\"</ETag></CompleteMultipartUploadResult>"))
+		case request.Method == http.MethodDelete && query.Get("uploadId") != "":
+			fake.aborted = true
+			writer.WriteHeader(http.StatusNoContent)
+		default:
+			writer.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return fake, server
+}
+
+func multipartUpload(server *httptest.Server, partSize int64, parts int) BackupVaultImportUpload {
+	upload := BackupVaultImportUpload{
+		Method: BackupVaultImportUploadMethodMultipart, UploadID: "up-1", PartSizeBytes: partSize,
+		CompleteURL: server.URL + "/o?uploadId=up-1&X-Amz-Signature=c", AbortURL: server.URL + "/o?uploadId=up-1&X-Amz-Signature=a",
+	}
+	for number := 1; number <= parts; number++ {
+		upload.Parts = append(upload.Parts, BackupVaultImportUploadPart{PartNumber: number, URL: fmt.Sprintf("%s/o?partNumber=%d&uploadId=up-1&X-Amz-Signature=p", server.URL, number)})
+	}
+	return upload
+}
+
+func TestUploadPresignedObjectSendsAMultipartUploadPartByPart(t *testing.T) {
+	fake, server := newMultipartFake(t)
+	apiClient := &Client{BaseURL: server.URL, Token: "secret-token", HTTP: server.Client()}
+	body := strings.NewReader("0123456789abcdefXYZ")
+	uploadError := apiClient.UploadPresignedObject(context.Background(), multipartUpload(server, 8, 3), body, 19)
+	if uploadError != nil {
+		t.Fatal(uploadError)
+	}
+	if fake.parts["1"] != "01234567" || fake.parts["2"] != "89abcdef" || fake.parts["3"] != "XYZ" {
+		t.Errorf("parts must be the body split at the part size, got %v", fake.parts)
+	}
+	for _, want := range []string{"<CompleteMultipartUpload>", "<Part><PartNumber>1</PartNumber><ETag>&#34;etag-1&#34;</ETag></Part>", "<PartNumber>3</PartNumber><ETag>&#34;etag-3&#34;</ETag>"} {
+		if !strings.Contains(fake.completed, want) {
+			t.Errorf("the completion must list every part with its ETag, want %q in:\n%s", want, fake.completed)
+		}
+	}
+	if fake.aborted {
+		t.Error("a successful upload must not be aborted")
+	}
+}
+
+func TestUploadPresignedObjectAbortsAMultipartUploadThatFails(t *testing.T) {
+	fake, server := newMultipartFake(t)
+	fake.failPart = "2"
+	apiClient := &Client{BaseURL: server.URL, HTTP: server.Client()}
+	uploadError := apiClient.UploadPresignedObject(context.Background(), multipartUpload(server, 8, 3), strings.NewReader("0123456789abcdefXYZ"), 19)
+	if uploadError == nil || !strings.Contains(uploadError.Error(), "part 2 of 3") {
+		t.Fatalf("the failing part must be named, got %v", uploadError)
+	}
+	if !fake.aborted || fake.completed != "" {
+		t.Errorf("a failed upload is aborted, never completed: aborted=%v completed=%q", fake.aborted, fake.completed)
+	}
+
+	fake, server = newMultipartFake(t)
+	fake.completeBody = "<Error><Code>InternalError</Code><Message>We encountered an internal error.</Message></Error>"
+	apiClient = &Client{BaseURL: server.URL, HTTP: server.Client()}
+	uploadError = apiClient.UploadPresignedObject(context.Background(), multipartUpload(server, 8, 3), strings.NewReader("0123456789abcdefXYZ"), 19)
+	if uploadError == nil || !strings.Contains(uploadError.Error(), "InternalError") {
+		t.Fatalf("a 200 carrying an error document is a failed completion, got %v", uploadError)
+	}
+	if !fake.aborted {
+		t.Error("a failed completion is aborted")
+	}
+
+	apiClient = &Client{BaseURL: server.URL, HTTP: server.Client()}
+	uploadError = apiClient.UploadPresignedObject(context.Background(), multipartUpload(server, 8, 2), strings.NewReader("0123456789abcdefXYZ"), 19)
+	if uploadError == nil || !strings.Contains(uploadError.Error(), "minted 2 part(s) for an artifact that needs 3") {
+		t.Errorf("a part count that does not cover the artifact is refused before any byte moves, got %v", uploadError)
 	}
 }


### PR DESCRIPTION
## What & why

Bead: ankra-k6ikc.5 (CLI half; platform half is the cluster PR "multipart uploads for import artifacts above 1 GiB").

- `BackupVaultImportUpload` gains the multipart shape the platform now mints (`upload_id`, `part_size_bytes`, `parts[{part_number,url}]`, `complete_url`, `abort_url`; `method: "multipart"`).
- `UploadPresignedObject(ctx, upload, body, size)` takes the upload as described: a single PUT as before, or part by part from each part's offset (`io.NewSectionReader` over the file), each part retried on its own on 5xx/transport failure, ETags collected, then a `CompleteMultipartUpload` document posted to the completion URL. S3 can answer the completion with 200 and an `<Error>` document; that is read as a failure. Any failure aborts the upload (best effort) so the vault keeps no half of it. A part list that does not cover the artifact is refused before a byte moves.
- The 5 GiB refusal becomes the platform's 625 GiB limit (`ImportArtifactMaximumBytes`, 10,000 × 64 MiB) in `restore` and in `up`'s plan warning. Progress says `Uploading db/shop.dump (3.0 GiB, 49 parts)`.
- `freeDiskBytes` is now a package variable so tests can pin the disk probe.

## Test plan

- Pre-commit hook (tests + golangci-lint) green.
- Client tests: a 19-byte body in 8-byte parts arrives as three parts with the completion listing each part's ETag in order; a failing part names itself and aborts without completing; a 200 with an `<Error>` document fails and aborts; a part count that does not cover the artifact is refused. Existing single-PUT tests moved to the struct form.
- `TestMigrateRestorePassesAMultipartUploadThrough`: the mock mints a multipart upload for one artifact and the CLI hands it through unchanged, printing the part count. Limit tests updated to 625 GiB; a new `up` test pins a too-small disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhfwAPcMpkMEbZs1jyfTxs
