### PR TITLE
fix(client): read the git-push error_code so a deferred GitOps commit is success, not a failed deploy (ankra-qezdv)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,24 @@
 
 ### Fixed
 
+- **A deferred GitOps commit is no longer reported as a failed deploy.** When
+  the values repository has commits the platform has not synced yet, a stack
+  write is applied to the cluster and is live, and only the commit back to
+  Git waits on the background sync - the platform says so explicitly, with
+  "do not re-apply". The CLI still exited 1 on that answer, so CI marked
+  successful deploys red and retry wrappers re-applied the change the message
+  warns against. The CLI now reads the machine-readable `error_code` the
+  platform attaches (`GIT_PUSH_DEFERRED` vs `GIT_PUSH_FAILED`) and treats a
+  deferral as success: exit 0, the platform's message printed verbatim, and
+  `git_push_deferred`/`git_push_message` fields in `-o json`. This covers
+  every write that can defer - addons upgrade/uninstall/update, manifests
+  upgrade/disconnect, encrypt, stack variables, stack rename, and
+  `cluster apply` (including `migrate up`). Genuine push failures and older
+  platforms that send no `error_code` keep the non-zero exit they have today.
+  One deliberate exception: `cluster draft`'s bootstrap import needs the new
+  cluster's ID from the response, which a deferral does not carry, so it
+  reports the saved-but-deferred state and asks you to re-run instead of
+  staging drafts against an empty cluster.
 - **`control-plane get` answers the count and the instance type separately.**
   The platform can now resize a running cluster's controllers one at a time,
   so the two controls stopped having the same answer - but the CLI still

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -112,6 +112,19 @@ func runApply(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
+	if importResponse.GitPushDeferred {
+		// Designed refusal: the cluster write is committed and live, only the
+		// commit back to Git waits on the background sync. The response
+		// carries no name/id payload, so render the deferral instead of the
+		// name-based success output. The message is printed verbatim — deploy
+		// tooling substring-matches it.
+		if rendered, err := renderStructured(cmd, importResponse); rendered || err != nil {
+			return err
+		}
+		printGitPushDeferral(cmd.OutOrStdout(), true, importResponse.GitPushMessage)
+		return nil
+	}
+
 	if len(importResponse.Errors) > 0 {
 		rendered, renderErr := renderStructured(cmd, importResponse)
 		if renderErr != nil {

--- a/cmd/cluster_addon.go
+++ b/cmd/cluster_addon.go
@@ -336,6 +336,7 @@ var clusterAddonsUninstallCmd = &cobra.Command{
 			} else {
 				fmt.Printf("Addon '%s' uninstalled successfully!\n", addonName)
 			}
+			printGitPushDeferral(cmd.OutOrStdout(), result.GitPushDeferred, result.Message)
 		}
 		return nil
 	},
@@ -378,11 +379,13 @@ Usage:
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		if err := apiClient.UpdateAddonSettings(ctx, cluster.ID, addonName, settings); err != nil {
+		result, err := apiClient.UpdateAddonSettings(ctx, cluster.ID, addonName, settings)
+		if err != nil {
 			return fmt.Errorf("updating addon settings: %w", err)
 		}
 
 		fmt.Printf("Settings for addon '%s' updated successfully!\n", addonName)
+		printGitPushDeferral(cmd.OutOrStdout(), result.GitPushDeferred, result.GitPushMessage)
 		return nil
 	},
 }

--- a/cmd/cluster_draft.go
+++ b/cmd/cluster_draft.go
@@ -155,6 +155,15 @@ func resolveClusterForDraft(ctx context.Context, importRequest client.CreateImpo
 	if len(importResponse.Errors) > 0 {
 		return "", fmt.Errorf("import of cluster %q failed: %v", importRequest.Name, importResponse.Errors)
 	}
+	if importResponse.GitPushDeferred {
+		// The bootstrap import WAS saved and is live (that is what a git-push
+		// deferral means), but the deferred response carries no cluster ID to
+		// attach drafts to — succeeding here would feed an empty ID into
+		// every staging call. Re-running resolves the now-existing cluster
+		// through the GetCluster lookup above and proceeds normally.
+		return "", fmt.Errorf("cluster %q was imported and is live, but the platform deferred its Git commit and returned no cluster ID; re-run the command to stage the drafts (the cluster now exists and will be found directly).\n%s",
+			importRequest.Name, importResponse.GitPushMessage)
+	}
 	fmt.Fprintf(os.Stderr, "Cluster %q imported.\n", importResponse.Name)
 	return importResponse.ClusterId, nil
 }

--- a/cmd/cluster_encrypt.go
+++ b/cmd/cluster_encrypt.go
@@ -1150,6 +1150,7 @@ func runEncryptManifestCluster(cmd *cobra.Command, manifestName string, leafKeys
 		return errors.New("encryption partially failed; see errors above")
 	}
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Manifest %q encrypted in stack %q.\n", manifestName, stack.Name)
+	printGitPushDeferral(cmd.OutOrStdout(), res.GitPushDeferred, res.GitPushMessage)
 	return nil
 }
 
@@ -1223,5 +1224,6 @@ func runEncryptAddonCluster(cmd *cobra.Command, addonName string, leafKeys []str
 		return errors.New("encryption partially failed; see errors above")
 	}
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Addon %q encrypted in stack %q.\n", addonName, stack.Name)
+	printGitPushDeferral(cmd.OutOrStdout(), res.GitPushDeferred, res.GitPushMessage)
 	return nil
 }

--- a/cmd/cluster_manifests.go
+++ b/cmd/cluster_manifests.go
@@ -107,10 +107,12 @@ cluster). Use --dry-run to preview the target without making changes.`,
 			return err
 		}
 
-		if _, err := apiClient.DisconnectManifest(ctx, clusterID, stack.Name, manifestName); err != nil {
+		result, err := apiClient.DisconnectManifest(ctx, clusterID, stack.Name, manifestName)
+		if err != nil {
 			return err
 		}
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Manifest %q disconnected from stack %q.\n", manifestName, stack.Name)
+		printGitPushDeferral(cmd.OutOrStdout(), result.GitPushDeferred, result.GitPushMessage)
 		return nil
 	},
 }

--- a/cmd/cluster_partial.go
+++ b/cmd/cluster_partial.go
@@ -333,7 +333,19 @@ func printAsOutput(out io.Writer, res *client.PatchStackResult, format outputFor
 	if res.CommitURL != "" {
 		_, _ = fmt.Fprintf(out, "  Commit URL:   %s\n", res.CommitURL)
 	}
+	printGitPushDeferral(out, res.GitPushDeferred, res.GitPushMessage)
 	return nil
+}
+
+// printGitPushDeferral prints the platform's git-push-deferral detail. The
+// message goes out VERBATIM on its own line: the deploy tooling still
+// substring-matches it (cluster scripts/deploy_upgrade_addons.sh
+// DEFERRED_COMMIT_MARKER), so it must not be reworded or wrapped.
+func printGitPushDeferral(out io.Writer, deferred bool, message string) {
+	if !deferred || message == "" {
+		return
+	}
+	_, _ = fmt.Fprintln(out, message)
 }
 
 // renderPatchResourceErrors prints the per-resource validation errors from a

--- a/cmd/cluster_stack_variables.go
+++ b/cmd/cluster_stack_variables.go
@@ -139,7 +139,8 @@ passing "-".`,
 			return nil
 		}
 
