### PR TITLE
ankra-8ufgk: README points at status.ankra.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ and flag descriptions in `cmd/`.
 - Verify `ANKRA_API_TOKEN` is set (or run `ankra login`)
 - Check connectivity: `ankra cluster list`
 - Visit the [documentation](https://docs.ankra.ai) for detailed guides
-- Check the [Ankra Platform status](https://status.ankra.io) for any service outages
+- Check the [Ankra Platform status](https://status.ankra.ai) for any service outages
 
 ## Learn More
 


### PR DESCRIPTION
The status page moved from status.ankra.io to status.ankra.ai (the old domain 301-redirects once ankra-up-production-values#76 rolls out). This updates the support link in the README.

Bead: ankra-8ufgk

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bZ5dyAPiFEwrF1Bvh3LpV