### PR TITLE
feat(cli): kubectl-style plugins, and installing migrate modules (ankra-k6ikc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@
 
 ### Added
 
+- **Unknown commands dispatch to plugins, kubectl style.** An executable
+  named `ankra-<command>` in `~/.ankra/plugins` or on PATH now runs as
+  `ankra <command>`, with the remaining arguments, this terminal's streams,
+  `ANKRA_CLI_VERSION` in its environment, and its exit code as the CLI's.
+  Built-in commands always win, multi-word names resolve longest first
+  (`ankra foo bar` prefers `ankra-foo-bar`), and `ankra plugins` lists what
+  is installed - warning about a plugin a built-in command shadows.
+- **`ankra migrate modules install` and `uninstall` manage external
+  modules.** `install <https-url-or-file>` fetches one module executable
+  into `~/.ankra/modules`, runs its describe verb before keeping anything,
+  and installs it under the name the module calls itself; `--sha256` pins
+  the download, `--force` replaces, and the confirmation says plainly that
+  a module runs with your permissions. `uninstall <name>` removes what
+  install placed there and refuses, with its location, a module that lives
+  on PATH.
 - **Dumps above 1 GiB are uploaded in parts, and the 5 GiB ceiling is
   gone.** `ankra migrate restore`, `data` and `up` now send a large dump
   as a multipart upload the platform starts for them: 64 MiB parts, each

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,9 @@ the un-injected fallback; never bump it for a release.
 
 - `main.go` → `cmd/` — flat package, one file per command using
   `<family>_<sub>.go` naming (e.g. `cluster_kubeconfig.go`), tests alongside.
+  `cmd/plugins.go` dispatches unknown commands to `ankra-<command>`
+  executables (kubectl style) before cobra reports them; built-ins always
+  win, so a new command silently shadows any plugin of the same name.
 - `internal/client` — typed HTTP client for the platform API, one file per
   resource family.
 - `internal/kubeconfig` — kubeconfig read/merge/write.

--- a/cmd/migrate_modules.go
+++ b/cmd/migrate_modules.go
@@ -55,6 +55,11 @@ The module writes the dumps under output_dir and reports their paths; the
 CLI measures sizes and checksums itself. Stderr is relayed live while an
 export runs, so narrate progress there.
 
+Install a module without touching PATH with 'ankra migrate modules
+install <https-url-or-file>' (validated via its describe verb; --sha256
+pins the download) and remove it with 'ankra migrate modules uninstall
+<name>'.
+
 The protocol version is ` + fmt.Sprint(migrate.ProtocolVersion) + `. The reference implementation is the built-in
 'docker' module; a worked external example lives in the CLI repository under
 examples/modules/.`,

--- a/cmd/migrate_modules_install.go
+++ b/cmd/migrate_modules_install.go
@@ -1,0 +1,230 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"ankra/internal/migrate"
+)
+
+// Installing a module is fetching one executable into ~/.ankra/modules and
+// asking it to describe itself. There is no index and no registration: the
+// URL (or file) is the distribution, the describe answer is the handshake.
+
+var (
+	migrateModulesInstallName   string
+	migrateModulesInstallSHA    string
+	migrateModulesInstallForce  bool
+	migrateModulesInstallYes    bool
+	migrateModulesUninstallYes  bool
+	migrateModuleNamePattern    = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+	maximumModuleDownloadBytes  = int64(256 << 20)
+	moduleDownloadClientTimeout = 10 * time.Minute
+)
+
+var migrateModulesInstallCmd = &cobra.Command{
+	Use:   "install <url-or-file>",
+	Short: "Install a migrate module into ~/.ankra/modules",
+	Long: `Fetch one module executable - from an https URL or a local file - into
+~/.ankra/modules, where 'ankra migrate' discovers it without touching PATH.
+
+Before anything is kept, the module's describe verb is run and its answer
+checked: the protocol version, and the name the module calls itself, which
+is the name it is installed under. A module runs with your permissions, on
+your files and your Docker socket; install only modules you trust, and pass
+--sha256 when the author publishes a checksum.`,
+	Example: `  ankra migrate modules install https://github.com/org/x/releases/download/v1/ankra-module-procfile
+  ankra migrate modules install ./ankra-module-procfile --yes
+  ankra migrate modules install https://example.com/m --sha256 9f86d081...`,
+	Args:        cobra.ExactArgs(1),
+	Annotations: map[string]string{annotationRequiresAuth: "false"},
+	RunE:        runMigrateModulesInstall,
+}
+
+var migrateModulesUninstallCmd = &cobra.Command{
+	Use:   "uninstall <name>",
+	Short: "Remove a module installed in ~/.ankra/modules",
+	Long: `Delete an installed module's executable from ~/.ankra/modules. A module
+found on PATH is managed by whatever put it there and is refused with its
+location, so nothing outside the CLI's own directory is ever removed.`,
+	Example:     `  ankra migrate modules uninstall procfile --yes`,
+	Args:        cobra.ExactArgs(1),
+	Annotations: map[string]string{annotationRequiresAuth: "false"},
+	RunE:        runMigrateModulesUninstall,
+}
+
+func init() {
+	migrateModulesInstallCmd.Flags().StringVar(&migrateModulesInstallName, "name", "", "Expected module name; refused when the module calls itself something else")
+	migrateModulesInstallCmd.Flags().StringVar(&migrateModulesInstallSHA, "sha256", "", "Hex sha256 the download must match")
+	migrateModulesInstallCmd.Flags().BoolVar(&migrateModulesInstallForce, "force", false, "Replace a module of the same name that is already installed")
+	migrateModulesInstallCmd.Flags().BoolVarP(&migrateModulesInstallYes, "yes", "y", false, "Skip the confirmation prompt")
+	migrateModulesCmd.AddCommand(migrateModulesInstallCmd)
+
+	migrateModulesUninstallCmd.Flags().BoolVarP(&migrateModulesUninstallYes, "yes", "y", false, "Skip the confirmation prompt")
+	migrateModulesCmd.AddCommand(migrateModulesUninstallCmd)
+}
+
+func runMigrateModulesInstall(cmd *cobra.Command, args []string) error {
+	source := args[0]
+	content, fetchError := fetchModuleContent(source)
+	if fetchError != nil {
+		return fetchError
+	}
+	digest := sha256.Sum256(content)
+	digestHex := hex.EncodeToString(digest[:])
+	if migrateModulesInstallSHA != "" && !strings.EqualFold(migrateModulesInstallSHA, digestHex) {
+		return fmt.Errorf("the download's sha256 is %s, not the %s you required; refusing it", digestHex, strings.ToLower(migrateModulesInstallSHA))
+	}
+
+	message := fmt.Sprintf("Install %s as a migrate module? Its describe verb runs now, and the module later runs with your permissions. [y/N] ", source)
+	if confirmError := confirmPrompt(cmd.InOrStdin(), cmd.ErrOrStderr(), message, migrateModulesInstallYes); confirmError != nil {
+		return confirmError
+	}
+
+	staging, stagingError := writeModuleStaging(content)
+	if stagingError != nil {
+		return stagingError
+	}
+	defer func() { _ = os.Remove(staging) }()
+
+	description, describeError := migrate.DescribeExecutable(cmd.Context(), staging)
+	if describeError != nil {
+		return fmt.Errorf("%s does not answer describe as a migrate module: %w", source, describeError)
+	}
+	if !migrateModuleNamePattern.MatchString(description.Name) {
+		return fmt.Errorf("the module calls itself %q, which is not a usable module name (lower-case letters, digits and dashes)", description.Name)
+	}
+	if migrateModulesInstallName != "" && migrateModulesInstallName != description.Name {
+		return withExitCode(exitUsage, fmt.Errorf("the module calls itself %q, not %q; drop --name or fetch the module you meant", description.Name, migrateModulesInstallName))
+	}
+
+	directory, directoryError := migrate.HomeModulesDir()
+	if directoryError != nil {
+		return directoryError
+	}
+	if mkdirError := os.MkdirAll(directory, 0o755); mkdirError != nil {
+		return mkdirError
+	}
+	destination := filepath.Join(directory, migrate.ExternalModulePrefix+description.Name)
+	if _, statError := os.Stat(destination); statError == nil && !migrateModulesInstallForce {
+		return withExitCode(exitUsage, fmt.Errorf("module %s is already installed at %s; pass --force to replace it", description.Name, destination))
+	}
+	if renameError := os.Rename(staging, destination); renameError != nil {
+		return renameError
+	}
+
+	summary := struct {
+		Name    string `json:"name" yaml:"name"`
+		Version string `json:"version" yaml:"version"`
+		Summary string `json:"summary" yaml:"summary"`
+		Path    string `json:"path" yaml:"path"`
+		SHA256  string `json:"sha256" yaml:"sha256"`
+	}{description.Name, description.Version, description.Summary, destination, digestHex}
+	if handled, err := renderStructured(cmd, summary); handled || err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Installed module %s %s to %s (sha256 %s).\n", description.Name, description.Version, destination, digestHex)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "See it with `ankra migrate modules`; try it with `ankra migrate detect` in a source directory.\n")
+	return nil
+}
+
+// fetchModuleContent reads the module from an https URL or a local file.
+// Plain http would let the network hand you an executable; it is refused.
+func fetchModuleContent(source string) ([]byte, error) {
+	if strings.HasPrefix(source, "http://") {
+		return nil, withExitCode(exitUsage, errors.New("modules are executables; fetch them over https, not http"))
+	}
+	if strings.HasPrefix(source, "https://") {
+		response, getError := newModuleDownloadClient().Get(source)
+		if getError != nil {
+			return nil, fmt.Errorf("downloading %s: %w", source, getError)
+		}
+		defer func() { _ = response.Body.Close() }()
+		if response.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("downloading %s: the server answered status %d", source, response.StatusCode)
+		}
+		content, readError := io.ReadAll(io.LimitReader(response.Body, maximumModuleDownloadBytes+1))
+		if readError != nil {
+			return nil, fmt.Errorf("downloading %s: %w", source, readError)
+		}
+		if int64(len(content)) > maximumModuleDownloadBytes {
+			return nil, fmt.Errorf("%s is larger than %d bytes, which no module should be", source, maximumModuleDownloadBytes)
+		}
+		return content, nil
+	}
+	content, readError := os.ReadFile(source)
+	if readError != nil {
+		return nil, readError
+	}
+	return content, nil
+}
+
+// newModuleDownloadClient builds the plain client a module download uses;
+// tests substitute one that trusts their server.
+var newModuleDownloadClient = func() *http.Client {
+	return &http.Client{Timeout: moduleDownloadClientTimeout}
+}
+
+// writeModuleStaging puts the content in an executable temporary file, so
+// describe can run before anything lands in the modules directory.
+func writeModuleStaging(content []byte) (string, error) {
+	staging, createError := os.CreateTemp("", "ankra-module-staging-*")
+	if createError != nil {
+		return "", createError
+	}
+	path := staging.Name()
+	_, writeError := staging.Write(content)
+	closeError := staging.Close()
+	if writeError != nil {
+		return "", writeError
+	}
+	if closeError != nil {
+		return "", closeError
+	}
+	if chmodError := os.Chmod(path, 0o755); chmodError != nil {
+		return "", chmodError
+	}
+	return path, nil
+}
+
+func runMigrateModulesUninstall(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	directory, directoryError := migrate.HomeModulesDir()
+	if directoryError != nil {
+		return directoryError
+	}
+	installed := filepath.Join(directory, migrate.ExternalModulePrefix+name)
+	if _, statError := os.Stat(installed); statError != nil {
+		if onPath, lookError := lookupModuleOnPath(name); lookError == nil {
+			return withExitCode(exitUsage, fmt.Errorf("module %s lives at %s, outside ~/.ankra/modules; remove it the way it was installed", name, onPath))
+		}
+		return withExitCode(exitNotFound, fmt.Errorf("no module named %s is installed in %s", name, directory))
+	}
+	message := fmt.Sprintf("Remove module %s (%s)? [y/N] ", name, installed)
+	if confirmError := confirmPrompt(cmd.InOrStdin(), cmd.ErrOrStderr(), message, migrateModulesUninstallYes); confirmError != nil {
+		return confirmError
+	}
+	if removeError := os.Remove(installed); removeError != nil {
+		return removeError
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Removed module %s.\n", name)
+	return nil
+}
+
+// lookupModuleOnPath finds a module executable on PATH, for the uninstall
+// refusal that names where it actually lives.
+func lookupModuleOnPath(name string) (string, error) {
+	return exec.LookPath(migrate.ExternalModulePrefix + name)
+}

--- a/cmd/migrate_modules_install_test.go
+++ b/cmd/migrate_modules_install_test.go
@@ -1,0 +1,163 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const installableModule = `#!/bin/sh
+case "$1" in
+  describe) printf '%s' '{"name":"procz","version":"1.0","protocol":1,"summary":"test module"}' ;;
+  detect) printf '%s' '{"confidence":0,"reason":"never"}' ;;
+  *) exit 2 ;;
+esac
+`
+
+func moduleInstallEnvironment(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stand-ins")
+	}
+	offlineRegistry(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	return home
+}
+
+func installedModulePath(home string) string {
+	return filepath.Join(home, ".ankra", "modules", "ankra-module-procz")
+}
+
+func TestMigrateModulesInstallFromAFile(t *testing.T) {
+	home := moduleInstallEnvironment(t)
+	source := filepath.Join(t.TempDir(), "some-download")
+	if err := os.WriteFile(source, []byte(installableModule), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, _, err := runMigrate(t, "modules", "install", source, "--yes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "Installed module procz 1.0") || !strings.Contains(stdout, "sha256 ") {
+		t.Errorf("stdout:\n%s", stdout)
+	}
+	info, statError := os.Stat(installedModulePath(home))
+	if statError != nil {
+		t.Fatal(statError)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Error("the installed module must be executable")
+	}
+	listing, _, listError := runMigrate(t, "modules")
+	if listError != nil || !strings.Contains(listing, "procz") {
+		t.Errorf("the installed module must be discovered: %v\n%s", listError, listing)
+	}
+
+	_, _, err = runMigrate(t, "modules", "install", source, "--yes")
+	if exitCodeFor(err) != exitUsage || !strings.Contains(err.Error(), "--force") {
+		t.Errorf("reinstalling without --force is refused with the fix, got %v", err)
+	}
+	if _, _, err = runMigrate(t, "modules", "install", source, "--yes", "--force"); err != nil {
+		t.Errorf("--force replaces: %v", err)
+	}
+}
+
+func TestMigrateModulesInstallFromAURL(t *testing.T) {
+	home := moduleInstallEnvironment(t)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = writer.Write([]byte(installableModule))
+	}))
+	t.Cleanup(server.Close)
+	original := newModuleDownloadClient
+	newModuleDownloadClient = func() *http.Client { return server.Client() }
+	t.Cleanup(func() { newModuleDownloadClient = original })
+
+	if _, _, err := runMigrate(t, "modules", "install", server.URL+"/ankra-module-procz", "--yes"); err != nil {
+		t.Fatal(err)
+	}
+	if _, statError := os.Stat(installedModulePath(home)); statError != nil {
+		t.Fatal(statError)
+	}
+}
+
+func TestMigrateModulesInstallRefusals(t *testing.T) {
+	home := moduleInstallEnvironment(t)
+	source := filepath.Join(t.TempDir(), "some-download")
+	if err := os.WriteFile(source, []byte(installableModule), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := runMigrate(t, "modules", "install", "http://example.com/m", "--yes")
+	if exitCodeFor(err) != exitUsage || !strings.Contains(err.Error(), "https") {
+		t.Errorf("plain http is refused, got %v", err)
+	}
+
+	_, _, err = runMigrate(t, "modules", "install", source, "--yes", "--sha256", strings.Repeat("0", 64))
+	if err == nil || !strings.Contains(err.Error(), "refusing it") {
+		t.Errorf("a checksum mismatch is refused, got %v", err)
+	}
+
+	_, _, err = runMigrate(t, "modules", "install", source, "--yes", "--name", "other")
+	if exitCodeFor(err) != exitUsage || !strings.Contains(err.Error(), `calls itself "procz"`) {
+		t.Errorf("a name mismatch is refused with the module's own name, got %v", err)
+	}
+
+	broken := filepath.Join(t.TempDir(), "not-a-module")
+	if writeError := os.WriteFile(broken, []byte("#!/bin/sh\nexit 2\n"), 0o644); writeError != nil {
+		t.Fatal(writeError)
+	}
+	_, _, err = runMigrate(t, "modules", "install", broken, "--yes")
+	if err == nil || !strings.Contains(err.Error(), "does not answer describe") {
+		t.Errorf("a non-module is refused after describe, got %v", err)
+	}
+
+	rootCmd.SetIn(strings.NewReader("n\n"))
+	t.Cleanup(func() { rootCmd.SetIn(nil) })
+	_, _, err = runMigrate(t, "modules", "install", source)
+	if exitCodeFor(err) != exitCancelled {
+		t.Errorf("a declined prompt exits %d, got %v", exitCancelled, err)
+	}
+	if _, statError := os.Stat(installedModulePath(home)); statError == nil {
+		t.Error("nothing may be installed after any refusal")
+	}
+}
+
+func TestMigrateModulesUninstall(t *testing.T) {
+	home := moduleInstallEnvironment(t)
+	source := filepath.Join(t.TempDir(), "some-download")
+	if err := os.WriteFile(source, []byte(installableModule), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := runMigrate(t, "modules", "install", source, "--yes"); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, _, err := runMigrate(t, "modules", "uninstall", "procz", "--yes")
+	if err != nil || !strings.Contains(stdout, "Removed module procz") {
+		t.Fatalf("uninstall: %v\n%s", err, stdout)
+	}
+	if _, statError := os.Stat(installedModulePath(home)); statError == nil {
+		t.Error("the executable must be gone")
+	}
+
+	_, _, err = runMigrate(t, "modules", "uninstall", "procz", "--yes")
+	if exitCodeFor(err) != exitNotFound {
+		t.Errorf("uninstalling twice exits %d, got %v", exitNotFound, err)
+	}
+
+	pathDir := t.TempDir()
+	if writeError := os.WriteFile(filepath.Join(pathDir, "ankra-module-pathy"), []byte(installableModule), 0o755); writeError != nil {
+		t.Fatal(writeError)
+	}
+	t.Setenv("PATH", pathDir)
+	_, _, err = runMigrate(t, "modules", "uninstall", "pathy", "--yes")
+	if exitCodeFor(err) != exitUsage || !strings.Contains(err.Error(), pathDir) {
+		t.Errorf("a PATH-managed module is refused with its location, got %v", err)
+	}
+}

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -84,6 +84,11 @@ func resetMigrateFlags() {
 	migrateUpStopSource = false
 	migrateUpYes = false
 	migrateUpPlanOnly = false
+	migrateModulesInstallName = ""
+	migrateModulesInstallSHA = ""
+	migrateModulesInstallForce = false
+	migrateModulesInstallYes = false
+	migrateModulesUninstallYes = false
 	for _, command := range []string{"convert", "detect", "modules", "up"} {
 		sub, _, _ := migrateCmd.Find([]string{command})
 		if sub != nil && sub.Flags().Lookup("output") != nil {

--- a/cmd/plugins.go
+++ b/cmd/plugins.go
@@ -1,0 +1,274 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+// The CLI dispatches unknown commands to external plugins the way kubectl
+// does: an executable named ankra-<command> on PATH or in ~/.ankra/plugins
+// runs as `ankra <command>`, with the remaining arguments and this
+// process's standard streams. Built-in commands always win, so a plugin can
+// extend the CLI but never change it.
+
+// externalPluginPrefix is what a plugin executable's file name starts with.
+const externalPluginPrefix = "ankra-"
+
+// pluginReservedNames are cobra's own entry points; they are dispatchable
+// commands even though they are not in the command list.
+var pluginReservedNames = map[string]bool{
+	"help": true, "completion": true, "__complete": true, "__completeNoDesc": true,
+}
+
+// dispatchExternalPlugin runs the plugin matching the arguments, if one
+// exists and the first argument is not a built-in command. It reports
+// whether a plugin ran and the exit code to finish with.
+func dispatchExternalPlugin(arguments []string) (bool, int) {
+	if len(arguments) == 0 || strings.HasPrefix(arguments[0], "-") {
+		return false, 0
+	}
+	if isKnownRootCommand(arguments[0]) {
+		return false, 0
+	}
+	nameParts := leadingCommandWords(arguments)
+	path, consumed := lookupExternalPlugin(nameParts)
+	if path == "" {
+		return false, 0
+	}
+	command := exec.Command(path, arguments[consumed:]...)
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	command.Env = append(os.Environ(), "ANKRA_CLI_VERSION="+version)
+	runError := command.Run()
+	if runError == nil {
+		return true, 0
+	}
+	var exitError *exec.ExitError
+	if isExit := isExitError(runError, &exitError); isExit {
+		return true, exitError.ExitCode()
+	}
+	_, _ = fmt.Fprintf(os.Stderr, "running %s: %v\n", path, runError)
+	return true, 1
+}
+
+// isExitError exists so the errors.As call reads as a question at the one
+// place it is asked.
+func isExitError(runError error, target **exec.ExitError) bool {
+	exitError, ok := runError.(*exec.ExitError)
+	if ok {
+		*target = exitError
+	}
+	return ok
+}
+
+// isKnownRootCommand says whether name is a built-in command or one of
+// cobra's reserved entry points; those are never dispatched to a plugin.
+func isKnownRootCommand(name string) bool {
+	if pluginReservedNames[name] {
+		return true
+	}
+	for _, command := range rootCmd.Commands() {
+		if command.Name() == name {
+			return true
+		}
+		for _, alias := range command.Aliases {
+			if alias == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// leadingCommandWords is the run of arguments before the first flag: the
+// words that can name a plugin.
+func leadingCommandWords(arguments []string) []string {
+	var words []string
+	for _, argument := range arguments {
+		if strings.HasPrefix(argument, "-") {
+			break
+		}
+		words = append(words, argument)
+	}
+	return words
+}
+
+// lookupExternalPlugin finds the plugin covering the most leading words,
+// kubectl's rule: `ankra foo bar` prefers ankra-foo-bar over ankra-foo.
+// Returns the executable's path and how many words its name consumed.
+func lookupExternalPlugin(words []string) (string, int) {
+	for consumed := len(words); consumed >= 1; consumed-- {
+		name := externalPluginPrefix + strings.Join(words[:consumed], "-")
+		if path := findPluginExecutable(name); path != "" {
+			return path, consumed
+		}
+	}
+	return "", 0
+}
+
+// homePluginsDir is ~/.ankra/plugins, so a plugin can be installed without
+// touching PATH - the twin of ~/.ankra/modules for migrate modules.
+func homePluginsDir() (string, bool) {
+	home, homeError := os.UserHomeDir()
+	if homeError != nil {
+		return "", false
+	}
+	return filepath.Join(home, ".ankra", "plugins"), true
+}
+
+// findPluginExecutable resolves a plugin name to an executable:
+// ~/.ankra/plugins first, then PATH.
+func findPluginExecutable(name string) string {
+	if directory, ok := homePluginsDir(); ok {
+		candidate := filepath.Join(directory, name)
+		if isExecutableFile(candidate) {
+			return candidate
+		}
+	}
+	if path, lookError := exec.LookPath(name); lookError == nil {
+		return path
+	}
+	return ""
+}
+
+func isExecutableFile(path string) bool {
+	info, statError := os.Stat(path)
+	if statError != nil || info.IsDir() {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return info.Mode()&0o111 != 0
+}
+
+// discoveredPlugin is one plugin as `ankra plugins` reports it.
+type discoveredPlugin struct {
+	Name    string `json:"name" yaml:"name"`
+	Command string `json:"command" yaml:"command"`
+	Path    string `json:"path" yaml:"path"`
+	// Shadowed names a built-in command with the same name, which always
+	// wins: the plugin can never run.
+	Shadowed bool `json:"shadowed,omitempty" yaml:"shadowed,omitempty"`
+}
+
+var pluginsCmd = &cobra.Command{
+	Use:   "plugins",
+	Short: "List the external plugins that extend this CLI",
+	Long: `List every executable the CLI would dispatch an unknown command to.
+
+A plugin is an executable named ankra-<command> in ~/.ankra/plugins or on
+PATH. Running 'ankra <command>' with a command the CLI does not know runs
+the plugin with the remaining arguments, this terminal's streams, and
+ANKRA_CLI_VERSION in its environment; its exit code is the CLI's. Built-in
+commands always win, and multi-word names resolve longest first, so
+'ankra foo bar' prefers ankra-foo-bar over ankra-foo.
+
+Plugins run with your permissions; install only ones you trust. Executables
+named ankra-module-<name> are migrate modules, a separate mechanism listed
+by 'ankra migrate modules'.`,
+	Example: `  ankra plugins
+  ankra plugins -o json`,
+	Args:        cobra.NoArgs,
+	Annotations: map[string]string{annotationRequiresAuth: "false"},
+	RunE:        runPlugins,
+}
+
+func init() {
+	registerStructuredOutputFlags(pluginsCmd)
+	rootCmd.AddCommand(pluginsCmd)
+}
+
+func runPlugins(cmd *cobra.Command, _ []string) error {
+	plugins := discoverPlugins()
+	if handled, err := renderStructured(cmd, plugins); handled || err != nil {
+		return err
+	}
+	out := cmd.OutOrStdout()
+	if len(plugins) == 0 {
+		_, _ = fmt.Fprintln(out, "No plugins found. Put an executable named ankra-<command> in ~/.ankra/plugins or on PATH.")
+		return nil
+	}
+	writer := table.NewWriter()
+	writer.SetOutputMirror(out)
+	writer.SetStyle(table.StyleRounded)
+	writer.AppendHeader(table.Row{"COMMAND", "PATH"})
+	for _, plugin := range plugins {
+		writer.AppendRow(table.Row{"ankra " + plugin.Command, plugin.Path})
+	}
+	writer.Render()
+	for _, plugin := range plugins {
+		if plugin.Shadowed {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s is shadowed by the built-in command %q and will never run\n", plugin.Path, plugin.Command)
+		}
+	}
+	return nil
+}
+
+// discoverPlugins scans ~/.ankra/plugins then PATH, first hit per name
+// winning - the same order dispatch resolves in.
+func discoverPlugins() []discoveredPlugin {
+	var directories []string
+	if directory, ok := homePluginsDir(); ok {
+		directories = append(directories, directory)
+	}
+	for _, directory := range filepath.SplitList(os.Getenv("PATH")) {
+		if directory != "" {
+			directories = append(directories, directory)
+		}
+	}
+	seen := map[string]bool{}
+	var plugins []discoveredPlugin
+	for _, directory := range directories {
+		entries, readError := os.ReadDir(directory)
+		if readError != nil {
+			continue
+		}
+		for _, entry := range entries {
+			name, ok := externalPluginName(entry.Name())
+			if !ok || seen[name] {
+				continue
+			}
+			path := filepath.Join(directory, entry.Name())
+			if !isExecutableFile(path) {
+				continue
+			}
+			seen[name] = true
+			plugins = append(plugins, discoveredPlugin{
+				Name:     entry.Name(),
+				Command:  strings.ReplaceAll(name, "-", " "),
+				Path:     path,
+				Shadowed: isKnownRootCommand(strings.SplitN(name, "-", 2)[0]),
+			})
+		}
+	}
+	sort.Slice(plugins, func(i, j int) bool { return plugins[i].Command < plugins[j].Command })
+	return plugins
+}
+
+// externalPluginName is the command a file name stands for, or ok=false for
+// files that are not plugins - migrate modules among them.
+func externalPluginName(fileName string) (string, bool) {
+	if runtime.GOOS == "windows" {
+		for _, extension := range []string{".exe", ".bat", ".cmd"} {
+			fileName = strings.TrimSuffix(fileName, extension)
+		}
+	}
+	if !strings.HasPrefix(fileName, externalPluginPrefix) {
+		return "", false
+	}
+	name := strings.TrimPrefix(fileName, externalPluginPrefix)
+	if name == "" || strings.HasPrefix(name, "module-") {
+		return "", false
+	}
+	return name, true
+}

--- a/cmd/plugins_test.go
+++ b/cmd/plugins_test.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func writePluginScript(t *testing.T, directory string, fileName string, marker string) {
+	t.Helper()
+	script := "#!/bin/sh\necho \"" + marker + " args:$* version:${ANKRA_CLI_VERSION}\" >> \"$PLUGIN_LOG\"\nexit 7\n"
+	if err := os.WriteFile(filepath.Join(directory, fileName), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func pluginTestEnvironment(t *testing.T) (string, string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stand-ins")
+	}
+	binDir := t.TempDir()
+	log := filepath.Join(t.TempDir(), "plugin.log")
+	t.Setenv("PATH", binDir)
+	t.Setenv("PLUGIN_LOG", log)
+	t.Setenv("HOME", t.TempDir())
+	return binDir, log
+}
+
+func TestDispatchExternalPluginRunsTheLongestMatch(t *testing.T) {
+	binDir, log := pluginTestEnvironment(t)
+	writePluginScript(t, binDir, "ankra-hello", "short")
+	writePluginScript(t, binDir, "ankra-hello-world", "long")
+
+	handled, exitCode := dispatchExternalPlugin([]string{"hello", "world", "extra", "--flag"})
+	if !handled || exitCode != 7 {
+		t.Fatalf("handled=%v exit=%d, want a plugin run exiting 7", handled, exitCode)
+	}
+	content, _ := os.ReadFile(log)
+	if !strings.Contains(string(content), "long args:extra --flag") {
+		t.Errorf("the longest name must win and consume its words, got %q", content)
+	}
+	if !strings.Contains(string(content), "version:"+version) {
+		t.Errorf("the plugin must see ANKRA_CLI_VERSION, got %q", content)
+	}
+}
+
+func TestDispatchExternalPluginNeverShadowsABuiltin(t *testing.T) {
+	binDir, log := pluginTestEnvironment(t)
+	writePluginScript(t, binDir, "ankra-migrate", "impostor")
+	writePluginScript(t, binDir, "ankra-help", "helpImpostor")
+
+	if handled, _ := dispatchExternalPlugin([]string{"migrate", "modules"}); handled {
+		t.Error("a built-in command must never be dispatched to a plugin")
+	}
+	if handled, _ := dispatchExternalPlugin([]string{"help"}); handled {
+		t.Error("cobra's own entry points must never be dispatched")
+	}
+	if handled, _ := dispatchExternalPlugin([]string{"--version"}); handled {
+		t.Error("flags are not plugin names")
+	}
+	if handled, _ := dispatchExternalPlugin([]string{"no-such-thing"}); handled {
+		t.Error("an unknown command without a plugin falls through to the normal error")
+	}
+	if content, _ := os.ReadFile(log); len(content) != 0 {
+		t.Errorf("nothing may have run, got %q", content)
+	}
+}
+
+func TestDispatchExternalPluginPrefersTheHomeDirectory(t *testing.T) {
+	binDir, log := pluginTestEnvironment(t)
+	writePluginScript(t, binDir, "ankra-hello", "from-path")
+	homePlugins := filepath.Join(os.Getenv("HOME"), ".ankra", "plugins")
+	if err := os.MkdirAll(homePlugins, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writePluginScript(t, homePlugins, "ankra-hello", "from-home")
+
+	if handled, exitCode := dispatchExternalPlugin([]string{"hello"}); !handled || exitCode != 7 {
+		t.Fatalf("handled=%v exit=%d", handled, exitCode)
+	}
+	if content, _ := os.ReadFile(log); !strings.Contains(string(content), "from-home") {
+		t.Errorf("~/.ankra/plugins wins over PATH, got %q", content)
+	}
+}
+
+func TestPluginsListsWhatWouldRun(t *testing.T) {
+	binDir, _ := pluginTestEnvironment(t)
+	writePluginScript(t, binDir, "ankra-hello-world", "x")
+	writePluginScript(t, binDir, "ankra-migrate", "impostor")
+	writePluginScript(t, binDir, "ankra-module-procfile", "module")
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"plugins"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), "ankra hello world") || !strings.Contains(stdout.String(), filepath.Join(binDir, "ankra-hello-world")) {
+		t.Errorf("the listing must show the command and its path:\n%s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "module-procfile") {
+		t.Errorf("migrate modules are not plugins:\n%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), `shadowed by the built-in command "migrate"`) {
+		t.Errorf("a plugin behind a built-in must be called out:\n%s", stderr.String())
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,7 +53,11 @@ var rootCmd = &cobra.Command{
 	Use:   "ankra",
 	Short: "CLI for the Ankra platform",
 	Long: `Ankra CLI allows you to manage clusters, applications, operations,
-addons, persistent selection, and more.`,
+addons, persistent selection, and more.
+
+A command the CLI does not know is dispatched to an external plugin: an
+executable named ankra-<command> in ~/.ankra/plugins or on PATH, kubectl
+style. 'ankra plugins' lists what is installed.`,
 	SilenceUsage:      true,
 	PersistentPreRunE: persistentPreRunE,
 }
@@ -71,6 +75,9 @@ func SetVersion(v string) {
 func Execute() {
 	rootCmd.Version = version
 	wrapArgsValidators(rootCmd)
+	if handled, exitCode := dispatchExternalPlugin(os.Args[1:]); handled {
+		os.Exit(exitCode)
+	}
 	executedCommand, err := rootCmd.ExecuteC()
 	if err != nil {
 		printSupportHintForUnexpectedError(os.Stderr, executedCommand, err)

--- a/internal/migrate/registry.go
+++ b/internal/migrate/registry.go
@@ -34,12 +34,33 @@ func NewRegistry(builtins ...Module) *Registry {
 	}
 }
 
+// HomeModulesDir is ~/.ankra/modules: where `ankra migrate modules install`
+// places modules and the first directory discovery searches.
+func HomeModulesDir() (string, error) {
+	home, homeError := os.UserHomeDir()
+	if homeError != nil {
+		return "", homeError
+	}
+	return filepath.Join(home, ".ankra", "modules"), nil
+}
+
+// DescribeExecutable runs one executable's describe verb and validates the
+// answer exactly the way discovery does, so an install checks a module
+// against the same bar it will later be loaded against.
+func DescribeExecutable(ctx context.Context, path string) (Description, error) {
+	module, loadError := loadExternal(ctx, path)
+	if loadError != nil {
+		return Description{}, loadError
+	}
+	return module.Describe(), nil
+}
+
 // defaultSearchDirs is ~/.ankra/modules followed by PATH, so a user can
 // install a module without touching their PATH.
 func defaultSearchDirs() []string {
 	var dirs []string
-	if home, err := os.UserHomeDir(); err == nil {
-		dirs = append(dirs, filepath.Join(home, ".ankra", "modules"))
+	if directory, err := HomeModulesDir(); err == nil {
+		dirs = append(dirs, directory)
 	}
 	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
 		if dir != "" {

--- a/internal/skills/embedded/skills/ankra-cli/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-cli/SKILL.md
@@ -113,7 +113,12 @@ ankra migrate restore ./app-data --cluster shop --wait
 ankra migrate restore-status <import-id> --wait    # follow a restore started without --wait
 ankra migrate imports list                         # the dumps a vault still holds (restore again, or clean up)
 ankra migrate imports delete <import-id> --yes     # remove an import's dumps from the vault
+ankra migrate modules install <https-url-or-file>  # add an external module into ~/.ankra/modules
 ```
+
+The CLI also dispatches unknown commands to plugins, kubectl style: an executable named
+`ankra-<command>` in `~/.ankra/plugins` or on PATH runs as `ankra <command>` (built-ins always
+win; `ankra plugins` lists what is installed).
 
 `up` plans before it touches anything (databases and their sizes from the running containers, free
 disk, cluster, stack, vault; `--plan` stops there), applies the stack under the cluster's name, waits


### PR DESCRIPTION
## What & why

Follow-up of the migrate modules lane (ankra-k6ikc; the beads tracker is partitioned, so no child bead id). The ask: make the module approach as open as kubectl/docker plugins - a general command fallback, and an installer.

### `ankra <x>` → `ankra-<x>` (kubectl-style plugins)
- `Execute()` dispatches an unknown first argument to an executable named `ankra-<command>` found in `~/.ankra/plugins` (first) or on PATH, passing the remaining arguments, the terminal's streams and `ANKRA_CLI_VERSION`; the plugin's exit code becomes the CLI's.
- Built-in commands and cobra's entry points (`help`, `completion`, `__complete*`) are never dispatched; multi-word names resolve longest first (`ankra foo bar` prefers `ankra-foo-bar` over `ankra-foo`), consuming the words the name covers.
- `ankra plugins` lists what would run (command, path; `-o json`), excludes `ankra-module-*` (migrate modules, a separate mechanism), and warns on stderr about a plugin shadowed by a built-in - which will never run.

### `ankra migrate modules install` / `uninstall`
- `install <https-url-or-file>` (offline, no auth): https or local file only (plain http refused), 256 MiB cap, sha256 always reported and `--sha256` enforced when given, a confirmation that says the module runs with your permissions (`--yes`), then the staged executable's `describe` verb is validated through the same `loadExternal` path discovery uses; the module lands in `~/.ankra/modules/ankra-module-<name>` under the name it calls itself (`--name` asserts, `--force` replaces).
- `uninstall <name>` removes only what lives in `~/.ankra/modules`; a PATH-managed module is refused with its location.
- New exported helpers `migrate.HomeModulesDir` and `migrate.DescribeExecutable` (reusing `loadExternal`, so install validates against the same bar as discovery).

Docs: root help, `migrate modules` help, both skill copies (identical), CHANGELOG, CLAUDE.md layout note (a new built-in command silently shadows same-named plugins).

## Test plan

- `go test ./...` green; pre-commit hook (tests + golangci-lint) green.
- Plugins: longest-match dispatch with args/env/exit-code 7 propagation; built-ins/reserved names/flags never dispatched and unknowns without a plugin fall through; `~/.ankra/plugins` beats PATH; `ankra plugins` shows command+path, hides migrate modules, warns about shadowed ones.
- Install: from file and from a TLS test server; installed 0755 and discovered by `ankra migrate modules`; reinstall refused without `--force`; http URL, checksum mismatch, `--name` mismatch, a non-module (describe fails) and a declined prompt all refuse with nothing written. Uninstall: removes, exits 3 when absent, refuses PATH-managed with the path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhfwAPcMpkMEbZs1jyfTxs