-		if err := patchStackVariables(ctx, clusterID, patchStack); err != nil {
+		res, err := patchStackVariables(ctx, clusterID, patchStack)
+		if err != nil {
 			return err
 		}
 		if existed {
@@ -147,6 +148,7 @@ passing "-".`,
 		} else {
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Stack %q variable %q created.\n", stackName, name)
 		}
+		printGitPushDeferral(cmd.OutOrStdout(), res.GitPushDeferred, res.GitPushMessage)
 		return nil
 	},
 }
@@ -198,10 +200,12 @@ var clusterStackVariablesDeleteCmd = &cobra.Command{
 			patchStack.Variables = map[string]string{}
 		}
 
-		if err := patchStackVariables(ctx, clusterID, patchStack); err != nil {
+		res, err := patchStackVariables(ctx, clusterID, patchStack)
+		if err != nil {
 			return err
 		}
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Stack %q variable %q deleted.\n", stackName, name)
+		printGitPushDeferral(cmd.OutOrStdout(), res.GitPushDeferred, res.GitPushMessage)
 		return nil
 	},
 }
@@ -247,16 +251,17 @@ func joinOrNone(items []string) string {
 // patchStackVariables sends a stack-only partial PATCH that carries metadata +
 // the updated variables map. Manifests/addons are intentionally omitted so
 // the backend preserves them.
-func patchStackVariables(ctx context.Context, clusterID string, patchStack client.StackSpec) error {
+func patchStackVariables(ctx context.Context, clusterID string, patchStack client.StackSpec) (*client.PatchStackResult, error) {
 	req := buildPartialStackPatch(patchStack)
-	if _, err := apiClient.PatchClusterStackPartial(ctx, clusterID, patchStack.Name, req); err != nil {
+	res, err := apiClient.PatchClusterStackPartial(ctx, clusterID, patchStack.Name, req)
+	if err != nil {
 		var perr *client.PatchStackError
 		if errors.As(err, &perr) {
-			return mapPatchError(perr)
+			return nil, mapPatchError(perr)
 		}
-		return err
+		return nil, err
 	}
-	return nil
+	return res, nil
 }
 
 func renderStackVariables(out io.Writer, stackName string, vars map[string]string, format outputFormat) error {

--- a/cmd/cluster_stacks.go
+++ b/cmd/cluster_stacks.go
@@ -257,6 +257,7 @@ var clusterStacksRenameCmd = &cobra.Command{
 
 		if result.Success {
 			fmt.Printf("Stack '%s' renamed to '%s' successfully!\n", oldName, newName)
+			printGitPushDeferral(cmd.OutOrStdout(), result.GitPushDeferred, result.Message)
 			return nil
 		}
 		return fmt.Errorf("rename request did not report success")

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -487,8 +487,8 @@ func (m baseMock) GetAddonSettings(clusterID, addonName string) (*client.GetAddo
 	return nil, errors.New("not implemented")
 }
 
-func (m baseMock) UpdateAddonSettings(ctx context.Context, clusterID, addonName string, settings client.AddonSettings) error {
-	return errors.New("not implemented")
+func (m baseMock) UpdateAddonSettings(ctx context.Context, clusterID, addonName string, settings client.AddonSettings) (*client.UpdateAddonSettingsResult, error) {
+	return nil, errors.New("not implemented")
 }
 
 func (m baseMock) GetAddonByName(clusterID, addonName string) (*client.ClusterAddonListItem, error) {

--- a/cmd/gitpush_deferral_test.go
+++ b/cmd/gitpush_deferral_test.go
@@ -1,0 +1,199 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+// cmdDeferralDetail mimics the platform's designed-refusal message. It
+// contains "only the commit back to Git was deferred" so these tests also
+// pin that the CLI surfaces the marker substring verbatim (the cluster
+// deploy script matches it).
+const cmdDeferralDetail = "Saved. Your change is applied to the cluster and is live; only the commit back to Git was deferred, because Git has newer changes that Ankra has not synced yet. The background sync merges both sides and commits your change on its own - do not re-apply it."
+
+// A deferred git push on addons upgrade is a successful deploy: exit 0 with
+// the platform message on stdout, not the retryable failure CI wrappers
+// re-applied five times against (ankra-qezdv).
+func TestRunAddonsUpgrade_DeferredGitPushIsSuccess(t *testing.T) {
+	mock := &upgradeMock{
+		iac: sampleIaCYAMLForCmd,
+		patchResult: &client.PatchStackResult{
+			StackName:       "demo-web-app",
+			GitPushDeferred: true,
+			GitPushMessage:  cmdDeferralDetail,
+		},
+	}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	output, err := executeCommand("cluster", "addons", "upgrade", "website",
+		"--chart-version", "1.0.146",
+		"--cluster", fakeClusterUUID,
+	)
+	if err != nil {
+		t.Fatalf("deferred git push must exit 0, got error: %v\noutput: %s", err, output)
+	}
+	if !strings.Contains(output, cmdDeferralDetail) {
+		t.Errorf("expected the platform deferral message verbatim in output, got: %s", output)
+	}
+	if !strings.Contains(output, `Stack "demo-web-app" updated.`) {
+		t.Errorf("expected the update summary in output, got: %s", output)
+	}
+}
+
+// -o json carries the deferral as machine-readable fields on parseable stdout.
+func TestRunAddonsUpgrade_DeferredGitPushJSON(t *testing.T) {
+	mock := &upgradeMock{
+		iac: sampleIaCYAMLForCmd,
+		patchResult: &client.PatchStackResult{
+			StackName:       "demo-web-app",
+			GitPushDeferred: true,
+			GitPushMessage:  cmdDeferralDetail,
+		},
+	}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(stderr)
+	rootCmd.SetArgs([]string{"cluster", "addons", "upgrade", "website",
+		"--chart-version", "1.0.146",
+		"--cluster", fakeClusterUUID,
+		"--output", "json",
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("deferred git push must exit 0, got error: %v\nstderr: %s", err, stderr.String())
+	}
+	var decoded struct {
+		StackName       string `json:"stack_name"`
+		GitPushDeferred bool   `json:"git_push_deferred"`
+		GitPushMessage  string `json:"git_push_message"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout is not parseable JSON: %v\nstdout: %s", err, stdout.String())
+	}
+	if !decoded.GitPushDeferred {
+		t.Error("git_push_deferred = false, want true")
+	}
+	if decoded.GitPushMessage != cmdDeferralDetail {
+		t.Errorf("git_push_message = %q, want the platform detail verbatim", decoded.GitPushMessage)
+	}
+}
+
+// GIT_PUSH_FAILED keeps today's non-zero "git push failed" exit.
+func TestRunAddonsUpgrade_FailedGitPushStaysError(t *testing.T) {
+	mock := &upgradeMock{
+		iac: sampleIaCYAMLForCmd,
+		patchErr: &client.PatchStackError{
+			StatusCode: 422,
+			Body:       []byte(`{"detail":"GitHub authentication failed","error_code":"GIT_PUSH_FAILED"}`),
+		},
+	}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	output, err := executeCommand("cluster", "addons", "upgrade", "website",
+		"--chart-version", "1.0.146",
+		"--cluster", fakeClusterUUID,
+	)
+	if err == nil {
+		t.Fatalf("expected error for GIT_PUSH_FAILED, got success; output: %s", output)
+	}
+	if !strings.Contains(err.Error(), "git push failed: GitHub authentication failed") {
+		t.Errorf("error = %v, want the git-push failure surfaced", err)
+	}
+}
+
+type applyGitPushMock struct {
+	baseMock
+	response *client.ImportResponse
+	err      error
+}
+
+func (m *applyGitPushMock) ApplyCluster(ctx context.Context, clusterReq client.CreateImportClusterRequest, wait bool) (*client.ImportResponse, bool, error) {
+	return m.response, false, m.err
+}
+
+// cluster apply with a deferred git push is a successful apply: exit 0 with
+// the platform message, no empty-name success rendering.
+func TestClusterApply_DeferredGitPushIsSuccess(t *testing.T) {
+	mock := &applyGitPushMock{
+		response: &client.ImportResponse{GitPushDeferred: true, GitPushMessage: cmdDeferralDetail},
+	}
+	setMockClient(t, mock)
+	yamlPath := writeDraftImportClusterYAML(t)
+
+	var output string
+	var err error
+	stdout := captureStdout(t, func() {
+		output, err = executeCommand("cluster", "apply", "-f", yamlPath)
+	})
+	if err != nil {
+		t.Fatalf("deferred git push must exit 0, got error: %v\noutput: %s%s", err, output, stdout)
+	}
+	combined := output + stdout
+	if !strings.Contains(combined, cmdDeferralDetail) {
+		t.Errorf("expected the platform deferral message verbatim, got: %s", combined)
+	}
+	if strings.Contains(combined, "Cluster ''") || strings.Contains(combined, `Cluster ""`) {
+		t.Errorf("deferral must not fall through to name-based rendering, got: %s", combined)
+	}
+}
+
+// Any apply error (including a genuine git-push failure) stays non-zero.
+func TestClusterApply_FailedGitPushStaysError(t *testing.T) {
+	mock := &applyGitPushMock{
+		err: client.NewUnexpectedResponseError(422, "request failed: status 422: GitHub authentication failed"),
+	}
+	setMockClient(t, mock)
+	yamlPath := writeDraftImportClusterYAML(t)
+
+	var err error
+	_ = captureStdout(t, func() {
+		_, err = executeCommand("cluster", "apply", "-f", yamlPath)
+	})
+	if err == nil {
+		t.Fatal("expected error for a failed git push, got success")
+	}
+}
+
+type draftDeferredMock struct {
+	draftBootstrapMock
+}
+
+func (m *draftDeferredMock) ApplyCluster(ctx context.Context, clusterReq client.CreateImportClusterRequest, wait bool) (*client.ImportResponse, bool, error) {
+	m.applyCalls++
+	return &client.ImportResponse{GitPushDeferred: true, GitPushMessage: cmdDeferralDetail}, false, nil
+}
+
+// The draft bootstrap needs the new cluster's ID from the apply response; a
+// deferred response carries none, so deferral-as-success is forbidden here —
+// it must fail with an actionable error instead of staging drafts against an
+// empty cluster ID (plan-gate Finding 1).
+func TestDraftBootstrap_DeferredGitPushFailsActionably(t *testing.T) {
+	mock := &draftDeferredMock{}
+	setMockClient(t, mock)
+	yamlPath := writeDraftImportClusterYAML(t)
+
+	var output string
+	var err error
+	_ = captureStdout(t, func() {
+		output, err = executeCommand("cluster", "draft", "-f", yamlPath)
+	})
+	if err == nil {
+		t.Fatalf("expected an error when the bootstrap import defers its git push; output: %s", output)
+	}
+	if !strings.Contains(err.Error(), "re-run") {
+		t.Errorf("error = %v, want an actionable re-run instruction", err)
+	}
+	if len(mock.draftClusterIDs) != 0 {
+		t.Errorf("no drafts may be staged without a cluster ID, got staging calls for %v", mock.draftClusterIDs)
+	}
+}

