### PR TITLE
feat(cluster): ankra cluster move --organisation (ankra-84744)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Added
 
+- **`ankra cluster move --organisation <id|slug|name>`** moves a cluster into
+  another organisation you administer. Only an administrator of both the
+  current organisation and the destination can run it; anyone else gets the
+  platform's permission denial (exit 7). The cluster keeps its id, agent,
+  executions, resources, security findings, insights, DNS records and
+  variables, while access grants, kube tokens, notification routes and mutes,
+  report schedules, trusted AI actions and cluster-group memberships from the
+  current organisation are detached and counted in the output. The platform
+  refuses the move while operations are running, while the cluster is in a
+  cluster mesh, for playground clusters, and when the destination already has
+  a cluster with the same name; the refusal reason is printed as-is.
+  `--yes` skips the confirmation and `-o json` returns the API document.
 - **`ankra security advisory <cve-id>`** shows the platform's own advisory for a
   CVE - the record Ankra parses from NVD and OSV (title, description, CVSS with
   its vector, weaknesses, aliases, affected products and version ranges written

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@
   variables, while access grants, kube tokens, notification routes and mutes,
   report schedules, trusted AI actions and cluster-group memberships from the
   current organisation are detached and counted in the output. The platform
-  refuses the move while operations are running, while the cluster is in a
-  cluster mesh, for playground clusters, and when the destination already has
-  a cluster with the same name; the refusal reason is printed as-is.
+  moves imported clusters only for now (Ankra-provisioned and managed
+  Kubernetes clusters use a provider credential that belongs to the current
+  organisation) and refuses the move while operations are running, while the
+  cluster is in a cluster mesh, while it has DNS zones bound to the current
+  organisation, for playground and sandbox clusters, and when the destination
+  already has a cluster with the same name; the refusal reason is printed
+  as-is.
   `--yes` skips the confirmation and `-o json` returns the API document.
 - **`ankra security advisory <cve-id>`** shows the platform's own advisory for a
   CVE - the record Ankra parses from NVD and OSV (title, description, CVSS with

--- a/cmd/cluster_move.go
+++ b/cmd/cluster_move.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"ankra/internal/client"
+)
+
+var clusterMoveCmd = &cobra.Command{
+	Use:   "move [cluster_name]",
+	Short: "Move a cluster to another organisation you administer",
+	Long: `Move a cluster into another existing organisation.
+
+Only an administrator of BOTH the current organisation and the destination can
+move a cluster. The cluster keeps its id, agent, executions, resources, security
+findings, insights, DNS records and variables. Bindings that belong to the
+current organisation are detached and reported: access grants, kube tokens,
+notification routes and mutes, security report schedules, trusted AI actions
+and cluster-group memberships. Billing, audit and chat history stay with the
+current organisation.
+
+The platform refuses the move while operations are running on the cluster,
+while the cluster is a member of a cluster mesh, for playground clusters, and
+when the destination already has a cluster with the same name.
+
+The destination is resolved among your organisations by id, slug or name.
+If no cluster name is provided, the currently selected cluster is moved.`,
+	Example: `  ankra cluster move edge-01 --organisation acme-prod
+  ankra cluster move --organisation 6f1c... --yes
+  ankra cluster move edge-01 --organisation "Acme Prod" -o json`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		destinationReference, _ := cmd.Flags().GetString("organisation")
+		yes, _ := cmd.Flags().GetBool("yes")
+		if destinationReference == "" {
+			return withExitCode(exitUsage, errors.New("--organisation is required: the id, slug or name of the destination organisation"))
+		}
+		format, formatError := structuredFormatFromFlags(cmd)
+		if formatError != nil {
+			return formatError
+		}
+
+		clusterID, clusterName, _, resolveError := resolveClusterFromArgsWithKind(cmd, args)
+		if resolveError != nil {
+			return resolveError
+		}
+		organisations, listError := apiClient.ListOrganisations()
+		if listError != nil {
+			return fmt.Errorf("listing organisations: %w", listError)
+		}
+		destination, destinationError := resolveOrganisationReference(organisations, destinationReference)
+		if destinationError != nil {
+			if errors.Is(destinationError, errOrganisationNotFound) {
+				return withExitCode(exitNotFound, destinationError)
+			}
+			return withExitCode(exitUsage, destinationError)
+		}
+		destinationLabel := organisationDisplayName(*destination)
+
+		if confirmError := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Move cluster %q to organisation %q? Access grants, kube tokens, notification routes "+
+				"and group memberships from the current organisation are detached. [y/N]: ", clusterName, destinationLabel),
+			yes); confirmError != nil {
+			return confirmError
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
+		result, moveError := apiClient.MoveCluster(ctx, clusterID, destination.OrganisationID)
+		if moveError != nil {
+			var refused *client.MoveClusterRefusedError
+			if errors.As(moveError, &refused) {
+				return fmt.Errorf("move refused (%s): %s", refused.Code, refused.Detail)
+			}
+			return fmt.Errorf("moving cluster: %w", moveError)
+		}
+		if format != outputDefault {
+			return encodeStructured(cmd.OutOrStdout(), format, result)
+		}
+		printClusterMoveResult(cmd, result)
+		return nil
+	},
+}
+
+func organisationDisplayName(organisation client.OrganisationSummary) string {
+	if organisation.Name != nil && *organisation.Name != "" {
+		return *organisation.Name
+	}
+	if organisation.Slug != nil && *organisation.Slug != "" {
+		return *organisation.Slug
+	}
+	return organisation.OrganisationID
+}
+
+func printClusterMoveResult(cmd *cobra.Command, result *client.MoveClusterResult) {
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "Cluster %q moved to organisation %q.\n", result.ClusterName, result.DestinationOrganisationName)
+	_, _ = fmt.Fprintf(out, "  Cluster ID: %s\n", result.ClusterID)
+	_, _ = fmt.Fprintf(out, "  Destination organisation ID: %s\n", result.DestinationOrganisationID)
+	detached := result.Detached
+	_, _ = fmt.Fprintf(out, "  Detached from the previous organisation: %d access grant(s), %d kube token(s), %d notification route(s), "+
+		"%d mute(s), %d subscription(s), %d report schedule(s), %d trusted action(s), %d group membership(s)\n",
+		detached.AccessGrants, detached.KubeTokens, detached.NotificationRoutes, detached.NotificationMutes,
+		detached.Subscriptions, detached.ReportSchedules, detached.TrustedActions, detached.GroupMemberships)
+	if detached.GitopsRepository != nil && *detached.GitopsRepository != "" {
+		_, _ = fmt.Fprintf(out, "  GitOps repository %q was detached; reconnect it in the destination organisation.\n", *detached.GitopsRepository)
+	}
+	if result.SecretsRelocated > 0 {
+		_, _ = fmt.Fprintf(out, "  Secrets relocated: %d\n", result.SecretsRelocated)
+	}
+	for _, warning := range result.Warnings {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", warning)
+	}
+	_, _ = fmt.Fprintf(out, "Switch to the destination with: ankra org switch %s\n", result.DestinationOrganisationID)
+}
+
+func init() {
+	clusterMoveCmd.Flags().String("organisation", "", "Destination organisation (id, slug or name); you must be an admin there (required)")
+	clusterMoveCmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
+	registerStructuredOutputFlags(clusterMoveCmd)
+	clusterCmd.AddCommand(clusterMoveCmd)
+}

