### PR TITLE
feat(proxmox): --network-mode and --site-public-ip on cluster create (ankra-0xsdd.25.13)

### DIFF
--- a/cmd/proxmox_cluster.go
+++ b/cmd/proxmox_cluster.go
@@ -41,6 +41,8 @@ var proxmoxCreateCmd = &cobra.Command{
 		etcdNodeCount, _ := cmd.Flags().GetInt("etcd-node-count")
 		etcdInstanceType, _ := cmd.Flags().GetString("etcd-instance-type")
 		cni, _ := cmd.Flags().GetString("cni")
+		networkMode, _ := cmd.Flags().GetString("network-mode")
+		sitePublicIP, _ := cmd.Flags().GetString("site-public-ip")
 		includeNetworking, _ := cmd.Flags().GetBool("include-networking")
 		includeDNS, _ := cmd.Flags().GetBool("include-dns")
 
@@ -63,6 +65,8 @@ var proxmoxCreateCmd = &cobra.Command{
 			EtcdNodeCount:            etcdNodeCount,
 			EtcdInstanceType:         etcdInstanceType,
 			CNI:                      cni,
+			NetworkMode:              networkMode,
+			SitePublicIP:             sitePublicIP,
 			IncludeNetworking:        includeNetworking,
 			IncludeDNS:               includeDNS,
 		}
@@ -354,6 +358,8 @@ func init() {
 	proxmoxCreateCmd.Flags().Int("etcd-node-count", 3, "Number of dedicated etcd nodes when --etcd-topology=external (3 or 5)")
 	proxmoxCreateCmd.Flags().String("etcd-instance-type", "px-medium", "Instance-size preset for dedicated etcd nodes when --etcd-topology=external")
 	proxmoxCreateCmd.Flags().String("cni", "", "CNI plugin (optional; the platform default is used when omitted)")
+	proxmoxCreateCmd.Flags().String("network-mode", "", "Network mode: private_network (default) or wireguard_mesh. wireguard_mesh puts the nodes on the platform WireGuard overlay behind the cluster bastion's site gateway, so the cluster can mesh with clusters on other sites and providers; kubeadm only, and a mesh cannot be retrofitted")
+	proxmoxCreateCmd.Flags().String("site-public-ip", "", "Public address other sites dial this cluster's bastion on for the overlay (required with --network-mode wireguard_mesh); the site forwards the overlay UDP port range from it to the bastion")
 	proxmoxCreateCmd.Flags().Bool("include-networking", true, "Install Traefik + cert-manager as Ankra-managed stacks for ingress (exposed via the built-in k3s service load balancer; default on)")
 	registerIncludeDNSFlag(proxmoxCreateCmd)
 

--- a/cmd/proxmox_cluster.go
+++ b/cmd/proxmox_cluster.go
@@ -17,6 +17,26 @@ var proxmoxCmd = &cobra.Command{
 	Long:    "Commands to create, stop, start, and inspect Proxmox VE clusters.",
 }
 
+// validateProxmoxOverlayFlags refuses the overlay flag pairs the platform
+// would refuse, before the request leaves the machine: an unknown mode,
+// and wireguard_mesh without the site address other sites dial.
+func validateProxmoxOverlayFlags(networkMode string, sitePublicIP string) error {
+	switch networkMode {
+	case "", "private_network":
+		if sitePublicIP != "" {
+			return fmt.Errorf("--site-public-ip needs --network-mode wireguard_mesh")
+		}
+		return nil
+	case "wireguard_mesh":
+		if sitePublicIP == "" {
+			return fmt.Errorf("--network-mode wireguard_mesh needs --site-public-ip: the address other sites dial this cluster's bastion on")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported --network-mode %q: must be private_network or wireguard_mesh", networkMode)
+	}
+}
+
 var proxmoxCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new Proxmox VE cluster",
@@ -45,6 +65,9 @@ var proxmoxCreateCmd = &cobra.Command{
 		sitePublicIP, _ := cmd.Flags().GetString("site-public-ip")
 		includeNetworking, _ := cmd.Flags().GetBool("include-networking")
 		includeDNS, _ := cmd.Flags().GetBool("include-dns")
+		if validationError := validateProxmoxOverlayFlags(networkMode, sitePublicIP); validationError != nil {
+			return validationError
+		}
 
 		request := client.CreateProxmoxClusterRequest{
 			Name:                     name,

--- a/cmd/proxmox_cluster_test.go
+++ b/cmd/proxmox_cluster_test.go
@@ -213,3 +213,30 @@ func TestProxmoxCreate_MapsOverlayFlags(t *testing.T) {
 		t.Errorf("overlay fields must be omitted when unset, got %q/%q", plain.gotRequest.NetworkMode, plain.gotRequest.SitePublicIP)
 	}
 }
+
+// TestProxmoxCreate_RefusesInconsistentOverlayFlags pins the client-side
+// checks: a mesh without a site address, a site address without a mesh, and
+// an unknown mode are refused before any request is sent.
+func TestProxmoxCreate_RefusesInconsistentOverlayFlags(t *testing.T) {
+	for name, flags := range map[string][]string{
+		"mesh without site address": {"--network-mode", "wireguard_mesh"},
+		"site address without mesh": {"--site-public-ip", "203.0.113.7"},
+		"unknown mode":              {"--network-mode", "vxlan", "--site-public-ip", "203.0.113.7"},
+	} {
+		mock := &proxmoxCreateMock{}
+		arguments := append([]string{
+			"cluster", "proxmox", "create",
+			"--name", "lab",
+			"--credential-id", "cred-1",
+			"--ssh-key-credential-id", "ssh-1",
+			"--node", "pve",
+			"--bridge", "ankra",
+		}, flags...)
+		_, runError := runWithInput(t, mock, "", arguments...)
+		if runError == nil || mock.called {
+			t.Errorf("%s must be refused before the request is sent (error=%v called=%v)", name, runError, mock.called)
+		}
+		_ = proxmoxCreateCmd.Flags().Set("network-mode", "")
+		_ = proxmoxCreateCmd.Flags().Set("site-public-ip", "")
+	}
+}

--- a/cmd/proxmox_cluster_test.go
+++ b/cmd/proxmox_cluster_test.go
@@ -171,3 +171,45 @@ func TestProxmoxHosts_PassesCredentialID(t *testing.T) {
 		t.Errorf("credential id = %q, want cred-1", mock.gotCredentialID)
 	}
 }
+
+// TestProxmoxCreate_MapsOverlayFlags pins the two overlay members of the
+// request: both ride through verbatim and both stay empty when omitted, so
+// the platform decides the default mode.
+func TestProxmoxCreate_MapsOverlayFlags(t *testing.T) {
+	mock := &proxmoxCreateMock{}
+	out, runError := runWithInput(t, mock, "",
+		"cluster", "proxmox", "create",
+		"--name", "lab-mesh",
+		"--credential-id", "cred-1",
+		"--ssh-key-credential-id", "ssh-1",
+		"--node", "pve",
+		"--bridge", "ankra",
+		"--network-mode", "wireguard_mesh",
+		"--site-public-ip", "203.0.113.7",
+	)
+	if runError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", runError, out)
+	}
+	if mock.gotRequest.NetworkMode != "wireguard_mesh" || mock.gotRequest.SitePublicIP != "203.0.113.7" {
+		t.Errorf("overlay fields = %q/%q, want wireguard_mesh/203.0.113.7", mock.gotRequest.NetworkMode, mock.gotRequest.SitePublicIP)
+	}
+	// Cobra flag values live on the shared command, so put them back before
+	// the next test reads the defaults.
+	_ = proxmoxCreateCmd.Flags().Set("network-mode", "")
+	_ = proxmoxCreateCmd.Flags().Set("site-public-ip", "")
+
+	plain := &proxmoxCreateMock{}
+	if _, plainError := runWithInput(t, plain, "",
+		"cluster", "proxmox", "create",
+		"--name", "lab",
+		"--credential-id", "cred-1",
+		"--ssh-key-credential-id", "ssh-1",
+		"--node", "pve",
+		"--bridge", "ankra",
+	); plainError != nil {
+		t.Fatalf("execute failed: %v", plainError)
+	}
+	if plain.gotRequest.NetworkMode != "" || plain.gotRequest.SitePublicIP != "" {
+		t.Errorf("overlay fields must be omitted when unset, got %q/%q", plain.gotRequest.NetworkMode, plain.gotRequest.SitePublicIP)
+	}
+}

--- a/internal/client/proxmox_clusters.go
+++ b/internal/client/proxmox_clusters.go
@@ -30,8 +30,14 @@ type CreateProxmoxClusterRequest struct {
 	EtcdNodeCount            int      `json:"etcd_node_count,omitempty"`
 	EtcdInstanceType         string   `json:"etcd_instance_type,omitempty"`
 	CNI                      string   `json:"cni,omitempty"`
-	IncludeNetworking        bool     `json:"include_networking"`
-	IncludeDNS               bool     `json:"include_dns"`
+	// NetworkMode is private_network (default) or wireguard_mesh: the
+	// platform WireGuard overlay behind the cluster bastion's site gateway.
+	NetworkMode string `json:"network_mode,omitempty"`
+	// SitePublicIP is the address other sites dial this cluster's bastion on
+	// for the overlay; required with wireguard_mesh.
+	SitePublicIP      string `json:"site_public_ip,omitempty"`
+	IncludeNetworking bool   `json:"include_networking"`
+	IncludeDNS        bool   `json:"include_dns"`
 }
 
 type CreateProxmoxClusterResponse struct {


### PR DESCRIPTION
Bead: ankra-0xsdd.25.13

Adds the two create-time inputs the platform gained in ankraio/cluster#2202 to `ankra cluster proxmox create`:

- `--network-mode private_network|wireguard_mesh` — `wireguard_mesh` puts the nodes on the platform WireGuard overlay behind the cluster bastion's site gateway (kubeadm only; a mesh cannot be retrofitted).
- `--site-public-ip <ip>` — the address other sites dial the bastion on; required with `wireguard_mesh`.

Both are omitted from the request when unset (`omitempty`), so the platform keeps deciding the default mode and pre-#2202 platforms see an unchanged body.

Test: `TestProxmoxCreate_MapsOverlayFlags` (values ride through; omitted stays empty).