--- a/cmd/migrate_up.go
+++ b/cmd/migrate_up.go
@@ -476,6 +476,15 @@ func deployMigrateUpStack(cmd *cobra.Command, clusterFile string) error {
 		}
 		return fmt.Errorf("the platform refused the stack:\n  %s", strings.Join(lines, "\n  "))
 	}
+	if response.GitPushDeferred {
+		// Designed refusal: the stack write is committed and live (the pod
+		// wait that follows verifies against the cluster itself); only the
+		// commit back to Git waits on the background sync. The response
+		// carries no name payload in that case.
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Stack applied; the agent is deploying it.")
+		printGitPushDeferral(cmd.ErrOrStderr(), true, response.GitPushMessage)
+		return nil
+	}
 	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Stack applied to cluster %s; the agent is deploying it.\n", response.Name)
 	return nil
 }

--- a/cmd/migrate_up.go
+++ b/cmd/migrate_up.go
@@ -477,10 +477,11 @@ func deployMigrateUpStack(cmd *cobra.Command, clusterFile string) error {
 		return fmt.Errorf("the platform refused the stack:\n  %s", strings.Join(lines, "\n  "))
 	}
 	if response.GitPushDeferred {
-		// Designed refusal: the stack write is committed and live (the pod
-		// wait that follows verifies against the cluster itself); only the
-		// commit back to Git waits on the background sync. The response
-		// carries no name payload in that case.
+		// Designed refusal: the stack write is committed and the agent is
+		// deploying it, exactly like a plain 200 (addon/manifest deploys are
+		// asynchronous on both paths; the pod wait only runs when data is
+		// carried). Only the commit back to Git waits on the background sync.
+		// The response carries no name payload in that case.
 		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Stack applied; the agent is deploying it.")
 		printGitPushDeferral(cmd.ErrOrStderr(), true, response.GitPushMessage)
 		return nil

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -33,7 +33,7 @@ type APIClient interface {
 	ListClusterAddons(clusterID string) ([]client.ClusterAddonListItem, error)
 	ListAvailableAddons(clusterID string) ([]client.AvailableAddon, error)
 	GetAddonSettings(clusterID, addonName string) (*client.GetAddonSettingsResponse, error)
-	UpdateAddonSettings(ctx context.Context, clusterID, addonName string, settings client.AddonSettings) error
+	UpdateAddonSettings(ctx context.Context, clusterID, addonName string, settings client.AddonSettings) (*client.UpdateAddonSettingsResult, error)
 	GetAddonByName(clusterID, addonName string) (*client.ClusterAddonListItem, error)
 	GetClusterAddonValues(ctx context.Context, clusterID, addonName string) (string, error)
 	UninstallAddon(ctx context.Context, clusterID, addonResourceID string, deletePermanently bool) (*client.UninstallAddonResult, error)

--- a/internal/client/addons.go
+++ b/internal/client/addons.go
@@ -74,6 +74,10 @@ type GetAddonSettingsResponse struct {
 type UninstallAddonResult struct {
 	Success bool   `json:"success"`
 	Message string `json:"message"`
+	// GitPushDeferred marks a designed git-push refusal: the uninstall is
+	// applied and live, only the commit back to Git waits on the background
+	// sync. Message then carries the platform's detail verbatim.
+	GitPushDeferred bool `json:"git_push_deferred,omitempty"`
 }
 
 type AvailableAddon struct {
@@ -127,36 +131,49 @@ func (c *Client) GetAddonSettings(clusterID, addonName string) (*GetAddonSetting
 	return &resp, nil
 }
 
-func (c *Client) UpdateAddonSettings(ctx context.Context, clusterID, addonName string, settings AddonSettings) error {
+// UpdateAddonSettingsResult reports the outcome of an addon-settings update.
+// The zero value is a plain success; GitPushDeferred marks a designed
+// git-push refusal — the settings are applied and live, only the commit back
+// to Git waits on the background sync — with the platform's detail verbatim
+// in GitPushMessage.
+type UpdateAddonSettingsResult struct {
+	GitPushDeferred bool   `json:"git_push_deferred,omitempty"`
+	GitPushMessage  string `json:"git_push_message,omitempty"`
+}
+
+func (c *Client) UpdateAddonSettings(ctx context.Context, clusterID, addonName string, settings AddonSettings) (*UpdateAddonSettingsResult, error) {
 	url := fmt.Sprintf("%s/api/v1/org/clusters/imported/%s/addons/%s/settings",
 		c.BaseURL, neturl.PathEscape(clusterID), neturl.PathEscape(addonName))
 	payload, err := json.Marshal(settings)
 	if err != nil {
-		return fmt.Errorf("marshal settings: %w", err)
+		return nil, fmt.Errorf("marshal settings: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(payload))
 	if err != nil {
-		return fmt.Errorf("create request: %w", err)
+		return nil, fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.Token)
 
 	resp, err := c.HTTP.Do(req)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return nil, fmt.Errorf("request failed: %w", err)
 	}
 	defer closeBody(resp)
 
 	body, err := readResponseBody(resp)
 	if err != nil {
-		return fmt.Errorf("read response: %w", err)
+		return nil, fmt.Errorf("read response: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return newUnexpectedResponseError("update failed", resp.StatusCode, redactedBodyForError(body, 500))
+		if deferral := gitPushDeferralFromResponse(resp.StatusCode, body); deferral != nil {
+			return &UpdateAddonSettingsResult{GitPushDeferred: true, GitPushMessage: deferral.Message}, nil
+		}
+		return nil, newUnexpectedResponseError("update failed", resp.StatusCode, redactedBodyForError(body, 500))
 	}
 
-	return nil
+	return &UpdateAddonSettingsResult{}, nil
 }
 
 func (c *Client) UninstallAddon(ctx context.Context, clusterID, addonResourceID string, deletePermanently bool) (*UninstallAddonResult, error) {
@@ -179,6 +196,9 @@ func (c *Client) UninstallAddon(ctx context.Context, clusterID, addonResourceID 
 		return nil, fmt.Errorf("read response: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
+		if deferral := gitPushDeferralFromResponse(resp.StatusCode, body); deferral != nil {
+			return &UninstallAddonResult{Success: true, Message: deferral.Message, GitPushDeferred: true}, nil
+		}
 		return nil, newUnexpectedResponseError("uninstall failed", resp.StatusCode, redactedBodyForError(body, 500))
 	}
 

--- a/internal/client/addons_test.go
+++ b/internal/client/addons_test.go
@@ -84,9 +84,12 @@ func TestUpdateAddonSettings(t *testing.T) {
 		}
 		w.WriteHeader(http.StatusOK)
 	})
-	err := testClient.UpdateAddonSettings(context.Background(), "cluster-id", "ingress", AddonSettings{})
+	result, err := testClient.UpdateAddonSettings(context.Background(), "cluster-id", "ingress", AddonSettings{})
 	if err != nil {
 		t.Fatalf("UpdateAddonSettings() error = %v", err)
+	}
+	if result.GitPushDeferred {
+		t.Errorf("UpdateAddonSettings() result.GitPushDeferred = true, want false on plain 200")
 	}
 }
 

--- a/internal/client/async_write.go
+++ b/internal/client/async_write.go
@@ -51,6 +51,18 @@ func (c *Client) httpClientForAsyncWrite(wait bool) *http.Client {
 	}
 }
 
+// gitPushDeferredError carries a git-push deferral out of the shared async
+// write path as an error, so a caller whose route can receive one (today only
+// ApplyCluster) converts it to success-with-deferral, while any other caller
+// keeps treating it as the failure it would have been before classification.
+type gitPushDeferredError struct {
+	deferral GitPushDeferral
+}
+
+func (e *gitPushDeferredError) Error() string {
+	return e.deferral.Message
+}
+
 func parseAsyncWriteResponse(
 	response *http.Response,
 	responseBody []byte,
@@ -62,6 +74,9 @@ func parseAsyncWriteResponse(
 	}
 	if denied := PermissionDeniedFromResponse(response.StatusCode, responseBody); denied != nil {
 		return false, denied
+	}
+	if deferral := gitPushDeferralFromResponse(response.StatusCode, responseBody); deferral != nil {
+		return false, &gitPushDeferredError{deferral: *deferral}
 	}
 	if wait {
 		if response.StatusCode < 200 || response.StatusCode >= 300 {

--- a/internal/client/clusters.go
+++ b/internal/client/clusters.go
@@ -373,11 +373,18 @@ type ImportResponseResourceError struct {
 	Errors []ImportResponseErrorItem `json:"errors"`
 }
 
+// ImportResponse mirrors the backend apply/import result.
+// GitPushDeferred/GitPushMessage are CLI-synthesized from a git-push-deferral
+// 422 (see GitPushDeferral): the cluster write is committed and live, only
+// the commit back to Git waits on the background sync — the platform sends
+// no result payload in that case, so every other field is empty.
 type ImportResponse struct {
-	Name          string                        `json:"name"`
-	ClusterId     string                        `json:"cluster_id"`
-	ImportCommand string                        `json:"import_command"`
-	Errors        []ImportResponseResourceError `json:"errors,omitempty"`
+	Name            string                        `json:"name"`
+	ClusterId       string                        `json:"cluster_id"`
+	ImportCommand   string                        `json:"import_command"`
+	Errors          []ImportResponseResourceError `json:"errors,omitempty"`
+	GitPushDeferred bool                          `json:"git_push_deferred,omitempty"`
+	GitPushMessage  string                        `json:"git_push_message,omitempty"`
 }
 
 // TriggerReconcileResult mirrors the platform's reconcile response (openapi
@@ -437,6 +444,13 @@ func (c *Client) ApplyCluster(ctx context.Context, clusterReq CreateImportCluste
 	var importResponse ImportResponse
 	submitted, err := c.doJSONWriteRequest(ctx, http.MethodPost, endpoint, payload, wait, &importResponse)
 	if err != nil {
+		var deferred *gitPushDeferredError
+		if errors.As(err, &deferred) {
+			return &ImportResponse{
+				GitPushDeferred: true,
+				GitPushMessage:  deferred.deferral.Message,
+			}, false, nil
+		}
 		return nil, false, err
 	}
 	if submitted {

--- a/internal/client/clusters_test.go
+++ b/internal/client/clusters_test.go
@@ -391,6 +391,56 @@ func TestApplyCluster(t *testing.T) {
 	}
 }
 
+// A git-push-deferral 422 on apply is a designed refusal — the cluster write
+// is committed and live — so it must come back as success carrying the
+// deferral, with the payload fields empty (the platform sends none); a
+// GIT_PUSH_FAILED or codeless 422 keeps today's error (ankra-qezdv).
+func TestApplyCluster_GitPushBoundary(t *testing.T) {
+	request := CreateImportClusterRequest{
+		Name: "test-cluster",
+		Spec: CreateResourceSpec{Stacks: []Stack{}},
+	}
+
+	t.Run("deferred is success", func(t *testing.T) {
+		testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(deferredBody))
+		})
+		got, submitted, err := testClient.ApplyCluster(context.Background(), request, true)
+		if err != nil {
+			t.Fatalf("deferred git push must be success, got error: %v", err)
+		}
+		if submitted {
+			t.Error("submitted = true, want false")
+		}
+		if got == nil || !got.GitPushDeferred {
+			t.Fatalf("got = %+v, want GitPushDeferred=true", got)
+		}
+		if got.GitPushMessage != deferralDetail {
+			t.Errorf("GitPushMessage = %q, want the platform detail verbatim", got.GitPushMessage)
+		}
+		if got.ClusterId != "" || got.Name != "" {
+			t.Errorf("payload fields must stay empty on a deferral, got name=%q id=%q", got.Name, got.ClusterId)
+		}
+	})
+
+	for name, body := range map[string]string{
+		"failed":   failedBody,
+		"codeless": `{"detail":"` + deferralDetail + `"}`,
+	} {
+		t.Run(name+" stays an error", func(t *testing.T) {
+			testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				_, _ = w.Write([]byte(body))
+			})
+			_, _, err := testClient.ApplyCluster(context.Background(), request, true)
+			if err == nil {
+				t.Fatal("expected error, got success")
+			}
+		})
+	}
+}
+
 // TestApplyClusterSendsGroupLabels pins the wire half of ankra-o0k2f: the
 // organizational 'group' label reaches the import body for the manifests and
 // addons that carry one, and is omitted entirely for the ones that do not, so

--- a/internal/client/gitpush.go
+++ b/internal/client/gitpush.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// The platform answers every GitOps-push rejection with HTTP 422 and a
+// machine-readable error_code alongside the human-readable detail
+// (ankra-71vbx): GIT_PUSH_DEFERRED is the designed refusal — the DB write is
+// committed, the cluster change is live, and only the write-back to Git
+// waits on the background sync — while GIT_PUSH_FAILED is a genuine push
+// failure where nothing reached Git. Both codes are always emitted together;
+// an absent error_code means the platform predates the contract, which is a
+// third answer, not the second: it keeps today's treat-as-error behavior.
+const (
+	gitPushErrorCodeDeferred = "GIT_PUSH_DEFERRED"
+)
+
+// GitPushDeferral reports a designed git-push refusal: the requested change
+// is saved and live on the cluster, and the platform will commit it back to
+// Git on its own. Message carries the platform's detail verbatim — callers
+// must print it unchanged, because the deploy tooling still substring-matches
+// it (cluster scripts/deploy_upgrade_addons.sh, pinned by
+// enginekit/clusterengine/gitsync_deploy_marker_test.go).
+type GitPushDeferral struct {
+	Message string
+}
+
+// gitPushDeferralFromResponse classifies a response as a git-push deferral:
+// non-nil only for a 422 whose body carries error_code GIT_PUSH_DEFERRED.
+// Every other response — GIT_PUSH_FAILED, a codeless 422 from an older
+// platform, any other status — returns nil so existing error paths apply.
+func gitPushDeferralFromResponse(statusCode int, body []byte) *GitPushDeferral {
+	if statusCode != http.StatusUnprocessableEntity {
+		return nil
+	}
+	var parsed struct {
+		Detail    string `json:"detail"`
+		ErrorCode string `json:"error_code"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil
+	}
+	if parsed.ErrorCode != gitPushErrorCodeDeferred {
+		return nil
+	}
+	return &GitPushDeferral{Message: parsed.Detail}
+}

--- a/internal/client/gitpush_test.go
+++ b/internal/client/gitpush_test.go
@@ -1,0 +1,114 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// deferralDetail mimics the platform's designed-refusal message. It must
+// contain "only the commit back to Git was deferred" so the tests also pin
+// that the CLI passes the marker substring through verbatim (the cluster
+// deploy script matches it; see GitPushDeferral).
+const deferralDetail = "Saved. Your change is applied to the cluster and is live; only the commit back to Git was deferred, because Git has newer changes that Ankra has not synced yet. The background sync merges both sides and commits your change on its own - do not re-apply it."
+
+const deferredBody = `{"detail":"` + deferralDetail + `","error_code":"GIT_PUSH_DEFERRED"}`
+const failedBody = `{"detail":"GitHub authentication failed","error_code":"GIT_PUSH_FAILED"}`
+
+func TestGitPushDeferralFromResponse(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		body       string
+		want       bool
+	}{
+		{"deferred 422", http.StatusUnprocessableEntity, deferredBody, true},
+		{"failed 422 stays an error", http.StatusUnprocessableEntity, failedBody, false},
+		{"codeless 422 (older platform) stays an error", http.StatusUnprocessableEntity, `{"detail":"` + deferralDetail + `"}`, false},
+		{"deferred body on 200 is not a deferral", http.StatusOK, deferredBody, false},
+		{"deferred body on 500 is not a deferral", http.StatusInternalServerError, deferredBody, false},
+		{"non-JSON body", http.StatusUnprocessableEntity, "<html>bad gateway</html>", false},
+		{"empty body", http.StatusUnprocessableEntity, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := gitPushDeferralFromResponse(tc.statusCode, []byte(tc.body))
+			if (got != nil) != tc.want {
+				t.Fatalf("gitPushDeferralFromResponse(%d, %q) = %v, want deferral=%v", tc.statusCode, tc.body, got, tc.want)
+			}
+			if got != nil && got.Message != deferralDetail {
+				t.Errorf("Message = %q, want the platform detail verbatim", got.Message)
+			}
+		})
+	}
+}
+
+// TestGitPushDeferralAcrossWriteLanes pins the class boundary on every
+// hand-rolled write lane that can receive a git-push 422: a deferral becomes
+// success carrying the platform message verbatim; GIT_PUSH_FAILED keeps
+// today's error. (PatchClusterStackPartial and ApplyCluster have their own
+// tests next to their richer harnesses.)
+func TestGitPushDeferralAcrossWriteLanes(t *testing.T) {
+	lanes := []struct {
+		name string
+		// call runs the lane against the test client and reports the
+		// deferral flag and message it surfaced (only read when err == nil).
+		call func(c *Client) (deferred bool, message string, err error)
+	}{
+		{"UninstallAddon", func(c *Client) (bool, string, error) {
+			res, err := c.UninstallAddon(context.Background(), "cluster-id", "resource-id", false)
+			if err != nil {
+				return false, "", err
+			}
+			return res.GitPushDeferred, res.Message, nil
+		}},
+		{"UpdateAddonSettings", func(c *Client) (bool, string, error) {
+			res, err := c.UpdateAddonSettings(context.Background(), "cluster-id", "ingress", AddonSettings{})
+			if err != nil {
+				return false, "", err
+			}
+			return res.GitPushDeferred, res.GitPushMessage, nil
+		}},
+		{"RenameStack", func(c *Client) (bool, string, error) {
+			res, err := c.RenameStack(context.Background(), "cluster-id", "old", "new")
+			if err != nil {
+				return false, "", err
+			}
+			return res.GitPushDeferred, res.Message, nil
+		}},
+		{"DisconnectManifest", func(c *Client) (bool, string, error) {
+			res, err := c.DisconnectManifest(context.Background(), "cluster-id", "stack", "manifest")
+			if err != nil {
+				return false, "", err
+			}
+			return res.GitPushDeferred, res.GitPushMessage, nil
+		}},
+	}
+	for _, lane := range lanes {
+		t.Run(lane.name+" deferred is success", func(t *testing.T) {
+			c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				_, _ = w.Write([]byte(deferredBody))
+			})
+			deferred, message, err := lane.call(c)
+			if err != nil {
+				t.Fatalf("deferred git push must be success, got error: %v", err)
+			}
+			if !deferred {
+				t.Error("deferral flag = false, want true")
+			}
+			if message != deferralDetail {
+				t.Errorf("message = %q, want the platform detail verbatim", message)
+			}
+		})
+		t.Run(lane.name+" failed stays an error", func(t *testing.T) {
+			c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				_, _ = w.Write([]byte(failedBody))
+			})
+			if _, _, err := lane.call(c); err == nil {
+				t.Fatal("expected error for GIT_PUSH_FAILED, got success")
+			}
+		})
+	}
+}

--- a/internal/client/iac.go
+++ b/internal/client/iac.go
@@ -117,13 +117,18 @@ type PatchStackResourceError struct {
 }
 
 // PatchStackResult mirrors UpdateClusterStackResult on the backend.
+// GitPushDeferred/GitPushMessage are CLI-synthesized from a git-push-deferral
+// 422 (see GitPushDeferral): the update is applied and live, only the commit
+// back to Git waits on the background sync, so the commit fields stay empty.
 type PatchStackResult struct {
-	StackName   string                    `json:"stack_name"`
-	Errors      []PatchStackResourceError `json:"errors,omitempty"`
-	CommitSHA   string                    `json:"commit_sha,omitempty"`
-	CommitURL   string                    `json:"commit_url,omitempty"`
-	OperationID string                    `json:"operation_id,omitempty"`
-	JobCount    int                       `json:"job_count"`
+	StackName       string                    `json:"stack_name"`
+	Errors          []PatchStackResourceError `json:"errors,omitempty"`
+	CommitSHA       string                    `json:"commit_sha,omitempty"`
+	CommitURL       string                    `json:"commit_url,omitempty"`
+	OperationID     string                    `json:"operation_id,omitempty"`
+	JobCount        int                       `json:"job_count"`
+	GitPushDeferred bool                      `json:"git_push_deferred,omitempty"`
+	GitPushMessage  string                    `json:"git_push_message,omitempty"`
 }
 
 // PatchStackError carries the HTTP status code and raw body for the PATCH
@@ -253,6 +258,17 @@ func (c *Client) PatchClusterStackPartial(ctx context.Context, clusterID, stackN
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if deferral := gitPushDeferralFromResponse(resp.StatusCode, respBody); deferral != nil {
+			// Designed refusal: the stack update is applied and live, only the
+			// Git write-back is deferred. Surfacing it as success here (not an
+			// error each caller must classify) is what stops CI wrappers from
+			// re-applying a live change (ankra-qezdv).
+			return &PatchStackResult{
+				StackName:       stackName,
+				GitPushDeferred: true,
+				GitPushMessage:  deferral.Message,
+			}, nil
+		}
 		perr := &PatchStackError{StatusCode: resp.StatusCode, Body: respBody}
 		if resp.StatusCode == http.StatusUnauthorized {
 			// Carry ErrUnauthorized at the source so any caller inspecting the

--- a/internal/client/iac_test.go
+++ b/internal/client/iac_test.go
@@ -234,6 +234,64 @@ func TestPatchClusterStackPartial_TypedErrorOnNon2xx(t *testing.T) {
 	}
 }
 
+// A git-push-deferral 422 is a designed refusal — the update is applied and
+// live — so it must come back as success carrying the deferral, never as the
+// error the CI retry wrappers key on (ankra-qezdv).
+func TestPatchClusterStackPartial_DeferredGitPushIsSuccess(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(deferredBody))
+	})
+	req := PatchStackRequest{
+		PartialStack: true,
+		Spec:         ResourceSpecSpec{Stacks: []StackSpec{{Name: "demo"}}},
+	}
+	res, err := testClient.PatchClusterStackPartial(context.Background(), "cluster-id", "demo", req)
+	if err != nil {
+		t.Fatalf("deferred git push must be success, got error: %v", err)
+	}
+	if !res.GitPushDeferred {
+		t.Error("GitPushDeferred = false, want true")
+	}
+	if res.GitPushMessage != deferralDetail {
+		t.Errorf("GitPushMessage = %q, want the platform detail verbatim", res.GitPushMessage)
+	}
+	if res.StackName != "demo" {
+		t.Errorf("StackName = %q, want demo", res.StackName)
+	}
+	if res.CommitSHA != "" || res.CommitURL != "" {
+		t.Errorf("commit fields must stay empty on a deferral, got %q / %q", res.CommitSHA, res.CommitURL)
+	}
+}
+
+// GIT_PUSH_FAILED and a codeless 422 (older platform) keep today's typed
+// error, pinning the non-zero direction of the boundary.
+func TestPatchClusterStackPartial_FailedAndCodelessGitPushStayErrors(t *testing.T) {
+	for name, body := range map[string]string{
+		"failed":   failedBody,
+		"codeless": `{"detail":"` + deferralDetail + `"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				_, _ = w.Write([]byte(body))
+			})
+			req := PatchStackRequest{
+				PartialStack: true,
+				Spec:         ResourceSpecSpec{Stacks: []StackSpec{{Name: "demo"}}},
+			}
+			_, err := testClient.PatchClusterStackPartial(context.Background(), "cluster-id", "demo", req)
+			var perr *PatchStackError
+			if !errors.As(err, &perr) {
+				t.Fatalf("expected *PatchStackError, got %T: %v", err, err)
+			}
+			if perr.StatusCode != http.StatusUnprocessableEntity {
+				t.Errorf("StatusCode = %d, want 422", perr.StatusCode)
+			}
+		})
+	}
+}
+
 func TestGetClusterAddonValues_DecodesBase64(t *testing.T) {
 	rawYAML := "image:\n  tag: 1.0.0\n"
 	encoded := base64.StdEncoding.EncodeToString([]byte(rawYAML))

--- a/internal/client/manifests.go
+++ b/internal/client/manifests.go
@@ -101,6 +101,12 @@ type DisconnectManifestResult struct {
 	DisconnectedAt string `json:"disconnected_at"`
 	CommitSHA      string `json:"commit_sha,omitempty"`
 	CommitURL      string `json:"commit_url,omitempty"`
+	// GitPushDeferred marks a designed git-push refusal: the disconnect is
+	// applied and live, only the commit back to Git waits on the background
+	// sync (no commit fields in that case). GitPushMessage carries the
+	// platform's detail verbatim.
+	GitPushDeferred bool   `json:"git_push_deferred,omitempty"`
+	GitPushMessage  string `json:"git_push_message,omitempty"`
 }
 
 // DisconnectManifest removes a manifest from a stack, deleting its resources
@@ -128,6 +134,9 @@ func (c *Client) DisconnectManifest(ctx context.Context, clusterID, stackName, m
 		return nil, ErrUnauthorized
 	}
 	if resp.StatusCode != http.StatusOK {
+		if deferral := gitPushDeferralFromResponse(resp.StatusCode, body); deferral != nil {
+			return &DisconnectManifestResult{GitPushDeferred: true, GitPushMessage: deferral.Message}, nil
+		}
 		return nil, newUnexpectedResponseError("disconnect manifest failed", resp.StatusCode, redactedBodyForError(body, 500))
 	}
 

--- a/internal/client/stacks.go
+++ b/internal/client/stacks.go
@@ -90,6 +90,10 @@ type RenameStackRequest struct {
 type RenameStackResult struct {
 	Success bool   `json:"success"`
 	Message string `json:"message"`
+	// GitPushDeferred marks a designed git-push refusal: the rename is
+	// applied and live, only the commit back to Git waits on the background
+	// sync. Message then carries the platform's detail verbatim.
+	GitPushDeferred bool `json:"git_push_deferred,omitempty"`
 }
 
 // ListClusterStacks pages through the full stack listing. The
@@ -195,6 +199,9 @@ func (c *Client) RenameStack(ctx context.Context, clusterID, stackName, newName 
 		return nil, fmt.Errorf("read response: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
+		if deferral := gitPushDeferralFromResponse(resp.StatusCode, body); deferral != nil {
+			return &RenameStackResult{Success: true, Message: deferral.Message, GitPushDeferred: true}, nil
+		}
 		return nil, newUnexpectedResponseError("rename failed", resp.StatusCode, redactedBodyForError(body, 500))
 	}
 


### PR DESCRIPTION
## What & why

The platform answers every GitOps-push rejection with a 422 that carries a
machine-readable `error_code` (ankra-71vbx): `GIT_PUSH_DEFERRED` is a designed
refusal — the DB write is committed, the cluster change is live, only the
write-back to Git waits on the background sync ("do not re-apply") — while
`GIT_PUSH_FAILED` is a genuine failure. The CLI dropped that field everywhere
(`detailFromBody` and siblings parse only `detail`), so both classes collapsed
into the same exit 1. On 2026-08-29 that made admin-portal's Build & Deploy
re-apply a live upgrade 5x and go red on a deploy that verifiably succeeded
(chart 0.1.118 live on ankra-prod-hel1).

`internal/client` now classifies git-push 422s (`gitpush.go`), and a deferral
becomes success-with-deferral at the source, so every current and future
caller inherits the right semantics:

- exit 0, the platform's message printed **verbatim** (deploy tooling
  substring-matches it), and `git_push_deferred` + `git_push_message` fields
  in `-o json`/`-o yaml`.
- `GIT_PUSH_FAILED` and codeless 422s from older platforms keep today's
  non-zero behavior byte-for-byte.

## Class sweep (every CLI lane that can receive the code)

| cliapi route | CLI lane | disposition |
|---|---|---|
| PATCH stacks/{name} | addons upgrade (observed), manifests upgrade, encrypt addon/manifest, stack variables set/delete | success-with-deferral |
| POST /clusters/import | cluster apply, migrate up | success-with-deferral |
| POST /clusters/import | cluster draft bootstrap (`resolveClusterForDraft`) | **clean actionable error**: a deferred response carries no cluster ID to stage drafts against; the error says the cluster was saved and is live and to re-run (the bootstrap's GetCluster lookup then finds it). Plan-gate Finding 1. |
| DELETE addons/{id} | addons uninstall | success-with-deferral |
| PUT addons/{name}/settings | addons update | success-with-deferral (signature now returns a result so the message survives; APIClient + baseMock updated) |
| POST rename-stack | stacks rename | success-with-deferral |
| POST manifests/{name}/disconnect | manifests disconnect | success-with-deferral |

Enumerated, not fixed (follow-up beads linked on the bead): DELETE
stacks/{name} — cliapi collapses GitPushFailure into a codeless 500, nothing
to classify CLI-side (platform bead); POST {imported}/stacks emits the code
but has no CLI caller; portal-facing clusterapi lanes are not CLI.

## Interim marker coupling (unchanged)

cluster's `deploy_upgrade_addons.sh` substring-matches the refusal message
(`DEFERRED_COMMIT_MARKER`, pinned by
`enginekit/clusterengine/gitsync_deploy_marker_test.go`) on **non-zero** CLI
exits. Old CLI binaries keep exit-1 + message, so the marker path still
catches them; this CLI prints the message verbatim on stdout and exits 0, so
the script takes its plain success path. The platform message is not reworded
or wrapped. Migrating the script off the marker needs a released CLI first —
follow-up bead filed and linked.

## Boundary tests (both directions)

- `internal/client/gitpush_test.go`: classifier — deferred 422 → deferral;
  failed 422 / codeless 422 (older platform) / deferred-shaped body on
  200/500 / non-JSON → nil. Plus a per-lane table over the four hand-rolled
  write lanes (uninstall, settings, rename, disconnect): deferred → success
  carrying the verbatim message; failed → error.
- `internal/client/iac_test.go`, `clusters_test.go`: PatchStack and apply
  lanes, deferred → success (red on old code), failed + codeless → typed
  error (pins non-zero).
- `cmd/gitpush_deferral_test.go`: addons upgrade deferred → exit 0 with the
  verbatim message on stdout, and `-o json` → parseable JSON carrying
  `git_push_deferred: true`; addons upgrade failed → non-zero
  "git push failed: …"; cluster apply both directions; cluster draft
  deferred → non-zero actionable error, zero staging calls.

## Test plan

All gates ran containerized (this host has no Go toolchain); full logs
written to files and judged from the files, not piped tails:

- **Full suite (race)**: `go test -race -count=1 ./...` in `golang:1.25` —
  all 6 test packages ok, exit 0, no failures/races
  (`test-full-3.log`, run on the final tree rebased onto origin/master
  fac3fe0; an identical pre-rebase run `test-full-2.log` was also green).
- **Mutation check (red on old code)**: with the classifier stubbed to
  always return nil (= the old dropped-error_code behavior),
  `go test -run "GitPush|Deferral|Deferred" ./internal/client/ ./cmd/` goes
  red in `internal/client` (deferred-is-success assertions fail with today's
  422 error) — `test-mutation.log`, MUTATION_EXIT=1. The cmd-level tests stay
  green under that mutation by design: they pin rendering/exit semantics
  through mocks and pin against old code at compile level (the
  `git_push_deferred` fields don't exist there).
- **Lint**: `golangci-lint run` via `golangci/golangci-lint:v2.12.2`
  (CI's exact pin), clean (`lint-1.log`).
- **Unobserved**: `make verify-skills` (no skills touched) and govulncheck
  ran only in CI, not locally.

## Band-aid declaration

The pre-commit gate (`go test` + `golangci-lint` on the host) could not run:
this machine has no host Go toolchain. The identical gates ran containerized
(golang:1.25 for `go test -race -count=1 ./...`, golangci/golangci-lint
v2.12.2 — CI's exact pin) with full logs written to files; the commit used
`--no-verify` for that stated reason only. No other tells: no retries added,
no timeouts raised, no tests weakened; the fix consumes the platform's
machine-readable contract, removing the dropped-error_code mechanism itself.


## Docs checklist

- [x] No user-facing command/flag changes — no docs needed (behaviour change is
  in exit semantics for one platform answer; documented in the CHANGELOG, and
  the exit-code contract in `cmd/exitcodes.go` is unchanged — 0 is success,
  which a deferral now correctly is)

Bead: ankra-qezdv

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDTeNbrky2DiZvDUvup4T5
