### PR TITLE
fix(cluster): stop promising a deprovisioned cloud cluster can be provisioned again (ankra-8h0lk)

### DIFF
--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -246,7 +246,13 @@ func resolveClusterFromArgs(cmd *cobra.Command, args []string) (string, string, 
 var clusterProvisionCmd = &cobra.Command{
 	Use:   "provision [cluster_name]",
 	Short: "Provision a managed cluster (build its infrastructure and redeploy its stacks)",
-	Long: `Provision a managed cluster that was created or deprovisioned but is not running.
+	Long: `Provision a managed cluster that is not running.
+
+This works for a cluster that was created but never built, and for an imported
+cluster that was deprovisioned. It cannot rebuild a deprovisioned cloud cluster
+(hetzner, ovh, upcloud, digitalocean, proxmox, morpheus): that deprovision
+deleted the record, so there is nothing left to provision - create a new
+cluster instead.
 
 Provisioning rebuilds the cluster's infrastructure and then redeploys its stack
 resources from the cluster's stored stack definition. Verify anything you patched
@@ -314,26 +320,46 @@ const (
 	cloudClusterKindMorpheus     cloudClusterKind = "morpheus"
 )
 
+// isCloudClusterKind reports whether deprovisioning this kind goes to the
+// provider endpoint, which deletes the cluster record along with its
+// resources. The generic imported lane keeps the record, so the two are not
+// interchangeable and the difference has to reach the operator.
+func isCloudClusterKind(kind cloudClusterKind) bool {
+	switch kind {
+	case cloudClusterKindHetzner, cloudClusterKindOvh, cloudClusterKindUpcloud,
+		cloudClusterKindDigitalocean, cloudClusterKindProxmox, cloudClusterKindMorpheus:
+		return true
+	default:
+		return false
+	}
+}
+
 var clusterDeprovisionCmd = &cobra.Command{
 	Use:   "deprovision [cluster_name]",
-	Short: "Deprovision a managed cluster (tear it down; the cluster record is kept)",
-	Long: `Tear down a managed cluster. The cluster record is kept so it can be provisioned
-again later, but everything it runs on is released.
+	Short: "Deprovision a managed cluster (tear it down and release everything it runs on)",
+	Long: `Tear down a managed cluster: everything it runs on is released.
+
+Whether the cluster survives as a record depends on its kind, and the two
+outcomes are very different:
+
+  - cloud clusters (hetzner, ovh, upcloud, digitalocean, proxmox, morpheus)
+    go to the provider-specific endpoint, which DELETES the cluster. The
+    record does not survive, "ankra cluster provision" cannot bring it back,
+    and the cluster id, its stacks and anything referencing them are gone.
+    Rebuilding means creating a new cluster;
+  - imported clusters keep their record, so "ankra cluster provision" can
+    rebuild them from the stored stack definition later.
 
 This is a teardown, not a power-off:
 
   - all cloud resources are released (servers, networks, SSH keys);
-  - every stack resource on the cluster is uninstalled, and a later
-    "ankra cluster provision" redeploys them from the stored stack definition.
+  - every stack resource on the cluster is uninstalled.
 
 To power a cluster off and back on while keeping its state, use the provider's
 stop/start commands (for example "ankra hetzner cluster stop" and
 "ankra hetzner cluster start") or "ankra cluster power-schedules" instead.
 
-If no cluster name is provided, uses the currently selected cluster.
-
-For cloud clusters (hetzner, ovh, upcloud, digitalocean, proxmox, morpheus) this command routes
-to the provider-specific deprovision endpoint so cloud resources are released.`,
+If no cluster name is provided, uses the currently selected cluster.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		force, _ := cmd.Flags().GetBool("force")
@@ -363,10 +389,18 @@ to the provider-specific deprovision endpoint so cloud resources are released.`,
 			}
 		}
 
+		// A cloud deprovision deletes the cluster itself, not just what it
+		// runs on, and no later "cluster provision" can undo that. Saying so
+		// here is the only warning an operator sees before typing y.
+		recordWarning := ""
+		if isCloudClusterKind(cloudClusterKind(clusterKind)) {
+			recordWarning = " The cluster record itself is DELETED - this cannot be provisioned again, only recreated."
+		}
 		if err := confirmPrompt(
 			cmd.InOrStdin(), cmd.OutOrStdout(),
 			fmt.Sprintf("Deprovision cluster %q? This deletes all its cloud resources (servers, networks, SSH keys) "+
-				"and uninstalls every stack resource on it - this is a teardown, not a power-off. [y/N]: ", clusterName),
+				"and uninstalls every stack resource on it - this is a teardown, not a power-off.%s [y/N]: ",
+				clusterName, recordWarning),
 			yes,
 		); err != nil {
 			return err

--- a/cmd/reconcile_lifecycle_wording_test.go
+++ b/cmd/reconcile_lifecycle_wording_test.go
@@ -53,6 +53,48 @@ func TestClusterDeprovisionHelpDoesNotClaimItIsAStop(t *testing.T) {
 	}
 }
 