--- a/cmd/cluster_move.go
+++ b/cmd/cluster_move.go
@@ -24,9 +24,14 @@ notification routes and mutes, security report schedules, trusted AI actions
 and cluster-group memberships. Billing, audit and chat history stay with the
 current organisation.
 
-The platform refuses the move while operations are running on the cluster,
-while the cluster is a member of a cluster mesh, for playground clusters, and
-when the destination already has a cluster with the same name.
+Only imported clusters can be moved for now: Ankra-provisioned and managed
+Kubernetes clusters use a provider credential that belongs to the current
+organisation, so the platform refuses to move them. The platform also refuses
+the move while operations are running on the cluster, while the cluster is a
+member of a cluster mesh, while it has DNS zones bound to the current
+organisation (a published cluster domain or custom DNS zones), for playground
+and sandbox clusters, and when the destination already has a cluster with the
+same name.
 
 The destination is resolved among your organisations by id, slug or name.
 If no cluster name is provided, the currently selected cluster is moved.`,
@@ -75,7 +80,7 @@ If no cluster name is provided, the currently selected cluster is moved.`,
 		if moveError != nil {
 			var refused *client.MoveClusterRefusedError
 			if errors.As(moveError, &refused) {
-				return fmt.Errorf("move refused (%s): %s", refused.Code, refused.Detail)
+				return fmt.Errorf("move refused (%s): %w", refused.Code, refused)
 			}
 			return fmt.Errorf("moving cluster: %w", moveError)
 		}
