### PR TITLE
fix(plugins): the CLI's own release binary on PATH is not a plugin called cli (ankra-k6ikc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Ankra CLI Changelog
 
+## Unreleased
+
+### Fixed
+
+- **A copy of the CLI's own release binary is not a plugin.** The release
+  assets are named `ankra-cli-<os>-<arch>`, so a machine that kept one on
+  PATH as `ankra-cli` saw it listed by `ankra plugins` as a plugin called
+  `cli`, and `ankra cli ...` would have run that older CLI. The name is now
+  ignored by discovery and dispatch; a plugin whose name merely starts with
+  `cli` still works.
+
 ## v0.14.0-rc7 — 2026-08-30
 
 ### Added

--- a/cmd/plugins.go
+++ b/cmd/plugins.go
@@ -22,6 +22,11 @@ import (
 // externalPluginPrefix is what a plugin executable's file name starts with.
 const externalPluginPrefix = "ankra-"
 
+// releaseBinaryName is the CLI's own release-asset name (ankra-cli, from
+// ankra-cli-<os>-<arch>). A copy on PATH under that name is another CLI,
+// not a plugin called "cli".
+const releaseBinaryName = "ankra-cli"
+
 // pluginReservedNames are cobra's own entry points; they are dispatchable
 // commands even though they are not in the command list.
 var pluginReservedNames = map[string]bool{
@@ -108,6 +113,9 @@ func leadingCommandWords(arguments []string) []string {
 func lookupExternalPlugin(words []string) (string, int) {
 	for consumed := len(words); consumed >= 1; consumed-- {
 		name := externalPluginPrefix + strings.Join(words[:consumed], "-")
+		if name == releaseBinaryName {
+			continue
+		}
 		if path := findPluginExecutable(name); path != "" {
 			return path, consumed
 		}
@@ -175,7 +183,8 @@ commands always win, and multi-word names resolve longest first, so
 
 Plugins run with your permissions; install only ones you trust. Executables
 named ankra-module-<name> are migrate modules, a separate mechanism listed
-by 'ankra migrate modules'.`,
+by 'ankra migrate modules', and ankra-cli - the CLI's own release binary -
+is never a plugin.`,
 	Example: `  ankra plugins
   ankra plugins -o json`,
 	Args:        cobra.NoArgs,
@@ -267,7 +276,7 @@ func externalPluginName(fileName string) (string, bool) {
 		return "", false
 	}
 	name := strings.TrimPrefix(fileName, externalPluginPrefix)
-	if name == "" || strings.HasPrefix(name, "module-") {
+	if name == "" || strings.HasPrefix(name, "module-") || fileName == releaseBinaryName {
 		return "", false
 	}
 	return name, true

--- a/cmd/plugins_test.go
+++ b/cmd/plugins_test.go
@@ -70,6 +70,27 @@ func TestDispatchExternalPluginNeverShadowsABuiltin(t *testing.T) {
 	}
 }
 
+func TestDispatchExternalPluginIgnoresTheReleaseBinary(t *testing.T) {
+	binDir, log := pluginTestEnvironment(t)
+	writePluginScript(t, binDir, "ankra-cli", "another-cli")
+	writePluginScript(t, binDir, "ankra-cli-tools", "tools")
+
+	if handled, _ := dispatchExternalPlugin([]string{"cli", "--version"}); handled {
+		t.Error("a copy of the CLI's release binary on PATH is not a plugin called cli")
+	}
+	if handled, exitCode := dispatchExternalPlugin([]string{"cli", "tools"}); !handled || exitCode != 7 {
+		t.Errorf("a plugin whose name merely starts with cli still dispatches: handled=%v exit=%d", handled, exitCode)
+	}
+	if content, _ := os.ReadFile(log); strings.Contains(string(content), "another-cli") {
+		t.Errorf("the release binary must never run as a plugin, got %q", content)
+	}
+	for _, plugin := range discoverPlugins() {
+		if plugin.Name == "ankra-cli" {
+			t.Errorf("the release binary must not be listed as a plugin: %+v", plugin)
+		}
+	}
+}
+
 func TestDispatchExternalPluginPrefersTheHomeDirectory(t *testing.T) {
 	binDir, log := pluginTestEnvironment(t)
 	writePluginScript(t, binDir, "ankra-hello", "from-path")


### PR DESCRIPTION
Found on the first upgraded machine: `ankra plugins` listed `/usr/local/bin/ankra-cli` (a year-old alpha kept under the release asset's name) as a plugin called `cli`, and `ankra cli ...` would have dispatched to it. Discovery and dispatch now skip the exact name `ankra-cli`; a plugin named `ankra-cli-<x>` still resolves (test covers both, plus the listing). Changelog under a fresh Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhfwAPcMpkMEbZs1jyfTxs