### PR TITLE
feat(mesh): ankra cluster mesh make-ready (ankra-0xsdd.25.6)

### DIFF
--- a/cmd/cluster_mesh.go
+++ b/cmd/cluster_mesh.go
@@ -135,6 +135,36 @@ var clusterMeshLeaveCmd = &cobra.Command{
 	},
 }
 
+var clusterMeshMakeReadySiteIP string
+
+var clusterMeshMakeReadyCmd = &cobra.Command{
+	Use:   "make-ready <cluster_id>",
+	Short: "Turn an existing cluster mesh-capable without recreating it",
+	Long: "Turn an existing cluster mesh-capable, day-2: allocate its Cilium identity and overlay range, stamp the " +
+		"overlay onto its stored definitions, and set its resources converging so every node joins the platform " +
+		"WireGuard overlay. The node-IP switch restarts kubelets once; nothing is deleted or recreated.\n\n" +
+		"Proxmox clusters need --site-public-ip: the address other sites dial this cluster's site gateway on.",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		result, makeReadyError := apiClient.MakeClusterMeshReady(args[0], clusterMeshMakeReadySiteIP)
+		if makeReadyError != nil {
+			return fmt.Errorf("making the cluster mesh-ready: %w", makeReadyError)
+		}
+		if handled, renderError := renderStructured(cmd, result); renderError != nil {
+			return renderError
+		} else if handled {
+			return nil
+		}
+		identity := "kept its existing network identity"
+		if result.IdentityAllocated {
+			identity = "was allocated a network identity"
+		}
+		fmt.Printf("Cluster %s %s: cilium-id=%d name=%s; %d resources converging onto the overlay.\n",
+			result.ClusterID, identity, result.CiliumClusterID, result.CiliumClusterName, result.TransitionedResources)
+		return nil
+	},
+}
+
 var clusterMeshReadinessCmd = &cobra.Command{
 	Use:   "readiness <cluster_id> [cluster_id...]",
 	Short: "Check whether clusters can mesh together, and why not",
@@ -186,5 +216,8 @@ func init() {
 	clusterMeshCmd.AddCommand(clusterMeshJoinCmd)
 	clusterMeshCmd.AddCommand(clusterMeshLeaveCmd)
 	clusterMeshCmd.AddCommand(clusterMeshReadinessCmd)
+	clusterMeshMakeReadyCmd.Flags().StringVar(&clusterMeshMakeReadySiteIP, "site-public-ip", "",
+		"Public address other sites dial this cluster's site gateway on (proxmox clusters only)")
+	clusterMeshCmd.AddCommand(clusterMeshMakeReadyCmd)
 	clusterCmd.AddCommand(clusterMeshCmd)
 }

--- a/cmd/cluster_mesh_test.go
+++ b/cmd/cluster_mesh_test.go
@@ -20,6 +20,10 @@ type clusterMeshMock struct {
 	readinessFor [][]string
 
 	joinError error
+
+	madeReadyCluster string
+	madeReadySiteIP  string
+	makeReadyError   error
 }
 
 func (m *clusterMeshMock) ListClusterMeshes() ([]client.ClusterMesh, error) {
@@ -43,6 +47,18 @@ func (m *clusterMeshMock) CreateClusterMesh(name string) (*client.ClusterMesh, e
 func (m *clusterMeshMock) DeleteClusterMesh(meshID string) error {
 	m.deleted = append(m.deleted, meshID)
 	return nil
+}
+
+func (m *clusterMeshMock) MakeClusterMeshReady(clusterID string, sitePublicIP string) (*client.ClusterMeshMakeReadyResult, error) {
+	m.madeReadyCluster = clusterID
+	m.madeReadySiteIP = sitePublicIP
+	if m.makeReadyError != nil {
+		return nil, m.makeReadyError
+	}
+	return &client.ClusterMeshMakeReadyResult{
+		ClusterID: clusterID, CiliumClusterID: 7, CiliumClusterName: "made-ready-7",
+		IdentityAllocated: true, TransitionedResources: 2,
+	}, nil
 }
 
 func (m *clusterMeshMock) JoinClusterMesh(meshID string, clusterID string) error {
@@ -171,5 +187,34 @@ func TestClusterMeshDeletePassesTheMesh(t *testing.T) {
 	}
 	if len(mock.deleted) != 1 || mock.deleted[0] != "mesh-1" {
 		t.Fatalf("expected one delete of mesh-1, got %v", mock.deleted)
+	}
+}
+
+
+func TestClusterMeshMakeReadyCommand(t *testing.T) {
+	mock := &clusterMeshMock{}
+	setMockClient(t, mock)
+
+	if err := executeMeshCommand(t, "cluster", "mesh", "make-ready", "cluster-9", "--site-public-ip", "203.0.113.9"); err != nil {
+		t.Fatalf("make-ready returned %v", err)
+	}
+	if mock.madeReadyCluster != "cluster-9" || mock.madeReadySiteIP != "203.0.113.9" {
+		t.Fatalf("make-ready must pass the cluster and site address through, got %q %q",
+			mock.madeReadyCluster, mock.madeReadySiteIP)
+	}
+}
+
+// The platform's refusal names the reason (an unwired provider, a missing
+// site address); the CLI must surface it, not replace it.
+func TestClusterMeshMakeReadySurfacesTheRefusalReason(t *testing.T) {
+	mock := &clusterMeshMock{makeReadyError: errors.New("network_mode is not supported for hetzner clusters")}
+	setMockClient(t, mock)
+
+	err := executeMeshCommand(t, "cluster", "mesh", "make-ready", "cluster-9")
+	if err == nil {
+		t.Fatal("expected the refusal to fail the command")
+	}
+	if !strings.Contains(err.Error(), "not supported for hetzner") {
+		t.Fatalf("the refusal must carry the platform's reason, got %v", err)
 	}
 }

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1464,6 +1464,10 @@ func (m baseMock) DeleteClusterMesh(string) error {
 	return errors.New("not implemented")
 }
 
+func (m baseMock) MakeClusterMeshReady(string, string) (*client.ClusterMeshMakeReadyResult, error) {
+	return &client.ClusterMeshMakeReadyResult{}, nil
+}
+
 func (m baseMock) JoinClusterMesh(string, string) error {
 	return errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -425,6 +425,7 @@ type APIClient interface {
 	CreateClusterMesh(name string) (*client.ClusterMesh, error)
 	DeleteClusterMesh(meshID string) error
 	JoinClusterMesh(meshID string, clusterID string) error
+	MakeClusterMeshReady(clusterID string, sitePublicIP string) (*client.ClusterMeshMakeReadyResult, error)
 	LeaveClusterMesh(meshID string, clusterID string) error
 	CheckClusterMeshReadiness(clusterIDs []string) (map[string]client.ClusterMeshReadiness, error)
 	CreatePlayground(planID string) (*client.CreatePlaygroundResult, error)

--- a/internal/client/clustermesh.go
+++ b/internal/client/clustermesh.go
@@ -113,6 +113,9 @@ func (c *Client) MakeClusterMeshReady(clusterID string, sitePublicIP string) (*C
 	if err := c.sendJSON(http.MethodPost, c.BaseURL+clusterMeshAPIPath+"/make-ready", body, &response); err != nil {
 		return nil, err
 	}
+	if response.MakeReady.CiliumClusterID == 0 && response.MakeReady.CiliumClusterName == "" {
+		return nil, fmt.Errorf("the platform answered without a make_ready result; the API and CLI may be out of step")
+	}
 	return &response.MakeReady, nil
 }
 

--- a/internal/client/clustermesh.go
+++ b/internal/client/clustermesh.go
@@ -91,6 +91,31 @@ func (c *Client) LeaveClusterMesh(meshID string, clusterID string) error {
 	return c.sendJSON(http.MethodDelete, url, nil, nil)
 }
 
+// ClusterMeshMakeReadyResult is what make-ready reports back: the identity
+// the cluster now carries and how many resources were set converging.
+type ClusterMeshMakeReadyResult struct {
+	ClusterID             string `json:"cluster_id"`
+	CiliumClusterID       int    `json:"cilium_cluster_id"`
+	CiliumClusterName     string `json:"cilium_cluster_name"`
+	IdentityAllocated     bool   `json:"identity_allocated"`
+	TransitionedResources int    `json:"transitioned_resources"`
+}
+
+// MakeClusterMeshReady turns an existing cluster mesh-capable, day-2.
+func (c *Client) MakeClusterMeshReady(clusterID string, sitePublicIP string) (*ClusterMeshMakeReadyResult, error) {
+	var response struct {
+		MakeReady ClusterMeshMakeReadyResult `json:"make_ready"`
+	}
+	body := map[string]any{"cluster_id": clusterID}
+	if sitePublicIP != "" {
+		body["site_public_ip"] = sitePublicIP
+	}
+	if err := c.sendJSON(http.MethodPost, c.BaseURL+clusterMeshAPIPath+"/make-ready", body, &response); err != nil {
+		return nil, err
+	}
+	return &response.MakeReady, nil
+}
+
 // CheckClusterMeshReadiness answers, per cluster, whether the given set could
 // mesh together and why not.
 func (c *Client) CheckClusterMeshReadiness(clusterIDs []string) (map[string]ClusterMeshReadiness, error) {


### PR DESCRIPTION
Bead: ankra-0xsdd.25.6

`ankra cluster mesh make-ready <cluster_id> [--site-public-ip <address>]` — the CLI half of cluster#2269. Turns an existing cluster mesh-capable in place: the platform allocates its Cilium identity and overlay range day-2, stamps the overlay onto its stored definitions, and sets its resources converging so every node joins the WireGuard overlay. Prints the identity and how many resources are converging (or renders structured with `-o json`); refusals surface the platform's reason verbatim (unwired provider, non-kubeadm, missing site address).

Tests: the command passes cluster and site address through, and a platform refusal fails the command carrying its reason. Full `cmd` + `client` suites and the repo linter green via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
