### PR TITLE
feat(security): ankra security advisory <cve-id> - the platform's own advisory for a CVE (ankra-p1zkv)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Added
+
+- **`ankra security advisory <cve-id>`** shows the platform's own advisory for a
+  CVE - the record Ankra parses from NVD and OSV (title, description, CVSS with
+  its vector, weaknesses, aliases, affected products and version ranges written
+  as "fixed from <build>"), CISA's KEV entry and SSVC decision, the EPSS
+  probability, your organisation's current findings for it, and the tagged
+  references - instead of an external advisory link. A CVE the platform has
+  not read yet is queued at the front of its read queue and reported as
+  pending; `-o json` returns the API document.
+
 ### Fixed
 
 - **A copy of the CLI's own release binary is not a plugin.** The release

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -952,6 +952,10 @@ func (m baseMock) GetSecurityFinding(string) (*client.SecurityFindingDetail, err
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) GetSecurityAdvisory(string) (*client.SecurityAdvisory, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) ListSecurityClusters(client.SecurityClustersOptions) (*client.SecurityClusterList, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/security.go
+++ b/cmd/security.go
@@ -507,9 +507,234 @@ func stringOrEmpty(value *string) string {
 	return *value
 }
 
+var securityAdvisoryCmd = &cobra.Command{
+	Use:   "advisory <cve-id>",
+	Short: "Show the platform's advisory for one CVE: the parsed NVD/OSV record, CISA's guidance and your exposure",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		advisory, err := apiClient.GetSecurityAdvisory(strings.ToUpper(strings.TrimSpace(args[0])))
+		if err != nil {
+			return fmt.Errorf("reading security advisory: %w", err)
+		}
+		if rendered, err := renderStructured(cmd, advisory); rendered || err != nil {
+			return err
+		}
+		renderSecurityAdvisory(cmd, advisory)
+		return nil
+	},
+}
+
+// advisoryRangeText says one affected range in words: a CNA range with
+// status unaffected names the build a fix ships in, so it reads "fixed
+// from"; an open-ended affected range reads "and later".
+func advisoryRangeText(versionRange client.SecurityAdvisoryVersionRange) string {
+	introduced := versionRange.Introduced
+	if introduced == "0" {
+		introduced = ""
+	}
+	switch {
+	case versionRange.Status == "unaffected" && introduced != "":
+		return "fixed from " + introduced
+	case versionRange.Status == "unaffected":
+		return "not affected"
+	case versionRange.Fixed != "" && introduced != "":
+		return fmt.Sprintf("%s before %s (fixed in %s)", introduced, versionRange.Fixed, versionRange.Fixed)
+	case versionRange.Fixed != "":
+		return fmt.Sprintf("all versions before %s (fixed in %s)", versionRange.Fixed, versionRange.Fixed)
+	case versionRange.LastAffected != "" && introduced != "":
+		return fmt.Sprintf("%s through %s", introduced, versionRange.LastAffected)
+	case versionRange.LastAffected != "":
+		return "up to " + versionRange.LastAffected
+	case introduced != "":
+		return introduced + " and later"
+	default:
+		return "all versions"
+	}
+}
+
+func advisoryAffectedSubject(entry client.SecurityAdvisoryAffected) string {
+	product := entry.Product
+	if entry.Vendor != "" && !strings.HasPrefix(strings.ToLower(entry.Product), strings.ToLower(entry.Vendor)) {
+		product = strings.TrimSpace(entry.Vendor + " " + entry.Product)
+	}
+	if product == "" {
+		product = entry.Vendor
+	}
+	if entry.Package != "" {
+		name := entry.Package
+		if entry.Ecosystem != "" {
+			name = entry.Ecosystem + ": " + entry.Package
+		}
+		if product != "" {
+			return name + " · " + product
+		}
+		return name
+	}
+	if product != "" {
+		return product
+	}
+	if entry.Repository != "" {
+		return entry.Repository
+	}
+	return "Unnamed product"
+}
+
+func renderSecurityAdvisory(cmd *cobra.Command, advisory *client.SecurityAdvisory) {
+	out := cmd.OutOrStdout()
+	record := advisory.Advisory
+	headline := advisory.CVEID
+	if record != nil && record.CVSSScore != nil && record.CVSSSeverity != nil {
+		headline += fmt.Sprintf("  %s  CVSS %.1f", severityCell(*record.CVSSSeverity), *record.CVSSScore)
+		if record.CVSSVersion != nil {
+			headline += " (" + *record.CVSSVersion + ")"
+		}
+	}
+	_, _ = fmt.Fprintln(out, headline)
+	if record != nil && record.Title != nil && *record.Title != "" {
+		_, _ = fmt.Fprintln(out, *record.Title)
+	} else if advisory.Intelligence.KevVulnerabilityName != nil {
+		_, _ = fmt.Fprintln(out, *advisory.Intelligence.KevVulnerabilityName)
+	}
+	_, _ = fmt.Fprintln(out)
+
+	switch advisory.Status {
+	case "pending":
+		_, _ = fmt.Fprintln(out, "Ankra is fetching this advisory from NVD and OSV now - it was queued at the front of the platform's read queue; ask again in a minute.")
+	case "missing":
+		_, _ = fmt.Fprintln(out, "No public advisory record for this CVE yet: neither NVD nor OSV holds one. Reserved or very new ids look like this until the CNA publishes; Ankra re-checks every two weeks.")
+	case "error":
+		_, _ = fmt.Fprintln(out, "The advisory sources could not be read; Ankra retries within the hour.")
+		if advisory.FetchError != nil {
+			_, _ = fmt.Fprintf(out, "  %s\n", *advisory.FetchError)
+		}
+	}
+	if record != nil {
+		if record.Description != nil && *record.Description != "" {
+			_, _ = fmt.Fprintln(out, *record.Description)
+			_, _ = fmt.Fprintln(out)
+		}
+	}
+
+	intelligence := advisory.Intelligence
+	if intelligence.KnownExploited {
+		_, _ = fmt.Fprintln(out, text.FgRed.Sprint("Known exploited in the wild (CISA KEV)"))
+		if intelligence.KevVulnerabilityName != nil {
+			vendor := strings.TrimSpace(strings.Join([]string{stringOrEmpty(intelligence.KevVendorProject), stringOrEmpty(intelligence.KevProduct)}, " "))
+			if vendor != "" {
+				_, _ = fmt.Fprintf(out, "  %s (%s)\n", *intelligence.KevVulnerabilityName, vendor)
+			} else {
+				_, _ = fmt.Fprintf(out, "  %s\n", *intelligence.KevVulnerabilityName)
+			}
+		}
+		if intelligence.KevDateAdded != nil {
+			_, _ = fmt.Fprintf(out, "  listed since %s\n", *intelligence.KevDateAdded)
+		}
+		if deadline := kevDeadlineText(intelligence.KevDueDate); deadline != "" {
+			_, _ = fmt.Fprintf(out, "  CISA %s\n", deadline)
+		}
+		if intelligence.KevRansomwareUse {
+			_, _ = fmt.Fprintln(out, "  "+text.FgRed.Sprint("used in ransomware campaigns"))
+		}
+		if intelligence.KevRequiredAction != nil {
+			_, _ = fmt.Fprintf(out, "  CISA required action: %s\n", *intelligence.KevRequiredAction)
+		}
+	} else if advisory.IntelligenceStatus.KevSyncedAt != nil {
+		_, _ = fmt.Fprintln(out, "Not on CISA's Known Exploited Vulnerabilities catalog")
+	} else {
+		_, _ = fmt.Fprintln(out, "CISA KEV status unknown: the platform has not synced the catalog yet")
+	}
+	if epss := epssText(intelligence.EPSSScore, intelligence.EPSSPercentile); epss != "" {
+		_, _ = fmt.Fprintf(out, "  %s exploitation probability in the next 30 days\n", epss)
+	}
+	if record != nil && record.SSVC != nil {
+		_, _ = fmt.Fprintf(out, "  CISA SSVC: exploitation %s · automatable %s · technical impact %s\n",
+			record.SSVC.Exploitation, record.SSVC.Automatable, record.SSVC.TechnicalImpact)
+	}
+	_, _ = fmt.Fprintln(out)
+
+	if record != nil {
+		if len(record.CWEIDs) > 0 || len(record.Aliases) > 0 {
+			if len(record.CWEIDs) > 0 {
+				_, _ = fmt.Fprintf(out, "Weaknesses: %s\n", strings.Join(record.CWEIDs, ", "))
+			}
+			if len(record.Aliases) > 0 {
+				_, _ = fmt.Fprintf(out, "Also known as: %s\n", strings.Join(record.Aliases, ", "))
+			}
+		}
+		if record.CVSSVector != nil {
+			_, _ = fmt.Fprintf(out, "Vector: %s\n", *record.CVSSVector)
+		}
+		if len(record.Affected) > 0 {
+			_, _ = fmt.Fprintln(out)
+			_, _ = fmt.Fprintln(out, "Affected versions")
+			for _, entry := range record.Affected {
+				subject := advisoryAffectedSubject(entry)
+				switch {
+				case len(entry.Ranges) > 0:
+					parts := make([]string, 0, len(entry.Ranges))
+					for _, versionRange := range entry.Ranges {
+						parts = append(parts, advisoryRangeText(versionRange))
+					}
+					_, _ = fmt.Fprintf(out, "  %s: %s\n", subject, strings.Join(parts, "; "))
+				case len(entry.Versions) > 0:
+					_, _ = fmt.Fprintf(out, "  %s: versions %s\n", subject, strings.Join(entry.Versions, ", "))
+				case entry.DefaultStatus == "affected":
+					_, _ = fmt.Fprintf(out, "  %s: all versions affected\n", subject)
+				case entry.DefaultStatus == "unaffected":
+					_, _ = fmt.Fprintf(out, "  %s: not affected\n", subject)
+				default:
+					_, _ = fmt.Fprintf(out, "  %s: no version ranges published\n", subject)
+				}
+			}
+		}
+	}
+
+	fleet := advisory.Fleet
+	_, _ = fmt.Fprintln(out)
+	if len(fleet.Findings) == 0 {
+		_, _ = fmt.Fprintln(out, "In your fleet: no current findings for this CVE")
+	} else {
+		_, _ = fmt.Fprintf(out, "In your fleet: %d findings · %d occurrences (%d with a fix) · %d clusters · %d workloads\n",
+			len(fleet.Findings), fleet.Occurrences, fleet.FixableOccurrences, fleet.AffectedClusters, fleet.AffectedWorkloads)
+		writer := newSecurityTable(out)
+		writer.AppendHeader(table.Row{"Package", "Type", "Severity", "Occurrences", "Fixable", "Clusters", "Last seen", "Finding"})
+		for _, finding := range fleet.Findings {
+			writer.AppendRow(table.Row{
+				finding.PackageName, finding.PackageType, severityCell(finding.Severity),
+				finding.Occurrences, finding.FixableOccurrences, finding.AffectedClusters,
+				optionalTimeAgo(&finding.LastSeenAt), finding.ID,
+			})
+		}
+		writer.Render()
+	}
+
+	if record != nil && len(record.References) > 0 {
+		_, _ = fmt.Fprintln(out)
+		_, _ = fmt.Fprintf(out, "References (%d)\n", len(record.References))
+		for _, reference := range record.References {
+			tag := "Other"
+			if len(reference.Tags) > 0 {
+				tag = reference.Tags[0]
+			}
+			_, _ = fmt.Fprintf(out, "  [%s] %s\n", tag, reference.URL)
+		}
+	}
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintf(out, "Parsed by Ankra from NVD (%s) and OSV (%s); records are re-read every 14 days.\n",
+		advisorySourceText(advisory.Sources.NVDFetchedAt, advisory.Sources.NVDURL),
+		advisorySourceText(advisory.Sources.OSVFetchedAt, advisory.Sources.OSVURL))
+}
+
+func advisorySourceText(fetchedAt *string, url string) string {
+	if fetchedAt == nil {
+		return "no record, " + url
+	}
+	return "read " + optionalTimeAgo(fetchedAt) + ", " + url
+}
+
 func init() {
 	rootCmd.AddCommand(securityCmd)
-	securityCmd.AddCommand(securityOverviewCmd, securityFindingsCmd, securityFindingCmd, securityClustersCmd)
+	securityCmd.AddCommand(securityOverviewCmd, securityFindingsCmd, securityFindingCmd, securityAdvisoryCmd, securityClustersCmd)
 
 	securityOverviewCmd.Flags().String("cluster", "", "Scope the overview to one cluster (name or id)")
 	securityOverviewCmd.Flags().String("addon", "", "Scope the overview to one add-on (slug)")
@@ -534,5 +759,5 @@ func init() {
 	securityClustersCmd.Flags().Int("page", 1, "Page number")
 	securityClustersCmd.Flags().Int("page-size", 50, "Clusters per page (max 100)")
 
-	registerStructuredOutputFlags(securityOverviewCmd, securityFindingsCmd, securityFindingCmd, securityClustersCmd)
+	registerStructuredOutputFlags(securityOverviewCmd, securityFindingsCmd, securityFindingCmd, securityAdvisoryCmd, securityClustersCmd)
 }

--- a/cmd/security_test.go
+++ b/cmd/security_test.go
@@ -17,6 +17,7 @@ type securityMock struct {
 	findings        *client.SecurityFindingList
 	findingsOptions *client.SecurityFindingsOptions
 	detail          *client.SecurityFindingDetail
+	advisory        *client.SecurityAdvisory
 	clusters        *client.SecurityClusterList
 }
 
@@ -33,12 +34,16 @@ func (m *securityMock) GetSecurityFinding(string) (*client.SecurityFindingDetail
 	return m.detail, nil
 }
 
+func (m *securityMock) GetSecurityAdvisory(string) (*client.SecurityAdvisory, error) {
+	return m.advisory, nil
+}
+
 func (m *securityMock) ListSecurityClusters(client.SecurityClustersOptions) (*client.SecurityClusterList, error) {
 	return m.clusters, nil
 }
 
 func securityCommandTree() []*cobra.Command {
-	return []*cobra.Command{securityOverviewCmd, securityFindingsCmd, securityFindingCmd, securityClustersCmd}
+	return []*cobra.Command{securityOverviewCmd, securityFindingsCmd, securityFindingCmd, securityAdvisoryCmd, securityClustersCmd}
 }
 
 func runSecurityCommand(t *testing.T, mock APIClient, args ...string) (string, error) {
@@ -231,5 +236,94 @@ func TestSecurityClustersFlagsTheKnownExploitedCount(t *testing.T) {
 		if !strings.Contains(output, expected) {
 			t.Fatalf("output lacks %q:\n%s", expected, output)
 		}
+	}
+}
+
+func TestSecurityAdvisoryRendersTheParsedRecordAndTheThreeStates(t *testing.T) {
+	title := "Glibc: buffer overflow in ld.so leading to privilege escalation"
+	description := "A buffer overflow was discovered in the GNU C Library's dynamic loader ld.so."
+	score := 7.8
+	severity := "HIGH"
+	vector := "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+	version := "3.1"
+	readAt := "2026-08-29T10:28:21Z"
+	finding := exploitedFinding()
+	finding.CVEID = "CVE-2023-4911"
+	finding.PackageName = "libc6"
+	fetched := &client.SecurityAdvisory{
+		CVEID:  "CVE-2023-4911",
+		Status: "fetched",
+		Sources: client.SecurityAdvisorySources{
+			NVDFetchedAt: &readAt, OSVFetchedAt: &readAt,
+			NVDURL: "https://nvd.nist.gov/vuln/detail/CVE-2023-4911", OSVURL: "https://osv.dev/vulnerability/CVE-2023-4911",
+		},
+		Advisory: &client.SecurityAdvisoryRecord{
+			Title: &title, Description: &description,
+			CVSSScore: &score, CVSSSeverity: &severity, CVSSVector: &vector, CVSSVersion: &version,
+			CWEIDs: []string{"CWE-122", "CWE-787"}, Aliases: []string{"GHSA-m77w-6vjw-wh2f"},
+			References: []client.SecurityAdvisoryReference{{URL: "https://access.redhat.com/errata/RHSA-2023:5453", Source: "nvd", Tags: []string{"Patch"}}},
+			Affected: []client.SecurityAdvisoryAffected{
+				{Source: "nvd", Package: "glibc", Ranges: []client.SecurityAdvisoryVersionRange{{Introduced: "2.34", Fixed: "2.39", Status: "affected"}}},
+				{Source: "nvd", Vendor: "Red Hat", Product: "Red Hat Enterprise Linux 8", Package: "glibc",
+					Ranges: []client.SecurityAdvisoryVersionRange{{Introduced: "0:2.28-225.el8_8.6", Status: "unaffected"}}},
+				{Source: "nvd", Vendor: "Siemens", Product: "SIMATIC S7-1500", Ranges: []client.SecurityAdvisoryVersionRange{{Introduced: "V3.1.5", Status: "affected"}}},
+			},
+			SSVC: &client.SecurityAdvisorySSVC{Exploitation: "active", Automatable: "no", TechnicalImpact: "total"},
+		},
+		Intelligence:       finding.SecurityExploitIntelligence,
+		IntelligenceStatus: client.SecurityIntelligenceStatus{KevSyncedAt: &readAt, EPSSSyncedAt: &readAt, KevListed: 1685},
+		Fleet: client.SecurityAdvisoryFleet{
+			Findings: []client.SecurityFinding{finding}, Occurrences: 48, FixableOccurrences: 9, AffectedClusters: 3, AffectedWorkloads: 7,
+		},
+	}
+	output, executeError := runSecurityCommand(t, &securityMock{advisory: fetched}, "security", "advisory", "cve-2023-4911")
+	if executeError != nil {
+		t.Fatalf("security advisory failed: %v", executeError)
+	}
+	for _, expected := range []string{
+		"CVE-2023-4911", "CVSS 7.8 (3.1)", title, description,
+		"Known exploited in the wild (CISA KEV)", "CISA required action: Apply mitigations per vendor instructions.",
+		"CISA SSVC: exploitation active · automatable no · technical impact total",
+		"Weaknesses: CWE-122, CWE-787", "Also known as: GHSA-m77w-6vjw-wh2f",
+		"glibc: 2.34 before 2.39 (fixed in 2.39)",
+		"glibc · Red Hat Enterprise Linux 8: fixed from 0:2.28-225.el8_8.6",
+		"Siemens SIMATIC S7-1500: V3.1.5 and later",
+		"In your fleet: 1 findings · 48 occurrences (9 with a fix) · 3 clusters · 7 workloads",
+		"libc6", "[Patch] https://access.redhat.com/errata/RHSA-2023:5453",
+		"https://nvd.nist.gov/vuln/detail/CVE-2023-4911",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("output lacks %q:\n%s", expected, output)
+		}
+	}
+
+	pending := &client.SecurityAdvisory{CVEID: "CVE-2077-0001", Status: "pending", RequestedAt: &readAt,
+		Sources:            client.SecurityAdvisorySources{NVDURL: "https://nvd.nist.gov/vuln/detail/CVE-2077-0001", OSVURL: "https://osv.dev/vulnerability/CVE-2077-0001"},
+		IntelligenceStatus: client.SecurityIntelligenceStatus{KevSyncedAt: &readAt}}
+	output, executeError = runSecurityCommand(t, &securityMock{advisory: pending}, "security", "advisory", "CVE-2077-0001")
+	if executeError != nil || !strings.Contains(output, "fetching this advisory from NVD and OSV now") || !strings.Contains(output, "no current findings") {
+		t.Fatalf("a pending advisory must say it is being fetched, got %v:\n%s", executeError, output)
+	}
+	missing := &client.SecurityAdvisory{CVEID: "CVE-2077-0002", Status: "missing",
+		Sources: client.SecurityAdvisorySources{NVDURL: "https://nvd.nist.gov/vuln/detail/CVE-2077-0002", OSVURL: "https://osv.dev/vulnerability/CVE-2077-0002"}}
+	output, executeError = runSecurityCommand(t, &securityMock{advisory: missing}, "security", "advisory", "CVE-2077-0002")
+	if executeError != nil || !strings.Contains(output, "No public advisory record for this CVE yet") || !strings.Contains(output, "CISA KEV status unknown") {
+		t.Fatalf("a missing advisory must say so and keep the KEV state honest, got %v:\n%s", executeError, output)
+	}
+}
+
+func TestSecurityAdvisoryStructuredOutputIsTheApiDocument(t *testing.T) {
+	advisory := &client.SecurityAdvisory{CVEID: "CVE-2023-4911", Status: "fetched",
+		Fleet: client.SecurityAdvisoryFleet{Findings: []client.SecurityFinding{}}}
+	output, executeError := runSecurityCommand(t, &securityMock{advisory: advisory}, "security", "advisory", "CVE-2023-4911", "-o", "json")
+	if executeError != nil {
+		t.Fatalf("security advisory -o json failed: %v", executeError)
+	}
+	var decoded map[string]any
+	if decodeError := json.Unmarshal([]byte(output), &decoded); decodeError != nil {
+		t.Fatalf("output is not JSON: %v\n%s", decodeError, output)
+	}
+	if decoded["cve_id"] != "CVE-2023-4911" || decoded["status"] != "fetched" {
+		t.Fatalf("structured output must be the API document, got %v", decoded)
 	}
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -40,6 +40,7 @@ type APIClient interface {
 	GetSecurityOverview(options client.SecurityOverviewOptions) (*client.SecurityOverview, error)
 	ListSecurityFindings(options client.SecurityFindingsOptions) (*client.SecurityFindingList, error)
 	GetSecurityFinding(findingID string) (*client.SecurityFindingDetail, error)
+	GetSecurityAdvisory(cveID string) (*client.SecurityAdvisory, error)
 	ListSecurityClusters(options client.SecurityClustersOptions) (*client.SecurityClusterList, error)
 
 	ListPowerSchedules(clusterID string) (*client.PowerScheduleListResult, error)

--- a/internal/client/security.go
+++ b/internal/client/security.go
@@ -379,3 +379,133 @@ func (c *Client) ListSecurityClusters(options SecurityClustersOptions) (*Securit
 	}
 	return &list, nil
 }
+
+// SecurityAdvisoryMetric is one CVSS assessment on the advisory (NVD's own
+// Primary metric, the CNA's Secondary one, across CVSS versions).
+type SecurityAdvisoryMetric struct {
+	Source                string   `json:"source" yaml:"source"`
+	Type                  string   `json:"type" yaml:"type"`
+	Version               string   `json:"version" yaml:"version"`
+	Vector                string   `json:"vector" yaml:"vector"`
+	BaseScore             float64  `json:"base_score" yaml:"base_score"`
+	BaseSeverity          string   `json:"base_severity" yaml:"base_severity"`
+	ExploitabilityScore   *float64 `json:"exploitability_score" yaml:"exploitability_score"`
+	ImpactScore           *float64 `json:"impact_score" yaml:"impact_score"`
+	AttackVector          string   `json:"attack_vector,omitempty" yaml:"attack_vector,omitempty"`
+	AttackComplexity      string   `json:"attack_complexity,omitempty" yaml:"attack_complexity,omitempty"`
+	PrivilegesRequired    string   `json:"privileges_required,omitempty" yaml:"privileges_required,omitempty"`
+	UserInteraction       string   `json:"user_interaction,omitempty" yaml:"user_interaction,omitempty"`
+	Scope                 string   `json:"scope,omitempty" yaml:"scope,omitempty"`
+	ConfidentialityImpact string   `json:"confidentiality_impact,omitempty" yaml:"confidentiality_impact,omitempty"`
+	IntegrityImpact       string   `json:"integrity_impact,omitempty" yaml:"integrity_impact,omitempty"`
+	AvailabilityImpact    string   `json:"availability_impact,omitempty" yaml:"availability_impact,omitempty"`
+}
+
+// SecurityAdvisoryReference is one link the sources publish, tagged the way
+// NVD tags them (Patch, Exploit, Vendor Advisory, ...).
+type SecurityAdvisoryReference struct {
+	URL    string   `json:"url" yaml:"url"`
+	Source string   `json:"source" yaml:"source"`
+	Tags   []string `json:"tags" yaml:"tags"`
+}
+
+// SecurityAdvisoryVersionRange is one affected span; a `status` of
+// unaffected names the build a fix ships in.
+type SecurityAdvisoryVersionRange struct {
+	Introduced   string `json:"introduced,omitempty" yaml:"introduced,omitempty"`
+	Fixed        string `json:"fixed,omitempty" yaml:"fixed,omitempty"`
+	LastAffected string `json:"last_affected,omitempty" yaml:"last_affected,omitempty"`
+	Status       string `json:"status,omitempty" yaml:"status,omitempty"`
+}
+
+// SecurityAdvisoryAffected is one affected product (source nvd) or package
+// (source osv).
+type SecurityAdvisoryAffected struct {
+	Source        string                         `json:"source" yaml:"source"`
+	Vendor        string                         `json:"vendor,omitempty" yaml:"vendor,omitempty"`
+	Product       string                         `json:"product,omitempty" yaml:"product,omitempty"`
+	Package       string                         `json:"package,omitempty" yaml:"package,omitempty"`
+	Ecosystem     string                         `json:"ecosystem,omitempty" yaml:"ecosystem,omitempty"`
+	CollectionURL string                         `json:"collection_url,omitempty" yaml:"collection_url,omitempty"`
+	Repository    string                         `json:"repository,omitempty" yaml:"repository,omitempty"`
+	DefaultStatus string                         `json:"default_status,omitempty" yaml:"default_status,omitempty"`
+	Ranges        []SecurityAdvisoryVersionRange `json:"ranges" yaml:"ranges"`
+	Versions      []string                       `json:"versions,omitempty" yaml:"versions,omitempty"`
+}
+
+// SecurityAdvisorySSVC is CISA's SSVC decision as NVD republishes it.
+type SecurityAdvisorySSVC struct {
+	Exploitation    string  `json:"exploitation" yaml:"exploitation"`
+	Automatable     string  `json:"automatable" yaml:"automatable"`
+	TechnicalImpact string  `json:"technical_impact" yaml:"technical_impact"`
+	Timestamp       *string `json:"timestamp" yaml:"timestamp"`
+}
+
+// SecurityAdvisoryRecord is the parsed public record, merged from NVD
+// (authoritative) and OSV.
+type SecurityAdvisoryRecord struct {
+	Title               *string                     `json:"title" yaml:"title"`
+	Description         *string                     `json:"description" yaml:"description"`
+	SourceIdentifier    *string                     `json:"source_identifier" yaml:"source_identifier"`
+	VulnerabilityStatus *string                     `json:"vulnerability_status" yaml:"vulnerability_status"`
+	PublishedAt         *string                     `json:"published_at" yaml:"published_at"`
+	LastModifiedAt      *string                     `json:"last_modified_at" yaml:"last_modified_at"`
+	CVSSScore           *float64                    `json:"cvss_score" yaml:"cvss_score"`
+	CVSSSeverity        *string                     `json:"cvss_severity" yaml:"cvss_severity"`
+	CVSSVector          *string                     `json:"cvss_vector" yaml:"cvss_vector"`
+	CVSSVersion         *string                     `json:"cvss_version" yaml:"cvss_version"`
+	Metrics             []SecurityAdvisoryMetric    `json:"metrics" yaml:"metrics"`
+	CWEIDs              []string                    `json:"cwe_ids" yaml:"cwe_ids"`
+	References          []SecurityAdvisoryReference `json:"references" yaml:"references"`
+	Affected            []SecurityAdvisoryAffected  `json:"affected" yaml:"affected"`
+	Aliases             []string                    `json:"aliases" yaml:"aliases"`
+	SSVC                *SecurityAdvisorySSVC       `json:"ssvc" yaml:"ssvc"`
+}
+
+// SecurityAdvisorySources says when each public source was last read and
+// where its own page lives.
+type SecurityAdvisorySources struct {
+	NVDFetchedAt *string `json:"nvd_fetched_at" yaml:"nvd_fetched_at"`
+	OSVFetchedAt *string `json:"osv_fetched_at" yaml:"osv_fetched_at"`
+	NVDURL       string  `json:"nvd_url" yaml:"nvd_url"`
+	OSVURL       string  `json:"osv_url" yaml:"osv_url"`
+}
+
+// SecurityAdvisoryFleet is the organisation's current findings for the CVE
+// and the totals across them.
+type SecurityAdvisoryFleet struct {
+	Findings           []SecurityFinding `json:"findings" yaml:"findings"`
+	Occurrences        int               `json:"occurrences" yaml:"occurrences"`
+	FixableOccurrences int               `json:"fixable_occurrences" yaml:"fixable_occurrences"`
+	AffectedClusters   int               `json:"affected_clusters" yaml:"affected_clusters"`
+	AffectedWorkloads  int               `json:"affected_workloads" yaml:"affected_workloads"`
+}
+
+// SecurityAdvisory is the platform's advisory page for one CVE. Status is
+// fetched (Advisory present), pending (not read yet - the request queued
+// it, ask again shortly), missing (no public record) or error.
+type SecurityAdvisory struct {
+	CVEID              string                      `json:"cve_id" yaml:"cve_id"`
+	Status             string                      `json:"status" yaml:"status"`
+	FetchError         *string                     `json:"fetch_error" yaml:"fetch_error"`
+	RequestedAt        *string                     `json:"requested_at" yaml:"requested_at"`
+	LastAttemptAt      *string                     `json:"last_attempt_at" yaml:"last_attempt_at"`
+	Sources            SecurityAdvisorySources     `json:"sources" yaml:"sources"`
+	Advisory           *SecurityAdvisoryRecord     `json:"advisory" yaml:"advisory"`
+	Intelligence       SecurityExploitIntelligence `json:"intelligence" yaml:"intelligence"`
+	IntelligenceStatus SecurityIntelligenceStatus  `json:"intelligence_status" yaml:"intelligence_status"`
+	Fleet              SecurityAdvisoryFleet       `json:"fleet" yaml:"fleet"`
+}
+
+// GetSecurityAdvisory reads the platform's advisory page for one CVE.
+func (c *Client) GetSecurityAdvisory(cveID string) (*SecurityAdvisory, error) {
+	var advisory SecurityAdvisory
+	requestURL := securityURL(c.BaseURL, "/advisories/"+neturl.PathEscape(cveID), neturl.Values{})
+	if err := c.getJSON(requestURL, &advisory); err != nil {
+		return nil, fmt.Errorf("security advisory request failed: %w", err)
+	}
+	if advisory.Fleet.Findings == nil {
+		advisory.Fleet.Findings = []SecurityFinding{}
+	}
+	return &advisory, nil
+}


### PR DESCRIPTION
Bead: ankra-p1zkv

`/review` Step 6 follow-up for the advisory lane (cluster #2126 / portal #1701): the CLI exposed `ankra security finding` but not the new advisory read.

**`ankra security advisory <cve-id>`** — twin of `GET /api/v1/org/security/advisories/{cve_id}`:

- the record Ankra parses from NVD and OSV: title, description, lead CVSS with its vector, weaknesses, aliases, and affected products/version ranges written as the CNA meant them (`glibc · Red Hat Enterprise Linux 8: fixed from 0:2.28-225.el8_8.6`, `Siemens SIMATIC S7-1500: V3.1.5 and later`)
- CISA's KEV entry (name, vendor/product, listed since, deadline in explicit tense, ransomware use, required action) and SSVC decision, the EPSS probability, with the honest "catalog never synced" case
- the organisation's current findings for the CVE (package table with occurrence/fixable/cluster counts and finding ids for `ankra security finding`)
- tagged references and a provenance line (when NVD/OSV were read, their own pages)
- three states: `pending` says the platform queued the read and to ask again shortly; `missing` says no public record exists; `error` prints the source failure
- `-o json` / `-o yaml` return the API document

Tests: `TestSecurityAdvisoryRendersTheParsedRecordAndTheThreeStates`, `TestSecurityAdvisoryStructuredOutputIsTheApiDocument`. `go build`, `go vet`, gofmt on the touched files; CHANGELOG `Unreleased` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVUWU7e87JaZJB938KSFmz
