### PR TITLE
fix(playground): stop telling custom-plan organisations to add a payment card (ankra-6ghi3)

### DIFF
--- a/cmd/cluster_playground.go
+++ b/cmd/cluster_playground.go
@@ -68,7 +68,7 @@ var clusterPlaygroundPlansCmd = &cobra.Command{
 		if !catalog.OrganisationHasPaidPlan {
 			_, _ = fmt.Fprintf(writer,
 				"Paid sizes need a billing plan - choose one on the billing page first.\n")
-		} else if !catalog.OrganisationHasPaymentCard {
+		} else if catalog.RequiresPaymentCard() && !catalog.OrganisationHasPaymentCard {
 			_, _ = fmt.Fprintf(writer,
 				"Paid sizes need a payment card on file - add one on the billing page first.\n")
 		}

--- a/cmd/cluster_playground_test.go
+++ b/cmd/cluster_playground_test.go
@@ -266,3 +266,47 @@ func TestPlaygroundDestroySurfacesTheServerError(t *testing.T) {
 		t.Errorf("the server detail must survive: %v", runError)
 	}
 }
+
+// A custom plan is invoiced against its agreement rather than collected by
+// Stripe, so the order gate never asks for a card and the listing must not
+// either. Every other plan still says so - including against a server too old
+// to send the field, where an absent answer is not an exemption.
+func TestPlaygroundPlansAsksForACardOnlyWhereStripeCollects(t *testing.T) {
+	requiresCard := true
+	exemptFromCard := false
+
+	for _, testCase := range []struct {
+		name          string
+		requiresField *bool
+		wantCardLine  bool
+	}{
+		{name: "custom plan", requiresField: &exemptFromCard, wantCardLine: false},
+		{name: "Stripe-collected plan", requiresField: &requiresCard, wantCardLine: true},
+		{name: "server predating the field", requiresField: nil, wantCardLine: true},
+	} {
+		withPlaygroundMock(t, &playgroundMock{
+			plansCatalog: &client.PlaygroundPlanCatalog{
+				DefaultPlanID:                   "trial",
+				Currency:                        "eur",
+				OrganisationHasPaidPlan:         true,
+				OrganisationHasPaymentCard:      false,
+				OrganisationRequiresPaymentCard: testCase.requiresField,
+				Plans: []client.PlaygroundPlan{
+					{ID: "small", DisplayName: "Small", Vcpus: 2, MemoryGB: 4, StorageGB: 50, PriceMonthlyCents: 1350, Currency: "eur", Available: true},
+				},
+			},
+		})
+		buffer := &strings.Builder{}
+		clusterPlaygroundPlansCmd.SetOut(buffer)
+		if err := clusterPlaygroundPlansCmd.RunE(clusterPlaygroundPlansCmd, nil); err != nil {
+			clusterPlaygroundPlansCmd.SetOut(nil)
+			t.Fatalf("%s: plans failed: %v", testCase.name, err)
+		}
+		output := buffer.String()
+		clusterPlaygroundPlansCmd.SetOut(nil)
+		if hasCardLine := strings.Contains(output, "payment card on file"); hasCardLine != testCase.wantCardLine {
+			t.Errorf("%s: card line present = %v, want %v; output: %s",
+				testCase.name, hasCardLine, testCase.wantCardLine, output)
+		}
+	}
+}

--- a/internal/client/playground.go
+++ b/internal/client/playground.go
@@ -67,9 +67,23 @@ type PlaygroundPlanCatalog struct {
 	// OrganisationHasPaymentCard is the second half of that answer: paid
 	// orders also refuse without a card on file.
 	OrganisationHasPaymentCard bool `json:"organisation_has_payment_card"`
+	// OrganisationRequiresPaymentCard says whether that card is a condition
+	// of ordering at all. It is false for an organisation on a custom plan,
+	// which is invoiced against its agreement rather than collected by
+	// Stripe. A pointer because an older server omits the field entirely,
+	// and an absent answer is not an exemption - see RequiresPaymentCard.
+	OrganisationRequiresPaymentCard *bool `json:"organisation_requires_payment_card"`
 	// Quota is the memory budget paid playgrounds share (the free trial
 	// sits outside it).
 	Quota PlaygroundMemoryQuota `json:"quota"`
+}
+
+// RequiresPaymentCard reports whether the organisation has to hold a card
+// before a paid order is accepted. A server that does not send the field at
+// all is read as requiring one: that is true of every plan but the custom
+// one, so an absent answer must not be mistaken for an exemption.
+func (catalog PlaygroundPlanCatalog) RequiresPaymentCard() bool {
+	return catalog.OrganisationRequiresPaymentCard == nil || *catalog.OrganisationRequiresPaymentCard
 }
 
 // ListPlaygroundPlans reads the orderable sizes with their prices and


### PR DESCRIPTION
Bead: ankra-6ghi3

Third and last surface of the custom-plan card exemption, after cluster#2251 (the gate + the `organisation_requires_payment_card` field) and portal#1759 (the picker warning).

## The problem

`ankra cluster playground plans` printed the card advice whenever no card was on file:

```
Order one with: ankra cluster playground create --size <id>
Paid sizes need a payment card on file - add one on the billing page first.
```

A custom plan is invoiced against its negotiated agreement rather than collected by Stripe, so the order gate never asks those organisations for a card. Since cluster#2251 the order that line warns about **succeeds** — so the advice is not just unnecessary, it is wrong.

This was reproduced against production: the `Ankra - Development` organisation is on a custom plan, and the live CLI printed the line anyway.

## The change

`organisation_requires_payment_card` now gates the line, as it already does in the portal picker.

**The field is a `*bool`, not a `bool.`** A server too old to send it omits the key entirely, and Go would decode that to `false` — silently suppressing a warning that *is* needed. `RequiresPaymentCard()` reads `nil` as "a card is required", which is true of every plan but the custom one. An absent answer is not an exemption.

## Tests

`TestPlaygroundPlansAsksForACardOnlyWhereStripeCollects` covers all three states: custom plan (no line), Stripe-collected plan (line), and a server predating the field (line). Red/green: reverting the gate fails the custom-plan case with the exact line in the output.

`go build ./...` clean, `go test ./cmd/` green, pre-commit linter reports 0 issues.

> `gofmt -l internal/client` flags `baseurl.go`, `credentials.go` and `helpers_test.go` on `master`. Those are pre-existing and untouched here — none of the three files this PR changes is flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADE27gpCPMqNFvmftt28kn
