### PR TITLE
feat(proxmox): set the Tailscale join settings on a credential from the CLI (ankra-xrpa9)

### DIFF
--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -2084,6 +2084,10 @@ func (m baseMock) CreateProxmoxCredential(request client.CreateProxmoxCredential
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) UpdateProxmoxCredentialTailscale(credentialID string, settings *client.ProxmoxTailscale) error {
+	return errors.New("not implemented")
+}
+
 func (m baseMock) ListProxmoxSSHKeyCredentials() ([]client.ProxmoxCredentialListItem, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/proxmox_credentials.go
+++ b/cmd/proxmox_credentials.go
@@ -19,6 +19,85 @@ var proxmoxCredCmd = &cobra.Command{
 	Long:    "Commands to list and create Proxmox VE API credentials and SSH key credentials.",
 }
 
+var proxmoxCredTailscaleCmd = &cobra.Command{
+	Use:   "tailscale",
+	Short: "Manage the Tailscale/Headscale join settings on a Proxmox VE credential",
+	Long: `Commands to set or clear the Tailscale/Headscale settings a Proxmox VE
+credential passes to the VMs it builds.`,
+}
+
+var proxmoxCredTailscaleSetCmd = &cobra.Command{
+	Use:   "set <credential-id>",
+	Short: "Set the Tailscale/Headscale join settings on a Proxmox VE credential",
+	Long: `Set the Tailscale/Headscale settings a Proxmox VE credential passes to the
+VMs it builds. Every VM - the bastion/gateway included - joins the tailnet
+through the QEMU guest agent as it is created.
+
+Set this before creating a cluster whose bridge is an SDN vnet: a Proxmox SDN
+is node-local, so the tailnet join is the only way the platform can reach
+those VMs. The settings apply to VMs built afterwards; VMs that already exist
+are not joined retrospectively.
+
+The auth key is collected via a masked prompt, never on the command line.
+
+Examples:
+  ankra credentials proxmox tailscale set 63fe1425-4ec1-4058-9fef-7e4caec04c79 \
+    --login-server https://headscale.example
+  ankra credentials proxmox tailscale set 63fe1425-4ec1-4058-9fef-7e4caec04c79 \
+    --login-server https://headscale.example --advertise-routes 10.20.0.0/16`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		loginServer, _ := cmd.Flags().GetString("login-server")
+		if loginServer == "" {
+			return errors.New("--login-server is required")
+		}
+		acceptRoutes, _ := cmd.Flags().GetBool("accept-routes")
+		advertiseRoutes, _ := cmd.Flags().GetString("advertise-routes")
+
+		prompt := promptui.Prompt{
+			Label: "Tailscale Auth Key",
+			Mask:  '*',
+			Validate: func(input string) error {
+				if len(input) == 0 {
+					return fmt.Errorf("auth key cannot be empty")
+				}
+				return nil
+			},
+		}
+		authKey, promptError := prompt.Run()
+		if promptError != nil {
+			return errors.New("prompt cancelled")
+		}
+
+		updateError := apiClient.UpdateProxmoxCredentialTailscale(args[0], &client.ProxmoxTailscale{
+			LoginServer:     loginServer,
+			AuthKey:         authKey,
+			AcceptRoutes:    acceptRoutes,
+			AdvertiseRoutes: advertiseRoutes,
+		})
+		if updateError != nil {
+			return updateError
+		}
+		fmt.Println("Tailscale settings saved. VMs built with this credential from now on will join the tailnet.")
+		return nil
+	},
+}
+
+var proxmoxCredTailscaleClearCmd = &cobra.Command{
+	Use:   "clear <credential-id>",
+	Short: "Remove the Tailscale/Headscale join settings from a Proxmox VE credential",
+	Long: `Remove the Tailscale/Headscale settings from a Proxmox VE credential. VMs
+built afterwards no longer join the tailnet; VMs already on it stay there.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if updateError := apiClient.UpdateProxmoxCredentialTailscale(args[0], nil); updateError != nil {
+			return updateError
+		}
+		fmt.Println("Tailscale settings cleared. VMs already on the tailnet stay on it.")
+		return nil
+	},
+}
+
 var proxmoxCredListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List Proxmox VE API credentials",
@@ -308,6 +387,13 @@ func init() {
 	proxmoxCredCmd.AddCommand(proxmoxCredListCmd)
 	proxmoxCredCmd.AddCommand(proxmoxCredCreateCmd)
 	proxmoxCredCmd.AddCommand(proxmoxSSHKeyCmd)
+
+	proxmoxCredTailscaleSetCmd.Flags().String("login-server", "", "Headscale/Tailscale control server URL, e.g. https://headscale.example (required)")
+	proxmoxCredTailscaleSetCmd.Flags().Bool("accept-routes", false, "Accept subnet routes advertised on the tailnet")
+	proxmoxCredTailscaleSetCmd.Flags().String("advertise-routes", "", "Comma-separated CIDRs the VMs advertise to the tailnet, e.g. 10.20.0.0/16")
+	proxmoxCredTailscaleCmd.AddCommand(proxmoxCredTailscaleSetCmd)
+	proxmoxCredTailscaleCmd.AddCommand(proxmoxCredTailscaleClearCmd)
+	proxmoxCredCmd.AddCommand(proxmoxCredTailscaleCmd)
 
 	credentialsCmd.AddCommand(proxmoxCredCmd)
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -602,6 +602,7 @@ type APIClient interface {
 
 	ListProxmoxCredentials() ([]client.ProxmoxCredentialListItem, error)
 	CreateProxmoxCredential(request client.CreateProxmoxCredentialRequest) (*client.CreateProxmoxCredentialResponse, error)
+	UpdateProxmoxCredentialTailscale(credentialID string, settings *client.ProxmoxTailscale) error
 	ListProxmoxSSHKeyCredentials() ([]client.ProxmoxCredentialListItem, error)
 	CreateProxmoxSSHKeyCredential(request client.CreateSSHKeyCredentialRequest) (*client.CreateSSHKeyCredentialResponse, error)
 

--- a/internal/client/proxmox_credentials.go
+++ b/internal/client/proxmox_credentials.go
@@ -86,6 +86,56 @@ func (c *Client) CreateProxmoxCredential(createRequest CreateProxmoxCredentialRe
 	return &result, nil
 }
 
+// ProxmoxTailscale carries the Tailscale/Headscale join settings the platform
+// stores on a Proxmox VE credential. Every VM the credential builds - the
+// bastion/gateway included - joins the tailnet through the guest agent, which
+// is the only way the platform can reach a VM on a node-local SDN.
+type ProxmoxTailscale struct {
+	LoginServer     string `json:"login_server"`
+	AuthKey         string `json:"auth_key"`
+	AcceptRoutes    bool   `json:"accept_routes,omitempty"`
+	AdvertiseRoutes string `json:"advertise_routes,omitempty"`
+}
+
+// updateProxmoxTailscaleRequest keeps the member explicit: a null "tailscale"
+// clears the settings, an object sets them.
+type updateProxmoxTailscaleRequest struct {
+	Tailscale *ProxmoxTailscale `json:"tailscale"`
+}
+
+// UpdateProxmoxCredentialTailscale sets the credential's Tailscale settings,
+// or clears them when settings is nil. It updates the existing credential in
+// place, without recreating it or re-running the infrastructure bootstrap.
+func (c *Client) UpdateProxmoxCredentialTailscale(credentialID string, settings *ProxmoxTailscale) error {
+	url := c.BaseURL + "/api/v1/credentials/proxmox/" + credentialID + "/tailscale"
+	payload, marshalError := json.Marshal(updateProxmoxTailscaleRequest{Tailscale: settings})
+	if marshalError != nil {
+		return fmt.Errorf("marshal request: %w", marshalError)
+	}
+
+	httpRequest, requestError := http.NewRequest(http.MethodPut, url, bytes.NewReader(payload))
+	if requestError != nil {
+		return fmt.Errorf("create request: %w", requestError)
+	}
+	httpRequest.Header.Set("Content-Type", "application/json")
+	httpRequest.Header.Set("Authorization", "Bearer "+c.Token)
+
+	httpResponse, sendError := c.HTTP.Do(httpRequest)
+	if sendError != nil {
+		return fmt.Errorf("request failed: %w", sendError)
+	}
+	defer closeBody(httpResponse)
+
+	body, readError := readResponseBody(httpResponse)
+	if readError != nil {
+		return fmt.Errorf("read response: %w", readError)
+	}
+	if httpResponse.StatusCode != http.StatusOK {
+		return newUnexpectedResponseError("update failed", httpResponse.StatusCode, redactedBodyForError(body, 500))
+	}
+	return nil
+}
+
 func (c *Client) ListProxmoxSSHKeyCredentials() ([]ProxmoxCredentialListItem, error) {
 	url := c.BaseURL + "/api/v1/credentials/proxmox/ssh-keys"
 	var credentials []ProxmoxCredentialListItem


### PR DESCRIPTION
Bead: ankra-xrpa9

Pairs with ankraio/cluster#2161, which serves the same write on the token API surface.

## The gap

When a Proxmox credential carries Tailscale/Headscale settings, `proxmoxjobs/server.go`
joins every VM it builds — the bastion/gateway included — to the tailnet through the QEMU
guest agent. Its own comment explains why that matters:

> the platform has no SSH path to a VM on a non-primary Proxmox host (the SDN is
> node-local), so the join cannot wait for the SSH lanes

So the tailnet join is the only way the platform can reach cluster VMs on an SDN vnet.
The scheduler read those settings and the credential secret stored them, but nothing
outside a session-authenticated browser could write them — the CLI had no command at all.

A Proxmox cluster on an SDN bridge therefore built every VM correctly and then failed with
`server 10.20.1.3 did not become reachable through bastion 10.20.1.1`, with no supported
way to supply the settings that would have fixed it.

## The change

```
ankra credentials proxmox tailscale set <credential-id> --login-server https://headscale.example
ankra credentials proxmox tailscale clear <credential-id>
```

- `set` takes `--login-server` (required), `--accept-routes` and `--advertise-routes`, and
  collects the auth key through a **masked prompt** — never on the command line — exactly
  as `credentials proxmox create` takes the API token secret.
- `clear` removes the block; VMs already on the tailnet stay there, VMs built afterwards
  do not join. The help text says so, since that asymmetry is easy to get wrong.
- Both call `PUT /api/v1/credentials/proxmox/{credential_id}/tailscale`, which updates the
  credential in place without recreating it or re-running the infrastructure bootstrap.

The help text also states that the settings apply to VMs built afterwards and that this
should be set *before* creating a cluster whose bridge is an SDN vnet — the ordering that
caused the failure above.

## Note

The client method is added to the `APIClient` interface and to `baseMock` in the e2e
tests, so the mock keeps satisfying the interface.

`gofmt`, `go build ./...`, `go vet` and `go test ./cmd/ ./internal/client/` all pass, and
the repo's pre-commit checks reported no issues.

Depends on ankraio/cluster#2161 being deployed: until that route exists on the token
surface, these commands will get a 404.
