### PR TITLE
fix(clusters): cluster info finds clusters past the first page (ankra-99r3d)

### DIFF
--- a/internal/client/clusters.go
+++ b/internal/client/clusters.go
@@ -78,11 +78,16 @@ func (c *Client) ListClusters(page int, pageSize int) (*ClusterListResponse, err
 	return response, nil
 }
 
-// GetCluster looks up a cluster by exact name. The backend's
-// /api/v1/clusters?cluster_name=... mode returns a ClusterListResponse
-// with the matching row in `result` (or an empty result on no match).
+// GetCluster looks up a cluster by exact name. The backend narrows with
+// its `name` filter and the exact match happens here.
+//
+// The old query string sent `cluster_name`, a parameter the server never
+// read - the request silently returned the default first page of 25, so
+// any cluster sorted past it answered "no cluster found" (ankra-99r3d,
+// the same truncation listAllClusters was already fixed for).
 func (c *Client) GetCluster(name string) (ClusterListItem, error) {
-	url := fmt.Sprintf("%s/api/v1/clusters?cluster_name=%s", c.BaseURL, neturl.QueryEscape(name))
+	url := fmt.Sprintf("%s/api/v1/clusters?name=%s&page=1&page_size=100",
+		c.BaseURL, neturl.QueryEscape(name))
 	var wrapper ClusterListResponse
 	if err := c.getJSON(url, &wrapper); err != nil {
 		return ClusterListItem{}, err

--- a/internal/client/clusters_test.go
+++ b/internal/client/clusters_test.go
@@ -62,7 +62,13 @@ func TestGetCluster(t *testing.T) {
 		{
 			name: "found",
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				if !strings.Contains(r.URL.RawQuery, "cluster_name=my-cluster") {
+				// The server reads `name` (cluster_name never existed
+				// server-side) and the page must be explicit, or the
+				// default 25-row first page hides everything sorted
+				// past it (ankra-99r3d).
+				if !strings.Contains(r.URL.RawQuery, "name=my-cluster") ||
+					strings.Contains(r.URL.RawQuery, "cluster_name=") ||
+					!strings.Contains(r.URL.RawQuery, "page_size=100") {
 					w.WriteHeader(http.StatusBadRequest)
 					return
 				}


### PR DESCRIPTION
`ankra cluster info <name>` sent `cluster_name=`, a query parameter the server never read (`listClustersHandler` reads `cluster_id/name/state/kind/...`). The request silently returned the default first page of 25 and the CLI filtered client-side - so for an organisation with more than 25 clusters, any cluster sorted past page 1 answered `no cluster found for name`.

Fix: narrow with the server's real `name` filter + explicit `page=1&page_size=100`, exact match client-side - the same truncation fix `listAllClusters` already carries. Fake-server test updated to pin the real query shape (rejects `cluster_name=`, requires the explicit page size).

Found during the playground/managed-k8s review (epic ankra-rnzyx).

Bead: ankra-99r3d

cc @ankraai

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sj8otCXmLWGAjdaHJFVj7T