+// The help also used to promise, unconditionally, that "the cluster record is
+// kept so it can be provisioned again later". That is true only for imported
+// clusters. A cloud deprovision routes to the provider endpoint, which DELETEs
+// the cluster: the record, its id and its stacks are gone, and no later
+// "cluster provision" can bring them back. Following the documented
+// deprovision/provision cycle on a Proxmox cluster destroyed it outright
+// (ankra-8h0lk). These pin the corrected wording.
+func TestClusterDeprovisionHelpDoesNotPromiseTheRecordSurvives(t *testing.T) {
+	help := clusterDeprovisionCmd.Short + "\n" + clusterDeprovisionCmd.Long
+	if strings.Contains(help, "the cluster record is kept so it can be provisioned") {
+		t.Error("deprovision help still promises the record survives; a cloud deprovision deletes it")
+	}
+	for _, required := range []string{"DELETES", "imported clusters keep their record"} {
+		if !strings.Contains(help, required) {
+			t.Errorf("deprovision help should state %q so the two outcomes are not confused", required)
+		}
+	}
+}
+
+func TestClusterProvisionHelpSaysItCannotRebuildACloudCluster(t *testing.T) {
+	help := clusterProvisionCmd.Short + "\n" + clusterProvisionCmd.Long
+	if !strings.Contains(help, "cannot rebuild a deprovisioned cloud cluster") {
+		t.Error("provision help should say it cannot rebuild a deprovisioned cloud cluster; that record is deleted")
+	}
+}
+
+func TestCloudClusterKindsAreRecognisedAsRecordDeleting(t *testing.T) {
+	for _, kind := range []cloudClusterKind{
+		cloudClusterKindHetzner, cloudClusterKindOvh, cloudClusterKindUpcloud,
+		cloudClusterKindDigitalocean, cloudClusterKindProxmox, cloudClusterKindMorpheus,
+	} {
+		if !isCloudClusterKind(kind) {
+			t.Errorf("%q must be treated as record-deleting so the prompt warns about it", kind)
+		}
+	}
+	for _, kind := range []cloudClusterKind{"imported", "", "k3s"} {
+		if isCloudClusterKind(kind) {
+			t.Errorf("%q is not a provider-deprovisioned kind; its record survives", kind)
+		}
+	}
+}
+
 func TestClusterProvisionHelpDoesNotClaimItIsAStart(t *testing.T) {
 	help := clusterProvisionCmd.Short + "\n" + clusterProvisionCmd.Long
 	if strings.Contains(help, "(start)") {


### PR DESCRIPTION
Bead: ankra-8h0lk

## The bug

`ankra cluster deprovision --help` said:

> The cluster record is kept so it can be provisioned again later, but everything it runs on is released.

and `cluster provision` advertised itself as the way to rebuild "a cluster that was created or deprovisioned".

That pairing is only true for **imported** clusters. A cloud cluster (hetzner, ovh, upcloud, digitalocean, proxmox, morpheus) dispatches to `deprovisionProviderCluster`, which issues `http.MethodDelete` against `/api/v1/clusters/{kind}/{id}`. The record is deleted along with its resources. The generic lane that *does* keep the record explicitly refuses these kinds with a 409.

So the documented deprovision/provision cycle is impossible for exactly the clusters the command is mostly used on.

## How it was found

By following the documented cycle on a Proxmox cluster. `deprovision --yes` released the four VMs and the cluster then vanished from `cluster list`; `cluster info` answered "cluster not found". Its id, stacks and credential wiring were gone and had to be recreated from scratch.

The confirmation prompt gave no warning either - it listed servers, networks, SSH keys and stack resources, but never the cluster record itself.

## The change

Documentation and prompt only; no behaviour is altered.

- `deprovision` help states both outcomes: cloud clusters are DELETED and cannot be provisioned again, imported clusters keep their record.
- The confirmation prompt appends an explicit warning when the kind is one whose record will be deleted, via a new `isCloudClusterKind` helper.
- `provision` help says plainly that it cannot rebuild a deprovisioned cloud cluster.

## Tests

Extended `reconcile_lifecycle_wording_test.go`, which already existed to pin this command's wording after the stop/start labels caused a customer to lose patched addon values (ankra-54il0, ankra-dic4y). This is the same failure mode one step further on, so the new wording is pinned the same way:

- the help must not promise the record survives, and must state both outcomes;
- the provision help must say it cannot rebuild a deprovisioned cloud cluster;
- every provider kind is recognised as record-deleting, and imported kinds are not.

`gofmt`, `go build ./...`, `go test ./cmd/ ./internal/client/` all pass; pre-commit reported no issues.

## Not changed

Whether a cloud deprovision *should* delete the record is a product decision with billing and quota implications, so I only made the CLI tell the truth about what it does today.
