### PR TITLE
docs(skills): ankra-migrate, ankra-backups, and the Security Center in ankra-security (ankra-fxk09)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ### Added
 
+- **Two new agent skills, and security coverage in a third.** `ankra-migrate`
+  teaches the whole `ankra migrate` journey - plan, convert, deploy, export,
+  restore through a backup vault, the rehearse-then-`--stop-source` cutover,
+  what is not carried, import cleanup and the module contract. `ankra-backups`
+  covers `ankra backup vaults`: provisioning a bucket from a provider
+  credential versus registering your own, the verification lifecycle, what a
+  vault holds and the two very different meanings of delete. `ankra-security`
+  gains the Security Center surface - `ankra security overview`, `findings`,
+  `finding`, `clusters` and `advisory`, with the KEV/EPSS exploitability
+  ordering - and its review pass now sweeps security findings and backup
+  vaults too.
 - **`ankra cluster move --organisation <id|slug|name>`** moves a cluster into
   another organisation you administer. Only an administrator of both the
   current organisation and the destination can run it; anyone else gets the

--- a/internal/skills/embedded/skills/ankra-backups/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-backups/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: ankra-backups
+description: Manage the organisation's backup vaults with `ankra backup vaults` - the S3-compatible buckets cluster backups and migration data move through. Let Ankra provision a bucket from a provider credential or register one you already run, watch the verification status, re-verify after rotating keys, see what a vault holds, and delete a vault with or without destroying the bucket behind it. Use when the user mentions backups, backup vaults, restore points, object storage for backups, an S3 or MinIO bucket for the platform, or asks where migration dumps are kept.
+---
+
+# Backup vaults
+
+A backup vault is an organisation-level target for data that must survive a cluster:
+an S3-compatible bucket plus the access keys to reach it, registered with Ankra. Cluster
+backups are written to it, and `ankra migrate restore` uploads database dumps through it.
+The platform verifies the keys against the bucket and the outcome is the vault's status -
+a vault that is not **ready** is a vault nothing can restore from.
+
+```bash
+ankra backup vaults list
+ankra backup vaults get offsite          # endpoint, bucket, status, and the failure excerpt when a check failed
+```
+
+## Adding a vault: provision or create
+
+**Provision** - Ankra creates the bucket for you from one of the organisation's provider
+credentials (Hetzner, UpCloud, DigitalOcean or Scaleway), mints or stores the keys, verifies
+and registers the vault:
+
+```bash
+ankra backup vaults provision                    # everything defaulted; prints what it chose first
+ankra backup vaults provision offsite --credential upcloud-main --region europe-1 --wait
+```
+
+Defaults are picked for you: the name (`backups`, then `backups-2`), the credential (the only
+one Ankra can provision from) and the region (the provider's usual one). The vault shows
+`provisioning` until the bucket exists and verifies. **Hetzner alone needs its Object Storage
+key pair passed in or prompted for** - Hetzner issues those in the Cloud Console and its API
+cannot mint them; the other providers need nothing beyond the credential.
+
+**Create** - register a bucket you already run (MinIO, AWS S3, any S3-compatible store):
+
+```bash
+ankra backup vaults create offsite --endpoint https://s3.example.com --bucket cluster-backups
+```
+
+Leave `--access-key-id` and `--secret-access-key` off and let the command prompt - the keys
+then never touch your shell history. `--region` only when the endpoint does not imply it;
+`--path-style` is the default addressing and fits MinIO, pass `--path-style=false` for stores
+that want virtual-hosted-style.
+
+Prefer **provision** when a supported provider credential exists - the keys are minted for
+the one bucket and never pass through your hands. Prefer **create** when backups must land in
+storage you already govern (retention policies, object locks, your own encryption).
+
+## Verification
+
+The credential check runs when the vault is registered and its result sticks as the status.
+After rotating or fixing the keys, re-run it:
+
+```bash
+ankra backup vaults verify offsite
+```
+
+`get` shows the failure excerpt when the last check failed - an endpoint typo, a dead key and
+a missing bucket permission each read differently there. Migrations and restores pick "the
+organisation's only **ready** vault" automatically; a vault stuck unverified breaks that
+default silently, so `verify` after every key rotation.
+
+## What a vault holds
+
+Migration restores keep their uploads in the vault under `imports/<import-id>/` so they can
+be restored again. List and remove them with `ankra migrate imports list` and
+`ankra migrate imports delete <import-id>` (see `ankra-migrate`) - those dumps are complete
+copies of production databases and should not outlive their purpose.
+
+## Deleting a vault
+
+```bash
+ankra backup vaults delete offsite
+ankra backup vaults delete offsite --destroy-provider-resources --yes
+```
+
+By default only Ankra's record and its stored keys go; **the bucket and everything in it stay
+in your cloud account** - and keep billing. `--destroy-provider-resources` also empties and
+deletes the bucket and removes what was minted for it (an UpCloud object-storage service, a
+DigitalOcean Spaces key); every restore point in it is gone for good. It is refused for a
+vault registering a bucket you created yourself - your bucket, your teardown.
+
+## Rules
+
+- **A vault is part of the recovery path - treat its bucket like production.** Scope the keys
+  to that one bucket, keep it private, and rotate keys like any other credential
+  (`verify` afterwards).
+- **Prompt for keys, don't pass them as flags** - flags land in shell history and process
+  lists.
+- **One ready vault keeps the defaults working.** Restores and migrations resolve "the only
+  ready vault"; with several, name one explicitly with `--vault` everywhere.
+- **Deleting the vault does not delete the data** - and `--destroy-provider-resources` very
+  much does. Know which of the two you mean before `--yes`.
+- **Clean up imports after a verified migration** - dumps left in object storage are the
+  quiet kind of data leak.
+
+## Related skills
+
+- `ankra-migrate` - the restore path that moves data through a vault.
+- `ankra-security` - credential scope and the review pass that should include vault keys.
+- `ankra-cloud-clusters` - the provider credentials `provision` draws on.

--- a/internal/skills/embedded/skills/ankra-cli/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-cli/SKILL.md
@@ -52,6 +52,9 @@ never rely on the selection — pass both explicitly.
 | AI provider, tools, runs, board | `ankra ai ...`, `ankra org mcp-servers ...`, `ankra agents ...`, `ankra tickets ...` | `ankra-ai-agents` |
 | Tokens, roles, cluster access | `ankra tokens`, `ankra org members\|roles`, `ankra cluster access` | `ankra-security` |
 | Credentials | `ankra credentials ...` | `ankra-security` |
+| Vulnerabilities and CVEs | `ankra security ...` | `ankra-security` |
+| Backup vaults | `ankra backup vaults ...` | `ankra-backups` |
+| Migrating existing deployments | `ankra migrate ...` | `ankra-migrate` |
 | Cloud cost | `ankra cost summary\|cluster\|settings` | below |
 | Support requests | `ankra support create\|list\|get\|comment\|attach\|close` | below |
 

--- a/internal/skills/embedded/skills/ankra-migrate/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-migrate/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: ankra-migrate
+description: Move an existing deployment - docker-compose, a bare Dockerfile, or containers on a running Docker daemon - into an Ankra-managed cluster with `ankra migrate`. Plan first, convert to a stack, deploy, dump every database and restore it through a backup vault, then cut over; or run the steps separately, clean up the imports a vault keeps, and add conversion modules for other formats. Use when the user wants to migrate or move an app, VM or server deployment onto Kubernetes, mentions `ankra migrate`, docker-compose to Kubernetes, lift-and-shift, a cutover, or carrying data into a cluster.
+---
+
+# Migrating a deployment into Ankra
+
+`ankra migrate` moves a deployment that exists today - a docker-compose project, a bare
+Dockerfile, or containers on a running Docker daemon, local or remote - into a cluster Ankra
+runs. One command does the whole journey; each step is also its own command when you want to
+inspect the result before the next one.
+
+## The one command
+
+```bash
+ankra migrate up ./app --cluster shop --plan     # print the plan, change nothing
+ankra migrate up ./app --cluster shop            # rehearse: convert, deploy, dump, restore
+ankra migrate up ./app --cluster shop --stop-source --yes   # the cutover
+```
+
+`up` runs five steps: **plan** (what will move, how big the databases are, what stays behind),
+**convert** (the deployment becomes a stack under `<out>/stack`), **deploy** (`cluster apply`
+plus a wait for the database workloads), **export** (every database dumped into `<out>/data`),
+**restore** (the dumps go through the backup vault into the cluster).
+
+It is idempotent by design: run it into the same output directory as often as you like - the
+stack is re-applied, the databases are dumped and restored again. **Rehearse while the source
+is still serving, then run once more with `--stop-source`**: that stops the source's
+non-database services first, so the final dump is the last word on the data.
+
+- `--plan` before anything else. The plan names every item that will *not* be carried.
+- `--no-data` deploys the workloads only; `--out` moves the working directory
+  (default `ankra-migration`); `--timeout` bounds each waiting step.
+- `--option key=value` reaches the module and applies to convert and export alike.
+
+**Not carried:** files in the volumes of non-database workloads, and data in engines the
+export does not dump (Redis, MongoDB, search indexes). Dumped engines today: PostgreSQL and
+MySQL/MariaDB. Nothing is silently dropped - the plan lists each such item; move the rest by
+hand after the workloads run.
+
+## Prerequisites
+
+- A cluster Ankra runs, selected or passed with `--cluster`.
+- A **ready backup vault** in the organisation - the restore uploads travel through it.
+  `ankra backup vaults provision` creates one from a provider credential; see `ankra-backups`.
+  With exactly one ready vault it is picked automatically; otherwise pass `--vault`.
+- The source must be up and reachable by the docker CLI - dumps are taken from the running
+  containers. This machine needs neither kubectl nor a database client, and Ankra never holds
+  the data: dumps upload straight to your vault with presigned URLs and the cluster's agent
+  restores them in place.
+
+## The steps as separate commands
+
+```bash
+ankra migrate detect ./app                       # which modules recognise it, most confident first
+ankra migrate convert ./app --out ./app-k8s      # write cluster.yaml + manifests; read the warnings
+ankra cluster apply -f ./app-k8s/cluster.yaml    # deploy the stack
+ankra migrate export ./app --out ./app-data      # dump the databases (manifest.json + SHA256SUMS)
+ankra migrate restore ./app-data --cluster shop --wait
+ankra migrate data ./app --cluster shop --wait   # export + restore back to back
+ankra migrate restore-status <import-id> --wait  # progress of a running restore
+```
+
+`convert`, `detect`, `export` and `modules` work offline; `up`, `restore`, `restore-status`
+and `data` talk to the platform. **Read convert's warnings**: they list what the module could
+not carry - locally built images, host directories, unresolved `${VAR}` references,
+credentials written in plain text - and each names the fix.
+
+Useful docker-module options (`--option`, repeatable, on convert/export/up):
+
+| Option | Meaning |
+|--------|---------|
+| `source=compose` / `dockerfile` / `daemon` | which source to read (default: detected) |
+| `profiles=app,dns` / `all-profiles=true` | compose profiles to include |
+| `project=<name>` / `containers=a,b` | compose project / specific containers, for the daemon |
+| `docker-host=ssh://root@203.0.113.7` | a remote Docker daemon, for daemon source and exports |
+| `image.<workload>=<registry/repo:tag>` | image for a locally built workload |
+| `ingress.<workload>=<host>` | expose a workload through an Ingress |
+| `cluster-issuer=letsencrypt-prod` | request TLS for every Ingress |
+| `volume-size=20Gi` / `storage-class=<name>` | sizing for every PersistentVolumeClaim |
+| `use-environment=true` | let your shell satisfy `${VAR}` references |
+
+## The imports a vault keeps
+
+Every restore uploads the export's dumps into the vault under `imports/<import-id>/` and
+keeps them, so the same upload can be restored again.
+
+```bash
+ankra migrate imports list --vault backups
+ankra migrate imports delete <import-id> --yes
+```
+
+Those dumps are **complete copies of production data**. Once the migration is verified,
+delete the imports you no longer need - a forgotten dump in an object-storage bucket is a
+breach waiting for lax bucket permissions. A delete is refused while a restore is still
+reading the import.
+
+## Other formats: modules
+
+Conversion and export are done by modules; `docker` is built in. Any executable named
+`ankra-module-<name>` in `~/.ankra/modules` or on PATH becomes a module: it answers
+`describe`, `detect` and `convert` (JSON on stdin/stdout, protocol 1), and optionally
+`export`. `ankra migrate modules` lists what is available and documents the full contract;
+a worked example lives in the CLI repository under `examples/modules/`.
+
+```bash
+ankra migrate modules
+ankra migrate modules install https://example.com/ankra-module-procfile --sha256 <hex>
+ankra migrate modules uninstall procfile
+```
+
+A module runs with your permissions, on your files and your Docker socket. **Install only
+modules you trust and pass `--sha256`** when the author publishes a checksum; `--name` refuses
+a module that calls itself something else.
+
+## Rules
+
+- **Plan, rehearse, then cut over.** `--plan` first; a full rehearsal while the source runs;
+  `--stop-source` exactly once, when you are ready to switch.
+- **Every dump is a snapshot of a live server** - only a `--stop-source` run (or exporting
+  after stopping the writers yourself) is consistent with the moment of cutover.
+- **Never commit an export.** `<out>/data` holds real production data; keep it out of Git and
+  delete it after the restore is verified, along with the vault import.
+- **The plan's "not carried" list is a checklist**, not a footnote - Redis state, uploaded
+  files and search indexes need their own move.
+- Review the generated stack like any change: pinned images, resources, Ingress hosts - then
+  it lives in GitOps like everything else.
+
+## Related skills
+
+- `ankra-backups` - the vault the restore path depends on.
+- `ankra-import-cluster` / `ankra-stacks-addons` - the stack YAML convert generates.
+- `ankra-troubleshooting` - when the deployed workloads misbehave.
+- `ankra-app-integrations` - wiring the migrated app to registries and secrets afterwards.

--- a/internal/skills/embedded/skills/ankra-security/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-security/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ankra-security
-description: Secure an Ankra organisation end to end - API tokens and their MCP scopes, organisation roles and membership, cluster access grants through the kube gateway, credential scope for Git/registry/cloud, secret handling with SOPS, application code and container scanning findings, and how much autonomy the AI agents and MCP tool servers are given. Use when the user asks about permissions, RBAC, who can access a cluster, token scopes, least privilege, a security review, hardening, or handling secrets safely.
+description: Secure an Ankra organisation end to end - API tokens and their MCP scopes, organisation roles and membership, cluster access grants through the kube gateway, credential scope for Git/registry/cloud, secret handling with SOPS, application code and container scanning findings, the Security Center's fleet-wide CVE findings with CISA KEV and EPSS exploitation intelligence, and how much autonomy the AI agents and MCP tool servers are given. Use when the user asks about permissions, RBAC, who can access a cluster, token scopes, least privilege, a security review, hardening, handling secrets safely, vulnerabilities, a CVE, or what is exploited in the wild.
 ---
 
 # Ankra security
@@ -140,7 +140,37 @@ An application whose build workflow has no scanning step is a finding in itself.
 image tag or an unpinned chart version: a mutable tag means the artefact you reviewed is not
 necessarily the artefact that runs, which defeats every other control here.
 
-## 7. Agent autonomy
+## 7. The Security Center: findings, KEV and EPSS
+
+```bash
+ankra security overview                          # fleet totals, KEV exposure, scanner coverage
+ankra security findings --known-exploited        # the CVEs CISA lists as exploited in the wild
+ankra security findings --severity critical --fixable true --sort epss
+ankra security finding <finding-id>              # CISA's guidance and every current occurrence
+ankra security clusters --status stale           # per-cluster posture and scanner freshness
+ankra security advisory CVE-2026-1234            # the platform's advisory: NVD/OSV, CISA, your exposure
+```
+
+This is the portal's Security Center from the terminal - one logical finding per CVE and
+package, deduplicated across clusters and workloads, each carrying its exploitation
+intelligence: whether CISA lists the CVE in its Known Exploited Vulnerabilities catalog (with
+the remediation deadline and required action) and the FIRST EPSS probability of exploitation
+in the next 30 days.
+
+- **The default sort is exploitability** - CISA listing first, then EPSS, then severity - so
+  the top of the list is what is being exploited, not what merely has the highest CVSS score.
+  Work it top-down; a medium on the KEV list outranks an unexploited critical.
+- The default listing is the actionable set (open and acknowledged). `--status any` widens it
+  to accepted-risk and resolved findings; `--cluster`, `--addon` and `--namespace` narrow the
+  blast radius question.
+- **`security clusters` answers "can I trust this picture?"** - a cluster whose scanner is
+  `stale` or `unscanned` has findings you are not seeing. Treat scanner freshness as a
+  finding of its own.
+- `advisory` works for any CVE id, in a finding or not - the fastest answer to "are we
+  exposed to the CVE in this morning's headlines?".
+- Everything takes `-o json` for reporting and automation.
+
+## 8. Agent autonomy
 
 ```bash
 ankra org mcp-servers list
@@ -173,7 +203,10 @@ ankra cluster access list --cluster <c>  # cluster-admin, cluster-wide grants
 ankra credentials list                   # then `credentials repositories` on each Git credential
 ankra cluster sops-config                # secrets encrypted, paths declared
 ankra application container-security <a> # per application; and code-security
+ankra security overview                  # KEV exposure and scanner coverage across the fleet
+ankra security findings --known-exploited # what is actually being exploited, fix these first
 ankra org mcp-servers list               # read_write tiers, wide tool grants
+ankra backup vaults list                 # every vault ready, keys scoped to their bucket
 ```
 
 Report findings ranked by exposure: what is reachable, by whom, and the one command or change that
@@ -194,6 +227,7 @@ closes it. Do not change anything in a review pass without asking, and never pri
 ## Related skills
 
 - `ankra-sops-secrets` — the encryption workflow in detail.
+- `ankra-backups` — backup vault keys and what lives in the buckets.
 - `ankra-app-integrations` — credential reuse and the registry credential split.
 - `ankra-ai-agents` — MCP servers, tool grants, and agent runs.
 - `ankra-ai-gateway` — Ask/Agent modes per integration.


### PR DESCRIPTION
The 2026-08-25 skills rewrite predates three whole command families, so no skill routed to them. This catches the shipped skills up with security, migration and backups.

## What changed

- **New `ankra-migrate` skill** — the `ankra migrate` journey: plan → convert → deploy → export → restore through a backup vault, the rehearse-then-`--stop-source` cutover pattern, what is *not* carried (non-database volumes, Redis/Mongo/search indexes), cleaning up the imports a vault keeps, and the module contract with checksummed installs.
- **New `ankra-backups` skill** — `ankra backup vaults`: provisioning a bucket from a provider credential versus registering your own (including the Hetzner Object Storage key-pair exception), the verification lifecycle and re-verifying after key rotation, what a vault holds, and delete versus `--destroy-provider-resources`.
- **`ankra-security` gains the Security Center** — `ankra security overview|findings|finding|clusters|advisory`, the KEV/EPSS exploitability ordering (work the list top-down: a medium on the KEV list outranks an unexploited critical), scanner freshness as a finding of its own; the review pass now sweeps security findings and backup vaults.
- **`ankra-cli` routing table** points at all three areas.
- CHANGELOG entry under Unreleased.

## Verification

- `TestSkillsDocumentOnlyRealCommands` resolves all 748 documented invocations (including everything added here) against the cobra tree — green.
- `go test ./internal/skills/...` green; pre-commit (full suite + golangci-lint) passed.
- The monorepo `ankra-skills/` folder is re-synced from this copy (it had drifted behind the embedded copy in 9 files from earlier CLI PRs), with `catalog.json`/`skills.txt` regenerated via `build-catalog.sh`, `lint-skills.sh` clean, and its README/CHANGELOG updated — that folder is local-only, so it ships nowhere but stays the sync source.

Bead: ankra-fxk09