@@ -103,10 +108,12 @@ func printClusterMoveResult(cmd *cobra.Command, result *client.MoveClusterResult
 	_, _ = fmt.Fprintf(out, "  Cluster ID: %s\n", result.ClusterID)
 	_, _ = fmt.Fprintf(out, "  Destination organisation ID: %s\n", result.DestinationOrganisationID)
 	detached := result.Detached
-	_, _ = fmt.Fprintf(out, "  Detached from the previous organisation: %d access grant(s), %d kube token(s), %d notification route(s), "+
-		"%d mute(s), %d subscription(s), %d report schedule(s), %d trusted action(s), %d group membership(s)\n",
-		detached.AccessGrants, detached.KubeTokens, detached.NotificationRoutes, detached.NotificationMutes,
-		detached.Subscriptions, detached.ReportSchedules, detached.TrustedActions, detached.GroupMemberships)
+	_, _ = fmt.Fprintf(out, "  Detached from the previous organisation: %d access grant(s), %d role assignment(s), %d kube token(s), "+
+		"%d notification route(s), %d mute(s), %d subscription(s), %d report schedule(s), %d trusted action(s), "+
+		"%d group membership(s), %d platform resource link(s), %d context repositor(y/ies)\n",
+		detached.AccessGrants, detached.RoleAssignments, detached.KubeTokens, detached.NotificationRoutes, detached.NotificationMutes,
+		detached.Subscriptions, detached.ReportSchedules, detached.TrustedActions, detached.GroupMemberships, detached.PlatformResourceLinks,
+		detached.ContextRepositories)
 	if detached.GitopsRepository != nil && *detached.GitopsRepository != "" {
 		_, _ = fmt.Fprintf(out, "  GitOps repository %q was detached; reconnect it in the destination organisation.\n", *detached.GitopsRepository)
 	}

--- a/cmd/cluster_move_test.go
+++ b/cmd/cluster_move_test.go
@@ -1,0 +1,149 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"ankra/internal/client"
+)
+
+type moveMock struct {
+	baseMock
+	cluster       client.ClusterListItem
+	organisations []client.OrganisationSummary
+	moveCalls     int
+	movedTo       string
+	moveError     error
+}
+
+func (m *moveMock) GetClusterByID(clusterID string) (client.ClusterListItem, error) {
+	if m.cluster.ID == clusterID {
+		return m.cluster, nil
+	}
+	return client.ClusterListItem{}, errors.New("not found")
+}
+
+func (m *moveMock) GetCluster(name string) (client.ClusterListItem, error) {
+	if m.cluster.Name == name || m.cluster.ID == name {
+		return m.cluster, nil
+	}
+	return client.ClusterListItem{}, errors.New("not found")
+}
+
+func (m *moveMock) ListOrganisations() ([]client.OrganisationSummary, error) {
+	return m.organisations, nil
+}
+
+func (m *moveMock) MoveCluster(ctx context.Context, clusterID string, destinationOrganisationID string) (*client.MoveClusterResult, error) {
+	m.moveCalls++
+	m.movedTo = destinationOrganisationID
+	if m.moveError != nil {
+		return nil, m.moveError
+	}
+	return &client.MoveClusterResult{
+		ClusterID: clusterID, ClusterName: m.cluster.Name,
+		DestinationOrganisationID: destinationOrganisationID, DestinationOrganisationName: "Acme Prod",
+		Detached: client.MoveClusterDetached{KubeTokens: 2}, SecretsRelocated: 3, Warnings: []string{},
+	}, nil
+}
+
+func newMoveMock() *moveMock {
+	acmeName, acmeSlug := "Acme Prod", "acme-prod"
+	currentName := "Current"
+	return &moveMock{
+		cluster: client.ClusterListItem{ID: "c-1", Name: "edge-01"},
+		organisations: []client.OrganisationSummary{
+			{OrganisationID: "org-current", Name: &currentName, UserCurrent: true},
+			{OrganisationID: "org-acme", Name: &acmeName, Slug: &acmeSlug},
+		},
+	}
+}
+
+func TestClusterMove_RequiresOrganisationFlag(t *testing.T) {
+	mock := newMoveMock()
+	_, err := runConfirmCommand(t, mock, "", []*cobra.Command{clusterMoveCmd}, "cluster", "move", "edge-01")
+	if err == nil || exitCodeFor(err) != exitUsage || !strings.Contains(err.Error(), "--organisation is required") {
+		t.Fatalf("expected a usage error, got %v", err)
+	}
+	if mock.moveCalls != 0 {
+		t.Fatalf("expected no move call, got %d", mock.moveCalls)
+	}
+}
+
+func TestClusterMove_DeclineDoesNotMove(t *testing.T) {
+	mock := newMoveMock()
+	output, err := runConfirmCommand(t, mock, "n\n", []*cobra.Command{clusterMoveCmd},
+		"cluster", "move", "edge-01", "--organisation", "acme-prod")
+	if !errors.Is(err, errCancelled) || exitCodeFor(err) != exitCancelled {
+		t.Fatalf("expected errCancelled on decline, got %v", err)
+	}
+	if !strings.Contains(output, `Move cluster "edge-01" to organisation "Acme Prod"?`) {
+		t.Fatalf("prompt must name both sides, got %q", output)
+	}
+	if mock.moveCalls != 0 {
+		t.Fatalf("expected no move call on decline, got %d", mock.moveCalls)
+	}
+}
+
+func TestClusterMove_YesFlagProceedsAndResolvesTheOrganisationByName(t *testing.T) {
+	mock := newMoveMock()
+	output, err := runConfirmCommand(t, mock, "", []*cobra.Command{clusterMoveCmd},
+		"cluster", "move", "edge-01", "--organisation", "acme prod", "--yes")
+	if err != nil {
+		t.Fatalf("expected success with --yes, got %v", err)
+	}
+	if mock.moveCalls != 1 || mock.movedTo != "org-acme" {
+		t.Fatalf("expected one move to org-acme, got %d to %q", mock.moveCalls, mock.movedTo)
+	}
+	for _, want := range []string{`Cluster "edge-01" moved to organisation "Acme Prod".`, "2 kube token(s)", "Secrets relocated: 3", "ankra org switch org-acme"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestClusterMove_PipedYesProceedsWithJSONOutput(t *testing.T) {
+	mock := newMoveMock()
+	output, err := runConfirmCommand(t, mock, "y\n", []*cobra.Command{clusterMoveCmd},
+		"cluster", "move", "edge-01", "--organisation", "org-acme", "-o", "json")
+	if err != nil {
+		t.Fatalf("expected success with piped y, got %v", err)
+	}
+	if mock.moveCalls != 1 || !strings.Contains(output, `"destination_organisation_id": "org-acme"`) {
+		t.Fatalf("expected a JSON move result, got calls=%d output=%q", mock.moveCalls, output)
+	}
+}
+
+func TestClusterMove_UnknownOrganisationExitsNotFound(t *testing.T) {
+	mock := newMoveMock()
+	_, err := runConfirmCommand(t, mock, "", []*cobra.Command{clusterMoveCmd},
+		"cluster", "move", "edge-01", "--organisation", "nowhere", "--yes")
+	if err == nil || exitCodeFor(err) != exitNotFound {
+		t.Fatalf("expected exit %d for an unknown organisation, got %v", exitNotFound, err)
+	}
+	if mock.moveCalls != 0 {
+		t.Fatalf("expected no move call, got %d", mock.moveCalls)
+	}
+}
+
+func TestClusterMove_RefusalAndDenialSurface(t *testing.T) {
+	mock := newMoveMock()
+	mock.moveError = &client.MoveClusterRefusedError{Code: "name_conflict", Detail: "The destination organisation already has a cluster named 'edge-01'."}
+	_, err := runConfirmCommand(t, mock, "", []*cobra.Command{clusterMoveCmd},
+		"cluster", "move", "edge-01", "--organisation", "acme-prod", "--yes")
+	if err == nil || !strings.Contains(err.Error(), "move refused (name_conflict)") {
+		t.Fatalf("expected the refusal to surface, got %v", err)
+	}
+
+	denied := newMoveMock()
+	denied.moveError = &client.PermissionDeniedError{Permission: "organisation.manage"}
+	_, err = runConfirmCommand(t, denied, "", []*cobra.Command{clusterMoveCmd},
+		"cluster", "move", "edge-01", "--organisation", "acme-prod", "--yes")
+	if err == nil || exitCodeFor(err) != exitForbidden {
+		t.Fatalf("expected exit %d for a permission denial, got %v", exitForbidden, err)
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -55,6 +55,10 @@ func (m baseMock) ProvisionCluster(ctx context.Context, clusterID string) (*clie
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) MoveCluster(ctx context.Context, clusterID string, destinationOrganisationID string) (*client.MoveClusterResult, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) DeprovisionCluster(ctx context.Context, clusterID string) (*client.DeprovisionClusterResult, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -20,6 +20,7 @@ type APIClient interface {
 	TriggerReconcile(ctx context.Context, clusterID string) (*client.TriggerReconcileResult, error)
 	ProvisionCluster(ctx context.Context, clusterID string) (*client.ProvisionClusterResult, error)
 	DeprovisionCluster(ctx context.Context, clusterID string) (*client.DeprovisionClusterResult, error)
+	MoveCluster(ctx context.Context, clusterID string, destinationOrganisationID string) (*client.MoveClusterResult, error)
 	RollToClusterResourceVersion(ctx context.Context, clusterID, versionID string) (*client.RollToClusterResourceVersionResult, error)
 	ApplyCluster(ctx context.Context, clusterReq client.CreateImportClusterRequest, wait bool) (*client.ImportResponse, bool, error)
 	ValidateCluster(ctx context.Context, spec client.CreateResourceSpec, strictSecrets bool, clusterID string) (*client.ValidateClusterResponse, error)

--- a/internal/client/clusters.go
+++ b/internal/client/clusters.go
@@ -603,16 +603,19 @@ type MoveClusterRequest struct {
 // MoveClusterDetached counts the source-organisation bindings the platform
 // revoked or removed while moving the cluster.
 type MoveClusterDetached struct {
-	AccessGrants       int64   `json:"access_grants"`
-	KubeTokens         int64   `json:"kube_tokens"`
-	Subscriptions      int64   `json:"subscriptions"`
-	NotificationMutes  int64   `json:"notification_mutes"`
-	NotificationRoutes int64   `json:"notification_routes"`
-	ReportSchedules    int64   `json:"report_schedules"`
-	TrustedActions     int64   `json:"trusted_actions"`
-	GroupMemberships   int64   `json:"group_memberships"`
-	PromotionLinks     int64   `json:"promotion_links"`
-	GitopsRepository   *string `json:"gitops_repository"`
+	AccessGrants          int64   `json:"access_grants"`
+	KubeTokens            int64   `json:"kube_tokens"`
+	Subscriptions         int64   `json:"subscriptions"`
+	NotificationMutes     int64   `json:"notification_mutes"`
+	NotificationRoutes    int64   `json:"notification_routes"`
+	ReportSchedules       int64   `json:"report_schedules"`
+	TrustedActions        int64   `json:"trusted_actions"`
+	GroupMemberships      int64   `json:"group_memberships"`
+	PromotionLinks        int64   `json:"promotion_links"`
+	RoleAssignments       int64   `json:"role_assignments"`
+	PlatformResourceLinks int64   `json:"platform_resource_links"`
+	ContextRepositories   int64   `json:"context_repositories"`
+	GitopsRepository      *string `json:"gitops_repository"`
 }
 
 // MoveClusterResult is the platform's answer to a successful move.

--- a/internal/client/clusters.go
+++ b/internal/client/clusters.go
@@ -594,3 +594,100 @@ func (c *Client) CreateStackDraft(ctx context.Context, clusterID string, stack S
 	}
 	return &StackDraftResult{DraftID: parsed.DraftID}, nil
 }
+
+// MoveClusterRequest names the organisation a cluster moves into.
+type MoveClusterRequest struct {
+	DestinationOrganisationID string `json:"destination_organisation_id"`
+}
+
+// MoveClusterDetached counts the source-organisation bindings the platform
+// revoked or removed while moving the cluster.
+type MoveClusterDetached struct {
+	AccessGrants       int64   `json:"access_grants"`
+	KubeTokens         int64   `json:"kube_tokens"`
+	Subscriptions      int64   `json:"subscriptions"`
+	NotificationMutes  int64   `json:"notification_mutes"`
+	NotificationRoutes int64   `json:"notification_routes"`
+	ReportSchedules    int64   `json:"report_schedules"`
+	TrustedActions     int64   `json:"trusted_actions"`
+	GroupMemberships   int64   `json:"group_memberships"`
+	PromotionLinks     int64   `json:"promotion_links"`
+	GitopsRepository   *string `json:"gitops_repository"`
+}
+
+// MoveClusterResult is the platform's answer to a successful move.
+type MoveClusterResult struct {
+	ClusterID                   string              `json:"cluster_id"`
+	ClusterName                 string              `json:"cluster_name"`
+	SourceOrganisationID        string              `json:"source_organisation_id"`
+	DestinationOrganisationID   string              `json:"destination_organisation_id"`
+	DestinationOrganisationName string              `json:"destination_organisation_name"`
+	Detached                    MoveClusterDetached `json:"detached"`
+	SecretsRelocated            int                 `json:"secrets_relocated"`
+	Warnings                    []string            `json:"warnings"`
+}
+
+// MoveClusterRefusedError is the platform's 409: a precondition the operator
+// can act on (running operations, a name clash, a cluster mesh membership).
+type MoveClusterRefusedError struct {
+	Code      string   `json:"code"`
+	Detail    string   `json:"detail"`
+	Conflicts []string `json:"conflicts"`
+}
+
+func (e *MoveClusterRefusedError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Detail
+}
+
+// MoveCluster moves the cluster into another organisation the caller
+// administers. A 403 surfaces as *PermissionDeniedError (exit 7), a 409 as
+// *MoveClusterRefusedError, a 404 as the platform's detail.
+func (c *Client) MoveCluster(ctx context.Context, clusterID string, destinationOrganisationID string) (*MoveClusterResult, error) {
+	url := fmt.Sprintf("%s/api/v1/clusters/%s/move", c.BaseURL, neturl.PathEscape(clusterID))
+	payload, marshalError := json.Marshal(MoveClusterRequest{DestinationOrganisationID: destinationOrganisationID})
+	if marshalError != nil {
+		return nil, fmt.Errorf("marshal request: %w", marshalError)
+	}
+	request, requestError := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if requestError != nil {
+		return nil, fmt.Errorf("create request: %w", requestError)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "Bearer "+c.Token)
+
+	response, doError := c.HTTP.Do(request)
+	if doError != nil {
+		return nil, fmt.Errorf("request failed: %w", doError)
+	}
+	defer closeBody(response)
+
+	body, readError := readResponseBody(response)
+	if readError != nil {
+		return nil, fmt.Errorf("read response: %w", readError)
+	}
+	switch response.StatusCode {
+	case http.StatusOK:
+		var result MoveClusterResult
+		if unmarshalError := json.Unmarshal(body, &result); unmarshalError != nil {
+			return nil, fmt.Errorf("decode response: %w", unmarshalError)
+		}
+		return &result, nil
+	case http.StatusUnauthorized:
+		return nil, ErrUnauthorized
+	case http.StatusConflict:
+		var refused MoveClusterRefusedError
+		if unmarshalError := json.Unmarshal(body, &refused); unmarshalError == nil && refused.Detail != "" {
+			return nil, &refused
+		}
+	}
+	if denied := PermissionDeniedFromResponse(response.StatusCode, body); denied != nil {
+		return nil, denied
+	}
+	if detail := detailFromBody(body); detail != "" {
+		return nil, newUnexpectedResponseErrorWithMessage(response.StatusCode, detail)
+	}
+	return nil, newUnexpectedResponseError("move failed", response.StatusCode, redactedBodyForError(body, 500))
+}

--- a/internal/client/clusters_move_test.go
+++ b/internal/client/clusters_move_test.go
@@ -1,0 +1,87 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestMoveCluster(t *testing.T) {
+	cases := []struct {
+		name        string
+		handler     http.HandlerFunc
+		wantError   bool
+		wantRefused bool
+		wantDenied  bool
+	}{
+		{
+			name: "success decodes the result",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/api/v1/clusters/c-1/move" || r.Method != http.MethodPost {
+					t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+				}
+				var body MoveClusterRequest
+				if decodeError := json.NewDecoder(r.Body).Decode(&body); decodeError != nil || body.DestinationOrganisationID != "org-acme" {
+					t.Errorf("unexpected body %+v (%v)", body, decodeError)
+				}
+				jsonResponse(t, w, http.StatusOK, map[string]any{
+					"cluster_id": "c-1", "cluster_name": "edge-01", "source_organisation_id": "org-current",
+					"destination_organisation_id": "org-acme", "destination_organisation_name": "Acme",
+					"detached": map[string]any{"kube_tokens": 1}, "secrets_relocated": 2, "warnings": []string{},
+				})
+			},
+		},
+		{
+			name: "conflict surfaces the refusal",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				jsonResponse(t, w, http.StatusConflict, map[string]any{"detail": "Operations are still running", "code": "operations_in_flight", "conflicts": []string{"upgrade"}})
+			},
+			wantError: true, wantRefused: true,
+		},
+		{
+			name: "forbidden surfaces the permission denial",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				jsonResponse(t, w, http.StatusForbidden, map[string]any{"detail": "permission_denied", "permission": "organisation.manage", "scope_type": "organisation"})
+			},
+			wantError: true, wantDenied: true,
+		},
+		{
+			name: "not found surfaces the detail",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				jsonResponse(t, w, http.StatusNotFound, map[string]any{"detail": "Cluster not found"})
+			},
+			wantError: true,
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			apiClient := newTestClient(t, testCase.handler)
+			result, moveError := apiClient.MoveCluster(context.Background(), "c-1", "org-acme")
+			if testCase.wantError {
+				if moveError == nil {
+					t.Fatalf("expected an error")
+				}
+				var refused *MoveClusterRefusedError
+				if errors.As(moveError, &refused) != testCase.wantRefused {
+					t.Fatalf("refused = %v, want %v (%v)", !testCase.wantRefused, testCase.wantRefused, moveError)
+				}
+				if testCase.wantRefused && (refused.Code != "operations_in_flight" || len(refused.Conflicts) != 1) {
+					t.Fatalf("refusal = %+v", refused)
+				}
+				var denied *PermissionDeniedError
+				if errors.As(moveError, &denied) != testCase.wantDenied {
+					t.Fatalf("denied = %v, want %v (%v)", !testCase.wantDenied, testCase.wantDenied, moveError)
+				}
+				return
+			}
+			if moveError != nil {
+				t.Fatalf("unexpected error: %v", moveError)
+			}
+			if result.ClusterName != "edge-01" || result.DestinationOrganisationName != "Acme" || result.Detached.KubeTokens != 1 || result.SecretsRelocated != 2 {
+				t.Fatalf("result = %+v", result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Bead: ankra-84744

## What

`ankra cluster move [cluster] --organisation <id|slug|name> [--yes] [-o json|yaml]`

- Resolves the cluster like `cluster deprovision` (positional name/id or the selected cluster) and the destination among the caller's organisations with the existing `resolveOrganisationReference` (unknown -> exit 3, ambiguous -> exit 2).
- Confirms with the destination named, then calls the new `client.MoveCluster` (`POST /api/v1/clusters/{id}/move`). A 403 surfaces as `*PermissionDeniedError` (exit 7), a 409 as `*MoveClusterRefusedError` printed with its code, a 404 as the platform detail.
- Prints the result with the detached-binding counts and the `ankra org switch <id>` hint; `-o json` returns the API document.
- `APIClient` interface + `baseMock` extended; CHANGELOG entry under Unreleased. The docs CLI reference regenerates from the command tree on the release tag.

## Tests

- `cmd/cluster_move_test.go`: missing flag, decline, `--yes` with name resolution, piped `y` with JSON output, unknown organisation exit code, refusal and permission-denial surfacing.
- `internal/client/clusters_move_test.go`: httptest lanes for 200/409/403/404.
- `golangci-lint` 0 issues, `go test -race ./...` green.

Backend: ankraio/cluster branch `feat/ankra-84744-move-cluster-organisation`.
