### PR TITLE
feat(cost): ankra cost summary, cluster and settings commands (ankra-25z58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Added
 
+- **`ankra cost`** brings the portal's Cost center to the terminal. `ankra cost
+  summary` is the fleet rollup - projected month end, month to date and run
+  rate in your display currency, the split by provider and the costliest
+  clusters; `ankra cost cluster <name-or-id>` adds a cluster's component
+  breakdown, namespace allocation (so each team sees the share it drives),
+  daily trend, and - when there is no estimate yet - the readiness reason
+  instead of zeros; `ankra cost settings get|set` reads and changes the display
+  currency, effective discount and network egress estimate (admins only, and
+  `set` changes only the flags you pass). Every command takes `-o json`.
+
 - **`ankra security advisory <cve-id>`** shows the platform's own advisory for a
   CVE - the record Ankra parses from NVD and OSV (title, description, CVSS with
   its vector, weaknesses, aliases, affected products and version ranges written

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ per command family:
 | [ankra stack-profiles](https://docs.ankra.ai/reference/cli/stack-profiles) | Manage reusable stack profiles |
 | [ankra support](https://docs.ankra.ai/reference/cli/support) | Create and track Ankra support requests |
 | [ankra tokens](https://docs.ankra.ai/reference/cli/tokens) | Manage API tokens |
+| [ankra cost](https://docs.ankra.ai/reference/cli/cost) | Read cloud cost: fleet rollup, cluster estimates and pricing settings |
 | [ankra upgrade](https://docs.ankra.ai/reference/cli/upgrade) | Upgrade the Ankra CLI to the latest release |
 
 The CLI is also self-documenting: `ankra --help` lists every command family and

--- a/cmd/cluster_playground.go
+++ b/cmd/cluster_playground.go
@@ -113,6 +113,8 @@ func currencySymbol(currency string) string {
 		return "€"
 	case "usd":
 		return "$"
+	case "gbp":
+		return "£"
 	default:
 		return currency + " "
 	}

--- a/cmd/cost.go
+++ b/cmd/cost.go
@@ -1,0 +1,367 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+// costHoursPerMonth is the basis the platform prices hourly components on
+// (365 x 24 / 12), so a monthly figure derived here matches the portal.
+const costHoursPerMonth = 730
+
+const costTopNamespaceRows = 15
+
+var costCmd = &cobra.Command{
+	Use:   "cost",
+	Short: "Read cloud cost: the fleet rollup, a cluster's estimate and the pricing settings",
+	Long: `Read the organisation's cloud cost - the same figures the portal shows under
+Cost - for reporting and automation.
+
+Every hour Ankra prices each cluster from its node inventory at the provider
+list price and allocates the result to namespaces by their CPU and memory
+share, so each team sees the share it drives. The fleet summary rolls every
+priced cluster up by provider and lists the costliest clusters; a cluster
+read adds the component breakdown, the namespace allocation and the daily
+trend. Pricing settings (display currency, effective discount, network
+egress estimate) apply to every figure.
+
+Pass -o json (or yaml) for the full API document.`,
+}
+
+var costSummaryCmd = &cobra.Command{
+	Use:   "summary",
+	Short: "Fleet cost rollup: projected month end, month to date, run rate, by provider and costliest clusters",
+	Args:  cobra.NoArgs,
+	Example: `  ankra cost summary
+  ankra cost summary -o json`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		summary, err := apiClient.GetFleetCloudCost()
+		if err != nil {
+			return fmt.Errorf("reading fleet cost: %w", err)
+		}
+		if rendered, err := renderStructured(cmd, summary); rendered || err != nil {
+			return err
+		}
+		renderFleetCloudCost(cmd.OutOrStdout(), summary)
+		return nil
+	},
+}
+
+var costClusterCmd = &cobra.Command{
+	Use:   "cluster <name-or-id>",
+	Short: "A cluster's cost estimate: totals, component breakdown, namespace allocation and readiness",
+	Args:  cobra.ExactArgs(1),
+	Example: `  ankra cost cluster prod-eu
+  ankra cost cluster 1834920e-3001-4157-8938-33c447031033 -o json`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		clusterID, err := resolveClusterID(args[0])
+		if err != nil {
+			return err
+		}
+		cost, err := apiClient.GetClusterCost(clusterID)
+		if err != nil {
+			return fmt.Errorf("reading cluster cost: %w", err)
+		}
+		if rendered, err := renderStructured(cmd, cost); rendered || err != nil {
+			return err
+		}
+		renderClusterCost(cmd.OutOrStdout(), args[0], cost)
+		return nil
+	},
+}
+
+var costSettingsCmd = &cobra.Command{
+	Use:   "settings",
+	Short: "Pricing settings: display currency, effective discount and the network egress estimate",
+}
+
+var costSettingsGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Show the organisation's pricing settings",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		settings, err := apiClient.GetCostSettings()
+		if err != nil {
+			return fmt.Errorf("reading cost settings: %w", err)
+		}
+		if rendered, err := renderStructured(cmd, settings); rendered || err != nil {
+			return err
+		}
+		renderCostSettings(cmd.OutOrStdout(), settings)
+		return nil
+	},
+}
+
+var costSettingsSetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Change the pricing settings (organisation admins only)",
+	Long: `Change one or more pricing settings. Only the flags you pass change; the
+other settings keep their current values. The route is organisation-admin
+only and every fleet and cluster figure re-prices on the next read.`,
+	Args: cobra.NoArgs,
+	Example: `  ankra cost settings set --currency eur
+  ankra cost settings set --discount 12.5
+  ankra cost settings set --include-egress=false`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		currencyChanged := cmd.Flags().Changed("currency")
+		discountChanged := cmd.Flags().Changed("discount")
+		egressChanged := cmd.Flags().Changed("include-egress")
+		if !currencyChanged && !discountChanged && !egressChanged {
+			return withExitCode(exitUsage, errors.New("pass at least one of --currency, --discount or --include-egress"))
+		}
+		current, err := apiClient.GetCostSettings()
+		if err != nil {
+			return fmt.Errorf("reading cost settings: %w", err)
+		}
+		update := *current
+		if currencyChanged {
+			currency, _ := cmd.Flags().GetString("currency")
+			update.Currency = strings.ToLower(strings.TrimSpace(currency))
+		}
+		if discountChanged {
+			discount, _ := cmd.Flags().GetFloat64("discount")
+			if discount < 0 || discount > 100 {
+				return withExitCode(exitUsage, errors.New("--discount must be between 0 and 100 (percent)"))
+			}
+			update.EffectiveDiscountPct = discount
+		}
+		if egressChanged {
+			includeEgress, _ := cmd.Flags().GetBool("include-egress")
+			update.IncludeNetworkEgressEstimate = includeEgress
+		}
+		saved, err := apiClient.UpdateCostSettings(update)
+		if err != nil {
+			return fmt.Errorf("updating cost settings: %w", err)
+		}
+		if rendered, err := renderStructured(cmd, saved); rendered || err != nil {
+			return err
+		}
+		out := cmd.OutOrStdout()
+		_, _ = fmt.Fprintln(out, "Cost settings updated.")
+		renderCostSettings(out, saved)
+		return nil
+	},
+}
+
+// formatCostCents renders integer cents in the display currency.
+func formatCostCents(cents int64, currency string) string {
+	return fmt.Sprintf("%s%.2f", currencySymbol(currency), float64(cents)/100)
+}
+
+func costProviderLabel(provider string) string {
+	switch provider {
+	case "aws":
+		return "Amazon Web Services"
+	case "gcp":
+		return "Google Cloud"
+	case "azure":
+		return "Microsoft Azure"
+	case "hetzner":
+		return "Hetzner Cloud"
+	case "ovh":
+		return "OVHcloud"
+	case "upcloud":
+		return "UpCloud"
+	case "scaleway":
+		return "Scaleway"
+	case "":
+		return "unknown provider"
+	default:
+		return provider
+	}
+}
+
+func newCostTable(out io.Writer) table.Writer {
+	writer := table.NewWriter()
+	writer.SetOutputMirror(out)
+	writer.SetStyle(table.StyleRounded)
+	return writer
+}
+
+func pluralClusters(count int) string {
+	if count == 1 {
+		return "1 cluster"
+	}
+	return fmt.Sprintf("%d clusters", count)
+}
+
+func renderFleetCloudCost(out io.Writer, summary *client.FleetCloudCost) {
+	if summary.ClusterCount == 0 {
+		_, _ = fmt.Fprintln(out, "No priced clusters yet.")
+		_, _ = fmt.Fprintln(out, "Estimates appear once a cluster on AWS, Google Cloud, Azure, Hetzner, OVHcloud, UpCloud or Scaleway has reported pricing in the last day; AWS, Google Cloud and Azure clusters need a connected cloud credential.")
+		return
+	}
+	currency := summary.Currency
+	_, _ = fmt.Fprintf(out, "Cloud cost (%s): %s projected month end · %s month to date · %s/mo run rate\n",
+		strings.ToUpper(currency), formatCostCents(summary.ProjectedMonthEndCents, currency),
+		formatCostCents(summary.MonthToDateCents, currency), formatCostCents(summary.MonthlyCostEstimateCents, currency))
+	_, _ = fmt.Fprintf(out, "  %s priced across %d provider(s)\n", pluralClusters(summary.ClusterCount), len(summary.ByProvider))
+	if len(summary.ByProvider) > 0 {
+		_, _ = fmt.Fprintln(out)
+		_, _ = fmt.Fprintln(out, "By provider:")
+		writer := newCostTable(out)
+		writer.AppendHeader(table.Row{"Provider", "Clusters", "Run rate/mo", "Month to date", "Projected"})
+		for _, provider := range summary.ByProvider {
+			writer.AppendRow(table.Row{
+				costProviderLabel(provider.Provider),
+				provider.ClusterCount,
+				formatCostCents(provider.MonthlyCostEstimateCents, currency),
+				formatCostCents(provider.MonthToDateCents, currency),
+				formatCostCents(provider.ProjectedMonthEndCents, currency),
+			})
+		}
+		writer.Render()
+	}
+	if len(summary.TopClusters) > 0 {
+		_, _ = fmt.Fprintln(out)
+		_, _ = fmt.Fprintln(out, "Costliest clusters:")
+		writer := newCostTable(out)
+		writer.AppendHeader(table.Row{"#", "Cluster", "Provider", "Projected", "Month to date", "Confidence", "Cluster ID"})
+		for index, cluster := range summary.TopClusters {
+			writer.AppendRow(table.Row{
+				index + 1,
+				cluster.ClusterName,
+				costProviderLabel(cluster.Provider),
+				formatCostCents(cluster.ProjectedMonthEndCents, currency),
+				formatCostCents(cluster.MonthToDateCents, currency),
+				cluster.ConfidenceLevel,
+				cluster.ClusterID,
+			})
+		}
+		writer.Render()
+	}
+}
+
+// costReadinessExplanation mirrors the portal's readiness copy so a missing
+// estimate reads as why it is missing, never as a zero.
+func costReadinessExplanation(readiness *client.CostReadiness) string {
+	if readiness == nil {
+		return "no estimate yet."
+	}
+	provider := "this provider"
+	if readiness.Provider != nil && *readiness.Provider != "" {
+		provider = costProviderLabel(*readiness.Provider)
+	}
+	switch readiness.State {
+	case "ready":
+		return "the estimate is ready; the next snapshot will carry figures."
+	case "no_credential":
+		return fmt.Sprintf("no cloud credential for %s is connected. Add one under Credentials to price this cluster.", provider)
+	case "unsupported_provider":
+		return fmt.Sprintf("cost is not estimated for %s yet.", provider)
+	case "cluster_offline":
+		return "the cluster is offline, so its node inventory cannot sync."
+	case "awaiting_nodes":
+		return "node inventory is still syncing."
+	case "awaiting_pricing":
+		return fmt.Sprintf("pricing for %s is still being collected.", provider)
+	case "estimate_pending":
+		return "everything is in place; the first estimate lands with the next hourly snapshot."
+	default:
+		return fmt.Sprintf("readiness is %q.", readiness.State)
+	}
+}
+
+func renderClusterCost(out io.Writer, clusterReference string, cost *client.ClusterCost) {
+	if !cost.HasData || cost.Summary == nil {
+		_, _ = fmt.Fprintf(out, "No cost estimate for %s: %s\n", clusterReference, costReadinessExplanation(cost.Readiness))
+		return
+	}
+	summary := cost.Summary
+	currency := summary.Currency
+	_, _ = fmt.Fprintf(out, "Cost for %s (%s, %s): %s projected month end · %s month to date · %s/mo run rate · %s/hr\n",
+		clusterReference, costProviderLabel(summary.Provider), strings.ToUpper(currency),
+		formatCostCents(summary.ProjectedMonthEndCents, currency), formatCostCents(summary.MonthToDateCents, currency),
+		formatCostCents(summary.MonthlyCostEstimateCents, currency), formatCostCents(summary.HourlyCostCents, currency))
+	coverage := fmt.Sprintf("%d of %d nodes priced", summary.PricedNodeCount, summary.TotalNodeCount)
+	if summary.CoverageIncomplete {
+		coverage += " (coverage incomplete - the estimate understates the true figure)"
+	}
+	_, _ = fmt.Fprintf(out, "  confidence %s · %s · %d volumes (%d unpriced)", summary.ConfidenceLevel, coverage,
+		summary.StorageVolumeCount, summary.UnpricedVolumeCount)
+	if summary.AppliedDiscountPct > 0 {
+		_, _ = fmt.Fprintf(out, " · %.1f%% discount applied", summary.AppliedDiscountPct)
+	}
+	if summary.SnapshotAt != "" {
+		_, _ = fmt.Fprintf(out, " · snapshot %s", summary.SnapshotAt)
+	}
+	_, _ = fmt.Fprintln(out)
+
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintln(out, "Run rate by component (per month):")
+	writer := newCostTable(out)
+	writer.AppendHeader(table.Row{"Component", "Per month"})
+	monthly := func(hourlyCents int64) string {
+		return formatCostCents(hourlyCents*costHoursPerMonth, currency)
+	}
+	writer.AppendRow(table.Row{"Compute (on-demand)", monthly(summary.ComputeOnDemandCents)})
+	if summary.ComputeSpotCents > 0 {
+		writer.AppendRow(table.Row{"Compute (spot)", monthly(summary.ComputeSpotCents)})
+	}
+	writer.AppendRow(table.Row{"Storage", monthly(summary.StorageCents)})
+	writer.AppendRow(table.Row{"Network", monthly(summary.NetworkCents)})
+	writer.AppendRow(table.Row{"Control plane", monthly(summary.ControlPlaneCents)})
+	if summary.InfrastructureCents > 0 {
+		writer.AppendRow(table.Row{"Bastion & VMs", monthly(summary.InfrastructureCents)})
+	}
+	writer.AppendRow(table.Row{"of which idle", monthly(summary.IdleHourlyCents)})
+	writer.AppendRow(table.Row{"Unallocated", monthly(summary.UnallocatedHourlyCents)})
+	writer.Render()
+
+	if len(cost.Namespaces) > 0 {
+		_, _ = fmt.Fprintln(out)
+		_, _ = fmt.Fprintf(out, "Namespace allocation (top %d of %d):\n", min(len(cost.Namespaces), costTopNamespaceRows), len(cost.Namespaces))
+		namespaceWriter := newCostTable(out)
+		namespaceWriter.AppendHeader(table.Row{"Namespace", "Per month", "CPU share", "Memory share", "Source"})
+		for index, namespace := range cost.Namespaces {
+			if index >= costTopNamespaceRows {
+				break
+			}
+			namespaceWriter.AppendRow(table.Row{
+				namespace.Namespace,
+				formatCostCents(namespace.AllocatedMonthlyCents, currency),
+				fmt.Sprintf("%.1f%%", namespace.CPUShare*100),
+				fmt.Sprintf("%.1f%%", namespace.MemoryShare*100),
+				namespace.AllocationSource,
+			})
+		}
+		namespaceWriter.Render()
+	}
+	if len(cost.Trend) > 0 {
+		first := cost.Trend[0]
+		last := cost.Trend[len(cost.Trend)-1]
+		_, _ = fmt.Fprintf(out, "\nTrend: %d daily points, %s/mo on %s -> %s/mo on %s\n", len(cost.Trend),
+			formatCostCents(first.MonthlyCostEstimateCents, currency), first.Day,
+			formatCostCents(last.MonthlyCostEstimateCents, currency), last.Day)
+	}
+}
+
+func renderCostSettings(out io.Writer, settings *client.CostSettings) {
+	egress := "off"
+	if settings.IncludeNetworkEgressEstimate {
+		egress = "on"
+	}
+	_, _ = fmt.Fprintf(out, "Display currency: %s\n", strings.ToUpper(settings.Currency))
+	_, _ = fmt.Fprintf(out, "Effective discount: %g%%\n", settings.EffectiveDiscountPct)
+	_, _ = fmt.Fprintf(out, "Network egress estimate: %s\n", egress)
+}
+
+func init() {
+	costSettingsSetCmd.Flags().String("currency", "", "Display currency: usd, eur or gbp")
+	costSettingsSetCmd.Flags().Float64("discount", 0, "Effective discount in percent (0-100), applied on top of list prices; 10 means 10%")
+	costSettingsSetCmd.Flags().Bool("include-egress", false, "Include an estimated network egress charge (pass --include-egress=false to drop it)")
+	registerStructuredOutputFlags(costSummaryCmd, costClusterCmd, costSettingsGetCmd, costSettingsSetCmd)
+	costSettingsCmd.AddCommand(costSettingsGetCmd)
+	costSettingsCmd.AddCommand(costSettingsSetCmd)
+	costCmd.AddCommand(costSummaryCmd)
+	costCmd.AddCommand(costClusterCmd)
+	costCmd.AddCommand(costSettingsCmd)
+	rootCmd.AddCommand(costCmd)
+}

--- a/cmd/cost_test.go
+++ b/cmd/cost_test.go
@@ -1,0 +1,234 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+type costMock struct {
+	baseMock
+	fleet       *client.FleetCloudCost
+	clusterCost *client.ClusterCost
+	settings    *client.CostSettings
+	updates     []client.CostSettings
+}
+
+func (m *costMock) GetFleetCloudCost() (*client.FleetCloudCost, error) {
+	return m.fleet, nil
+}
+
+func (m *costMock) GetClusterCost(string) (*client.ClusterCost, error) {
+	return m.clusterCost, nil
+}
+
+func (m *costMock) GetCostSettings() (*client.CostSettings, error) {
+	return m.settings, nil
+}
+
+func (m *costMock) UpdateCostSettings(settings client.CostSettings) (*client.CostSettings, error) {
+	m.updates = append(m.updates, settings)
+	saved := settings
+	return &saved, nil
+}
+
+func costCommandTree() []*cobra.Command {
+	return []*cobra.Command{costSummaryCmd, costClusterCmd, costSettingsGetCmd, costSettingsSetCmd}
+}
+
+func runCostCommand(t *testing.T, mock APIClient, args ...string) (string, error) {
+	t.Helper()
+	withTempHome(t)
+	setMockClient(t, mock)
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs(args)
+	t.Cleanup(func() { resetTreeFlags(t, costCommandTree()...) })
+	executeError := rootCmd.Execute()
+	return stdout.String(), executeError
+}
+
+func fleetCostFixture() *client.FleetCloudCost {
+	return &client.FleetCloudCost{
+		Currency:                 "eur",
+		ClusterCount:             3,
+		MonthlyCostEstimateCents: 84200,
+		MonthToDateCents:         41000,
+		ProjectedMonthEndCents:   86000,
+		ByProvider: []client.FleetProviderCost{
+			{Provider: "hetzner", ClusterCount: 2, MonthlyCostEstimateCents: 60000, MonthToDateCents: 30000, ProjectedMonthEndCents: 64500},
+			{Provider: "aws", ClusterCount: 1, MonthlyCostEstimateCents: 24200, MonthToDateCents: 11000, ProjectedMonthEndCents: 21500},
+		},
+		TopClusters: []client.FleetClusterCost{
+			{ClusterID: "11111111-1111-4111-8111-111111111111", ClusterName: "prod-eu", Provider: "hetzner",
+				MonthlyCostEstimateCents: 40000, MonthToDateCents: 20000, ProjectedMonthEndCents: 43000, ConfidenceLevel: "high"},
+		},
+	}
+}
+
+const costClusterID = "1834920e-3001-4157-8938-33c447031033"
+
+func TestCostSummaryRendersTotalsProvidersAndTopClusters(t *testing.T) {
+	output, executeError := runCostCommand(t, &costMock{fleet: fleetCostFixture()}, "cost", "summary")
+	if executeError != nil {
+		t.Fatalf("cost summary failed: %v", executeError)
+	}
+	for _, expected := range []string{
+		"Cloud cost (EUR): €860.00 projected month end · €410.00 month to date · €842.00/mo run rate",
+		"3 clusters priced across 2 provider(s)",
+		"Hetzner Cloud", "Amazon Web Services", "€645.00", "prod-eu", "€430.00", "high",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("output lacks %q:\n%s", expected, output)
+		}
+	}
+}
+
+func TestCostSummaryStructuredOutputIsTheApiDocument(t *testing.T) {
+	output, executeError := runCostCommand(t, &costMock{fleet: fleetCostFixture()}, "cost", "summary", "-o", "json")
+	if executeError != nil {
+		t.Fatalf("cost summary -o json failed: %v", executeError)
+	}
+	var decoded map[string]any
+	if unmarshalError := json.Unmarshal([]byte(output), &decoded); unmarshalError != nil {
+		t.Fatalf("output is not JSON: %v\n%s", unmarshalError, output)
+	}
+	if decoded["currency"] != "eur" || decoded["projected_month_end_cents"] != float64(86000) {
+		t.Fatalf("structured document lacks the wire fields: %+v", decoded)
+	}
+	if len(decoded["by_provider"].([]any)) != 2 {
+		t.Fatalf("by_provider missing: %+v", decoded)
+	}
+}
+
+func TestCostSummaryWithNothingPricedSaysWhy(t *testing.T) {
+	empty := &client.FleetCloudCost{Currency: "usd", ByProvider: []client.FleetProviderCost{}, TopClusters: []client.FleetClusterCost{}}
+	output, executeError := runCostCommand(t, &costMock{fleet: empty}, "cost", "summary")
+	if executeError != nil {
+		t.Fatalf("cost summary failed: %v", executeError)
+	}
+	if !strings.Contains(output, "No priced clusters yet.") || strings.Contains(output, "$0.00") {
+		t.Fatalf("an empty rollup must read as absent, not as zero cost:\n%s", output)
+	}
+}
+
+func TestCostClusterRendersBreakdownAndNamespaces(t *testing.T) {
+	stackID := "22222222-2222-4222-8222-222222222222"
+	cost := &client.ClusterCost{
+		HasData: true,
+		Summary: &client.ClusterCostSummary{
+			Provider: "hetzner", Currency: "eur", TotalNodeCount: 4, PricedNodeCount: 4,
+			HourlyCostCents: 115, MonthlyCostEstimateCents: 84200, MonthToDateCents: 41000, ProjectedMonthEndCents: 86000,
+			ConfidenceLevel: "high", SnapshotAt: "2026-08-30T14:00:00",
+			ComputeOnDemandCents: 100, StorageCents: 10, NetworkCents: 2, ControlPlaneCents: 3, InfrastructureCents: 5,
+			IdleHourlyCents: 20, UnallocatedHourlyCents: 30, StorageVolumeCount: 3, AppliedDiscountPct: 10,
+		},
+		Trend: []client.CostTrendPoint{
+			{Day: "2026-08-01", MonthlyCostEstimateCents: 80000},
+			{Day: "2026-08-30", MonthlyCostEstimateCents: 84200},
+		},
+		Namespaces: []client.NamespaceCost{
+			{Namespace: "payments", StackID: &stackID, AllocatedMonthlyCents: 30000, CPUShare: 0.4, MemoryShare: 0.35, AllocationSource: "requests"},
+		},
+		Readiness: &client.CostReadiness{State: "ready"},
+	}
+	output, executeError := runCostCommand(t, &costMock{clusterCost: cost}, "cost", "cluster", costClusterID)
+	if executeError != nil {
+		t.Fatalf("cost cluster failed: %v", executeError)
+	}
+	for _, expected := range []string{
+		"€860.00 projected month end", "€1.15/hr", "4 of 4 nodes priced", "10.0% discount applied",
+		"Compute (on-demand)", "€730.00", "Bastion & VMs", "€36.50",
+		"payments", "€300.00", "40.0%", "35.0%", "requests",
+		"Trend: 2 daily points",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("output lacks %q:\n%s", expected, output)
+		}
+	}
+}
+
+func TestCostClusterWithoutEstimateExplainsReadiness(t *testing.T) {
+	provider := "aws"
+	cost := &client.ClusterCost{
+		HasData:    false,
+		Trend:      []client.CostTrendPoint{},
+		Namespaces: []client.NamespaceCost{},
+		Readiness:  &client.CostReadiness{State: "no_credential", Provider: &provider},
+	}
+	output, executeError := runCostCommand(t, &costMock{clusterCost: cost}, "cost", "cluster", costClusterID)
+	if executeError != nil {
+		t.Fatalf("cost cluster failed: %v", executeError)
+	}
+	if !strings.Contains(output, "No cost estimate for "+costClusterID) ||
+		!strings.Contains(output, "no cloud credential for Amazon Web Services is connected") {
+		t.Fatalf("a missing estimate must say why:\n%s", output)
+	}
+	if strings.Contains(output, "€0.00") || strings.Contains(output, "$0.00") {
+		t.Fatalf("a missing estimate must not print zeros:\n%s", output)
+	}
+}
+
+func TestCostSettingsGetRendersEverySetting(t *testing.T) {
+	settings := &client.CostSettings{Currency: "gbp", EffectiveDiscountPct: 7.5, IncludeNetworkEgressEstimate: true}
+	output, executeError := runCostCommand(t, &costMock{settings: settings}, "cost", "settings", "get")
+	if executeError != nil {
+		t.Fatalf("cost settings get failed: %v", executeError)
+	}
+	for _, expected := range []string{"Display currency: GBP", "Effective discount: 7.5%", "Network egress estimate: on"} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("output lacks %q:\n%s", expected, output)
+		}
+	}
+}
+
+func TestCostSettingsSetChangesOnlyThePassedFlags(t *testing.T) {
+	mock := &costMock{settings: &client.CostSettings{Currency: "usd", EffectiveDiscountPct: 0, IncludeNetworkEgressEstimate: true}}
+	output, executeError := runCostCommand(t, mock, "cost", "settings", "set", "--discount", "12.5")
+	if executeError != nil {
+		t.Fatalf("cost settings set failed: %v", executeError)
+	}
+	if len(mock.updates) != 1 {
+		t.Fatalf("expected one update, got %d", len(mock.updates))
+	}
+	sent := mock.updates[0]
+	if sent.Currency != "usd" || sent.EffectiveDiscountPct != 12.5 || !sent.IncludeNetworkEgressEstimate {
+		t.Fatalf("update must keep the unchanged settings: %+v", sent)
+	}
+	if !strings.Contains(output, "Cost settings updated.") || !strings.Contains(output, "Effective discount: 12.5%") {
+		t.Fatalf("output lacks the confirmation:\n%s", output)
+	}
+}
+
+func TestCostSettingsSetNormalisesCurrencyAndDropsEgress(t *testing.T) {
+	mock := &costMock{settings: &client.CostSettings{Currency: "usd", EffectiveDiscountPct: 5, IncludeNetworkEgressEstimate: true}}
+	_, executeError := runCostCommand(t, mock, "cost", "settings", "set", "--currency", " EUR ", "--include-egress=false")
+	if executeError != nil {
+		t.Fatalf("cost settings set failed: %v", executeError)
+	}
+	sent := mock.updates[0]
+	if sent.Currency != "eur" || sent.EffectiveDiscountPct != 5 || sent.IncludeNetworkEgressEstimate {
+		t.Fatalf("unexpected update: %+v", sent)
+	}
+}
+
+func TestCostSettingsSetRefusesNoFlagsAndOutOfRangeDiscount(t *testing.T) {
+	mock := &costMock{settings: &client.CostSettings{Currency: "usd"}}
+	_, executeError := runCostCommand(t, mock, "cost", "settings", "set")
+	if executeError == nil || exitCodeFor(executeError) != exitUsage {
+		t.Fatalf("expected a usage error without flags, got %v", executeError)
+	}
+	_, executeError = runCostCommand(t, mock, "cost", "settings", "set", "--discount", "140")
+	if executeError == nil || exitCodeFor(executeError) != exitUsage {
+		t.Fatalf("expected a usage error for an out-of-range discount, got %v", executeError)
+	}
+	if len(mock.updates) != 0 {
+		t.Fatalf("no update must be sent on a refused invocation, got %d", len(mock.updates))
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -3804,3 +3804,19 @@ func (m baseMock) GetTerminalTranscript(sessionID string, afterSequence int, lim
 func (m baseMock) OpenPodTerminal(ctx context.Context, clusterID string, request client.PodTerminalRequest) (client.PodTerminal, error) {
 	return nil, errors.New("not implemented")
 }
+
+func (m baseMock) GetFleetCloudCost() (*client.FleetCloudCost, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetClusterCost(clusterID string) (*client.ClusterCost, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetCostSettings() (*client.CostSettings, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) UpdateCostSettings(settings client.CostSettings) (*client.CostSettings, error) {
+	return nil, errors.New("not implemented")
+}

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -48,6 +48,11 @@ type APIClient interface {
 	UpdatePowerSchedule(clusterID, scheduleID string, request client.PowerScheduleRequest) (*client.PowerScheduleListResult, error)
 	DeletePowerSchedule(clusterID, scheduleID string) (*client.DeletePowerScheduleResult, error)
 
+	GetFleetCloudCost() (*client.FleetCloudCost, error)
+	GetClusterCost(clusterID string) (*client.ClusterCost, error)
+	GetCostSettings() (*client.CostSettings, error)
+	UpdateCostSettings(settings client.CostSettings) (*client.CostSettings, error)
+
 	ListBackupVaults() (*client.BackupVaultListResult, error)
 	GetBackupVault(vaultID string) (*client.BackupVault, error)
 	CreateBackupVault(request client.CreateBackupVaultRequest) (*client.BackupVault, error)

--- a/internal/client/cost.go
+++ b/internal/client/cost.go
@@ -1,0 +1,179 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+	neturl "net/url"
+)
+
+const costBasePath = "/api/v1/org/cloud-cost"
+
+// FleetProviderCost is one provider's slice of the organisation-wide cost
+// rollup. Amounts are integer cents in the organisation's display currency.
+type FleetProviderCost struct {
+	Provider                 string `json:"provider" yaml:"provider"`
+	ClusterCount             int    `json:"cluster_count" yaml:"cluster_count"`
+	MonthlyCostEstimateCents int64  `json:"monthly_cost_estimate_cents" yaml:"monthly_cost_estimate_cents"`
+	MonthToDateCents         int64  `json:"month_to_date_cents" yaml:"month_to_date_cents"`
+	ProjectedMonthEndCents   int64  `json:"projected_month_end_cents" yaml:"projected_month_end_cents"`
+}
+
+// FleetClusterCost is one of the organisation's costliest clusters.
+type FleetClusterCost struct {
+	ClusterID                string `json:"cluster_id" yaml:"cluster_id"`
+	ClusterName              string `json:"cluster_name" yaml:"cluster_name"`
+	Provider                 string `json:"provider" yaml:"provider"`
+	MonthlyCostEstimateCents int64  `json:"monthly_cost_estimate_cents" yaml:"monthly_cost_estimate_cents"`
+	MonthToDateCents         int64  `json:"month_to_date_cents" yaml:"month_to_date_cents"`
+	ProjectedMonthEndCents   int64  `json:"projected_month_end_cents" yaml:"projected_month_end_cents"`
+	ConfidenceLevel          string `json:"confidence_level" yaml:"confidence_level"`
+}
+
+// FleetCloudCost is the organisation-wide cost rollup: every cluster whose
+// latest snapshot is younger than a day, in the display currency.
+type FleetCloudCost struct {
+	Currency                 string              `json:"currency" yaml:"currency"`
+	ClusterCount             int                 `json:"cluster_count" yaml:"cluster_count"`
+	MonthlyCostEstimateCents int64               `json:"monthly_cost_estimate_cents" yaml:"monthly_cost_estimate_cents"`
+	MonthToDateCents         int64               `json:"month_to_date_cents" yaml:"month_to_date_cents"`
+	ProjectedMonthEndCents   int64               `json:"projected_month_end_cents" yaml:"projected_month_end_cents"`
+	ByProvider               []FleetProviderCost `json:"by_provider" yaml:"by_provider"`
+	TopClusters              []FleetClusterCost  `json:"top_clusters" yaml:"top_clusters"`
+}
+
+// CostReadiness explains why a cluster has no estimate yet (or that it is
+// ready). State is one of ready, no_credential, unsupported_provider,
+// cluster_offline, awaiting_nodes, awaiting_pricing, estimate_pending.
+type CostReadiness struct {
+	State              string  `json:"state" yaml:"state"`
+	Provider           *string `json:"provider" yaml:"provider"`
+	HasCloudCredential bool    `json:"has_cloud_credential" yaml:"has_cloud_credential"`
+	NodesSynced        bool    `json:"nodes_synced" yaml:"nodes_synced"`
+	ClusterOnline      bool    `json:"cluster_online" yaml:"cluster_online"`
+	PricingAvailable   bool    `json:"pricing_available" yaml:"pricing_available"`
+}
+
+// ClusterCostSummary is a cluster's latest cost snapshot. The component
+// fields (compute, storage, network, control plane, infrastructure, idle,
+// unallocated) are HOURLY cents; the monthly, month-to-date and projected
+// totals are already monthly.
+type ClusterCostSummary struct {
+	Provider                 string  `json:"provider" yaml:"provider"`
+	Currency                 string  `json:"currency" yaml:"currency"`
+	TotalNodeCount           int     `json:"total_node_count" yaml:"total_node_count"`
+	PricedNodeCount          int     `json:"priced_node_count" yaml:"priced_node_count"`
+	CoverageIncomplete       bool    `json:"coverage_incomplete" yaml:"coverage_incomplete"`
+	HourlyCostCents          int64   `json:"hourly_cost_cents" yaml:"hourly_cost_cents"`
+	MonthlyCostEstimateCents int64   `json:"monthly_cost_estimate_cents" yaml:"monthly_cost_estimate_cents"`
+	MonthToDateCents         int64   `json:"month_to_date_cents" yaml:"month_to_date_cents"`
+	ProjectedMonthEndCents   int64   `json:"projected_month_end_cents" yaml:"projected_month_end_cents"`
+	ConfidenceLevel          string  `json:"confidence_level" yaml:"confidence_level"`
+	IsEstimated              bool    `json:"is_estimated" yaml:"is_estimated"`
+	SnapshotAt               string  `json:"snapshot_at" yaml:"snapshot_at"`
+	ComputeOnDemandCents     int64   `json:"compute_on_demand_cents" yaml:"compute_on_demand_cents"`
+	ComputeSpotCents         int64   `json:"compute_spot_cents" yaml:"compute_spot_cents"`
+	StorageCents             int64   `json:"storage_cents" yaml:"storage_cents"`
+	NetworkCents             int64   `json:"network_cents" yaml:"network_cents"`
+	ControlPlaneCents        int64   `json:"control_plane_cents" yaml:"control_plane_cents"`
+	InfrastructureCents      int64   `json:"infrastructure_cents" yaml:"infrastructure_cents"`
+	IdleHourlyCents          int64   `json:"idle_hourly_cents" yaml:"idle_hourly_cents"`
+	UnallocatedHourlyCents   int64   `json:"unallocated_hourly_cents" yaml:"unallocated_hourly_cents"`
+	SpotNodeCount            int     `json:"spot_node_count" yaml:"spot_node_count"`
+	OnDemandNodeCount        int     `json:"on_demand_node_count" yaml:"on_demand_node_count"`
+	StorageVolumeCount       int     `json:"storage_volume_count" yaml:"storage_volume_count"`
+	UnpricedVolumeCount      int     `json:"unpriced_volume_count" yaml:"unpriced_volume_count"`
+	AppliedDiscountPct       float64 `json:"applied_discount_pct" yaml:"applied_discount_pct"`
+}
+
+// CostTrendPoint is one day of the monthly estimate series.
+type CostTrendPoint struct {
+	Day                      string `json:"day" yaml:"day"`
+	MonthlyCostEstimateCents int64  `json:"monthly_cost_estimate_cents" yaml:"monthly_cost_estimate_cents"`
+}
+
+// NamespaceCost is a namespace's allocated share of the cluster estimate.
+type NamespaceCost struct {
+	Namespace                    string  `json:"namespace" yaml:"namespace"`
+	StackID                      *string `json:"stack_id" yaml:"stack_id"`
+	AllocatedHourlyCents         int64   `json:"allocated_hourly_cents" yaml:"allocated_hourly_cents"`
+	AllocatedMonthlyCents        int64   `json:"allocated_monthly_cents" yaml:"allocated_monthly_cents"`
+	AllocatedComputeMonthlyCents int64   `json:"allocated_compute_monthly_cents" yaml:"allocated_compute_monthly_cents"`
+	AllocatedStorageMonthlyCents int64   `json:"allocated_storage_monthly_cents" yaml:"allocated_storage_monthly_cents"`
+	CPUShare                     float64 `json:"cpu_share" yaml:"cpu_share"`
+	MemoryShare                  float64 `json:"memory_share" yaml:"memory_share"`
+	AllocationSource             string  `json:"allocation_source" yaml:"allocation_source"`
+}
+
+// ClusterCost is GET /org/clusters/{cluster_id}/cost. HasData false means no
+// snapshot exists yet; Readiness then says why.
+type ClusterCost struct {
+	HasData    bool                `json:"has_data" yaml:"has_data"`
+	Summary    *ClusterCostSummary `json:"summary" yaml:"summary"`
+	Trend      []CostTrendPoint    `json:"trend" yaml:"trend"`
+	Namespaces []NamespaceCost     `json:"namespaces" yaml:"namespaces"`
+	Readiness  *CostReadiness      `json:"readiness,omitempty" yaml:"readiness,omitempty"`
+}
+
+// CostSettings is the organisation's pricing configuration: the display
+// currency (usd, eur or gbp), the effective discount in percent applied on
+// top of list prices, and whether a network egress estimate is included.
+type CostSettings struct {
+	EffectiveDiscountPct         float64 `json:"effective_discount_pct" yaml:"effective_discount_pct"`
+	Currency                     string  `json:"currency" yaml:"currency"`
+	IncludeNetworkEgressEstimate bool    `json:"include_network_egress_estimate" yaml:"include_network_egress_estimate"`
+}
+
+// GetFleetCloudCost returns the organisation-wide cost rollup.
+// GET /api/v1/org/cloud-cost/summary
+func (c *Client) GetFleetCloudCost() (*FleetCloudCost, error) {
+	var result FleetCloudCost
+	if err := c.sendJSON(http.MethodGet, c.BaseURL+costBasePath+"/summary", nil, &result); err != nil {
+		return nil, err
+	}
+	if result.ByProvider == nil {
+		result.ByProvider = []FleetProviderCost{}
+	}
+	if result.TopClusters == nil {
+		result.TopClusters = []FleetClusterCost{}
+	}
+	return &result, nil
+}
+
+// GetClusterCost returns a cluster's latest cost estimate with its namespace
+// allocation and daily trend, or its readiness when there is no estimate yet.
+// GET /api/v1/org/clusters/{cluster_id}/cost
+func (c *Client) GetClusterCost(clusterID string) (*ClusterCost, error) {
+	url := fmt.Sprintf("%s/api/v1/org/clusters/%s/cost", c.BaseURL, neturl.PathEscape(clusterID))
+	var result ClusterCost
+	if err := c.sendJSON(http.MethodGet, url, nil, &result); err != nil {
+		return nil, err
+	}
+	if result.Trend == nil {
+		result.Trend = []CostTrendPoint{}
+	}
+	if result.Namespaces == nil {
+		result.Namespaces = []NamespaceCost{}
+	}
+	return &result, nil
+}
+
+// GetCostSettings returns the organisation's pricing configuration.
+// GET /api/v1/org/cloud-cost/settings
+func (c *Client) GetCostSettings() (*CostSettings, error) {
+	var result CostSettings
+	if err := c.sendJSON(http.MethodGet, c.BaseURL+costBasePath+"/settings", nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// UpdateCostSettings replaces the organisation's pricing configuration. The
+// route is organisation-admin only and guarded by the CSRF double-submit.
+// PUT /api/v1/org/cloud-cost/settings
+func (c *Client) UpdateCostSettings(settings CostSettings) (*CostSettings, error) {
+	var result CostSettings
+	if err := c.putCSRFJSON(c.BaseURL+costBasePath+"/settings", settings, &result, "update cost settings"); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/internal/client/cost_test.go
+++ b/internal/client/cost_test.go
@@ -1,0 +1,105 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestGetFleetCloudCost_Success(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/org/cloud-cost/summary" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		jsonResponse(t, w, http.StatusOK, FleetCloudCost{
+			Currency: "eur", ClusterCount: 2, ProjectedMonthEndCents: 86000,
+			ByProvider: []FleetProviderCost{{Provider: "hetzner", ClusterCount: 2, ProjectedMonthEndCents: 86000}},
+		})
+	}
+	testClient := newTestClient(t, handler)
+	result, err := testClient.GetFleetCloudCost()
+	if err != nil {
+		t.Fatalf("GetFleetCloudCost: %v", err)
+	}
+	if result.Currency != "eur" || result.ClusterCount != 2 || len(result.ByProvider) != 1 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if result.TopClusters == nil {
+		t.Fatalf("an absent top_clusters list must decode as empty, not nil")
+	}
+}
+
+func TestGetClusterCost_Success(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/org/clusters/cluster-123/cost" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		jsonResponse(t, w, http.StatusOK, map[string]any{
+			"has_data":   false,
+			"summary":    nil,
+			"trend":      []any{},
+			"namespaces": []any{},
+			"readiness":  map[string]any{"state": "no_credential", "provider": "aws"},
+		})
+	}
+	testClient := newTestClient(t, handler)
+	result, err := testClient.GetClusterCost("cluster-123")
+	if err != nil {
+		t.Fatalf("GetClusterCost: %v", err)
+	}
+	if result.HasData || result.Summary != nil || result.Readiness == nil || result.Readiness.State != "no_credential" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestUpdateCostSettings_SendsPutWithCSRFAndBody(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("method = %s, want PUT", r.Method)
+		}
+		if r.URL.Path != "/api/v1/org/cloud-cost/settings" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		header := r.Header.Get("X-Ankra-CSRF")
+		cookie, cookieError := r.Cookie("ankra_csrf")
+		if header == "" || cookieError != nil || cookie.Value != header {
+			t.Errorf("CSRF double-submit missing: header=%q cookieError=%v", header, cookieError)
+		}
+		var body map[string]any
+		if decodeError := json.NewDecoder(r.Body).Decode(&body); decodeError != nil {
+			t.Fatalf("decode body: %v", decodeError)
+		}
+		if body["currency"] != "eur" || body["effective_discount_pct"] != 12.5 || body["include_network_egress_estimate"] != true {
+			t.Errorf("unexpected body: %+v", body)
+		}
+		jsonResponse(t, w, http.StatusOK, CostSettings{Currency: "eur", EffectiveDiscountPct: 12.5, IncludeNetworkEgressEstimate: true})
+	}
+	testClient := newTestClient(t, handler)
+	result, err := testClient.UpdateCostSettings(CostSettings{Currency: "eur", EffectiveDiscountPct: 12.5, IncludeNetworkEgressEstimate: true})
+	if err != nil {
+		t.Fatalf("UpdateCostSettings: %v", err)
+	}
+	if result.Currency != "eur" || result.EffectiveDiscountPct != 12.5 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestCost_BackendDetailSurfaces(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(t, w, http.StatusForbidden, map[string]string{
+			"detail": "Only organisation admins can change cloud cost settings"})
+	}
+	testClient := newTestClient(t, handler)
+	_, err := testClient.UpdateCostSettings(CostSettings{Currency: "usd"})
+	if err == nil || !strings.Contains(err.Error(), "Only organisation admins") {
+		t.Fatalf("expected the backend detail to surface, got %v", err)
+	}
+	_, err = testClient.GetCostSettings()
+	if err == nil || !strings.Contains(err.Error(), "Only organisation admins") {
+		t.Fatalf("expected the backend detail to surface on a read too, got %v", err)
+	}
+}

--- a/internal/client/csrf.go
+++ b/internal/client/csrf.go
@@ -118,3 +118,16 @@ func generateClientCSRFToken() string {
 	}
 	return base64.RawURLEncoding.EncodeToString(tokenBytes)
 }
+func (c *Client) putCSRFJSON(requestURL string, requestBody interface{}, target interface{}, operation string) error {
+	payload, err := marshalOptionalJSON(requestBody)
+	if err != nil {
+		return err
+	}
+	request, err := http.NewRequest(http.MethodPut, requestURL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	c.applyAuthAndCSRFHeaders(request)
+	return c.doJSON(request, target, operation)
+}

--- a/internal/skills/embedded/skills/ankra-cli/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-cli/SKILL.md
@@ -52,6 +52,7 @@ never rely on the selection — pass both explicitly.
 | AI provider, tools, runs, board | `ankra ai ...`, `ankra org mcp-servers ...`, `ankra agents ...`, `ankra tickets ...` | `ankra-ai-agents` |
 | Tokens, roles, cluster access | `ankra tokens`, `ankra org members\|roles`, `ankra cluster access` | `ankra-security` |
 | Credentials | `ankra credentials ...` | `ankra-security` |
+| Cloud cost | `ankra cost summary\|cluster\|settings` | below |
 | Support requests | `ankra support create\|list\|get\|comment\|attach\|close` | below |
 
 ## Applying configuration
@@ -165,6 +166,20 @@ ankra support close <ticket-id>
 
 Every request is reviewed by Ankra AI before it reaches the team; `--force` on `create` submits a
 flagged request anyway. Attach the evidence (operations output, logs) rather than describing it.
+
+## Cloud cost
+
+```bash
+ankra cost summary                       # fleet rollup: projected month end, month to date, run rate, by provider, costliest clusters
+ankra cost cluster prod-eu               # one cluster: breakdown by component, namespace allocation, daily trend
+ankra cost settings get                  # display currency, effective discount, network egress estimate
+ankra cost settings set --currency eur --discount 12.5   # admins only; only the flags you pass change
+```
+
+Figures are list-price estimates in the organisation's display currency, priced hourly from each
+cluster's node inventory and allocated to namespaces by CPU and memory share. A cluster with no
+estimate prints its readiness reason (no cloud credential, unsupported provider, nodes still
+syncing) - never zeros. Add `-o json` to script against the same document the portal reads.
 
 ## Scripting
 


### PR DESCRIPTION
Bead: ankra-25z58

## What

`ankra cost` — the portal's Cost center (portal#1744) and clusters cost strip (portal#1739) in the terminal:

- **`ankra cost summary`** — fleet rollup from `GET /org/cloud-cost/summary`: projected month end, month to date, run rate (display currency), by-provider table and the costliest clusters. An empty rollup prints "No priced clusters yet" and how to get pricing, never `$0.00`.
- **`ankra cost cluster <name-or-id>`** — `GET /org/clusters/{id}/cost`: totals with confidence and node coverage, the per-month component breakdown (hourly cents × 730, matching the platform), namespace allocation with CPU/memory shares (top 15), daily trend, and — when there is no estimate — the readiness reason (no credential / unsupported provider / nodes syncing / …) instead of zeros.
- **`ankra cost settings get|set`** — `GET`/`PUT /org/cloud-cost/settings`. `set` fetches the current settings and changes only the flags passed (`--currency`, `--discount` in percent, `--include-egress`); no flag or a discount outside 0–100 is a usage error (exit 2) before any request. The PUT is admin-only and CSRF double-submit guarded server-side, so `internal/client` gains `putCSRFJSON` next to the existing POST/PATCH/DELETE helpers.

Every command takes `-o json|yaml` and emits the API document unchanged. The reads use `sendJSON` so a backend `{detail}` reaches the user (the `getJSON` helper discards it). `currencySymbol` learns `gbp`.

## Also
- CHANGELOG `Unreleased / Added` entry, README command-table row, and a **Cloud cost** row + section in the embedded `ankra-cli` skill.
- `docs.ankra.ai/reference/cli/cost` will be generated at the next stable tag (`docs-sync.yml`); it needs a `docs.json` nav entry then.

## Tests
- `cmd/cost_test.go`: human and `-o json` rendering of the summary, empty rollup, cluster breakdown/namespaces/trend, missing estimate → readiness reason, settings get, `set` changing only passed flags, currency normalisation, usage errors without flags / out-of-range discount.
- `internal/client/cost_test.go`: paths and methods, nil-slice normalisation, PUT body + CSRF header/cookie double-submit, backend `{detail}` surfacing on read and write.
- `go build ./...`, `go test ./...` (one pre-existing load-sensitive `internal/migrate` test timed out under a parallel build and passes alone), `golangci-lint run ./...` — 0 issues.
