### PR TITLE
feat(application): ankra application ship — one-shot idea-to-live (ankra-lhsv6, + login status, git credentials in list, flag consistency)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,13 @@
   to the target cluster, and follows the installation until the workload is
   healthy - then prints `Live: https://<host>` from the deployment's
   published ingress hostname (with a caveat when nothing on the cluster
-  publishes DNS for it). Re-running ship is safe at any point: it re-reads
-  where the flow
+  publishes DNS for it). The Live line is gated on pods actually running and
+  ready: a workload scaled to zero reports "parked" and exits non-zero
+  instead of presenting a 503 URL as live. Supplied `--set` values always
+  produce a deploy - an in-flight deploy is waited to settlement and even a
+  healthy installation is deployed again to apply them; adoption without a
+  new deploy is only for flag-less resumes. Re-running ship is safe at any
+  point: it re-reads where the flow
   actually is and continues from there, and an expired `--timeout` exits 5
   with exactly that hint. `--ankra-build` builds the first image on Ankra's
   builders instead of waiting for the merge and the repository's CI, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@
   waits for the setup analysis, walks you through the setup pull request
   merge gate, waits for a green image build of the tracked branch, deploys
   to the target cluster, and follows the installation until the workload is
-  healthy - then prints `Live: https://<host>` when an ingress publishes
-  one. Re-running ship is safe at any point: it re-reads where the flow
+  healthy - then prints `Live: https://<host>` from the deployment's
+  published ingress hostname (with a caveat when nothing on the cluster
+  publishes DNS for it). Re-running ship is safe at any point: it re-reads
+  where the flow
   actually is and continues from there, and an expired `--timeout` exits 5
   with exactly that hint. `--ankra-build` builds the first image on Ankra's
   builders instead of waiting for the merge and the repository's CI, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Ankra CLI Changelog
 
+## Unreleased
+
+### Added
+
+- **`ankra application ship [path]`** takes a local checkout to a live
+  deployment in one command, composing the lanes that already exist as
+  separate subcommands: it registers the repository as an application when
+  the organisation does not have it yet (same flags as `application add`),
+  waits for the setup analysis, walks you through the setup pull request
+  merge gate, waits for a green image build of the tracked branch, deploys
+  to the target cluster, and follows the installation until the workload is
+  healthy - then prints `Live: https://<host>` when an ingress publishes
+  one. Re-running ship is safe at any point: it re-reads where the flow
+  actually is and continues from there, and an expired `--timeout` exits 5
+  with exactly that hint. `--ankra-build` builds the first image on Ankra's
+  builders instead of waiting for the merge and the repository's CI, and
+  `-o json` emits one structured result document for scripts.
+- **`ankra login status`** reports whether you are logged in - the API base
+  URL in use, where the token came from (config file, environment, or flag),
+  the saved token name, and the current organisation - without ever opening
+  a browser, and exits 6 when not logged in so scripts can probe the state.
+
+### Fixed
+
+- **`ankra login <anything>` no longer starts a browser sign-in.** An
+  unknown positional argument used to fall through to the interactive login
+  flow, so a probe like `ankra login status` on an older CLI silently opened
+  the browser; unknown arguments are now rejected with a pointer at
+  `ankra login status`.
+- **`ankra credentials list` always shows the organisation's GitHub
+  credentials.** When the unfiltered listing omits git credentials, they are
+  now fetched through the same provider-filtered read `application add`
+  resolves its credential from and merged in, App-installation-backed
+  entries read as `github (App)`, and the listing points at
+  `ankra credentials repositories <name>` for what a credential can reach -
+  the GitHub connection is the first prerequisite of `application add` and
+  was invisible.
+- **`ankra cluster domain` without an argument uses the selected cluster**,
+  like its sibling cluster commands, instead of failing with
+  "accepts 1 arg(s)"; the resolved cluster is named on stderr since
+  `--enable`/`--remove` mutate through the same fallback.
+
 ## v0.14.0 — 2026-08-31
 
 Promotes v0.14.0-rc0 through rc8. The headline is the migration lane:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   deployment in one command, composing the lanes that already exist as
   separate subcommands: it registers the repository as an application when
   the organisation does not have it yet (same flags as `application add`),
+  with --name as part of the application's identity - a repository hosting
+  several applications ships the named one, `--name` with a new name
+  registers another rooted at the given path, and a multi-application
+  repository without --name is refused with the names listed rather than
+  one picked silently -
   waits for the setup analysis, walks you through the setup pull request
   merge gate, waits for a green image build of the tracked branch, deploys
   to the target cluster, and follows the installation until the workload is

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -41,6 +41,7 @@ func newApplicationCommand() *cobra.Command {
 		Long:    "Connect application source repositories to Ankra for analysis, packaging, and deployment.",
 	}
 	applicationCommand.AddCommand(newApplicationAddCommand())
+	applicationCommand.AddCommand(newApplicationShipCommand())
 	registerApplicationResourceCommands(applicationCommand)
 	return applicationCommand
 }
@@ -69,32 +70,39 @@ registry added later leaves a workflow that logs in with the wrong one.`,
 		Args: cobra.ExactArgs(1),
 		RunE: runApplicationAdd,
 	}
-	addCommand.Flags().String("name", "", "Application name (defaults to the repository name)")
-	addCommand.Flags().String("credential", "", "GitHub credential name or ID (auto-detected when omitted)")
-	addCommand.Flags().String("branch", "", "Repository branch (auto-detected when omitted)")
-	addCommand.Flags().String("remote", "origin", "Git remote used to identify the GitHub repository")
-	addCommand.Flags().String("registry-url", "",
-		"Registry project the application publishes to, as oci://<host>/<project>")
-	addCommand.Flags().String("registry-credential", "",
-		"Registry credential of this organisation that authenticates to it")
-	addCommand.Flags().String("registry-api-url", "",
-		"Registry management API base (defaults to https://<host>)")
-	addCommand.Flags().String("registry-pull-secret", "",
-		"Name of the dockerconfigjson Secret generated manifests reference")
-	addCommand.Flags().String("registry-username-secret", "",
-		"Repository Actions secret the build workflow logs in with")
-	addCommand.Flags().String("registry-password-secret", "",
-		"Repository Actions secret holding the registry password")
-	addCommand.Flags().Bool("registry-manage-actions-secrets", false,
-		"Let Ankra write the named credential into the repository's Actions secrets")
-	addCommand.Flags().String("registry-admin-credential", "",
-		"Registry credential with project administrator rights, for Ankra to mint the application's robot")
-	addCommand.Flags().Bool("registry-flat-repositories", false,
-		"Publish monorepo components as <project>/<component> instead of <project>/<app>/<component>")
-	addCommand.Flags().StringArray("registry-component-repository", nil,
-		"Repository inside the project for one component, as <component>=<repository> (repeatable)")
+	registerApplicationAddFlags(addCommand)
 	registerStructuredOutputFlags(addCommand)
 	return addCommand
+}
+
+// registerApplicationAddFlags registers the flags the add flow reads.
+// `application ship` registers the same set, so registering an application
+// through ship carries the identical contract as `application add`.
+func registerApplicationAddFlags(command *cobra.Command) {
+	command.Flags().String("name", "", "Application name (defaults to the repository name)")
+	command.Flags().String("credential", "", "GitHub credential name or ID (auto-detected when omitted)")
+	command.Flags().String("branch", "", "Repository branch (auto-detected when omitted)")
+	command.Flags().String("remote", "origin", "Git remote used to identify the GitHub repository")
+	command.Flags().String("registry-url", "",
+		"Registry project the application publishes to, as oci://<host>/<project>")
+	command.Flags().String("registry-credential", "",
+		"Registry credential of this organisation that authenticates to it")
+	command.Flags().String("registry-api-url", "",
+		"Registry management API base (defaults to https://<host>)")
+	command.Flags().String("registry-pull-secret", "",
+		"Name of the dockerconfigjson Secret generated manifests reference")
+	command.Flags().String("registry-username-secret", "",
+		"Repository Actions secret the build workflow logs in with")
+	command.Flags().String("registry-password-secret", "",
+		"Repository Actions secret holding the registry password")
+	command.Flags().Bool("registry-manage-actions-secrets", false,
+		"Let Ankra write the named credential into the repository's Actions secrets")
+	command.Flags().String("registry-admin-credential", "",
+		"Registry credential with project administrator rights, for Ankra to mint the application's robot")
+	command.Flags().Bool("registry-flat-repositories", false,
+		"Publish monorepo components as <project>/<component> instead of <project>/<app>/<component>")
+	command.Flags().StringArray("registry-component-repository", nil,
+		"Repository inside the project for one component, as <component>=<repository> (repeatable)")
 }
 
 // applicationAddRegistryFlags are the flags that only mean something
@@ -163,36 +171,47 @@ func applicationAddImageRegistry(command *cobra.Command) (*client.ApplicationIma
 	}, nil
 }
 
-func runApplicationAdd(command *cobra.Command, arguments []string) error {
-	if _, outputError := structuredFormatFromFlags(command); outputError != nil {
-		return outputError
-	}
+// applicationAddPlan is everything the add flow resolves before it calls the
+// platform: the repository identity, the application name, the GitHub
+// credential, and the optional registry declaration.
+type applicationAddPlan struct {
+	repository    localApplicationRepository
+	name          string
+	credential    client.Credential
+	imageRegistry *client.ApplicationImageRegistry
+}
+
+// resolveApplicationAddPlan reads the add flags and the local checkout into a
+// creation plan. Flag validation runs before the repository inspection and the
+// inspection before the credential listing, so an invocation mistake never
+// costs an API round-trip.
+func resolveApplicationAddPlan(command *cobra.Command, repositoryPath string) (applicationAddPlan, error) {
 	imageRegistry, registryError := applicationAddImageRegistry(command)
 	if registryError != nil {
-		return registryError
+		return applicationAddPlan{}, registryError
 	}
 
 	remoteName, _ := command.Flags().GetString("remote")
 	branchOverride, _ := command.Flags().GetString("branch")
 	branchOverride = strings.TrimSpace(branchOverride)
 	if command.Flags().Changed("branch") && branchOverride == "" {
-		return withExitCode(exitUsage, errors.New("branch cannot be empty"))
+		return applicationAddPlan{}, withExitCode(exitUsage, errors.New("branch cannot be empty"))
 	}
 	repository, repositoryError := inspectLocalApplicationRepository(
 		command.Context(),
-		arguments[0],
+		repositoryPath,
 		strings.TrimSpace(remoteName),
 		branchOverride,
 	)
 	if repositoryError != nil {
-		return repositoryError
+		return applicationAddPlan{}, repositoryError
 	}
 
 	applicationName, _ := command.Flags().GetString("name")
 	applicationName = strings.TrimSpace(applicationName)
 	if applicationName == "" {
 		if command.Flags().Changed("name") {
-			return withExitCode(exitUsage, errors.New("application name cannot be empty"))
+			return applicationAddPlan{}, withExitCode(exitUsage, errors.New("application name cannot be empty"))
 		}
 		applicationName = repository.Name
 	}
@@ -200,12 +219,12 @@ func runApplicationAdd(command *cobra.Command, arguments []string) error {
 	requestedCredential, _ := command.Flags().GetString("credential")
 	requestedCredential = strings.TrimSpace(requestedCredential)
 	if command.Flags().Changed("credential") && requestedCredential == "" {
-		return withExitCode(exitUsage, errors.New("credential cannot be empty"))
+		return applicationAddPlan{}, withExitCode(exitUsage, errors.New("credential cannot be empty"))
 	}
 	githubProvider := "github"
 	credentials, credentialsError := apiClient.ListCredentials(&githubProvider)
 	if credentialsError != nil {
-		return fmt.Errorf("listing GitHub credentials: %w", credentialsError)
+		return applicationAddPlan{}, fmt.Errorf("listing GitHub credentials: %w", credentialsError)
 	}
 	selectedCredential, selectionError := selectApplicationCredential(
 		credentials,
@@ -213,39 +232,65 @@ func runApplicationAdd(command *cobra.Command, arguments []string) error {
 		requestedCredential,
 	)
 	if selectionError != nil {
-		return selectionError
+		return applicationAddPlan{}, selectionError
 	}
 
-	applicationResponse, createError := apiClient.CreateApplication(command.Context(), client.CreateApplicationRequest{
-		Name:                     applicationName,
-		RepositoryCredentialName: selectedCredential.Name,
-		RepositoryOwner:          repository.Owner,
-		RepositoryName:           repository.Name,
-		RepositoryBranch:         repository.Branch,
-		ImageRegistry:            imageRegistry,
+	return applicationAddPlan{
+		repository:    repository,
+		name:          applicationName,
+		credential:    selectedCredential,
+		imageRegistry: imageRegistry,
+	}, nil
+}
+
+// createApplicationFromPlan registers the planned application on the platform
+// and returns the created identity.
+func createApplicationFromPlan(requestContext context.Context, plan applicationAddPlan) (applicationAddOutput, error) {
+	applicationResponse, createError := apiClient.CreateApplication(requestContext, client.CreateApplicationRequest{
+		Name:                     plan.name,
+		RepositoryCredentialName: plan.credential.Name,
+		RepositoryOwner:          plan.repository.Owner,
+		RepositoryName:           plan.repository.Name,
+		RepositoryBranch:         plan.repository.Branch,
+		ImageRegistry:            plan.imageRegistry,
 	})
 	if createError != nil {
-		return fmt.Errorf("adding application: %w", createError)
+		return applicationAddOutput{}, fmt.Errorf("adding application: %w", createError)
 	}
 	if applicationResponse == nil {
-		return errors.New("adding application: platform returned an empty response")
+		return applicationAddOutput{}, errors.New("adding application: platform returned an empty response")
 	}
 	if len(applicationResponse.Errors) > 0 {
-		return applicationCreationError(applicationResponse.Errors)
+		return applicationAddOutput{}, applicationCreationError(applicationResponse.Errors)
 	}
 	if applicationResponse.ID == nil || strings.TrimSpace(*applicationResponse.ID) == "" {
-		return errors.New("adding application: platform response did not include an application ID")
+		return applicationAddOutput{}, errors.New("adding application: platform response did not include an application ID")
 	}
 
 	result := applicationAddOutput{
 		ID:             *applicationResponse.ID,
-		Name:           applicationName,
-		Repository:     repository.Owner + "/" + repository.Name,
-		Branch:         repository.Branch,
-		CredentialName: selectedCredential.Name,
+		Name:           plan.name,
+		Repository:     plan.repository.Owner + "/" + plan.repository.Name,
+		Branch:         plan.repository.Branch,
+		CredentialName: plan.credential.Name,
 	}
-	if imageRegistry != nil {
-		result.RegistryURL = imageRegistry.URL
+	if plan.imageRegistry != nil {
+		result.RegistryURL = plan.imageRegistry.URL
+	}
+	return result, nil
+}
+
+func runApplicationAdd(command *cobra.Command, arguments []string) error {
+	if _, outputError := structuredFormatFromFlags(command); outputError != nil {
+		return outputError
+	}
+	plan, planError := resolveApplicationAddPlan(command, arguments[0])
+	if planError != nil {
+		return planError
+	}
+	result, createError := createApplicationFromPlan(command.Context(), plan)
+	if createError != nil {
+		return createError
 	}
 	if rendered, renderError := renderStructured(command, result); rendered || renderError != nil {
 		return renderError

--- a/cmd/application_ship.go
+++ b/cmd/application_ship.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -330,15 +331,17 @@ type shipApplicationListingPage struct {
 	} `json:"pagination"`
 }
 
-// findApplicationByRepository walks the applications listing for one whose
-// repository matches the local checkout. The listing's `search` filter only
-// matches names, so the walk is unfiltered; the same page bounds as
+// findApplicationsByRepository walks the applications listing for every
+// application whose repository matches the local checkout - one repository
+// legitimately hosts several applications rooted at different paths, so all
+// matches are returned and the caller decides. The listing's `search` filter
+// only matches names, so the walk is unfiltered; the same page bounds as
 // resolveApplicationID keep it finite, and a walk that does not finish is an
 // error rather than an answer from partial data.
-func findApplicationByRepository(
+func findApplicationsByRepository(
 	requestContext context.Context,
 	repository localApplicationRepository,
-) (*shipApplicationView, error) {
+) ([]shipApplicationView, error) {
 	matches := []shipApplicationView{}
 	listingExhausted := false
 	for page := 1; page <= maxApplicationLookupPages; page++ {
@@ -380,17 +383,58 @@ func findApplicationByRepository(
 			"the applications listing did not end within %d pages; cannot decide whether %s/%s is already registered",
 			maxApplicationLookupPages, repository.Owner, repository.Name)
 	}
-	if len(matches) == 0 {
-		return nil, nil
-	}
-	// Several applications can track the same repository on different
-	// branches; the one tracking this checkout's branch is the one meant.
-	for index := range matches {
-		if strings.EqualFold(matches[index].AppRepoBranch, repository.Branch) {
-			return &matches[index], nil
+	return matches, nil
+}
+
+// selectShipApplication decides which of a repository's applications this
+// ship is about, or that a new one must be registered (nil).
+//
+// One repository legitimately hosts several applications rooted at different
+// paths, so a match on the repository alone is not identity: the first live
+// monorepo run matched by repository only, adopted the OTHER application,
+// and redeployed it onto the caller's hostname. With --name the name is part
+// of the match - an existing application with a different name is somebody
+// else's, and the named one is registered fresh when absent. Without --name
+// a multi-application repository is refused with the names listed, because
+// picking one silently is exactly the hijack this prevents.
+func selectShipApplication(
+	matches []shipApplicationView,
+	repository localApplicationRepository,
+	requestedName string,
+) (*shipApplicationView, error) {
+	if requestedName != "" {
+		named := []shipApplicationView{}
+		for index := range matches {
+			if strings.EqualFold(matches[index].Name, requestedName) {
+				named = append(named, matches[index])
+			}
+		}
+		switch len(named) {
+		case 0:
+			return nil, nil
+		case 1:
+			return &named[0], nil
+		default:
+			return nil, withExitCode(exitUsage, fmt.Errorf(
+				"%d applications named %q are registered for %s/%s; resolve the duplicate with 'ankra application list' before shipping",
+				len(named), requestedName, repository.Owner, repository.Name))
 		}
 	}
-	return &matches[0], nil
+	switch len(matches) {
+	case 0:
+		return nil, nil
+	case 1:
+		return &matches[0], nil
+	default:
+		names := make([]string, 0, len(matches))
+		for _, match := range matches {
+			names = append(names, match.Name)
+		}
+		sort.Strings(names)
+		return nil, withExitCode(exitUsage, fmt.Errorf(
+			"%d applications are registered for %s/%s (%s); pass --name to say which one to ship, or --name with a new name to register another",
+			len(matches), repository.Owner, repository.Name, strings.Join(names, ", ")))
+	}
 }
 
 // resolveOrRegisterApplication finds the application already registered for
@@ -402,9 +446,15 @@ func resolveOrRegisterApplication(
 	repositoryPath string,
 	repository localApplicationRepository,
 ) (shipApplicationView, bool, error) {
-	existing, lookupError := findApplicationByRepository(requestContext, repository)
+	matches, lookupError := findApplicationsByRepository(requestContext, repository)
 	if lookupError != nil {
 		return shipApplicationView{}, false, lookupError
+	}
+	requestedName, _ := command.Flags().GetString("name")
+	requestedName = strings.TrimSpace(requestedName)
+	existing, selectError := selectShipApplication(matches, repository, requestedName)
+	if selectError != nil {
+		return shipApplicationView{}, false, selectError
 	}
 	if existing != nil {
 		_, _ = fmt.Fprintf(progress, "Using existing application %q (%s) for %s/%s.\n",
@@ -416,6 +466,16 @@ func resolveOrRegisterApplication(
 				existing.AppRepoBranch, repository.Branch)
 		}
 		return *existing, false, nil
+	}
+	if requestedName != "" && len(matches) > 0 {
+		otherNames := make([]string, 0, len(matches))
+		for _, match := range matches {
+			otherNames = append(otherNames, match.Name)
+		}
+		sort.Strings(otherNames)
+		_, _ = fmt.Fprintf(progress,
+			"The repository already has %d other application(s) (%s); registering %q as a separate application.\n",
+			len(matches), strings.Join(otherNames, ", "), requestedName)
 	}
 
 	plan, planError := resolveApplicationAddPlan(command, repositoryPath)
@@ -439,12 +499,13 @@ func resolveOrRegisterApplication(
 }
 
 // warnIgnoredRegistrationFlags says out loud which explicitly-passed add
-// flags did nothing because the repository already has an application: they
-// shape how an application is REGISTERED, and silently ignoring an explicit
-// flag is how a caller comes to believe a re-run retargeted something it did
-// not.
+// flags did nothing because an existing application was adopted: they shape
+// how an application is REGISTERED, and silently ignoring an explicit flag
+// is how a caller comes to believe a re-run retargeted something it did not.
+// --name is absent here on purpose: it participates in choosing WHICH
+// application is adopted (selectShipApplication), so it is never ignored.
 func warnIgnoredRegistrationFlags(command *cobra.Command, progress io.Writer) {
-	registrationFlags := append([]string{"name", "credential", "registry-url"}, applicationAddRegistryFlags...)
+	registrationFlags := append([]string{"credential", "registry-url"}, applicationAddRegistryFlags...)
 	ignored := []string{}
 	for _, flagName := range registrationFlags {
 		if command.Flags().Changed(flagName) {

--- a/cmd/application_ship.go
+++ b/cmd/application_ship.go
@@ -325,7 +325,20 @@ func findApplicationByRepository(
 				matches = append(matches, application)
 			}
 		}
-		if listing.Pagination.TotalPages <= page || len(listing.Result) == 0 {
+		if len(listing.Result) == 0 {
+			listingExhausted = true
+			break
+		}
+		// A non-empty page whose pagination reports no page count is
+		// undecidable, not exhausted: stopping here would answer "not
+		// registered" from partial data, and the wrong answer to that
+		// question registers a duplicate application.
+		if listing.Pagination.TotalPages == 0 {
+			return nil, fmt.Errorf(
+				"the applications listing did not report its page count; cannot decide whether %s/%s is already registered",
+				repository.Owner, repository.Name)
+		}
+		if listing.Pagination.TotalPages <= page {
 			listingExhausted = true
 			break
 		}
@@ -520,6 +533,12 @@ type shipWorkflowRunsPage struct {
 	Error *string           `json:"error"`
 }
 
+// maxConsecutiveWorkflowListingErrors bounds how long a refused
+// workflow-runs read may masquerade as "no run yet": a listing that keeps
+// answering with an error is a failure of the read, not CI taking its time,
+// and must not wait out the whole --timeout budget.
+const maxConsecutiveWorkflowListingErrors = 10
+
 // waitForWorkflowSuccess polls the repository's workflow runs until the
 // latest run on the tracked branch concludes. Success returns the run URL as
 // the build reference; a failed conclusion is the command's failure, with the
@@ -533,6 +552,7 @@ func waitForWorkflowSuccess(
 	announcedWaiting := false
 	announcedRunning := ""
 	announcedListingError := ""
+	consecutiveListingErrors := 0
 	for {
 		payload, readError := apiClient.GetApplicationWorkflowRuns(waitContext, applicationID, "", 1, 20)
 		if readError != nil {
@@ -542,9 +562,20 @@ func waitForWorkflowSuccess(
 		if unmarshalError := json.Unmarshal(payload, &runs); unmarshalError != nil {
 			return "", fmt.Errorf("reading the workflow runs: %w", unmarshalError)
 		}
-		if runs.Error != nil && *runs.Error != "" && *runs.Error != announcedListingError {
-			_, _ = fmt.Fprintf(progress, "Workflow runs could not be listed (%s); retrying.\n", *runs.Error)
-			announcedListingError = *runs.Error
+		if runs.Error != nil && *runs.Error != "" {
+			consecutiveListingErrors++
+			if consecutiveListingErrors >= maxConsecutiveWorkflowListingErrors {
+				return "", fmt.Errorf(
+					"the workflow runs could not be listed after %d attempts: %s - check the application's repository credential with 'ankra credentials repositories'",
+					consecutiveListingErrors, *runs.Error)
+			}
+			if *runs.Error != announcedListingError {
+				_, _ = fmt.Fprintf(progress, "Workflow runs could not be listed (%s); retrying.\n", *runs.Error)
+				announcedListingError = *runs.Error
+			}
+		} else {
+			consecutiveListingErrors = 0
+			announcedListingError = ""
 		}
 		var latest *shipWorkflowRun
 		for index := range runs.Runs {

--- a/cmd/application_ship.go
+++ b/cmd/application_ship.go
@@ -1,0 +1,920 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// `ankra application ship` composes the lanes that already exist as separate
+// subcommands - add, get, workflow-runs, build, deploy, installations - into
+// the one sentence they were built for: take this checkout to a live
+// deployment.
+//
+// The command is a state machine over platform reads, not a script of writes:
+// every step first reads where the flow actually is and only acts on what is
+// missing. That is what makes re-running it safe - a ship interrupted at any
+// point resumes from the current state instead of registering, building or
+// deploying twice.
+
+// shipPollInterval paces the setup, build and installation polls;
+// shipMergePollInterval paces the human-speed merge gate. Variables so the
+// tests can drive the loops without sleeping through them.
+var (
+	shipPollInterval      = 5 * time.Second
+	shipMergePollInterval = 15 * time.Second
+)
+
+// shipResult is the -o json document: the identities a script needs to keep
+// driving the application afterwards.
+type shipResult struct {
+	ApplicationID    string `json:"application_id" yaml:"application_id"`
+	ApplicationName  string `json:"application_name" yaml:"application_name"`
+	Repository       string `json:"repository" yaml:"repository"`
+	Branch           string `json:"branch" yaml:"branch"`
+	Registered       bool   `json:"registered" yaml:"registered"`
+	SetupPRURL       string `json:"setup_pr_url,omitempty" yaml:"setup_pr_url,omitempty"`
+	BuildRef         string `json:"build_ref,omitempty" yaml:"build_ref,omitempty"`
+	OrganisationName string `json:"organisation_name" yaml:"organisation_name"`
+	ClusterID        string `json:"cluster_id" yaml:"cluster_id"`
+	ClusterName      string `json:"cluster_name" yaml:"cluster_name"`
+	Namespace        string `json:"namespace" yaml:"namespace"`
+	InstallationID   string `json:"installation_id,omitempty" yaml:"installation_id,omitempty"`
+	URL              string `json:"url,omitempty" yaml:"url,omitempty"`
+	State            string `json:"state" yaml:"state"`
+}
+
+// shipApplicationView is the slice of the application detail (and of each
+// listing row - the fields are shared) the ship flow steers by.
+type shipApplicationView struct {
+	ID                  string  `json:"id"`
+	Name                string  `json:"name"`
+	State               string  `json:"state"`
+	ErrorMessage        *string `json:"error_message"`
+	AppRepoOwner        string  `json:"app_repo_owner"`
+	AppRepoName         string  `json:"app_repo_name"`
+	AppRepoBranch       string  `json:"app_repo_branch"`
+	PullRequestURL      *string `json:"pull_request_url"`
+	PullRequestMergedAt *string `json:"pull_request_merged_at"`
+}
+
+func newApplicationShipCommand() *cobra.Command {
+	shipCommand := &cobra.Command{
+		Use:   "ship [path]",
+		Short: "Take a local checkout to a live deployment in one command",
+		Long: `Take a local checkout to a live deployment in one command.
+
+Ship composes the existing application lanes: it registers the repository as
+an application when the organisation does not have it yet (with exactly the
+'application add' flags), waits for the setup analysis, walks you through the
+setup pull request merge gate, waits for a green image build of the tracked
+branch, deploys to the target cluster, and follows the installation until the
+workload is running - then prints the published URL when one exists.
+
+Every wait step says what it is waiting on and where to look. Re-running ship
+is safe at any point: it re-reads where the flow actually is and continues
+from there, so an interrupted or timed-out run is resumed, not repeated.
+
+With --ankra-build the first image is built on Ankra's builders from the head
+commit of the tracked branch, so ship does not wait for the setup pull
+request to merge or for the repository's own CI. The platform-build routes
+answer 404 for organisations without the platform_builds feature flag.
+
+The image tag and ingress publication are the platform's defaults: the latest
+green build is deployed, and ingress is derived server-side. Pass --set only
+for deploy inputs you want to pin.`,
+		Example: `  ankra application ship .
+  ankra application ship . --cluster production
+  ankra application ship ./services/payments --cluster staging --namespace payments
+  ankra application ship . --cluster staging --ankra-build --set replicas=2 -o json`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runApplicationShip,
+	}
+	registerApplicationAddFlags(shipCommand)
+	shipCommand.Flags().String("cluster", "",
+		"Target cluster name or ID (defaults to the selected cluster, echoed before acting)")
+	shipCommand.Flags().String("namespace", "",
+		"Target namespace (defaults to the namespace the platform derives from the application name)")
+	shipCommand.Flags().StringArray("set", nil, "Deploy input as key=value (repeatable)")
+	shipCommand.Flags().Bool("ankra-build", false,
+		"Build the first image on Ankra's builders instead of waiting for the setup PR merge and repository CI")
+	shipCommand.Flags().Duration("timeout", time.Hour, "Overall budget for every wait step combined")
+	registerStructuredOutputFlags(shipCommand)
+	return shipCommand
+}
+
+func runApplicationShip(command *cobra.Command, arguments []string) error {
+	if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+		return formatError
+	}
+	setValues, _ := command.Flags().GetStringArray("set")
+	deployInputs, parseError := parseKeyValueFlags(setValues)
+	if parseError != nil {
+		return withExitCode(exitUsage, parseError)
+	}
+	useAnkraBuild, _ := command.Flags().GetBool("ankra-build")
+	namespaceFlag, _ := command.Flags().GetString("namespace")
+	namespaceFlag = strings.TrimSpace(namespaceFlag)
+	timeout, timeoutFlagError := command.Flags().GetDuration("timeout")
+	if timeoutFlagError != nil {
+		return fmt.Errorf("reading --timeout: %w", timeoutFlagError)
+	}
+	repositoryPath := "."
+	if len(arguments) == 1 {
+		repositoryPath = arguments[0]
+	}
+
+	// The organisation and cluster are resolved and echoed before anything
+	// acts: a --org override or a stale `ankra cluster select` retargets every
+	// write below, and naming both is the defence against shipping into the
+	// wrong place.
+	organisation, _, organisationError := resolveTargetOrganisation(command)
+	if organisationError != nil {
+		return organisationError
+	}
+	organisationName := organisation.OrganisationID
+	if organisation.Name != nil && strings.TrimSpace(*organisation.Name) != "" {
+		organisationName = *organisation.Name
+	}
+	cluster, clusterError := resolveActiveCluster(command)
+	if clusterError != nil {
+		return clusterError
+	}
+	if cluster.OrganisationID != "" && organisation.OrganisationID != "" &&
+		cluster.OrganisationID != organisation.OrganisationID {
+		return withExitCode(exitUsage, fmt.Errorf(
+			"the selected cluster %q belongs to a different organisation than %q; "+
+				"run 'ankra cluster select' or pass --cluster", cluster.Name, organisationName))
+	}
+
+	// Progress goes to stderr so -o json stdout stays parseable.
+	progress := command.ErrOrStderr()
+	_, _ = fmt.Fprintf(progress, "Shipping to organisation %q, cluster %q.\n", organisationName, cluster.Name)
+
+	remoteName, _ := command.Flags().GetString("remote")
+	branchOverride, _ := command.Flags().GetString("branch")
+	branchOverride = strings.TrimSpace(branchOverride)
+	if command.Flags().Changed("branch") && branchOverride == "" {
+		return withExitCode(exitUsage, errors.New("branch cannot be empty"))
+	}
+	repository, repositoryError := inspectLocalApplicationRepository(
+		command.Context(), repositoryPath, strings.TrimSpace(remoteName), branchOverride)
+	if repositoryError != nil {
+		return repositoryError
+	}
+
+	waitContext, cancelWait := context.WithTimeout(command.Context(), timeout)
+	defer cancelWait()
+
+	application, registered, resolveError := resolveOrRegisterApplication(
+		waitContext, command, progress, repositoryPath, repository)
+	if resolveError != nil {
+		return resolveError
+	}
+
+	application, setupError := waitForApplicationSetup(waitContext, progress, application.ID)
+	if setupError != nil {
+		return setupError
+	}
+	trackedBranch := application.AppRepoBranch
+	if trackedBranch == "" {
+		trackedBranch = repository.Branch
+	}
+	setupPRURL := ""
+	if application.PullRequestURL != nil {
+		setupPRURL = *application.PullRequestURL
+	}
+
+	var buildReference string
+	if useAnkraBuild {
+		var buildError error
+		buildReference, buildError = runShipPlatformBuild(waitContext, command, progress, application.ID, trackedBranch)
+		if buildError != nil {
+			return buildError
+		}
+	} else {
+		if mergeError := waitForSetupPullRequestMerge(waitContext, progress, application.ID, application); mergeError != nil {
+			return mergeError
+		}
+		var workflowError error
+		buildReference, workflowError = waitForWorkflowSuccess(waitContext, progress, application.ID, trackedBranch)
+		if workflowError != nil {
+			return workflowError
+		}
+	}
+
+	namespace := namespaceFlag
+	if namespace == "" {
+		namespace = defaultShipNamespace(application.Name)
+	}
+	installationID, deployMessage, deployError := ensureApplicationDeployed(
+		waitContext, progress, application.ID, cluster.ID, namespace, deployInputs)
+	if deployError != nil {
+		return deployError
+	}
+
+	if verifyError := waitForInstallationHealthy(
+		waitContext, progress, application.ID, installationID, cluster.ID, namespace); verifyError != nil {
+		return verifyError
+	}
+	reportNamespacePods(progress, cluster.ID, namespace)
+
+	liveURL := findPublishedApplicationURL(progress, cluster.ID, namespace)
+
+	result := shipResult{
+		ApplicationID:    application.ID,
+		ApplicationName:  application.Name,
+		Repository:       repository.Owner + "/" + repository.Name,
+		Branch:           trackedBranch,
+		Registered:       registered,
+		SetupPRURL:       setupPRURL,
+		BuildRef:         buildReference,
+		OrganisationName: organisationName,
+		ClusterID:        cluster.ID,
+		ClusterName:      cluster.Name,
+		Namespace:        namespace,
+		InstallationID:   installationID,
+		URL:              liveURL,
+		State:            "healthy",
+	}
+	if rendered, renderError := renderStructured(command, result); rendered || renderError != nil {
+		return renderError
+	}
+
+	output := command.OutOrStdout()
+	if liveURL != "" {
+		_, _ = fmt.Fprintf(output, "Live: %s\n", liveURL)
+		return nil
+	}
+	_, _ = fmt.Fprintf(output,
+		"Deployed to cluster %q, namespace %q - no published URL yet (no Ingress with a hostname was found in the namespace).\n",
+		cluster.Name, namespace)
+	if deployMessage != "" {
+		_, _ = fmt.Fprintln(output, deployMessage)
+	}
+	return nil
+}
+
+// shipWaitTick sleeps one poll interval, turning an expired --timeout budget
+// into the wait-timeout exit with the resumable hint - re-running ship is the
+// designed recovery, so every expiry says so.
+func shipWaitTick(waitContext context.Context, interval time.Duration, waitingOn string) error {
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	select {
+	case <-waitContext.Done():
+		return withExitCode(exitWaitTimeout, fmt.Errorf(
+			"--timeout expired %s; nothing is lost - re-run 'ankra application ship' and it continues from the current state",
+			waitingOn))
+	case <-timer.C:
+		return nil
+	}
+}
+
+// shipReadError distinguishes an expired --timeout budget from a genuine API
+// failure surfaced by a poll read.
+func shipReadError(waitContext context.Context, what string, readError error) error {
+	if waitContext.Err() != nil {
+		return withExitCode(exitWaitTimeout, fmt.Errorf(
+			"--timeout expired while %s; re-run 'ankra application ship' to continue from the current state", what))
+	}
+	return fmt.Errorf("%s: %w", what, readError)
+}
+
+// shipApplicationListingPage is the slice of the applications listing the
+// repository lookup reads.
+type shipApplicationListingPage struct {
+	Result     []shipApplicationView `json:"result"`
+	Pagination struct {
+		TotalPages int `json:"total_pages"`
+	} `json:"pagination"`
+}
+
+// findApplicationByRepository walks the applications listing for one whose
+// repository matches the local checkout. The listing's `search` filter only
+// matches names, so the walk is unfiltered; the same page bounds as
+// resolveApplicationID keep it finite, and a walk that does not finish is an
+// error rather than an answer from partial data.
+func findApplicationByRepository(
+	requestContext context.Context,
+	repository localApplicationRepository,
+) (*shipApplicationView, error) {
+	matches := []shipApplicationView{}
+	listingExhausted := false
+	for page := 1; page <= maxApplicationLookupPages; page++ {
+		payload, listError := apiClient.ListApplicationsRaw(
+			requestContext, page, maxApplicationLookupPageSize, "")
+		if listError != nil {
+			return nil, fmt.Errorf("listing applications: %w", listError)
+		}
+		var listing shipApplicationListingPage
+		if unmarshalError := json.Unmarshal(payload, &listing); unmarshalError != nil {
+			return nil, fmt.Errorf("reading the applications listing: %w", unmarshalError)
+		}
+		for _, application := range listing.Result {
+			if strings.EqualFold(application.AppRepoOwner, repository.Owner) &&
+				strings.EqualFold(application.AppRepoName, repository.Name) {
+				matches = append(matches, application)
+			}
+		}
+		if listing.Pagination.TotalPages <= page || len(listing.Result) == 0 {
+			listingExhausted = true
+			break
+		}
+	}
+	if !listingExhausted {
+		return nil, fmt.Errorf(
+			"the applications listing did not end within %d pages; cannot decide whether %s/%s is already registered",
+			maxApplicationLookupPages, repository.Owner, repository.Name)
+	}
+	if len(matches) == 0 {
+		return nil, nil
+	}
+	// Several applications can track the same repository on different
+	// branches; the one tracking this checkout's branch is the one meant.
+	for index := range matches {
+		if strings.EqualFold(matches[index].AppRepoBranch, repository.Branch) {
+			return &matches[index], nil
+		}
+	}
+	return &matches[0], nil
+}
+
+// resolveOrRegisterApplication finds the application already registered for
+// the checkout's repository, or runs the add flow. It prints which happened.
+func resolveOrRegisterApplication(
+	requestContext context.Context,
+	command *cobra.Command,
+	progress io.Writer,
+	repositoryPath string,
+	repository localApplicationRepository,
+) (shipApplicationView, bool, error) {
+	existing, lookupError := findApplicationByRepository(requestContext, repository)
+	if lookupError != nil {
+		return shipApplicationView{}, false, lookupError
+	}
+	if existing != nil {
+		_, _ = fmt.Fprintf(progress, "Using existing application %q (%s) for %s/%s.\n",
+			existing.Name, existing.ID, repository.Owner, repository.Name)
+		return *existing, false, nil
+	}
+
+	plan, planError := resolveApplicationAddPlan(command, repositoryPath)
+	if planError != nil {
+		return shipApplicationView{}, false, planError
+	}
+	created, createError := createApplicationFromPlan(requestContext, plan)
+	if createError != nil {
+		return shipApplicationView{}, false, createError
+	}
+	_, _ = fmt.Fprintf(progress, "Registered application %q (%s) for %s/%s@%s with credential %q.\n",
+		created.Name, created.ID, plan.repository.Owner, plan.repository.Name,
+		plan.repository.Branch, plan.credential.Name)
+	return shipApplicationView{
+		ID:            created.ID,
+		Name:          created.Name,
+		AppRepoOwner:  plan.repository.Owner,
+		AppRepoName:   plan.repository.Name,
+		AppRepoBranch: plan.repository.Branch,
+	}, true, nil
+}
+
+// shipSetupFailureStates are the application states that mean setup is not
+// going to reach `up` without intervention.
+var shipSetupFailureStates = map[string]bool{"error": true, "down": true, "failed": true}
+
+// waitForApplicationSetup polls the application detail until the setup
+// analysis lands the application in state `up`.
+func waitForApplicationSetup(
+	waitContext context.Context,
+	progress io.Writer,
+	applicationID string,
+) (shipApplicationView, error) {
+	announcedState := ""
+	announcedPullRequest := false
+	for {
+		payload, readError := apiClient.GetApplicationRaw(waitContext, applicationID)
+		if readError != nil {
+			return shipApplicationView{}, shipReadError(waitContext, "reading the application", readError)
+		}
+		var application shipApplicationView
+		if unmarshalError := json.Unmarshal(payload, &application); unmarshalError != nil {
+			return shipApplicationView{}, fmt.Errorf("reading the application: %w", unmarshalError)
+		}
+		if application.PullRequestURL != nil && *application.PullRequestURL != "" && !announcedPullRequest {
+			_, _ = fmt.Fprintf(progress, "Setup pull request: %s\n", *application.PullRequestURL)
+			announcedPullRequest = true
+		}
+		if application.State == "up" {
+			_, _ = fmt.Fprintf(progress, "Application setup is complete (state: up).\n")
+			return application, nil
+		}
+		if shipSetupFailureStates[application.State] {
+			message := "no error message was recorded"
+			if application.ErrorMessage != nil && strings.TrimSpace(*application.ErrorMessage) != "" {
+				message = *application.ErrorMessage
+			}
+			return shipApplicationView{}, fmt.Errorf(
+				"application setup failed (state: %s): %s - fix the cause, then 'ankra application retry %s'",
+				application.State, message, applicationID)
+		}
+		if application.State != announcedState {
+			_, _ = fmt.Fprintf(progress,
+				"Waiting for application setup (state: %s) - follow it with 'ankra application get %s'.\n",
+				application.State, applicationID)
+			announcedState = application.State
+		}
+		if tickError := shipWaitTick(waitContext, shipPollInterval, "waiting for application setup"); tickError != nil {
+			return shipApplicationView{}, tickError
+		}
+	}
+}
+
+// waitForSetupPullRequestMerge is the merge gate: the generated build
+// workflow only starts building images once the setup pull request lands on
+// the tracked branch, and merging it is a human's decision - so the gate says
+// exactly what is being waited on and polls at human speed.
+func waitForSetupPullRequestMerge(
+	waitContext context.Context,
+	progress io.Writer,
+	applicationID string,
+	application shipApplicationView,
+) error {
+	if application.PullRequestURL == nil || *application.PullRequestURL == "" {
+		return nil
+	}
+	if application.PullRequestMergedAt != nil && *application.PullRequestMergedAt != "" {
+		return nil
+	}
+	_, _ = fmt.Fprintf(progress,
+		"Waiting for the setup pull request to be merged:\n  %s\nMerge it to let the repository's CI build the first image (or re-run with --ankra-build to build on Ankra's builders instead).\n",
+		*application.PullRequestURL)
+	for {
+		if tickError := shipWaitTick(waitContext, shipMergePollInterval,
+			"waiting for the setup pull request to be merged"); tickError != nil {
+			return tickError
+		}
+		payload, readError := apiClient.GetApplicationRaw(waitContext, applicationID)
+		if readError != nil {
+			return shipReadError(waitContext, "checking the setup pull request", readError)
+		}
+		var current shipApplicationView
+		if unmarshalError := json.Unmarshal(payload, &current); unmarshalError != nil {
+			return fmt.Errorf("checking the setup pull request: %w", unmarshalError)
+		}
+		if current.PullRequestMergedAt != nil && *current.PullRequestMergedAt != "" {
+			_, _ = fmt.Fprintln(progress, "Setup pull request merged.")
+			return nil
+		}
+	}
+}
+
+// shipWorkflowRun and shipWorkflowRunsPage are the slice of the
+// workflow-runs read the image wait steers by.
+type shipWorkflowRun struct {
+	ID         int64   `json:"id"`
+	Status     string  `json:"status"`
+	Conclusion *string `json:"conclusion"`
+	Branch     string  `json:"branch"`
+	HTMLURL    string  `json:"html_url"`
+}
+
+type shipWorkflowRunsPage struct {
+	Runs  []shipWorkflowRun `json:"runs"`
+	Error *string           `json:"error"`
+}
+
+// waitForWorkflowSuccess polls the repository's workflow runs until the
+// latest run on the tracked branch concludes. Success returns the run URL as
+// the build reference; a failed conclusion is the command's failure, with the
+// run URL as the place to look.
+func waitForWorkflowSuccess(
+	waitContext context.Context,
+	progress io.Writer,
+	applicationID string,
+	trackedBranch string,
+) (string, error) {
+	announcedWaiting := false
+	announcedRunning := ""
+	announcedListingError := ""
+	for {
+		payload, readError := apiClient.GetApplicationWorkflowRuns(waitContext, applicationID, "", 1, 20)
+		if readError != nil {
+			return "", shipReadError(waitContext, "reading the workflow runs", readError)
+		}
+		var runs shipWorkflowRunsPage
+		if unmarshalError := json.Unmarshal(payload, &runs); unmarshalError != nil {
+			return "", fmt.Errorf("reading the workflow runs: %w", unmarshalError)
+		}
+		if runs.Error != nil && *runs.Error != "" && *runs.Error != announcedListingError {
+			_, _ = fmt.Fprintf(progress, "Workflow runs could not be listed (%s); retrying.\n", *runs.Error)
+			announcedListingError = *runs.Error
+		}
+		var latest *shipWorkflowRun
+		for index := range runs.Runs {
+			if strings.EqualFold(runs.Runs[index].Branch, trackedBranch) {
+				latest = &runs.Runs[index]
+				break
+			}
+		}
+		switch {
+		case latest == nil:
+			if !announcedWaiting {
+				_, _ = fmt.Fprintf(progress,
+					"Waiting for a workflow run on branch %q - follow them with 'ankra application workflow-runs %s'.\n",
+					trackedBranch, applicationID)
+				announcedWaiting = true
+			}
+		case latest.Status != "completed":
+			if latest.HTMLURL != announcedRunning {
+				_, _ = fmt.Fprintf(progress, "CI is building the image: %s\n", latest.HTMLURL)
+				announcedRunning = latest.HTMLURL
+			}
+		default:
+			conclusion := ""
+			if latest.Conclusion != nil {
+				conclusion = *latest.Conclusion
+			}
+			if conclusion == "success" {
+				_, _ = fmt.Fprintf(progress, "CI built the image: %s\n", latest.HTMLURL)
+				return latest.HTMLURL, nil
+			}
+			return "", fmt.Errorf(
+				"the workflow run on branch %q concluded %q: %s - fix the workflow, or re-run it with 'ankra application rerun-workflow %s %d'",
+				trackedBranch, conclusion, latest.HTMLURL, applicationID, latest.ID)
+		}
+		if tickError := shipWaitTick(waitContext, shipPollInterval, "waiting for the image build"); tickError != nil {
+			return "", tickError
+		}
+	}
+}
+
+// shipBranchListing is the slice of the branches read the platform-build lane
+// uses to name the commit to build.
+type shipBranchListing struct {
+	Branches []struct {
+		Name    string `json:"name"`
+		HeadSHA string `json:"head_sha"`
+	} `json:"branches"`
+	Error *string `json:"error"`
+}
+
+// runShipPlatformBuild builds the tracked branch's head commit on Ankra's
+// builders and follows the build to a pushed image, reusing the build lane's
+// own polling. The routes answer 404 for organisations without the
+// platform_builds feature flag, and that answer is translated rather than
+// passed through as a bare not-found.
+func runShipPlatformBuild(
+	waitContext context.Context,
+	command *cobra.Command,
+	progress io.Writer,
+	applicationID string,
+	trackedBranch string,
+) (string, error) {
+	branchesPayload, branchesError := apiClient.GetApplicationBranches(waitContext, applicationID)
+	if branchesError != nil {
+		return "", fmt.Errorf("reading the repository branches: %w", branchesError)
+	}
+	var branches shipBranchListing
+	if unmarshalError := json.Unmarshal(branchesPayload, &branches); unmarshalError != nil {
+		return "", fmt.Errorf("reading the repository branches: %w", unmarshalError)
+	}
+	if branches.Error != nil && *branches.Error != "" {
+		return "", fmt.Errorf("reading the repository branches: %s", *branches.Error)
+	}
+	headSHA := ""
+	for _, branch := range branches.Branches {
+		if strings.EqualFold(branch.Name, trackedBranch) {
+			headSHA = branch.HeadSHA
+			break
+		}
+	}
+	if headSHA == "" {
+		return "", fmt.Errorf("branch %q was not found in the repository, so there is no commit to build", trackedBranch)
+	}
+
+	startPayload, startError := apiClient.StartApplicationPlatformBuild(waitContext, applicationID,
+		client.StartApplicationPlatformBuildRequest{HeadSHA: headSHA, Ref: trackedBranch})
+	if startError != nil {
+		var unexpected *client.UnexpectedResponseError
+		if errors.As(startError, &unexpected) && unexpected.StatusCode == 404 {
+			return "", errors.New(
+				"platform builds are not enabled for this organisation (the platform_builds feature flag is off; ask Ankra support to enable it) - re-run without --ankra-build to use the repository's own CI")
+		}
+		return "", fmt.Errorf("starting the platform build: %w", startError)
+	}
+	var started startedBuild
+	if unmarshalError := json.Unmarshal(startPayload, &started); unmarshalError != nil {
+		return "", fmt.Errorf("reading the queued build: %w", unmarshalError)
+	}
+	if started.AlreadyRequested {
+		_, _ = fmt.Fprintf(progress, "Joined the platform build already queued for commit %s (request %s).\n",
+			headSHA, started.RequestID)
+	} else {
+		_, _ = fmt.Fprintf(progress, "Queued a platform build of commit %s (request %s).\n", headSHA, started.RequestID)
+	}
+
+	buildID, claimError := awaitClaimedBuild(waitContext, progress, applicationID, started)
+	if claimError != nil {
+		return "", claimError
+	}
+	finished, followError := awaitFinishedBuild(waitContext, progress, applicationID, buildID)
+	if followError != nil {
+		return "", followError
+	}
+	if finished.build.Status != "succeeded" {
+		return "", describeFailedBuild(finished.build)
+	}
+	buildReference := finished.build.ID
+	if finished.build.ImageRef != nil && *finished.build.ImageRef != "" {
+		buildReference = *finished.build.ImageRef
+	}
+	_, _ = fmt.Fprintf(progress, "Platform build succeeded: %s\n", buildReference)
+	return buildReference, nil
+}
+
+// defaultShipNamespace mirrors the platform's default_deploy_namespace
+// derivation, so ship knows the namespace a deploy without --namespace lands
+// in and can verify pods and read the ingress there.
+func defaultShipNamespace(applicationName string) string {
+	sanitized := strings.ToLower(strings.TrimSpace(applicationName))
+	var builder strings.Builder
+	for _, character := range sanitized {
+		isSafe := (character >= 'a' && character <= 'z') ||
+			(character >= '0' && character <= '9') ||
+			character == '-'
+		switch {
+		case isSafe:
+			builder.WriteRune(character)
+		case character == '_' || character == '.' || character == ' ':
+			builder.WriteByte('-')
+		}
+	}
+	namespace := strings.Trim(builder.String(), "-")
+	if namespace == "" {
+		return "default"
+	}
+	if len(namespace) > 63 {
+		namespace = strings.TrimRight(namespace[:63], "-")
+	}
+	return namespace
+}
+
+// shipInstallationsListing is the slice of the installations read the deploy
+// and verify steps steer by.
+type shipInstallationsListing struct {
+	Installations []shipInstallation `json:"installations"`
+}
+
+type shipInstallation struct {
+	ID           string  `json:"id"`
+	ClusterID    string  `json:"cluster_id"`
+	Namespace    string  `json:"namespace"`
+	Status       string  `json:"status"`
+	ErrorMessage *string `json:"error_message"`
+}
+
+// shipDeployAnswer is the deploy result: the installation to follow and the
+// platform's message, which carries the ingress derivation note when the
+// platform provides one.
+type shipDeployAnswer struct {
+	InstallationID string `json:"installation_id"`
+	Status         string `json:"status"`
+	Message        string `json:"message"`
+}
+
+// ensureApplicationDeployed reads the installations first and only deploys
+// when this cluster+namespace has no installation converging already: a
+// healthy installation is left alone, an in-flight one is followed, and only
+// a missing or settled-failed one triggers a new deploy.
+func ensureApplicationDeployed(
+	waitContext context.Context,
+	progress io.Writer,
+	applicationID string,
+	clusterID string,
+	namespace string,
+	deployInputs map[string]string,
+) (string, string, error) {
+	existing, readError := findShipInstallation(waitContext, applicationID, clusterID, namespace, "")
+	if readError != nil {
+		return "", "", readError
+	}
+	if existing != nil {
+		switch existing.Status {
+		case "healthy":
+			_, _ = fmt.Fprintf(progress, "Already deployed and healthy in namespace %q (installation %s).\n",
+				namespace, existing.ID)
+			return existing.ID, "", nil
+		case "pending", "deploying":
+			_, _ = fmt.Fprintf(progress, "A deploy is already in flight (installation %s, status %s); following it.\n",
+				existing.ID, existing.Status)
+			return existing.ID, "", nil
+		}
+	}
+
+	payload, deployError := apiClient.DeployApplication(waitContext, applicationID, client.DeployApplicationRequest{
+		ClusterID: clusterID,
+		Namespace: namespace,
+		Inputs:    deployInputs,
+	})
+	if deployError != nil {
+		return "", "", fmt.Errorf("deploying the application: %w", deployError)
+	}
+	var answer shipDeployAnswer
+	if unmarshalError := json.Unmarshal(payload, &answer); unmarshalError != nil {
+		return "", "", fmt.Errorf("reading the deploy answer: %w", unmarshalError)
+	}
+	if answer.InstallationID == "" {
+		return "", "", errors.New("the deploy answer did not name an installation to follow")
+	}
+	_, _ = fmt.Fprintf(progress, "Deploy started (installation %s, namespace %q).\n", answer.InstallationID, namespace)
+	if answer.Message != "" {
+		_, _ = fmt.Fprintf(progress, "%s\n", answer.Message)
+	}
+	return answer.InstallationID, answer.Message, nil
+}
+
+// findShipInstallation reads the installations and returns the one matching
+// the installation id when given, else the cluster+namespace pair; nil when
+// none matches.
+func findShipInstallation(
+	waitContext context.Context,
+	applicationID string,
+	clusterID string,
+	namespace string,
+	installationID string,
+) (*shipInstallation, error) {
+	payload, listError := apiClient.GetApplicationInstallations(waitContext, applicationID)
+	if listError != nil {
+		return nil, shipReadError(waitContext, "reading the installations", listError)
+	}
+	var listing shipInstallationsListing
+	if unmarshalError := json.Unmarshal(payload, &listing); unmarshalError != nil {
+		return nil, fmt.Errorf("reading the installations: %w", unmarshalError)
+	}
+	for index := range listing.Installations {
+		installation := &listing.Installations[index]
+		if installationID != "" {
+			if installation.ID == installationID {
+				return installation, nil
+			}
+			continue
+		}
+		if installation.ClusterID == clusterID && installation.Namespace == namespace {
+			return installation, nil
+		}
+	}
+	return nil, nil
+}
+
+// waitForInstallationHealthy follows the installation to `healthy`. A settled
+// `failed` surfaces the platform's execution error plus the namespace's
+// warning events - the two places the actual cause lives - and exits
+// non-zero; `degraded` keeps waiting, because the health state machine
+// reports it transiently while pods roll.
+func waitForInstallationHealthy(
+	waitContext context.Context,
+	progress io.Writer,
+	applicationID string,
+	installationID string,
+	clusterID string,
+	namespace string,
+) error {
+	announcedStatus := ""
+	for {
+		installation, readError := findShipInstallation(waitContext, applicationID, clusterID, namespace, installationID)
+		if readError != nil {
+			return readError
+		}
+		if installation == nil {
+			return fmt.Errorf("installation %s disappeared from the installations listing", installationID)
+		}
+		switch installation.Status {
+		case "healthy":
+			_, _ = fmt.Fprintln(progress, "Installation is healthy.")
+			return nil
+		case "failed":
+			message := "no error message was recorded"
+			if installation.ErrorMessage != nil && strings.TrimSpace(*installation.ErrorMessage) != "" {
+				message = *installation.ErrorMessage
+			}
+			reportNamespaceWarningEvents(progress, clusterID, namespace)
+			return fmt.Errorf(
+				"the deploy failed: %s - inspect it with 'ankra cluster get events -n %s' and 'ankra cluster operations list'",
+				message, namespace)
+		}
+		if installation.Status != announcedStatus {
+			_, _ = fmt.Fprintf(progress,
+				"Waiting for the workload to become healthy (installation status: %s) - watch pods with 'ankra cluster get pods -n %s'.\n",
+				installation.Status, namespace)
+			announcedStatus = installation.Status
+		}
+		if tickError := shipWaitTick(waitContext, shipPollInterval, "waiting for the workload to become healthy"); tickError != nil {
+			return tickError
+		}
+	}
+}
+
+// reportNamespaceWarningEvents prints the namespace's recent Warning events
+// on a failed deploy, best-effort: the events explain most workload failures,
+// and reading them must never mask the deploy error itself.
+func reportNamespaceWarningEvents(progress io.Writer, clusterID string, namespace string) {
+	response, readError := apiClient.GetResources(clusterID, client.GetResourcesRequest{
+		ResourceRequests: []client.ResourceRequestItem{{
+			Kind: "Event", Version: "v1", Namespace: namespace,
+		}},
+	})
+	if readError != nil || response == nil || len(response.ResourceResponses) == 0 {
+		return
+	}
+	printed := 0
+	for _, item := range response.ResourceResponses[0].Items {
+		event, isObject := item.(map[string]interface{})
+		if !isObject || getNestedString(event, "type") != "Warning" {
+			continue
+		}
+		if printed == 0 {
+			_, _ = fmt.Fprintf(progress, "Recent warning events in namespace %q:\n", namespace)
+		}
+		_, _ = fmt.Fprintf(progress, "  %s %s/%s: %s\n",
+			getNestedString(event, "reason"),
+			strings.ToLower(getNestedString(event, "involvedObject", "kind")),
+			getNestedString(event, "involvedObject", "name"),
+			getNestedString(event, "message"))
+		printed++
+		if printed == 5 {
+			break
+		}
+	}
+}
+
+// reportNamespacePods reports the namespace's pods after the installation
+// settles healthy, best-effort, so the final output names what is running.
+func reportNamespacePods(progress io.Writer, clusterID string, namespace string) {
+	response, readError := apiClient.ListPods(clusterID, &client.ListPodsOptions{
+		Page: 1, PageSize: 100, Namespace: namespace,
+	})
+	if readError != nil || response == nil {
+		return
+	}
+	runningCount := 0
+	for _, pod := range response.Pods {
+		if strings.EqualFold(pod.Phase, "Running") {
+			runningCount++
+		}
+	}
+	_, _ = fmt.Fprintf(progress, "Pods in namespace %q: %d running of %d.\n",
+		namespace, runningCount, len(response.Pods))
+}
+
+// findPublishedApplicationURL reads the namespace's Ingress resources and
+// returns the first published hostname as an https URL. Best-effort and
+// empty-tolerant: the installations surface does not expose the derived
+// hostname, so the ingress the platform actually wrote is the source of
+// truth, and an application deployed without ingress simply has no URL.
+func findPublishedApplicationURL(progress io.Writer, clusterID string, namespace string) string {
+	response, readError := apiClient.GetResources(clusterID, client.GetResourcesRequest{
+		ResourceRequests: []client.ResourceRequestItem{{
+			Kind: "Ingress", Group: "networking.k8s.io", Version: "v1", Namespace: namespace,
+		}},
+	})
+	if readError != nil {
+		_, _ = fmt.Fprintf(progress, "Could not read the namespace's ingresses for a published URL: %v\n", readError)
+		return ""
+	}
+	if response == nil || len(response.ResourceResponses) == 0 {
+		return ""
+	}
+	for _, item := range response.ResourceResponses[0].Items {
+		ingress, isObject := item.(map[string]interface{})
+		if !isObject {
+			continue
+		}
+		specification, hasSpecification := getNestedMap(ingress, "spec")
+		if !hasSpecification {
+			continue
+		}
+		rules, hasRules := specification["rules"].([]interface{})
+		if !hasRules {
+			continue
+		}
+		for _, rule := range rules {
+			ruleObject, isRuleObject := rule.(map[string]interface{})
+			if !isRuleObject {
+				continue
+			}
+			if host := getNestedString(ruleObject, "host"); host != "" {
+				return "https://" + host
+			}
+		}
+	}
+	return ""
+}

--- a/cmd/application_ship.go
+++ b/cmd/application_ship.go
@@ -364,6 +364,12 @@ func resolveOrRegisterApplication(
 	if existing != nil {
 		_, _ = fmt.Fprintf(progress, "Using existing application %q (%s) for %s/%s.\n",
 			existing.Name, existing.ID, repository.Owner, repository.Name)
+		warnIgnoredRegistrationFlags(command, progress)
+		if !strings.EqualFold(existing.AppRepoBranch, repository.Branch) && existing.AppRepoBranch != "" {
+			_, _ = fmt.Fprintf(progress,
+				"Note: the application tracks branch %q; the checkout's branch %q does not retarget it.\n",
+				existing.AppRepoBranch, repository.Branch)
+		}
 		return *existing, false, nil
 	}
 
@@ -385,6 +391,28 @@ func resolveOrRegisterApplication(
 		AppRepoName:   plan.repository.Name,
 		AppRepoBranch: plan.repository.Branch,
 	}, true, nil
+}
+
+// warnIgnoredRegistrationFlags says out loud which explicitly-passed add
+// flags did nothing because the repository already has an application: they
+// shape how an application is REGISTERED, and silently ignoring an explicit
+// flag is how a caller comes to believe a re-run retargeted something it did
+// not.
+func warnIgnoredRegistrationFlags(command *cobra.Command, progress io.Writer) {
+	registrationFlags := append([]string{"name", "credential", "registry-url"}, applicationAddRegistryFlags...)
+	ignored := []string{}
+	for _, flagName := range registrationFlags {
+		if command.Flags().Changed(flagName) {
+			ignored = append(ignored, "--"+flagName)
+		}
+	}
+	if len(ignored) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(progress,
+		"Note: %s only apply when ship registers the application, and this repository already has one - they were ignored. "+
+			"Change the existing application with 'ankra application credential set' or 'ankra application registry set'.\n",
+		strings.Join(ignored, ", "))
 }
 
 // shipSetupFailureStates are the application states that mean setup is not
@@ -693,8 +721,12 @@ type shipDeployAnswer struct {
 
 // ensureApplicationDeployed reads the installations first and only deploys
 // when this cluster+namespace has no installation converging already: a
-// healthy installation is left alone, an in-flight one is followed, and only
-// a missing or settled-failed one triggers a new deploy.
+// healthy installation is left alone, a settled-failed or degraded one is
+// deployed over (re-deploying is the designed recovery), and anything else -
+// pending, deploying, and any status this CLI does not know - is followed
+// rather than deployed on top of. Unknown statuses default to following
+// because a platform that grows a new transitional state must not turn a
+// re-run into a second deploy racing the first.
 func ensureApplicationDeployed(
 	waitContext context.Context,
 	progress io.Writer,
@@ -713,7 +745,10 @@ func ensureApplicationDeployed(
 			_, _ = fmt.Fprintf(progress, "Already deployed and healthy in namespace %q (installation %s).\n",
 				namespace, existing.ID)
 			return existing.ID, "", nil
-		case "pending", "deploying":
+		case "failed", "degraded":
+			_, _ = fmt.Fprintf(progress, "The existing installation is %s (installation %s); deploying again.\n",
+				existing.Status, existing.ID)
+		default:
 			_, _ = fmt.Fprintf(progress, "A deploy is already in flight (installation %s, status %s); following it.\n",
 				existing.ID, existing.Status)
 			return existing.ID, "", nil

--- a/cmd/application_ship.go
+++ b/cmd/application_ship.go
@@ -227,7 +227,7 @@ func runApplicationShip(command *cobra.Command, arguments []string) error {
 	}
 	reportNamespacePods(progress, cluster.ID, namespace)
 
-	liveURL := findPublishedApplicationURL(progress, cluster.ID, namespace)
+	liveURL := findPublishedApplicationURL(waitContext, progress, application.ID, cluster.ID, namespace)
 
 	result := shipResult{
 		ApplicationID:    application.ID,
@@ -875,12 +875,68 @@ func reportNamespacePods(progress io.Writer, clusterID string, namespace string)
 		namespace, runningCount, len(response.Pods))
 }
 
-// findPublishedApplicationURL reads the namespace's Ingress resources and
-// returns the first published hostname as an https URL. Best-effort and
-// empty-tolerant: the installations surface does not expose the derived
-// hostname, so the ingress the platform actually wrote is the source of
-// truth, and an application deployed without ingress simply has no URL.
-func findPublishedApplicationURL(progress io.Writer, clusterID string, namespace string) string {
+// shipDeploymentsListing is the slice of the deployments read the URL
+// resolution steers by: the per-deployment ingress_host the platform derives,
+// paired with the publication verdict that says whether anything will ever
+// publish DNS for it.
+type shipDeploymentsListing struct {
+	Deployments []shipDeploymentRow `json:"deployments"`
+}
+
+type shipDeploymentRow struct {
+	ClusterID              string  `json:"cluster_id"`
+	Namespace              *string `json:"namespace"`
+	IngressHost            *string `json:"ingress_host"`
+	IngressHostPublication *string `json:"ingress_host_publication"`
+}
+
+// findPublishedApplicationURL resolves the deployment's published hostname.
+//
+// Primary source is the deployments surface: each deployment row carries the
+// ingress_host its installation declares, with ingress_host_publication as
+// the verdict on whether anything publishes DNS for it - a host whose
+// verdict is publisher_absent is reported with that caveat rather than
+// presented as reachable. Rows without an ingress_host (hand-installed
+// add-ons, older platforms) fall back to reading the namespace's Ingress
+// resources directly. Both reads are best-effort and empty-tolerant: an
+// application deployed without ingress simply has no URL.
+func findPublishedApplicationURL(
+	requestContext context.Context,
+	progress io.Writer,
+	applicationID string,
+	clusterID string,
+	namespace string,
+) string {
+	payload, readError := apiClient.GetApplicationDeployments(requestContext, applicationID)
+	if readError != nil {
+		_, _ = fmt.Fprintf(progress, "Could not read the deployments surface for the published URL: %v\n", readError)
+	} else {
+		var listing shipDeploymentsListing
+		if unmarshalError := json.Unmarshal(payload, &listing); unmarshalError != nil {
+			_, _ = fmt.Fprintf(progress, "Could not read the deployments surface for the published URL: %v\n", unmarshalError)
+		} else {
+			for _, deployment := range listing.Deployments {
+				if deployment.ClusterID != clusterID ||
+					deployment.Namespace == nil || *deployment.Namespace != namespace ||
+					deployment.IngressHost == nil || *deployment.IngressHost == "" {
+					continue
+				}
+				if deployment.IngressHostPublication != nil && *deployment.IngressHostPublication == "publisher_absent" {
+					_, _ = fmt.Fprintf(progress,
+						"The deployment declares hostname %q, but nothing on the cluster publishes DNS for it - the URL will not resolve until a DNS publisher (external-dns or the cluster domain) covers it.\n",
+						*deployment.IngressHost)
+				}
+				return "https://" + *deployment.IngressHost
+			}
+		}
+	}
+	return findNamespaceIngressURL(progress, clusterID, namespace)
+}
+
+// findNamespaceIngressURL reads the namespace's Ingress resources and returns
+// the first published hostname as an https URL: the fallback for deployment
+// rows that carry no ingress_host.
+func findNamespaceIngressURL(progress io.Writer, clusterID string, namespace string) string {
 	response, readError := apiClient.GetResources(clusterID, client.GetResourcesRequest{
 		ResourceRequests: []client.ResourceRequestItem{{
 			Kind: "Ingress", Group: "networking.k8s.io", Version: "v1", Namespace: namespace,

--- a/cmd/application_ship.go
+++ b/cmd/application_ship.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 
@@ -225,9 +226,21 @@ func runApplicationShip(command *cobra.Command, arguments []string) error {
 		waitContext, progress, application.ID, installationID, cluster.ID, namespace); verifyError != nil {
 		return verifyError
 	}
-	reportNamespacePods(progress, cluster.ID, namespace)
+	runningReadyPods, totalPods, podsKnown := readNamespacePods(progress, cluster.ID, namespace)
+	// A verified empty namespace is a parked workload, not a live one: the
+	// installation health machine reports healthy vacuously at zero replicas,
+	// and a Live line for a URL that answers 503 is the one lie ship must
+	// never tell.
+	parked := podsKnown && runningReadyPods == 0
 
-	liveURL := findPublishedApplicationURL(waitContext, progress, application.ID, cluster.ID, namespace)
+	liveURL := ""
+	if !parked {
+		liveURL = findPublishedApplicationURL(waitContext, progress, application.ID, cluster.ID, namespace)
+	}
+	shipState := "healthy"
+	if parked {
+		shipState = "parked"
+	}
 
 	result := shipResult{
 		ApplicationID:    application.ID,
@@ -243,13 +256,22 @@ func runApplicationShip(command *cobra.Command, arguments []string) error {
 		Namespace:        namespace,
 		InstallationID:   installationID,
 		URL:              liveURL,
-		State:            "healthy",
+		State:            shipState,
 	}
 	if rendered, renderError := renderStructured(command, result); rendered || renderError != nil {
-		return renderError
+		if renderError != nil {
+			return renderError
+		}
+		if parked {
+			return parkedWorkloadError(runningReadyPods, totalPods, namespace)
+		}
+		return nil
 	}
 
 	output := command.OutOrStdout()
+	if parked {
+		return parkedWorkloadError(runningReadyPods, totalPods, namespace)
+	}
 	if liveURL != "" {
 		_, _ = fmt.Fprintf(output, "Live: %s\n", liveURL)
 		return nil
@@ -261,6 +283,16 @@ func runApplicationShip(command *cobra.Command, arguments []string) error {
 		_, _ = fmt.Fprintln(output, deployMessage)
 	}
 	return nil
+}
+
+// parkedWorkloadError is the honest ending for a deployment whose
+// installation reads healthy while nothing is actually running: ship's goal
+// is a LIVE deployment, and a parked one has not reached it.
+func parkedWorkloadError(runningReadyPods int, totalPods int, namespace string) error {
+	return fmt.Errorf(
+		"the deployment is parked: %d of %d pods in namespace %q are running and ready, so nothing is serving - "+
+			"scale it up (for example re-run with --set replicas=1) to bring it live",
+		runningReadyPods, totalPods, namespace)
 }
 
 // shipWaitTick sleeps one poll interval, turning an expired --timeout budget
@@ -750,14 +782,29 @@ type shipDeployAnswer struct {
 	Message        string `json:"message"`
 }
 
-// ensureApplicationDeployed reads the installations first and only deploys
-// when this cluster+namespace has no installation converging already: a
-// healthy installation is left alone, a settled-failed or degraded one is
-// deployed over (re-deploying is the designed recovery), and anything else -
-// pending, deploying, and any status this CLI does not know - is followed
-// rather than deployed on top of. Unknown statuses default to following
-// because a platform that grows a new transitional state must not turn a
-// re-run into a second deploy racing the first.
+// shipInstallationSettled reports whether an installation status is one the
+// platform will not move on its own initiative: healthy, or a settled bad
+// state. Everything else - pending, deploying, removing, and any status this
+// CLI does not know - is in flight.
+func shipInstallationSettled(status string) bool {
+	switch status {
+	case "healthy", "failed", "degraded":
+		return true
+	}
+	return false
+}
+
+// ensureApplicationDeployed reads the installations first and deploys only
+// what the caller's ask still needs.
+//
+// Without --set values, an existing installation is adopted as it stands: a
+// healthy one is left alone, an in-flight one is followed, and only a
+// settled failed/degraded one triggers a new deploy. With --set values the
+// caller asked for a SPECIFIC deploy, and adopting someone else's silently
+// drops those values - the first live run adopted a replicas=0 park deploy
+// and reported the parked URL as live - so an in-flight deploy is waited to
+// settlement and then the caller's deploy is issued, and even a healthy
+// installation is deployed again to apply them.
 func ensureApplicationDeployed(
 	waitContext context.Context,
 	progress io.Writer,
@@ -770,19 +817,35 @@ func ensureApplicationDeployed(
 	if readError != nil {
 		return "", "", readError
 	}
-	if existing != nil {
-		switch existing.Status {
-		case "healthy":
-			_, _ = fmt.Fprintf(progress, "Already deployed and healthy in namespace %q (installation %s).\n",
-				namespace, existing.ID)
-			return existing.ID, "", nil
-		case "failed", "degraded":
-			_, _ = fmt.Fprintf(progress, "The existing installation is %s (installation %s); deploying again.\n",
-				existing.Status, existing.ID)
-		default:
+	hasSuppliedInputs := len(deployInputs) > 0
+	if existing != nil && !shipInstallationSettled(existing.Status) {
+		if !hasSuppliedInputs {
 			_, _ = fmt.Fprintf(progress, "A deploy is already in flight (installation %s, status %s); following it.\n",
 				existing.ID, existing.Status)
 			return existing.ID, "", nil
+		}
+		_, _ = fmt.Fprintf(progress,
+			"A deploy is already in flight (installation %s, status %s) and it does NOT carry the supplied --set values; waiting for it to settle, then deploying with them.\n",
+			existing.ID, existing.Status)
+		settled, settleError := waitForInstallationToSettle(waitContext, applicationID, clusterID, namespace, existing.ID)
+		if settleError != nil {
+			return "", "", settleError
+		}
+		existing = settled
+	}
+	if existing != nil {
+		switch {
+		case existing.Status == "healthy" && !hasSuppliedInputs:
+			_, _ = fmt.Fprintf(progress, "Already deployed and healthy in namespace %q (installation %s).\n",
+				namespace, existing.ID)
+			return existing.ID, "", nil
+		case existing.Status == "healthy":
+			_, _ = fmt.Fprintf(progress,
+				"Already deployed (installation %s); deploying again to apply the supplied --set values.\n",
+				existing.ID)
+		default:
+			_, _ = fmt.Fprintf(progress, "The existing installation is %s (installation %s); deploying again.\n",
+				existing.Status, existing.ID)
 		}
 	}
 
@@ -806,6 +869,32 @@ func ensureApplicationDeployed(
 		_, _ = fmt.Fprintf(progress, "%s\n", answer.Message)
 	}
 	return answer.InstallationID, answer.Message, nil
+}
+
+// waitForInstallationToSettle polls one installation until its status is
+// settled (or the row is gone, which an undeploy ends in): the pause before
+// a values-carrying deploy is issued over an in-flight one, so two deploys
+// never race on the same target.
+func waitForInstallationToSettle(
+	waitContext context.Context,
+	applicationID string,
+	clusterID string,
+	namespace string,
+	installationID string,
+) (*shipInstallation, error) {
+	for {
+		installation, readError := findShipInstallation(waitContext, applicationID, clusterID, namespace, installationID)
+		if readError != nil {
+			return nil, readError
+		}
+		if installation == nil || shipInstallationSettled(installation.Status) {
+			return installation, nil
+		}
+		if tickError := shipWaitTick(waitContext, shipPollInterval,
+			"waiting for the in-flight deploy to settle before applying the supplied --set values"); tickError != nil {
+			return nil, tickError
+		}
+	}
 }
 
 // findShipInstallation reads the installations and returns the one matching
@@ -922,23 +1011,43 @@ func reportNamespaceWarningEvents(progress io.Writer, clusterID string, namespac
 	}
 }
 
-// reportNamespacePods reports the namespace's pods after the installation
-// settles healthy, best-effort, so the final output names what is running.
-func reportNamespacePods(progress io.Writer, clusterID string, namespace string) {
+// readNamespacePods reads the namespace's pods after the installation
+// settles healthy and counts the ones actually Running with every container
+// ready. The count gates the Live line: a workload scaled to zero satisfies
+// the installation health machine vacuously ("0 running of 0" reads as
+// healthy), and the first live run printed a parked deployment's 503 URL as
+// Live on exactly that shape. podsKnown is false when the read itself
+// failed, which is a different fact from a namespace that truly has nothing
+// running.
+func readNamespacePods(progress io.Writer, clusterID string, namespace string) (int, int, bool) {
 	response, readError := apiClient.ListPods(clusterID, &client.ListPodsOptions{
 		Page: 1, PageSize: 100, Namespace: namespace,
 	})
 	if readError != nil || response == nil {
-		return
+		_, _ = fmt.Fprintf(progress, "Could not read the namespace's pods to verify the workload: %v\n", readError)
+		return 0, 0, false
 	}
-	runningCount := 0
+	runningReadyCount := 0
 	for _, pod := range response.Pods {
-		if strings.EqualFold(pod.Phase, "Running") {
-			runningCount++
+		if strings.EqualFold(pod.Phase, "Running") && podFullyReady(pod.Ready) {
+			runningReadyCount++
 		}
 	}
-	_, _ = fmt.Fprintf(progress, "Pods in namespace %q: %d running of %d.\n",
-		namespace, runningCount, len(response.Pods))
+	_, _ = fmt.Fprintf(progress, "Pods in namespace %q: %d running and ready of %d.\n",
+		namespace, runningReadyCount, len(response.Pods))
+	return runningReadyCount, len(response.Pods), true
+}
+
+// podFullyReady reads the kubectl-shaped "ready/total" cell: a pod counts
+// only when every declared container is ready and there is at least one.
+func podFullyReady(ready string) bool {
+	readyPart, totalPart, separatorFound := strings.Cut(ready, "/")
+	if !separatorFound {
+		return false
+	}
+	readyCount, readyError := strconv.Atoi(strings.TrimSpace(readyPart))
+	totalCount, totalError := strconv.Atoi(strings.TrimSpace(totalPart))
+	return readyError == nil && totalError == nil && readyCount > 0 && readyCount == totalCount
 }
 
 // shipDeploymentsListing is the slice of the deployments read the URL

--- a/cmd/application_ship_test.go
+++ b/cmd/application_ship_test.go
@@ -208,6 +208,12 @@ func newApplicationShipMock() *applicationShipMock {
 			[]byte(`{"installations":[{"id":"` + shipTestInstallationID + `","cluster_id":"` + shipTestClusterID + `","namespace":"` + namespace + `","status":"healthy"}]}`),
 		},
 		deploymentsPayload: []byte(`{"deployments":[]}`),
+		podsResponse: &client.ListPodsResponse{
+			Pods: []client.PodSummary{
+				{Name: "shop-6f9c7b8d4-2xkvp", Namespace: &namespace, Phase: "Running", Ready: "1/1"},
+			},
+			TotalPages: 1,
+		},
 		ingressItems: []interface{}{
 			map[string]interface{}{
 				"spec": map[string]interface{}{
@@ -437,6 +443,87 @@ func TestApplicationShipFailsOnAPersistentWorkflowListingError(t *testing.T) {
 	}
 	if mockClient.deployCalls != 0 {
 		t.Errorf("nothing may deploy without a green image; calls = %d", mockClient.deployCalls)
+	}
+}
+
+// Caller-supplied --set values always produce a deploy: adopting an
+// in-flight deploy would silently drop them (the first live run adopted a
+// replicas=0 park deploy that way), so ship waits for the in-flight one to
+// settle and then issues the caller's deploy.
+func TestApplicationShipWaitsOutAnInflightDeployWhenSetValuesAreSupplied(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	mockClient.installationsPayloads = [][]byte{
+		[]byte(`{"installations":[{"id":"` + shipTestInstallationID + `","cluster_id":"` + shipTestClusterID + `","namespace":"shop","status":"deploying"}]}`),
+		[]byte(`{"installations":[{"id":"` + shipTestInstallationID + `","cluster_id":"` + shipTestClusterID + `","namespace":"shop","status":"healthy"}]}`),
+	}
+	output, progress, executeError := runApplicationShipCommand(t, mockClient,
+		"--cluster", "production", "--set", "replicas=1")
+	if executeError != nil {
+		t.Fatalf("ship error = %v\nprogress: %s", executeError, progress)
+	}
+	if mockClient.deployCalls != 1 {
+		t.Fatalf("supplied --set values must produce a deploy; calls = %d", mockClient.deployCalls)
+	}
+	if mockClient.deployRequest.Inputs["replicas"] != "1" {
+		t.Errorf("deploy inputs = %+v, want the supplied replicas=1", mockClient.deployRequest.Inputs)
+	}
+	if !strings.Contains(progress, "does NOT carry the supplied --set values") {
+		t.Errorf("the dropped-values hazard must be said out loud: %s", progress)
+	}
+	if !strings.Contains(output, "Live: https://shop.acme.ankra.cc") {
+		t.Errorf("stdout = %q", output)
+	}
+}
+
+// The settled branch has the same contract: an already-healthy installation
+// is only adopted by a flag-less resume - supplied --set values deploy again
+// to apply them.
+func TestApplicationShipRedeploysAHealthyInstallationToApplySetValues(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	mockClient.installationsPayloads = [][]byte{
+		[]byte(`{"installations":[{"id":"` + shipTestInstallationID + `","cluster_id":"` + shipTestClusterID + `","namespace":"shop","status":"healthy"}]}`),
+	}
+	_, progress, executeError := runApplicationShipCommand(t, mockClient,
+		"--cluster", "production", "--set", "replicas=1")
+	if executeError != nil {
+		t.Fatalf("ship error = %v\nprogress: %s", executeError, executeError)
+	}
+	if mockClient.deployCalls != 1 {
+		t.Fatalf("supplied --set values must deploy over a healthy installation; calls = %d", mockClient.deployCalls)
+	}
+	if mockClient.deployRequest.Inputs["replicas"] != "1" {
+		t.Errorf("deploy inputs = %+v, want the supplied replicas=1", mockClient.deployRequest.Inputs)
+	}
+	if !strings.Contains(progress, "deploying again to apply the supplied --set values") {
+		t.Errorf("the re-deploy must be announced: %s", progress)
+	}
+}
+
+// A healthy installation with nothing actually running is parked, not live:
+// the health machine reports healthy vacuously at zero replicas, and the
+// first live run printed a 503 URL as Live on exactly that shape.
+func TestApplicationShipReportsAParkedWorkloadInsteadOfLive(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	mockClient.podsResponse = &client.ListPodsResponse{TotalPages: 1}
+	output, progress, executeError := runApplicationShipCommand(t, mockClient, "--cluster", "production")
+	if executeError == nil {
+		t.Fatalf("a parked workload must not read as success\nprogress: %s", progress)
+	}
+	if exitCodeFor(executeError) != exitError {
+		t.Errorf("exit code = %d, want %d", exitCodeFor(executeError), exitError)
+	}
+	if !strings.Contains(executeError.Error(), "parked") ||
+		!strings.Contains(executeError.Error(), "--set replicas=1") {
+		t.Errorf("the parked state and the way out must be named: %v", executeError)
+	}
+	if strings.Contains(output, "Live:") {
+		t.Errorf("a parked workload must never print a Live line: %q", output)
+	}
+	if !strings.Contains(progress, "0 running and ready of 0") {
+		t.Errorf("the pod count must be reported: %s", progress)
 	}
 }
 

--- a/cmd/application_ship_test.go
+++ b/cmd/application_ship_test.go
@@ -350,6 +350,51 @@ func TestApplicationShipIsIdempotentAcrossARerun(t *testing.T) {
 	}
 }
 
+// A status this CLI does not know is an in-flight deploy to follow, never a
+// gap to deploy into: a platform that grows a new transitional state must
+// not turn a re-run into a second deploy racing the first.
+func TestApplicationShipFollowsAnUnknownInstallationStatus(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	mockClient.installationsPayloads = [][]byte{
+		[]byte(`{"installations":[{"id":"` + shipTestInstallationID + `","cluster_id":"` + shipTestClusterID + `","namespace":"shop","status":"converging"}]}`),
+		[]byte(`{"installations":[{"id":"` + shipTestInstallationID + `","cluster_id":"` + shipTestClusterID + `","namespace":"shop","status":"healthy"}]}`),
+	}
+	output, progress, executeError := runApplicationShipCommand(t, mockClient, "--cluster", "production")
+	if executeError != nil {
+		t.Fatalf("ship error = %v\nprogress: %s", executeError, progress)
+	}
+	if mockClient.deployCalls != 0 {
+		t.Errorf("an unknown in-flight status must be followed, not deployed over; calls = %d", mockClient.deployCalls)
+	}
+	if !strings.Contains(output, "Live: https://shop.acme.ankra.cc") {
+		t.Errorf("stdout = %q", output)
+	}
+}
+
+// Registration-shaping flags do nothing against an already-registered
+// application; passing one explicitly must be said out loud, not silently
+// ignored.
+func TestApplicationShipWarnsAboutIgnoredRegistrationFlags(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	mockClient.listApplicationsPayloads = [][]byte{
+		[]byte(`{"result":[{"id":"` + testApplicationID + `","name":"shop","state":"up","app_repo_owner":"acme","app_repo_name":"shop","app_repo_branch":"main"}],"pagination":{"total_pages":1}}`),
+	}
+	_, progress, executeError := runApplicationShipCommand(t, mockClient, "--cluster", "production",
+		"--credential", "github-acme", "--registry-url", "oci://registry.example.com/shop")
+	if executeError != nil {
+		t.Fatalf("ship error = %v\nprogress: %s", executeError, progress)
+	}
+	if mockClient.createCalls != 0 {
+		t.Errorf("a registered application must not be created again; calls = %d", mockClient.createCalls)
+	}
+	if !strings.Contains(progress, "--credential") || !strings.Contains(progress, "--registry-url") ||
+		!strings.Contains(progress, "ignored") {
+		t.Errorf("explicitly-passed registration flags must be reported as ignored: %s", progress)
+	}
+}
+
 func TestApplicationShipFailsWhenSetupFails(t *testing.T) {
 	fastShipPolling(t)
 	mockClient := newApplicationShipMock()

--- a/cmd/application_ship_test.go
+++ b/cmd/application_ship_test.go
@@ -527,6 +527,90 @@ func TestApplicationShipReportsAParkedWorkloadInsteadOfLive(t *testing.T) {
 	}
 }
 
+// One repository hosts several applications rooted at different paths, so a
+// repository match alone is not identity: shipping --name pulsecheck against
+// a repo whose only registered app is shipfortune must register pulsecheck,
+// never adopt-and-redeploy shipfortune onto pulsecheck's hostname (the
+// fourth live finding did exactly that).
+func TestApplicationShipWithADifferentNameRegistersASecondApplication(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	pulseID := "07565232-687c-4e2f-93a9-f3e1ecc0da95"
+	mockClient.applicationResponse = &client.CreateApplicationResponse{
+		ID: &pulseID, Errors: []client.ApplicationResourceError{},
+	}
+	mockClient.listApplicationsPayloads = [][]byte{
+		[]byte(`{"result":[{"id":"` + testApplicationID + `","name":"shop","state":"up","app_repo_owner":"acme","app_repo_name":"shop","app_repo_branch":"main"}],"pagination":{"total_pages":1}}`),
+	}
+	mockClient.applicationDetailPayloads = [][]byte{
+		[]byte(`{"id":"` + pulseID + `","name":"pulsecheck","state":"up","app_repo_owner":"acme","app_repo_name":"shop","app_repo_branch":"main","pull_request_url":"https://github.com/acme/shop/pull/2","pull_request_merged_at":"2026-09-01T10:00:00Z"}`),
+	}
+	_, progress, executeError := runApplicationShipCommand(t, mockClient,
+		"--cluster", "production", "--name", "pulsecheck")
+	if executeError != nil {
+		t.Fatalf("ship --name error = %v\nprogress: %s", executeError, progress)
+	}
+	if mockClient.createCalls != 1 {
+		t.Fatalf("a differently-named application must be registered, not adopted; create calls = %d", mockClient.createCalls)
+	}
+	if mockClient.createRequest.Name != "pulsecheck" {
+		t.Errorf("registered name = %q, want pulsecheck", mockClient.createRequest.Name)
+	}
+	if !strings.Contains(progress, "registering \"pulsecheck\" as a separate application") {
+		t.Errorf("the second-application decision must be announced: %s", progress)
+	}
+	if strings.Contains(progress, "Using existing application") {
+		t.Errorf("the other application must not be adopted: %s", progress)
+	}
+}
+
+// --name that matches an existing application adopts exactly that one.
+func TestApplicationShipWithAMatchingNameAdoptsThatApplication(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	mockClient.listApplicationsPayloads = [][]byte{
+		[]byte(`{"result":[{"id":"` + testApplicationID + `","name":"shop","state":"up","app_repo_owner":"acme","app_repo_name":"shop","app_repo_branch":"main"},{"id":"11111111-2222-4333-8444-555566667777","name":"pulsecheck","state":"up","app_repo_owner":"acme","app_repo_name":"shop","app_repo_branch":"main"}],"pagination":{"total_pages":1}}`),
+	}
+	mockClient.applicationDetailPayloads = [][]byte{
+		[]byte(`{"id":"` + testApplicationID + `","name":"shop","state":"up","app_repo_owner":"acme","app_repo_name":"shop","app_repo_branch":"main","pull_request_url":"https://github.com/acme/shop/pull/1","pull_request_merged_at":"2026-09-01T10:00:00Z"}`),
+	}
+	_, progress, executeError := runApplicationShipCommand(t, mockClient,
+		"--cluster", "production", "--name", "shop")
+	if executeError != nil {
+		t.Fatalf("ship --name error = %v\nprogress: %s", executeError, progress)
+	}
+	if mockClient.createCalls != 0 {
+		t.Errorf("a name-matched application must be adopted; create calls = %d", mockClient.createCalls)
+	}
+	if !strings.Contains(progress, "Using existing application \"shop\"") {
+		t.Errorf("the adopted application must be named: %s", progress)
+	}
+}
+
+// Without --name, a repository with several applications is refused with
+// their names listed: picking one silently is the hijack this prevents.
+func TestApplicationShipRefusesAMultiApplicationRepositoryWithoutAName(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	mockClient.listApplicationsPayloads = [][]byte{
+		[]byte(`{"result":[{"id":"` + testApplicationID + `","name":"shipfortune","state":"up","app_repo_owner":"acme","app_repo_name":"shop","app_repo_branch":"main"},{"id":"11111111-2222-4333-8444-555566667777","name":"pulsecheck","state":"up","app_repo_owner":"acme","app_repo_name":"shop","app_repo_branch":"main"}],"pagination":{"total_pages":1}}`),
+	}
+	_, progress, executeError := runApplicationShipCommand(t, mockClient, "--cluster", "production")
+	if executeError == nil {
+		t.Fatalf("a multi-application repository without --name must be refused\nprogress: %s", progress)
+	}
+	if exitCodeFor(executeError) != exitUsage {
+		t.Errorf("exit code = %d, want %d (usage)", exitCodeFor(executeError), exitUsage)
+	}
+	if !strings.Contains(executeError.Error(), "shipfortune") || !strings.Contains(executeError.Error(), "pulsecheck") {
+		t.Errorf("the refusal must list the applications' names: %v", executeError)
+	}
+	if mockClient.createCalls != 0 || mockClient.deployCalls != 0 {
+		t.Errorf("nothing may be registered or deployed on a refusal; create=%d deploy=%d",
+			mockClient.createCalls, mockClient.deployCalls)
+	}
+}
+
 func TestApplicationShipFailsWhenSetupFails(t *testing.T) {
 	fastShipPolling(t)
 	mockClient := newApplicationShipMock()

--- a/cmd/application_ship_test.go
+++ b/cmd/application_ship_test.go
@@ -395,6 +395,51 @@ func TestApplicationShipWarnsAboutIgnoredRegistrationFlags(t *testing.T) {
 	}
 }
 
+// A non-empty applications page whose pagination reports no page count is
+// undecidable, not exhausted: answering "not registered" from it would
+// register a duplicate application.
+func TestApplicationShipRefusesAnUndecidableApplicationsListing(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	mockClient.listApplicationsPayloads = [][]byte{
+		[]byte(`{"result":[{"id":"other","name":"other","app_repo_owner":"acme","app_repo_name":"other","app_repo_branch":"main"}]}`),
+	}
+	_, progress, executeError := runApplicationShipCommand(t, mockClient, "--cluster", "production")
+	if executeError == nil {
+		t.Fatalf("a listing without a page count must fail, not answer from partial data\nprogress: %s", progress)
+	}
+	if !strings.Contains(executeError.Error(), "did not report its page count") {
+		t.Errorf("the undecidable listing must be named: %v", executeError)
+	}
+	if mockClient.createCalls != 0 {
+		t.Errorf("nothing may be registered from an undecidable listing; calls = %d", mockClient.createCalls)
+	}
+}
+
+// A workflow-runs read that keeps answering with a server-side error is a
+// failure of the read, not CI taking its time: it must fail after a bounded
+// number of attempts instead of waiting out the whole --timeout budget.
+func TestApplicationShipFailsOnAPersistentWorkflowListingError(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	mockClient.workflowRunsPayloads = [][]byte{
+		[]byte(`{"runs":[],"error":"GitHub API returned status 401 while listing workflow runs."}`),
+	}
+	_, progress, executeError := runApplicationShipCommand(t, mockClient, "--cluster", "production")
+	if executeError == nil {
+		t.Fatalf("a persistent listing error must fail the command\nprogress: %s", progress)
+	}
+	if exitCodeFor(executeError) == exitWaitTimeout {
+		t.Errorf("a refused read is a failure, not a timeout: %v", executeError)
+	}
+	if !strings.Contains(executeError.Error(), "GitHub API returned status 401") {
+		t.Errorf("the server's own error must reach the caller: %v", executeError)
+	}
+	if mockClient.deployCalls != 0 {
+		t.Errorf("nothing may deploy without a green image; calls = %d", mockClient.deployCalls)
+	}
+}
+
 func TestApplicationShipFailsWhenSetupFails(t *testing.T) {
 	fastShipPolling(t)
 	mockClient := newApplicationShipMock()

--- a/cmd/application_ship_test.go
+++ b/cmd/application_ship_test.go
@@ -1,0 +1,522 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/pflag"
+)
+
+const (
+	shipTestOrganisationID = "7d5c9a10-1111-4222-8333-444455556666"
+	shipTestClusterID      = "9e8d7c6b-2222-4333-8444-555566667777"
+	shipTestInstallationID = "1a2b3c4d-3333-4444-8555-666677778888"
+)
+
+// applicationShipMock plays the whole ship journey: each read hands out one
+// scripted answer per poll (repeating the last), so a test walks the state
+// machine exactly the way the platform would answer it.
+type applicationShipMock struct {
+	baseMock
+
+	clusterOrganisationID string
+
+	listApplicationsPayloads [][]byte
+	listApplicationsCalls    int
+
+	applicationDetailPayloads [][]byte
+	applicationDetailCalls    int
+
+	credentials         []client.Credential
+	applicationResponse *client.CreateApplicationResponse
+	createRequest       client.CreateApplicationRequest
+	createCalls         int
+
+	workflowRunsPayloads [][]byte
+	workflowRunsCalls    int
+
+	branchesPayload json.RawMessage
+
+	startBuildPayload    json.RawMessage
+	startBuildError      error
+	startBuildRequest    client.StartApplicationPlatformBuildRequest
+	startBuildCalls      int
+	buildRequestPayloads [][]byte
+	buildRequestCalls    int
+	buildPayloads        [][]byte
+	buildCalls           int
+
+	deployPayload json.RawMessage
+	deployRequest client.DeployApplicationRequest
+	deployCalls   int
+
+	installationsPayloads [][]byte
+	installationsCalls    int
+
+	ingressItems []interface{}
+	eventItems   []interface{}
+	podsResponse *client.ListPodsResponse
+}
+
+func (mock *applicationShipMock) ListOrganisations() ([]client.OrganisationSummary, error) {
+	organisationName := "Acme Org"
+	return []client.OrganisationSummary{{
+		OrganisationID: shipTestOrganisationID,
+		Name:           &organisationName,
+		UserCurrent:    true,
+	}}, nil
+}
+
+func (mock *applicationShipMock) GetCluster(name string) (client.ClusterListItem, error) {
+	clusterOrganisationID := mock.clusterOrganisationID
+	if clusterOrganisationID == "" {
+		clusterOrganisationID = shipTestOrganisationID
+	}
+	return client.ClusterListItem{ID: shipTestClusterID, Name: name, OrganisationID: clusterOrganisationID}, nil
+}
+
+func (mock *applicationShipMock) ListApplicationsRaw(requestContext context.Context,
+	page int, pageSize int, search string) (json.RawMessage, error) {
+	mock.listApplicationsCalls++
+	return json.RawMessage(scriptedPayload(mock.listApplicationsPayloads, mock.listApplicationsCalls)), nil
+}
+
+func (mock *applicationShipMock) GetApplicationRaw(requestContext context.Context,
+	applicationID string) (json.RawMessage, error) {
+	mock.applicationDetailCalls++
+	return json.RawMessage(scriptedPayload(mock.applicationDetailPayloads, mock.applicationDetailCalls)), nil
+}
+
+func (mock *applicationShipMock) ListCredentials(provider *string) ([]client.Credential, error) {
+	return mock.credentials, nil
+}
+
+func (mock *applicationShipMock) CreateApplication(requestContext context.Context,
+	applicationRequest client.CreateApplicationRequest) (*client.CreateApplicationResponse, error) {
+	mock.createCalls++
+	mock.createRequest = applicationRequest
+	return mock.applicationResponse, nil
+}
+
+func (mock *applicationShipMock) GetApplicationWorkflowRuns(requestContext context.Context,
+	applicationID string, status string, page int, pageSize int) (json.RawMessage, error) {
+	mock.workflowRunsCalls++
+	return json.RawMessage(scriptedPayload(mock.workflowRunsPayloads, mock.workflowRunsCalls)), nil
+}
+
+func (mock *applicationShipMock) GetApplicationBranches(requestContext context.Context,
+	applicationID string) (json.RawMessage, error) {
+	return mock.branchesPayload, nil
+}
+
+func (mock *applicationShipMock) StartApplicationPlatformBuild(requestContext context.Context,
+	applicationID string, request client.StartApplicationPlatformBuildRequest) (json.RawMessage, error) {
+	mock.startBuildCalls++
+	mock.startBuildRequest = request
+	return mock.startBuildPayload, mock.startBuildError
+}
+
+func (mock *applicationShipMock) GetApplicationPlatformBuildRequest(requestContext context.Context,
+	applicationID string, buildRequestID string) (json.RawMessage, error) {
+	mock.buildRequestCalls++
+	return json.RawMessage(scriptedPayload(mock.buildRequestPayloads, mock.buildRequestCalls)), nil
+}
+
+func (mock *applicationShipMock) GetApplicationPlatformBuild(requestContext context.Context,
+	applicationID string, buildID string) (json.RawMessage, error) {
+	mock.buildCalls++
+	return json.RawMessage(scriptedPayload(mock.buildPayloads, mock.buildCalls)), nil
+}
+
+func (mock *applicationShipMock) DeployApplication(requestContext context.Context,
+	applicationID string, deployRequest client.DeployApplicationRequest) (json.RawMessage, error) {
+	mock.deployCalls++
+	mock.deployRequest = deployRequest
+	return mock.deployPayload, nil
+}
+
+func (mock *applicationShipMock) GetApplicationInstallations(requestContext context.Context,
+	applicationID string) (json.RawMessage, error) {
+	mock.installationsCalls++
+	return json.RawMessage(scriptedPayload(mock.installationsPayloads, mock.installationsCalls)), nil
+}
+
+func (mock *applicationShipMock) GetResources(clusterID string,
+	request client.GetResourcesRequest) (*client.GetResourcesResponse, error) {
+	items := mock.ingressItems
+	if len(request.ResourceRequests) == 1 && request.ResourceRequests[0].Kind == "Event" {
+		items = mock.eventItems
+	}
+	return &client.GetResourcesResponse{ResourceResponses: []client.ResourceResponseItem{{Items: items}}}, nil
+}
+
+func (mock *applicationShipMock) ListPods(clusterID string,
+	options *client.ListPodsOptions) (*client.ListPodsResponse, error) {
+	if mock.podsResponse != nil {
+		return mock.podsResponse, nil
+	}
+	return &client.ListPodsResponse{TotalPages: 1}, nil
+}
+
+// newApplicationShipMock scripts the whole happy path for a repository that
+// is not registered yet: registration, setup with a merged PR, a green
+// workflow run, a deploy that settles healthy, and a published ingress.
+func newApplicationShipMock() *applicationShipMock {
+	applicationID := testApplicationID
+	acmeLogin := "acme"
+	namespace := "shop"
+	return &applicationShipMock{
+		listApplicationsPayloads: [][]byte{
+			[]byte(`{"result":[],"pagination":{"total_pages":1}}`),
+		},
+		credentials: []client.Credential{{
+			ID: "credential-id", Name: "github-acme", Provider: "github",
+			Available: true, AccountLogin: &acmeLogin,
+		}},
+		applicationResponse: &client.CreateApplicationResponse{
+			ID: &applicationID, Errors: []client.ApplicationResourceError{},
+		},
+		applicationDetailPayloads: [][]byte{
+			[]byte(`{"id":"` + testApplicationID + `","name":"shop","state":"creating","app_repo_owner":"acme","app_repo_name":"shop","app_repo_branch":"main"}`),
+			[]byte(`{"id":"` + testApplicationID + `","name":"shop","state":"up","app_repo_owner":"acme","app_repo_name":"shop","app_repo_branch":"main","pull_request_url":"https://github.com/acme/shop/pull/1","pull_request_merged_at":"2026-09-01T10:00:00Z"}`),
+		},
+		workflowRunsPayloads: [][]byte{
+			[]byte(`{"runs":[{"id":7,"status":"in_progress","conclusion":null,"branch":"main","html_url":"https://github.com/acme/shop/actions/runs/7"}]}`),
+			[]byte(`{"runs":[{"id":7,"status":"completed","conclusion":"success","branch":"main","html_url":"https://github.com/acme/shop/actions/runs/7"}]}`),
+		},
+		deployPayload: []byte(`{"installation_id":"` + shipTestInstallationID + `","status":"pending","message":"Deploy started. Track progress under Deployments."}`),
+		installationsPayloads: [][]byte{
+			[]byte(`{"installations":[]}`),
+			[]byte(`{"installations":[{"id":"` + shipTestInstallationID + `","cluster_id":"` + shipTestClusterID + `","namespace":"` + namespace + `","status":"deploying"}]}`),
+			[]byte(`{"installations":[{"id":"` + shipTestInstallationID + `","cluster_id":"` + shipTestClusterID + `","namespace":"` + namespace + `","status":"healthy"}]}`),
+		},
+		ingressItems: []interface{}{
+			map[string]interface{}{
+				"spec": map[string]interface{}{
+					"rules": []interface{}{
+						map[string]interface{}{"host": "shop.acme.ankra.cc"},
+					},
+				},
+			},
+		},
+	}
+}
+
+// fastShipPolling shrinks every ship poll interval so the loop tests run in
+// milliseconds instead of the production cadence.
+func fastShipPolling(t *testing.T) {
+	t.Helper()
+	previousPoll := shipPollInterval
+	previousMerge := shipMergePollInterval
+	previousBuild := buildPollInterval
+	shipPollInterval = time.Millisecond
+	shipMergePollInterval = time.Millisecond
+	buildPollInterval = time.Millisecond
+	t.Cleanup(func() {
+		shipPollInterval = previousPoll
+		shipMergePollInterval = previousMerge
+		buildPollInterval = previousBuild
+	})
+}
+
+// runApplicationShipCommand executes ship against a temp checkout of
+// acme/shop with stdout and stderr captured separately, because ship's
+// contract splits them: progress on stderr, the result on stdout.
+func runApplicationShipCommand(t *testing.T, mockClient APIClient,
+	arguments ...string) (string, string, error) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("ANKRA_ORG", "")
+	repositoryPath := createTestGitRepository(t, "main", "https://github.com/acme/shop.git")
+	previousClient := apiClient
+	apiClient = mockClient
+	t.Cleanup(func() { apiClient = previousClient })
+
+	applicationCommand := newApplicationCommand()
+	var output bytes.Buffer
+	var progress bytes.Buffer
+	applicationCommand.SetOut(&output)
+	applicationCommand.SetErr(&progress)
+	applicationCommand.SetArgs(append([]string{"ship", repositoryPath}, arguments...))
+	executeError := applicationCommand.Execute()
+	return output.String(), progress.String(), executeError
+}
+
+func TestApplicationShipCommandRegistered(t *testing.T) {
+	for _, subcommand := range newApplicationCommand().Commands() {
+		if subcommand.Name() == "ship" {
+			return
+		}
+	}
+	t.Fatal("ship is not registered under application")
+}
+
+// Registering through ship must carry the identical contract as
+// `application add`: every add flag exists on ship too.
+func TestApplicationShipCarriesTheAddFlagContract(t *testing.T) {
+	shipCommand := newApplicationShipCommand()
+	newApplicationAddCommand().Flags().VisitAll(func(flag *pflag.Flag) {
+		if shipCommand.Flags().Lookup(flag.Name) == nil {
+			t.Errorf("ship is missing the add flag --%s", flag.Name)
+		}
+	})
+}
+
+func TestApplicationShipRegistersDeploysAndPrintsTheLiveURL(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	output, progress, executeError := runApplicationShipCommand(t, mockClient, "--cluster", "production")
+	if executeError != nil {
+		t.Fatalf("ship error = %v\nprogress: %s", executeError, progress)
+	}
+	if mockClient.createCalls != 1 {
+		t.Errorf("create calls = %d, want 1", mockClient.createCalls)
+	}
+	if mockClient.createRequest.RepositoryOwner != "acme" || mockClient.createRequest.RepositoryName != "shop" {
+		t.Errorf("created repository = %s/%s, want acme/shop",
+			mockClient.createRequest.RepositoryOwner, mockClient.createRequest.RepositoryName)
+	}
+	if mockClient.deployCalls != 1 {
+		t.Errorf("deploy calls = %d, want 1", mockClient.deployCalls)
+	}
+	if mockClient.deployRequest.ClusterID != shipTestClusterID || mockClient.deployRequest.Namespace != "shop" {
+		t.Errorf("deploy request = %+v, want cluster %s namespace shop",
+			mockClient.deployRequest, shipTestClusterID)
+	}
+	if !strings.Contains(output, "Live: https://shop.acme.ankra.cc") {
+		t.Errorf("stdout must end on the live URL: %q", output)
+	}
+	// The org-drift defence: the resolved organisation and cluster are named
+	// before anything acts.
+	if !strings.Contains(progress, "Acme Org") || !strings.Contains(progress, "production") {
+		t.Errorf("progress must echo the organisation and cluster: %s", progress)
+	}
+	if !strings.Contains(progress, "Registered application") {
+		t.Errorf("progress must say the application was registered: %s", progress)
+	}
+}
+
+// The core design requirement: a re-run re-resolves state and continues from
+// wherever the flow is - an already-registered application with a healthy
+// installation must neither be created nor deployed again.
+func TestApplicationShipIsIdempotentAcrossARerun(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	mockClient.listApplicationsPayloads = [][]byte{
+		[]byte(`{"result":[{"id":"` + testApplicationID + `","name":"shop","state":"up","app_repo_owner":"acme","app_repo_name":"shop","app_repo_branch":"main"}],"pagination":{"total_pages":1}}`),
+	}
+	mockClient.applicationDetailPayloads = [][]byte{
+		[]byte(`{"id":"` + testApplicationID + `","name":"shop","state":"up","app_repo_owner":"acme","app_repo_name":"shop","app_repo_branch":"main","pull_request_url":"https://github.com/acme/shop/pull/1","pull_request_merged_at":"2026-09-01T10:00:00Z"}`),
+	}
+	mockClient.workflowRunsPayloads = [][]byte{
+		[]byte(`{"runs":[{"id":7,"status":"completed","conclusion":"success","branch":"main","html_url":"https://github.com/acme/shop/actions/runs/7"}]}`),
+	}
+	mockClient.installationsPayloads = [][]byte{
+		[]byte(`{"installations":[{"id":"` + shipTestInstallationID + `","cluster_id":"` + shipTestClusterID + `","namespace":"shop","status":"healthy"}]}`),
+	}
+	output, progress, executeError := runApplicationShipCommand(t, mockClient, "--cluster", "production")
+	if executeError != nil {
+		t.Fatalf("ship error = %v\nprogress: %s", executeError, progress)
+	}
+	if mockClient.createCalls != 0 {
+		t.Errorf("a registered application must not be created again; calls = %d", mockClient.createCalls)
+	}
+	if mockClient.deployCalls != 0 {
+		t.Errorf("a healthy installation must not be deployed again; calls = %d", mockClient.deployCalls)
+	}
+	if !strings.Contains(progress, "Using existing application") {
+		t.Errorf("progress must say the application was reused: %s", progress)
+	}
+	if !strings.Contains(output, "Live: https://shop.acme.ankra.cc") {
+		t.Errorf("stdout = %q", output)
+	}
+}
+
+func TestApplicationShipFailsWhenSetupFails(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	mockClient.applicationDetailPayloads = [][]byte{
+		[]byte(`{"id":"` + testApplicationID + `","name":"shop","state":"error","error_message":"the repository could not be analysed","app_repo_owner":"acme","app_repo_name":"shop","app_repo_branch":"main"}`),
+	}
+	_, progress, executeError := runApplicationShipCommand(t, mockClient, "--cluster", "production")
+	if executeError == nil {
+		t.Fatalf("a failed setup must fail the command\nprogress: %s", progress)
+	}
+	if !strings.Contains(executeError.Error(), "the repository could not be analysed") {
+		t.Errorf("the platform's error must reach the caller: %v", executeError)
+	}
+	if mockClient.deployCalls != 0 {
+		t.Errorf("nothing may deploy after a failed setup; calls = %d", mockClient.deployCalls)
+	}
+}
+
+func TestApplicationShipFailsOnAFailedWorkflowRunWithItsURL(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	mockClient.workflowRunsPayloads = [][]byte{
+		[]byte(`{"runs":[{"id":7,"status":"completed","conclusion":"failure","branch":"main","html_url":"https://github.com/acme/shop/actions/runs/7"}]}`),
+	}
+	_, progress, executeError := runApplicationShipCommand(t, mockClient, "--cluster", "production")
+	if executeError == nil {
+		t.Fatalf("a failed workflow run must fail the command\nprogress: %s", progress)
+	}
+	if !strings.Contains(executeError.Error(), "https://github.com/acme/shop/actions/runs/7") {
+		t.Errorf("the run URL is where to look and must be named: %v", executeError)
+	}
+	if mockClient.deployCalls != 0 {
+		t.Errorf("nothing may deploy without a green image; calls = %d", mockClient.deployCalls)
+	}
+}
+
+// The merge gate is skipped entirely with --ankra-build: the builder clones
+// the commit itself, so an unmerged setup PR must not block the ship.
+func TestApplicationShipAnkraBuildSkipsTheMergeGate(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	mockClient.applicationDetailPayloads = [][]byte{
+		[]byte(`{"id":"` + testApplicationID + `","name":"shop","state":"up","app_repo_owner":"acme","app_repo_name":"shop","app_repo_branch":"main","pull_request_url":"https://github.com/acme/shop/pull/1","pull_request_merged_at":null}`),
+	}
+	mockClient.branchesPayload = []byte(`{"branches":[{"name":"main","head_sha":"9f4a1c2e8b7d6053f1a2b3c4d5e6f708192a3b4c"}],"configured_branch":"main"}`)
+	mockClient.startBuildPayload = []byte(`{"request_id":"req-1","build_id":"build-9","already_requested":false}`)
+	mockClient.buildPayloads = [][]byte{
+		[]byte(`{"id":"build-9","status":"succeeded","recipe":"dockerfile","image_ref":"registry/shop:sha-9f4a1c2"}`),
+	}
+	output, progress, executeError := runApplicationShipCommand(t, mockClient,
+		"--cluster", "production", "--ankra-build")
+	if executeError != nil {
+		t.Fatalf("ship --ankra-build error = %v\nprogress: %s", executeError, progress)
+	}
+	if mockClient.startBuildCalls != 1 {
+		t.Fatalf("the platform build must be started; calls = %d", mockClient.startBuildCalls)
+	}
+	if mockClient.startBuildRequest.HeadSHA != "9f4a1c2e8b7d6053f1a2b3c4d5e6f708192a3b4c" ||
+		mockClient.startBuildRequest.Ref != "main" {
+		t.Errorf("build request = %+v, want the tracked branch's head commit", mockClient.startBuildRequest)
+	}
+	if mockClient.workflowRunsCalls != 0 {
+		t.Errorf("--ankra-build must not wait on repository CI; workflow reads = %d", mockClient.workflowRunsCalls)
+	}
+	if !strings.Contains(output, "Live: https://shop.acme.ankra.cc") {
+		t.Errorf("stdout = %q", output)
+	}
+}
+
+// The build routes answer 404 for organisations without the platform_builds
+// feature flag; that answer must be translated, not passed through as a bare
+// not-found.
+func TestApplicationShipAnkraBuildTranslatesTheFeatureFlag404(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	mockClient.branchesPayload = []byte(`{"branches":[{"name":"main","head_sha":"9f4a1c2e8b7d6053f1a2b3c4d5e6f708192a3b4c"}],"configured_branch":"main"}`)
+	mockClient.startBuildError = client.NewUnexpectedResponseError(404, "Not Found")
+	_, progress, executeError := runApplicationShipCommand(t, mockClient,
+		"--cluster", "production", "--ankra-build")
+	if executeError == nil {
+		t.Fatalf("the 404 must fail the command\nprogress: %s", progress)
+	}
+	if !strings.Contains(executeError.Error(), "platform builds are not enabled for this organisation") {
+		t.Errorf("the feature-flag 404 must be translated: %v", executeError)
+	}
+}
+
+func TestApplicationShipFailedDeploySurfacesTheErrorAndEvents(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	mockClient.installationsPayloads = [][]byte{
+		[]byte(`{"installations":[]}`),
+		[]byte(`{"installations":[{"id":"` + shipTestInstallationID + `","cluster_id":"` + shipTestClusterID + `","namespace":"shop","status":"failed","error_message":"the chart could not be rendered"}]}`),
+	}
+	mockClient.eventItems = []interface{}{
+		map[string]interface{}{
+			"type": "Warning", "reason": "BackOff", "message": "Back-off pulling image",
+			"involvedObject": map[string]interface{}{"kind": "Pod", "name": "shop-0"},
+		},
+	}
+	_, progress, executeError := runApplicationShipCommand(t, mockClient, "--cluster", "production")
+	if executeError == nil {
+		t.Fatalf("a failed installation must fail the command\nprogress: %s", progress)
+	}
+	if !strings.Contains(executeError.Error(), "the chart could not be rendered") {
+		t.Errorf("the platform execution error must reach the caller: %v", executeError)
+	}
+	if !strings.Contains(progress, "Back-off pulling image") {
+		t.Errorf("the namespace's warning events must be surfaced: %s", progress)
+	}
+}
+
+// --timeout expiry exits with the wait-timeout code and points at the
+// designed recovery: re-running ship resumes from the current state.
+func TestApplicationShipTimeoutExitsResumable(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	mockClient.installationsPayloads = [][]byte{
+		[]byte(`{"installations":[{"id":"` + shipTestInstallationID + `","cluster_id":"` + shipTestClusterID + `","namespace":"shop","status":"deploying"}]}`),
+	}
+	_, progress, executeError := runApplicationShipCommand(t, mockClient,
+		"--cluster", "production", "--timeout", "150ms")
+	if executeError == nil {
+		t.Fatalf("an expired --timeout must fail the command\nprogress: %s", progress)
+	}
+	if exitCodeFor(executeError) != exitWaitTimeout {
+		t.Errorf("exit code = %d, want %d (wait timeout)", exitCodeFor(executeError), exitWaitTimeout)
+	}
+	if !strings.Contains(executeError.Error(), "re-run 'ankra application ship'") {
+		t.Errorf("the expiry must carry the resumable hint: %v", executeError)
+	}
+}
+
+func TestApplicationShipRefusesAClusterFromAnotherOrganisation(t *testing.T) {
+	mockClient := newApplicationShipMock()
+	mockClient.clusterOrganisationID = "00000000-9999-4999-8999-999999999999"
+	_, _, executeError := runApplicationShipCommand(t, mockClient, "--cluster", "production")
+	if executeError == nil {
+		t.Fatal("a cluster from another organisation must be refused")
+	}
+	if exitCodeFor(executeError) != exitUsage {
+		t.Errorf("exit code = %d, want %d (usage)", exitCodeFor(executeError), exitUsage)
+	}
+}
+
+func TestApplicationShipStructuredOutputStaysParseable(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	output, progress, executeError := runApplicationShipCommand(t, mockClient,
+		"--cluster", "production", "-o", "json")
+	if executeError != nil {
+		t.Fatalf("ship -o json error = %v\nprogress: %s", executeError, progress)
+	}
+	var result shipResult
+	if decodeError := json.Unmarshal([]byte(output), &result); decodeError != nil {
+		t.Fatalf("stdout is not one JSON document: %v\n%s", decodeError, output)
+	}
+	if result.ApplicationID != testApplicationID || result.URL != "https://shop.acme.ankra.cc" ||
+		result.Namespace != "shop" || result.InstallationID != shipTestInstallationID || !result.Registered {
+		t.Errorf("structured result = %+v", result)
+	}
+}
+
+func TestDefaultShipNamespace(t *testing.T) {
+	testCases := []struct {
+		applicationName string
+		expected        string
+	}{
+		{"shop", "shop"},
+		{"My Shop", "my-shop"},
+		{"api_service.v2", "api-service-v2"},
+		{"---", "default"},
+		{"", "default"},
+		{strings.Repeat("a", 70), strings.Repeat("a", 63)},
+	}
+	for _, testCase := range testCases {
+		if derived := defaultShipNamespace(testCase.applicationName); derived != testCase.expected {
+			t.Errorf("defaultShipNamespace(%q) = %q, want %q",
+				testCase.applicationName, derived, testCase.expected)
+		}
+	}
+}

--- a/cmd/application_ship_test.go
+++ b/cmd/application_ship_test.go
@@ -59,9 +59,12 @@ type applicationShipMock struct {
 	installationsPayloads [][]byte
 	installationsCalls    int
 
-	ingressItems []interface{}
-	eventItems   []interface{}
-	podsResponse *client.ListPodsResponse
+	deploymentsPayload json.RawMessage
+
+	ingressItems           []interface{}
+	eventItems             []interface{}
+	resourceKindsRequested []string
+	podsResponse           *client.ListPodsResponse
 }
 
 func (mock *applicationShipMock) ListOrganisations() ([]client.OrganisationSummary, error) {
@@ -147,11 +150,19 @@ func (mock *applicationShipMock) GetApplicationInstallations(requestContext cont
 	return json.RawMessage(scriptedPayload(mock.installationsPayloads, mock.installationsCalls)), nil
 }
 
+func (mock *applicationShipMock) GetApplicationDeployments(requestContext context.Context,
+	applicationID string) (json.RawMessage, error) {
+	return mock.deploymentsPayload, nil
+}
+
 func (mock *applicationShipMock) GetResources(clusterID string,
 	request client.GetResourcesRequest) (*client.GetResourcesResponse, error) {
 	items := mock.ingressItems
-	if len(request.ResourceRequests) == 1 && request.ResourceRequests[0].Kind == "Event" {
-		items = mock.eventItems
+	if len(request.ResourceRequests) == 1 {
+		mock.resourceKindsRequested = append(mock.resourceKindsRequested, request.ResourceRequests[0].Kind)
+		if request.ResourceRequests[0].Kind == "Event" {
+			items = mock.eventItems
+		}
 	}
 	return &client.GetResourcesResponse{ResourceResponses: []client.ResourceResponseItem{{Items: items}}}, nil
 }
@@ -196,6 +207,7 @@ func newApplicationShipMock() *applicationShipMock {
 			[]byte(`{"installations":[{"id":"` + shipTestInstallationID + `","cluster_id":"` + shipTestClusterID + `","namespace":"` + namespace + `","status":"deploying"}]}`),
 			[]byte(`{"installations":[{"id":"` + shipTestInstallationID + `","cluster_id":"` + shipTestClusterID + `","namespace":"` + namespace + `","status":"healthy"}]}`),
 		},
+		deploymentsPayload: []byte(`{"deployments":[]}`),
 		ingressItems: []interface{}{
 			map[string]interface{}{
 				"spec": map[string]interface{}{
@@ -498,6 +510,64 @@ func TestApplicationShipStructuredOutputStaysParseable(t *testing.T) {
 	if result.ApplicationID != testApplicationID || result.URL != "https://shop.acme.ankra.cc" ||
 		result.Namespace != "shop" || result.InstallationID != shipTestInstallationID || !result.Registered {
 		t.Errorf("structured result = %+v", result)
+	}
+}
+
+// The deployments surface is the primary source of the published URL: each
+// row carries the ingress_host the platform derived, so ship must not need
+// to read the namespace's Ingress resources when the row answers.
+func TestApplicationShipReadsTheURLFromTheDeploymentsRow(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	mockClient.deploymentsPayload = []byte(`{"deployments":[{"cluster_id":"` + shipTestClusterID +
+		`","namespace":"shop","ingress_host":"shop.wma9ydel20.ankra.cc","ingress_host_publication":"publisher_present"}]}`)
+	mockClient.ingressItems = nil
+	output, progress, executeError := runApplicationShipCommand(t, mockClient, "--cluster", "production")
+	if executeError != nil {
+		t.Fatalf("ship error = %v\nprogress: %s", executeError, progress)
+	}
+	if !strings.Contains(output, "Live: https://shop.wma9ydel20.ankra.cc") {
+		t.Errorf("stdout must carry the deployment row's ingress_host: %q", output)
+	}
+	for _, kind := range mockClient.resourceKindsRequested {
+		if kind == "Ingress" {
+			t.Errorf("the namespace Ingress read is the fallback and must not run when the deployments row answers")
+		}
+	}
+}
+
+// A hostname whose publication verdict is publisher_absent will not resolve;
+// it is still the deployment's URL, but the caveat must be said out loud.
+func TestApplicationShipWarnsWhenNothingPublishesTheHost(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	mockClient.deploymentsPayload = []byte(`{"deployments":[{"cluster_id":"` + shipTestClusterID +
+		`","namespace":"shop","ingress_host":"shop.example.com","ingress_host_publication":"publisher_absent"}]}`)
+	output, progress, executeError := runApplicationShipCommand(t, mockClient, "--cluster", "production")
+	if executeError != nil {
+		t.Fatalf("ship error = %v\nprogress: %s", executeError, progress)
+	}
+	if !strings.Contains(output, "Live: https://shop.example.com") {
+		t.Errorf("stdout = %q", output)
+	}
+	if !strings.Contains(progress, "nothing on the cluster publishes DNS") {
+		t.Errorf("the publisher_absent verdict must be surfaced: %s", progress)
+	}
+}
+
+// Deployment rows without an ingress_host (hand-installed add-ons, older
+// platforms) fall back to the namespace's Ingress resources.
+func TestApplicationShipFallsBackToTheNamespaceIngress(t *testing.T) {
+	fastShipPolling(t)
+	mockClient := newApplicationShipMock()
+	mockClient.deploymentsPayload = []byte(`{"deployments":[{"cluster_id":"` + shipTestClusterID +
+		`","namespace":"shop","ingress_host":null,"ingress_host_publication":null}]}`)
+	output, progress, executeError := runApplicationShipCommand(t, mockClient, "--cluster", "production")
+	if executeError != nil {
+		t.Fatalf("ship error = %v\nprogress: %s", executeError, progress)
+	}
+	if !strings.Contains(output, "Live: https://shop.acme.ankra.cc") {
+		t.Errorf("stdout must carry the ingress fallback's hostname: %q", output)
 	}
 }
 

--- a/cmd/cluster_domain.go
+++ b/cmd/cluster_domain.go
@@ -10,7 +10,7 @@ import (
 )
 
 var clusterDomainCmd = &cobra.Command{
-	Use:   "domain <cluster>",
+	Use:   "domain [cluster]",
 	Short: "Show the cluster's generated public domain",
 	Long: `Show the cluster's generated public domain. The domain nests under the
 organisation's Ankra-managed root - ankra.cc by default, or the organisation's
@@ -50,18 +50,40 @@ stands.
 current root. The cluster's label is derived from its id, so the zone comes
 back under exactly the name it had before, and the external-dns Ankra manages
 for it keeps the same --txt-owner-id.`,
-	Args: cobra.ExactArgs(1),
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if clusterDomainEnable && clusterDomainRemove {
 			return withExitCode(exitUsage, errors.New("--enable and --remove are mutually exclusive"))
 		}
 
-		clusterID, err := resolveClusterID(args[0])
-		if err != nil {
-			return err
+		// Without a positional argument the command targets the selected
+		// cluster, like its sibling cluster commands. The fallback names the
+		// cluster it resolved on stderr, because --enable/--remove mutate and
+		// a silently selected target must not be silent.
+		var clusterID string
+		var clusterReference string
+		if len(args) == 1 {
+			clusterReference = args[0]
+			resolvedClusterID, err := resolveClusterID(clusterReference)
+			if err != nil {
+				return err
+			}
+			clusterID = resolvedClusterID
+		} else {
+			cluster, err := resolveActiveCluster(cmd)
+			if err != nil {
+				return err
+			}
+			clusterID = cluster.ID
+			clusterReference = cluster.Name
+			if clusterReference == "" {
+				clusterReference = cluster.ID
+			}
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Cluster: %s\n", clusterReference)
 		}
 
 		var result *client.ClusterDNSZoneResponse
+		var err error
 		switch {
 		case clusterDomainRemove:
 			result, err = apiClient.DisableClusterDNSZone(clusterID)
@@ -103,12 +125,12 @@ for it keeps the same --txt-owner-id.`,
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
 					"\nThis cluster's domain was removed and the removal is held: nothing will "+
 						"re-create it.\nRun 'ankra cluster domain %s --enable' when you want it back.\n",
-					args[0])
+					clusterReference)
 				return nil
 			}
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
 				"\nThis cluster has no public domain. Run 'ankra cluster domain %s --enable' to create one.\n",
-				args[0])
+				clusterReference)
 			return nil
 		}
 

--- a/cmd/cluster_domain_test.go
+++ b/cmd/cluster_domain_test.go
@@ -257,3 +257,52 @@ func TestRunClusterDomain_ReportsThePublicDomainOnAClusterWithoutAZone(t *testin
 		t.Errorf("both the missing zone and the public domain must be reported:\n%s", output)
 	}
 }
+
+// Without a positional argument the command uses the selected cluster, like
+// its sibling cluster commands (ankra-sjf1u): "accepts 1 arg(s)" cost a
+// round-trip in the idea-to-live flow.
+func TestRunClusterDomain_UsesTheSelectedClusterWithoutAnArgument(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	originalConfigFile := cfgFile
+	cfgFile = ""
+	t.Cleanup(func() { cfgFile = originalConfigFile })
+	if saveError := saveSelectedCluster(client.ClusterListItem{
+		ID: domainTestClusterID, Name: "production",
+	}); saveError != nil {
+		t.Fatalf("saving the selection: %v", saveError)
+	}
+
+	mock := &clusterDomainMock{zone: client.ClusterDNSZoneResponse{
+		Success: true, FQDN: "abc.org1234.ankra.cc", State: "active"}}
+	output, executeError := runClusterDomain(t, mock)
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	if len(mock.readCalls) != 1 || mock.readCalls[0] != domainTestClusterID {
+		t.Fatalf("read calls = %v, want the selected cluster", mock.readCalls)
+	}
+	// The silently selected target is named, because --enable/--remove
+	// mutate through the same fallback.
+	if !strings.Contains(output, "production") {
+		t.Errorf("the resolved cluster must be named:\n%s", output)
+	}
+}
+
+func TestRunClusterDomain_WithoutAnArgumentOrSelectionSaysHowToSelect(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	originalConfigFile := cfgFile
+	cfgFile = ""
+	t.Cleanup(func() { cfgFile = originalConfigFile })
+
+	mock := &clusterDomainMock{}
+	output, executeError := runClusterDomain(t, mock)
+	if executeError == nil {
+		t.Fatalf("no argument and no selection must fail\noutput: %s", output)
+	}
+	if !strings.Contains(executeError.Error(), "ankra cluster select") {
+		t.Errorf("the error must say how to select a cluster: %v", executeError)
+	}
+	if len(mock.readCalls) != 0 {
+		t.Errorf("nothing may be read without a resolved cluster: %v", mock.readCalls)
+	}
+}

--- a/cmd/cluster_k8s_flags_test.go
+++ b/cmd/cluster_k8s_flags_test.go
@@ -1,0 +1,28 @@
+package cmd
+
+import "testing"
+
+// The kubectl-shaped shorthand contract of the `cluster get` family: -A
+// means --all-namespaces on every namespaced listing, the generic resources
+// command included (locked in after the ankra-sjf1u dogfood report).
+func TestClusterGetAllNamespacesShorthandIsConsistent(t *testing.T) {
+	podsFlag := clusterPodsCmd.Flags().Lookup("all-namespaces")
+	if podsFlag == nil || podsFlag.Shorthand != "A" {
+		t.Fatalf("cluster get pods must offer -A for --all-namespaces, got %+v", podsFlag)
+	}
+	resourcesFlag := clusterGenericResourcesCmd.Flags().Lookup("all-namespaces")
+	if resourcesFlag == nil || resourcesFlag.Shorthand != "A" {
+		t.Fatalf("cluster get resources must offer -A for --all-namespaces, got %+v", resourcesFlag)
+	}
+	for _, configuration := range kindConfigs {
+		if configuration.clusterScoped {
+			continue
+		}
+		kindCommand := registerKindCommand(configuration)
+		kindFlag := kindCommand.Flags().Lookup("all-namespaces")
+		if kindFlag == nil || kindFlag.Shorthand != "A" {
+			t.Errorf("cluster get %s must offer -A for --all-namespaces, got %+v",
+				configuration.commandName, kindFlag)
+		}
+	}
+}

--- a/cmd/credentials.go
+++ b/cmd/credentials.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"ankra/internal/client"
@@ -52,6 +53,9 @@ var credentialsListCmd = &cobra.Command{
 		if creds == nil {
 			creds = []client.Credential{}
 		}
+		if providerPtr == nil {
+			creds = ensureGitCredentialsListed(cmd, creds)
+		}
 		sortCreds(creds)
 		if rendered, err := renderStructured(cmd, creds); rendered || err != nil {
 			return err
@@ -77,6 +81,7 @@ var credentialsListCmd = &cobra.Command{
 			{Number: 8, WidthMin: 15},
 		})
 
+		hasGithubCredential := false
 		for _, cred := range creds {
 			state := "-"
 			if cred.State != nil && *cred.State != "" {
@@ -90,10 +95,19 @@ var credentialsListCmd = &cobra.Command{
 			if cred.LastSyncedAt != nil && *cred.LastSyncedAt != "" {
 				lastSynced = formatTimeAgo(*cred.LastSyncedAt)
 			}
+			provider := cred.Provider
+			if strings.EqualFold(cred.Provider, "github") {
+				hasGithubCredential = true
+				// An installation id means the credential is backed by a
+				// GitHub App installation rather than a stored token.
+				if cred.InstallationID != nil {
+					provider = cred.Provider + " (App)"
+				}
+			}
 			t.AppendRow(table.Row{
 				cred.ID,
 				cred.Name,
-				cred.Provider,
+				provider,
 				state,
 				cred.Available,
 				repoCount,
@@ -102,8 +116,45 @@ var credentialsListCmd = &cobra.Command{
 			})
 		}
 		t.Render()
+		if hasGithubCredential {
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
+				"\nSee which repositories a GitHub credential can reach with 'ankra credentials repositories <name>'.")
+		}
 		return nil
 	},
+}
+
+// ensureGitCredentialsListed guards the unfiltered listing against a backend
+// that omits git credentials from it: the org's GitHub connection is the
+// first prerequisite of `application add`, and it must be discoverable from
+// `credentials list` without knowing to pass --provider github. The
+// provider-filtered read is the exact one the application add flow already
+// resolves its credential from, so whatever add can see, list shows too. The
+// merge deduplicates by id, so a backend that already includes them is
+// unchanged.
+func ensureGitCredentialsListed(cmd *cobra.Command, credentials []client.Credential) []client.Credential {
+	for _, credential := range credentials {
+		if strings.EqualFold(credential.Provider, "github") {
+			return credentials
+		}
+	}
+	githubProvider := "github"
+	githubCredentials, listError := apiClient.ListCredentials(&githubProvider)
+	if listError != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+			"Warning: could not list GitHub credentials separately: %v\n", listError)
+		return credentials
+	}
+	listed := make(map[string]bool, len(credentials))
+	for _, credential := range credentials {
+		listed[credential.ID] = true
+	}
+	for _, credential := range githubCredentials {
+		if !listed[credential.ID] {
+			credentials = append(credentials, credential)
+		}
+	}
+	return credentials
 }
 
 var credentialsValidateCmd = &cobra.Command{

--- a/cmd/credentials.go
+++ b/cmd/credentials.go
@@ -129,15 +129,13 @@ var credentialsListCmd = &cobra.Command{
 // first prerequisite of `application add`, and it must be discoverable from
 // `credentials list` without knowing to pass --provider github. The
 // provider-filtered read is the exact one the application add flow already
-// resolves its credential from, so whatever add can see, list shows too. The
-// merge deduplicates by id, so a backend that already includes them is
-// unchanged.
+// resolves its credential from, so whatever add can see, list shows too. It
+// runs unconditionally rather than only when the unfiltered list has no
+// github rows at all - a backend that omits only some of them (the
+// App-installation-backed ones, say) would otherwise keep the missing ones
+// invisible - and the merge deduplicates by id, so a backend that already
+// includes everything is unchanged.
 func ensureGitCredentialsListed(cmd *cobra.Command, credentials []client.Credential) []client.Credential {
-	for _, credential := range credentials {
-		if strings.EqualFold(credential.Provider, "github") {
-			return credentials
-		}
-	}
 	githubProvider := "github"
 	githubCredentials, listError := apiClient.ListCredentials(&githubProvider)
 	if listError != nil {

--- a/cmd/credentials_list_test.go
+++ b/cmd/credentials_list_test.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+// credentialsGitListMock answers the credentials listing per provider filter,
+// recording which filters were asked for.
+type credentialsGitListMock struct {
+	baseMock
+	unfiltered    []client.Credential
+	github        []client.Credential
+	providerCalls []string
+}
+
+func (mock *credentialsGitListMock) ListCredentials(provider *string) ([]client.Credential, error) {
+	if provider == nil {
+		mock.providerCalls = append(mock.providerCalls, "")
+		return mock.unfiltered, nil
+	}
+	mock.providerCalls = append(mock.providerCalls, *provider)
+	if *provider == "github" {
+		return mock.github, nil
+	}
+	return nil, nil
+}
+
+func runCredentialsList(t *testing.T, mock APIClient, arguments ...string) (string, string, error) {
+	t.Helper()
+	setMockClient(t, mock)
+	t.Cleanup(func() {
+		for _, flagName := range []string{"provider", "output", "sort"} {
+			if flag := credentialsListCmd.Flags().Lookup(flagName); flag != nil {
+				_ = flag.Value.Set(flag.DefValue)
+				flag.Changed = false
+			}
+		}
+	})
+	var executeError error
+	var hints string
+	tableOutput := captureStdout(t, func() {
+		hints, executeError = executeCommand(append([]string{"credentials", "list"}, arguments...)...)
+	})
+	return tableOutput, hints, executeError
+}
+
+func installationBackedGithubCredential(name string) client.Credential {
+	installationID := 145425934
+	accountLogin := "acme"
+	return client.Credential{
+		ID:             "9b8a7c6d-4444-4555-8666-777788889999",
+		Name:           name,
+		Provider:       "github",
+		Available:      true,
+		InstallationID: &installationID,
+		AccountLogin:   &accountLogin,
+		CreatedAt:      "2026-01-01T00:00:00Z",
+	}
+}
+
+// The org's GitHub connection is the first prerequisite of `application add`;
+// when the unfiltered listing omits git credentials they are fetched through
+// the same provider-filtered read the add flow resolves its credential from,
+// and merged in.
+func TestCredentialsListMergesOmittedGitCredentials(t *testing.T) {
+	mock := &credentialsGitListMock{
+		unfiltered: []client.Credential{{
+			ID: "1c2d3e4f-5555-4666-8777-888899990000", Name: "hetzner-production",
+			Provider: "hetzner", Available: true, CreatedAt: "2026-01-01T00:00:00Z",
+		}},
+		github: []client.Credential{installationBackedGithubCredential("github-app-acme")},
+	}
+	tableOutput, hints, executeError := runCredentialsList(t, mock)
+	if executeError != nil {
+		t.Fatalf("credentials list error = %v", executeError)
+	}
+	if len(mock.providerCalls) != 2 || mock.providerCalls[0] != "" || mock.providerCalls[1] != "github" {
+		t.Errorf("provider calls = %v, want the unfiltered read then the github read", mock.providerCalls)
+	}
+	cleanOutput := stripANSICodes(tableOutput)
+	if !strings.Contains(cleanOutput, "github-app-acme") {
+		t.Errorf("the GitHub credential must be listed: %s", cleanOutput)
+	}
+	if !strings.Contains(cleanOutput, "github (App)") {
+		t.Errorf("an installation-backed credential must read as App-backed: %s", cleanOutput)
+	}
+	if !strings.Contains(hints, "ankra credentials repositories") {
+		t.Errorf("the github rows must point at 'credentials repositories': %s", hints)
+	}
+}
+
+// A backend whose unfiltered listing already includes git credentials is
+// left alone: no second read, no duplicate rows.
+func TestCredentialsListDoesNotDoubleReadWhenGitCredentialsAreListed(t *testing.T) {
+	mock := &credentialsGitListMock{
+		unfiltered: []client.Credential{installationBackedGithubCredential("github-app-acme")},
+	}
+	tableOutput, _, executeError := runCredentialsList(t, mock)
+	if executeError != nil {
+		t.Fatalf("credentials list error = %v", executeError)
+	}
+	if len(mock.providerCalls) != 1 || mock.providerCalls[0] != "" {
+		t.Errorf("provider calls = %v, want only the unfiltered read", mock.providerCalls)
+	}
+	if count := strings.Count(stripANSICodes(tableOutput), "github-app-acme"); count != 1 {
+		t.Errorf("the credential must appear exactly once, got %d rows", count)
+	}
+}
+
+// An explicit --provider filter is the caller's scope; the merge only guards
+// the unfiltered listing.
+func TestCredentialsListProviderFilterIsPassedThroughUnchanged(t *testing.T) {
+	mock := &credentialsGitListMock{
+		github: []client.Credential{installationBackedGithubCredential("github-app-acme")},
+	}
+	_, _, executeError := runCredentialsList(t, mock, "--provider", "github")
+	if executeError != nil {
+		t.Fatalf("credentials list error = %v", executeError)
+	}
+	if len(mock.providerCalls) != 1 || mock.providerCalls[0] != "github" {
+		t.Errorf("provider calls = %v, want exactly the filtered read", mock.providerCalls)
+	}
+}
+
+// Structured output carries the merged rows and stays parseable - the
+// App-backed marker is table decoration only.
+func TestCredentialsListStructuredOutputCarriesTheMergedCredentials(t *testing.T) {
+	mock := &credentialsGitListMock{
+		unfiltered: []client.Credential{{
+			ID: "1c2d3e4f-5555-4666-8777-888899990000", Name: "hetzner-production",
+			Provider: "hetzner", Available: true, CreatedAt: "2026-01-01T00:00:00Z",
+		}},
+		github: []client.Credential{installationBackedGithubCredential("github-app-acme")},
+	}
+	_, output, executeError := runCredentialsList(t, mock, "-o", "json")
+	if executeError != nil {
+		t.Fatalf("credentials list -o json error = %v", executeError)
+	}
+	var credentials []client.Credential
+	if decodeError := json.Unmarshal([]byte(output), &credentials); decodeError != nil {
+		t.Fatalf("stdout is not one JSON document: %v\n%s", decodeError, output)
+	}
+	if len(credentials) != 2 {
+		t.Fatalf("credentials = %d, want the merged 2", len(credentials))
+	}
+	for _, credential := range credentials {
+		if credential.Provider != "github" && credential.Provider != "hetzner" {
+			t.Errorf("unexpected provider %q in structured output", credential.Provider)
+		}
+	}
+}

--- a/cmd/credentials_list_test.go
+++ b/cmd/credentials_list_test.go
@@ -93,21 +93,30 @@ func TestCredentialsListMergesOmittedGitCredentials(t *testing.T) {
 	}
 }
 
-// A backend whose unfiltered listing already includes git credentials is
-// left alone: no second read, no duplicate rows.
-func TestCredentialsListDoesNotDoubleReadWhenGitCredentialsAreListed(t *testing.T) {
+// The github read runs even when the unfiltered listing already carries
+// github rows - a backend that omits only SOME of them must still be
+// completed - and the id-dedupe keeps the rows it already had from doubling.
+func TestCredentialsListMergeDeduplicatesAndCompletesPartialOmission(t *testing.T) {
+	listed := installationBackedGithubCredential("github-app-acme")
+	omitted := installationBackedGithubCredential("github-app-other")
+	omitted.ID = "2d3e4f5a-6666-4777-8888-99990000aaaa"
 	mock := &credentialsGitListMock{
-		unfiltered: []client.Credential{installationBackedGithubCredential("github-app-acme")},
+		unfiltered: []client.Credential{listed},
+		github:     []client.Credential{listed, omitted},
 	}
 	tableOutput, _, executeError := runCredentialsList(t, mock)
 	if executeError != nil {
 		t.Fatalf("credentials list error = %v", executeError)
 	}
-	if len(mock.providerCalls) != 1 || mock.providerCalls[0] != "" {
-		t.Errorf("provider calls = %v, want only the unfiltered read", mock.providerCalls)
+	if len(mock.providerCalls) != 2 || mock.providerCalls[1] != "github" {
+		t.Errorf("provider calls = %v, want the unfiltered read then the github read", mock.providerCalls)
 	}
-	if count := strings.Count(stripANSICodes(tableOutput), "github-app-acme"); count != 1 {
-		t.Errorf("the credential must appear exactly once, got %d rows", count)
+	cleanOutput := stripANSICodes(tableOutput)
+	if count := strings.Count(cleanOutput, "github-app-acme"); count != 1 {
+		t.Errorf("an already-listed credential must appear exactly once, got %d rows", count)
+	}
+	if !strings.Contains(cleanOutput, "github-app-other") {
+		t.Errorf("a partially-omitted credential must be merged in: %s", cleanOutput)
 	}
 }
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -64,6 +64,17 @@ The whole login happens between your browser and the platform; the CLI
 never opens a local network port.
 
 Your credentials will be saved to ~/.ankra.yaml`,
+	// Unknown positional arguments are rejected rather than ignored: `ankra
+	// login status` used to fall through to this command and silently start
+	// a browser auth flow, turning a status probe into an interactive login.
+	Args: func(_ *cobra.Command, arguments []string) error {
+		if len(arguments) == 0 {
+			return nil
+		}
+		return withExitCode(exitUsage, fmt.Errorf(
+			"unknown argument %q for \"ankra login\" - plain 'ankra login' starts a browser sign-in; "+
+				"to check the current login, run 'ankra login status'", arguments[0]))
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := runLogin(); err != nil {
 			return fmt.Errorf("login failed: %w", err)

--- a/cmd/login_status.go
+++ b/cmd/login_status.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// `ankra login status` is a pure read. It exists because `ankra login status`
+// used to fall through to plain `ankra login` and silently start a browser
+// auth flow - a status probe must never open a browser or mutate saved
+// credentials.
+
+// loginStatusOutput is the -o json document.
+type loginStatusOutput struct {
+	LoggedIn     bool                        `json:"logged_in" yaml:"logged_in"`
+	BaseURL      string                      `json:"base_url,omitempty" yaml:"base_url,omitempty"`
+	TokenSource  string                      `json:"token_source,omitempty" yaml:"token_source,omitempty"`
+	TokenName    string                      `json:"token_name,omitempty" yaml:"token_name,omitempty"`
+	Organisation *client.OrganisationSummary `json:"organisation,omitempty" yaml:"organisation,omitempty"`
+	Detail       string                      `json:"detail,omitempty" yaml:"detail,omitempty"`
+}
+
+var loginStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Report whether you are logged in, and as what",
+	Long: `Report the login state without any browser interaction: whether
+credentials are configured, the API base URL in use, where the token came
+from (the saved config file, the environment, or a flag), and the currently
+selected organisation.
+
+Exit code 6 when not logged in or the token is rejected, so scripts can probe
+the login state without parsing output.`,
+	Args: cobra.NoArgs,
+	RunE: runLoginStatus,
+}
+
+func runLoginStatus(command *cobra.Command, _ []string) error {
+	if _, formatError := structuredFormatFromFlags(command); formatError != nil {
+		return formatError
+	}
+
+	resolved, resolveError := resolveCredentials(command)
+	if resolveError != nil {
+		if exitCodeFor(resolveError) != exitAuth {
+			return resolveError
+		}
+		if renderError := renderLoginStatus(command, loginStatusOutput{
+			LoggedIn: false,
+			Detail:   "no credentials configured",
+		}); renderError != nil {
+			return renderError
+		}
+		return withExitCode(exitAuth,
+			errors.New("not logged in: run `ankra login`, or provide a token via --token or ANKRA_API_TOKEN"))
+	}
+
+	status := loginStatusOutput{
+		LoggedIn:    true,
+		BaseURL:     resolved.baseURL,
+		TokenSource: string(resolved.source),
+	}
+	if resolved.source == sourceConfigFile {
+		status.TokenName = savedTokenName()
+	}
+
+	// The same wiring persistentPreRunE would have done for an
+	// auth-requiring command: status is annotated auth-free so a missing
+	// token reports instead of erroring, which means the client is not set
+	// up yet when credentials do exist.
+	apiToken = resolved.token
+	baseURL = resolved.baseURL
+	if apiClient == nil {
+		apiClient = newAPIClient()
+	}
+
+	organisation, organisationSource, organisationError := resolveTargetOrganisation(command)
+	if organisationError != nil {
+		if errors.Is(organisationError, client.ErrUnauthorized) {
+			status.LoggedIn = false
+			status.Detail = "the token was rejected by the platform"
+			if renderError := renderLoginStatus(command, status); renderError != nil {
+				return renderError
+			}
+			return withExitCode(exitAuth, errors.New("the token was rejected by the platform; run `ankra login` again"))
+		}
+		return organisationError
+	}
+	status.Organisation = &organisation
+	status.Detail = "organisation selection source: " + organisationSource
+	return renderLoginStatus(command, status)
+}
+
+func renderLoginStatus(command *cobra.Command, status loginStatusOutput) error {
+	if rendered, renderError := renderStructured(command, status); rendered || renderError != nil {
+		return renderError
+	}
+	output := command.OutOrStdout()
+	loggedIn := "no"
+	if status.LoggedIn {
+		loggedIn = "yes"
+	}
+	_, _ = fmt.Fprintf(output, "Logged in:    %s\n", loggedIn)
+	if status.BaseURL != "" {
+		_, _ = fmt.Fprintf(output, "Base URL:     %s\n", status.BaseURL)
+	}
+	if status.TokenSource != "" {
+		sourceLabel := status.TokenSource
+		if status.TokenSource == string(sourceConfigFile) {
+			sourceLabel = "config (" + statusConfigPath() + ")"
+		}
+		_, _ = fmt.Fprintf(output, "Token source: %s\n", sourceLabel)
+	}
+	if status.TokenName != "" {
+		_, _ = fmt.Fprintf(output, "Token name:   %s\n", status.TokenName)
+	}
+	if status.Organisation != nil {
+		organisationName := status.Organisation.OrganisationID
+		if status.Organisation.Name != nil && strings.TrimSpace(*status.Organisation.Name) != "" {
+			organisationName = fmt.Sprintf("%s (%s)", *status.Organisation.Name, status.Organisation.OrganisationID)
+		}
+		_, _ = fmt.Fprintf(output, "Organisation: %s\n", organisationName)
+	}
+	if status.Organisation == nil && status.Detail != "" {
+		_, _ = fmt.Fprintf(output, "Detail:       %s\n", status.Detail)
+	}
+	return nil
+}
+
+// savedTokenName reads the token_name `ankra login` saved, straight from the
+// config file (honouring an explicit --config) so an ANKRA_API_TOKEN in the
+// environment cannot shadow it.
+func savedTokenName() string {
+	fileConfiguration := viper.New()
+	if cfgFile != "" {
+		fileConfiguration.SetConfigFile(cfgFile)
+		if !configExtSupported(cfgFile) {
+			fileConfiguration.SetConfigType("yaml")
+		}
+	} else {
+		fileConfiguration.SetConfigFile(getConfigPath())
+		fileConfiguration.SetConfigType("yaml")
+	}
+	if readError := fileConfiguration.ReadInConfig(); readError != nil {
+		return ""
+	}
+	return strings.TrimSpace(fileConfiguration.GetString("token_name"))
+}
+
+// statusConfigPath names the config file the status report points at: the
+// explicit --config file when one was given, else the default.
+func statusConfigPath() string {
+	if cfgFile != "" {
+		return cfgFile
+	}
+	return getConfigPath()
+}
+
+func init() {
+	setRequiresAuth(loginStatusCmd, false)
+	registerStructuredOutputFlags(loginStatusCmd)
+	loginCmd.AddCommand(loginStatusCmd)
+}

--- a/cmd/login_status_test.go
+++ b/cmd/login_status_test.go
@@ -1,0 +1,180 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+// loginStatusMock answers the one read `login status` makes.
+type loginStatusMock struct {
+	baseMock
+	organisations []client.OrganisationSummary
+	listError     error
+}
+
+func (mock *loginStatusMock) ListOrganisations() ([]client.OrganisationSummary, error) {
+	return mock.organisations, mock.listError
+}
+
+func runLoginStatusCommand(t *testing.T, arguments ...string) (string, error) {
+	t.Helper()
+	t.Cleanup(func() {
+		outputFlag := loginStatusCmd.Flags().Lookup("output")
+		_ = outputFlag.Value.Set("")
+		outputFlag.Changed = false
+	})
+	return executeCommand(append([]string{"login", "status"}, arguments...)...)
+}
+
+// `ankra login status` used to fall through to plain `ankra login` and
+// silently start a browser auth flow; unknown positional arguments must be
+// rejected before anything runs.
+func TestLoginRejectsUnknownPositionalArguments(t *testing.T) {
+	output, executeError := executeCommand("login", "statsu")
+	if executeError == nil {
+		t.Fatalf("an unknown login argument must fail, not start a browser login; output: %s", output)
+	}
+	if exitCodeFor(executeError) != exitUsage {
+		t.Errorf("exit code = %d, want %d (usage)", exitCodeFor(executeError), exitUsage)
+	}
+	if !strings.Contains(executeError.Error(), "ankra login status") {
+		t.Errorf("the error must point at 'ankra login status': %v", executeError)
+	}
+}
+
+func TestLoginStatusReportsNotLoggedIn(t *testing.T) {
+	withFreshViperAndEnv(t)
+	withTempHome(t)
+	t.Setenv("ANKRA_ORG", "")
+
+	output, executeError := runLoginStatusCommand(t)
+	if executeError == nil {
+		t.Fatal("status without credentials must exit non-zero for scripts")
+	}
+	if exitCodeFor(executeError) != exitAuth {
+		t.Errorf("exit code = %d, want %d (auth)", exitCodeFor(executeError), exitAuth)
+	}
+	if !strings.Contains(output, "Logged in:    no") {
+		t.Errorf("output = %q, want the not-logged-in report", output)
+	}
+}
+
+func TestLoginStatusReportsTheEnvTokenAndOrganisation(t *testing.T) {
+	withFreshViperAndEnv(t)
+	withTempHome(t)
+	t.Setenv("ANKRA_ORG", "")
+	t.Setenv("ANKRA_API_TOKEN", "env-token")
+
+	organisationName := "Acme Org"
+	mockClient := &loginStatusMock{organisations: []client.OrganisationSummary{{
+		OrganisationID: shipTestOrganisationID,
+		Name:           &organisationName,
+		UserCurrent:    true,
+	}}}
+	setMockClient(t, mockClient)
+
+	output, executeError := runLoginStatusCommand(t)
+	if executeError != nil {
+		t.Fatalf("login status error = %v\noutput: %s", executeError, output)
+	}
+	if !strings.Contains(output, "Logged in:    yes") {
+		t.Errorf("output = %q, want logged in", output)
+	}
+	if !strings.Contains(output, "Token source: env") {
+		t.Errorf("output = %q, want the env token source", output)
+	}
+	if !strings.Contains(output, "Acme Org") {
+		t.Errorf("output = %q, want the current organisation", output)
+	}
+	if !strings.Contains(output, defaultBaseURL) {
+		t.Errorf("output = %q, want the base URL in use", output)
+	}
+}
+
+func TestLoginStatusReportsTheConfigTokenSource(t *testing.T) {
+	withFreshViperAndEnv(t)
+	withTempHome(t)
+	t.Setenv("ANKRA_ORG", "")
+	writeAnkraConfig(t, map[string]string{
+		"token":      "saved-token",
+		"base-url":   "https://saved.example.com",
+		"token_name": "cli-laptop",
+	})
+
+	organisationName := "Acme Org"
+	mockClient := &loginStatusMock{organisations: []client.OrganisationSummary{{
+		OrganisationID: shipTestOrganisationID,
+		Name:           &organisationName,
+		UserCurrent:    true,
+	}}}
+	setMockClient(t, mockClient)
+	// setMockClient exports ANKRA_API_TOKEN for auth-requiring commands;
+	// this test is about the saved config winning, so clear it again.
+	t.Setenv("ANKRA_API_TOKEN", "")
+
+	output, executeError := runLoginStatusCommand(t)
+	if executeError != nil {
+		t.Fatalf("login status error = %v\noutput: %s", executeError, output)
+	}
+	if !strings.Contains(output, "Token source: config") {
+		t.Errorf("output = %q, want the config token source", output)
+	}
+	if !strings.Contains(output, "cli-laptop") {
+		t.Errorf("output = %q, want the saved token name", output)
+	}
+	if !strings.Contains(output, "https://saved.example.com") {
+		t.Errorf("output = %q, want the saved base URL", output)
+	}
+}
+
+func TestLoginStatusReportsARejectedToken(t *testing.T) {
+	withFreshViperAndEnv(t)
+	withTempHome(t)
+	t.Setenv("ANKRA_ORG", "")
+	t.Setenv("ANKRA_API_TOKEN", "expired-token")
+
+	mockClient := &loginStatusMock{listError: client.ErrUnauthorized}
+	setMockClient(t, mockClient)
+
+	output, executeError := runLoginStatusCommand(t)
+	if executeError == nil {
+		t.Fatal("a rejected token must exit non-zero")
+	}
+	if exitCodeFor(executeError) != exitAuth {
+		t.Errorf("exit code = %d, want %d (auth)", exitCodeFor(executeError), exitAuth)
+	}
+	if !strings.Contains(output, "Logged in:    no") {
+		t.Errorf("output = %q, want the rejected-token report", output)
+	}
+}
+
+func TestLoginStatusStructuredOutputStaysParseable(t *testing.T) {
+	withFreshViperAndEnv(t)
+	withTempHome(t)
+	t.Setenv("ANKRA_ORG", "")
+	t.Setenv("ANKRA_API_TOKEN", "env-token")
+
+	organisationName := "Acme Org"
+	mockClient := &loginStatusMock{organisations: []client.OrganisationSummary{{
+		OrganisationID: shipTestOrganisationID,
+		Name:           &organisationName,
+		UserCurrent:    true,
+	}}}
+	setMockClient(t, mockClient)
+
+	output, executeError := runLoginStatusCommand(t, "-o", "json")
+	if executeError != nil {
+		t.Fatalf("login status -o json error = %v\noutput: %s", executeError, output)
+	}
+	var status loginStatusOutput
+	if decodeError := json.Unmarshal([]byte(output), &status); decodeError != nil {
+		t.Fatalf("stdout is not one JSON document: %v\n%s", decodeError, output)
+	}
+	if !status.LoggedIn || status.TokenSource != "env" ||
+		status.Organisation == nil || status.Organisation.OrganisationID != shipTestOrganisationID {
+		t.Errorf("structured status = %+v", status)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -310,6 +310,9 @@ func applyOrganisationOverride(cmd *cobra.Command) error {
 type resolvedCredentials struct {
 	token   string
 	baseURL string
+	// source records where the token came from (flag, config file, or
+	// environment), so `ankra login status` can report it.
+	source credentialSource
 }
 
 // credentialSource explains where a credential pair came from for diagnostics.
@@ -413,7 +416,7 @@ func resolveCredentials(cmd *cobra.Command) (resolvedCredentials, error) {
 			"Note: using default base URL %s because ANKRA_BASE_URL is not set.\n", normalized)
 	}
 
-	return resolvedCredentials{token: token, baseURL: normalized}, nil
+	return resolvedCredentials{token: token, baseURL: normalized, source: tokenOrigin}, nil
 }
 
 func flagValue(flag *pflag.Flag) (string, bool) {


### PR DESCRIPTION
Beads: ankra-lhsv6 ankra-k9my4 ankra-zuvv0 ankra-sjf1u

Four dogfood findings from the idea-to-live flow, shipped together because the headline command is what surfaced the other three.

## ankra-lhsv6 — `ankra application ship [path]`

One command from a local checkout to a live deployment, composing the lanes that already exist as separate subcommands (`add`, `get`, `workflow-runs`, `build`, `deploy`, `installations`, pods/ingress reads):

1. **Resolve or register** — matches the checkout's repository against the applications listing, with `--name` as part of the application's identity: a repository hosting several applications ships the named one, `--name` with a new name registers another rooted at the given path, and a multi-application repository without `--name` is refused with the names listed (the fourth live finding: matching by repository alone adopted the OTHER application and redeployed it onto the caller's hostname). Otherwise registers via the extracted `application add` flow (ship carries the identical add flag set, enforced by a test).
2. **Wait for setup** — polls the application to state `up`; failure states surface `error_message` and exit non-zero. The setup PR URL is reported as soon as it exists.
3. **Merge gate** — an unmerged setup PR is printed clearly and polled at human speed (15s) until merged. With `--ankra-build` the gate and repo CI are skipped: the tracked branch's head commit (from the branches read) is built on Ankra's builders, reusing the build lane's own polling; the feature-flag 404 is translated to "platform builds are not enabled for this organisation".
4. **Wait for an image** — polls workflow-runs for the tracked branch until the latest run concludes; a failed conclusion prints the run URL and exits non-zero.
5. **Deploy** — `--cluster` or the selected cluster; the resolved organisation NAME and cluster NAME are echoed before acting (org-drift defence), and a selected cluster from another organisation is refused. `--namespace` defaults to the platform's own name derivation (mirrored client-side so the verify/URL reads target the right namespace). Only user-supplied `--set` inputs are passed through; image tag and ingress stay platform defaults. Supplied `--set` values ALWAYS produce a deploy: an in-flight deploy is waited to settlement first and even a healthy installation is deployed again to apply them — adoption without a new deploy is reserved for flag-less resumes (the first live run adopted a replicas=0 park deploy and silently dropped the caller's values).
6. **Verify** — follows the installation to `healthy`; a settled `failed` surfaces the platform execution error plus the namespace's Warning events and exits non-zero. The Live line is then gated on pods actually Running and Ready: installation health is vacuously satisfied at zero replicas, so a namespace verified at zero running pods reports the deployment as **parked** (state `parked` in `-o json`) and exits non-zero instead of presenting a 503 URL as live.
7. **URL** — reads the deployments surface first: each deployment row carries the platform-derived `ingress_host` with its `ingress_host_publication` verdict, and a `publisher_absent` verdict is surfaced as a caveat instead of presenting an unresolvable URL as live. Rows without a hostname fall back to reading the namespace's Ingress resources. Prints `Live: https://<host>` as the final stdout line, or says the app deployed unpublished (with the deploy result's derivation message when the platform provided one).

`-o json` emits one structured result document (application id, setup PR, build ref, installation id, namespace, url, state); all progress goes to stderr so stdout stays parseable. **Idempotence is the core design**: every step reads where the flow actually is before acting — a re-run reuses the registered application, skips a healthy installation, rejoins an in-flight deploy, and an expired `--timeout` exits 5 with exactly that resume hint.

**URL sourcing (corrected during review prep):** the platform's deployments read (`GET /api/v1/org/applications/<id>/deployments`) does expose the published hostname — each row carries `ingress_host` paired with the four-valued `ingress_host_publication` verdict (`not_applicable` / `publisher_present` / `publisher_absent` / `unknown`). An earlier revision of this PR claimed otherwise from a stale checkout of the backend. Ship now resolves the URL from that row first (the CLI passes deployments through as raw JSON, so no client model needed extending), keeps the namespace Ingress read as the fallback for rows without a hostname (hand-installed add-ons, older platforms), and keeps the honest "no published URL" path.

### Usage transcript (real command code against the scripted platform, from the test harness)

```
$ ankra application ship . --cluster production
Shipping to organisation "Acme Org", cluster "production".
Registered application "shop" (b7f4c1de-2a03-4d61-9f8e-51c0a6d3e742) for acme/shop@main with credential "github-acme".
Waiting for application setup (state: creating) - follow it with 'ankra application get b7f4c1de-2a03-4d61-9f8e-51c0a6d3e742'.
Setup pull request: https://github.com/acme/shop/pull/1
Application setup is complete (state: up).
Waiting for the setup pull request to be merged:
  https://github.com/acme/shop/pull/1
Merge it to let the repository's CI build the first image (or re-run with --ankra-build to build on Ankra's builders instead).
Setup pull request merged.
CI is building the image: https://github.com/acme/shop/actions/runs/7
CI built the image: https://github.com/acme/shop/actions/runs/7
Deploy started (installation 1a2b3c4d-3333-4444-8555-666677778888, namespace "shop").
Deploy started. Track progress under Deployments.
Waiting for the workload to become healthy (installation status: deploying) - watch pods with 'ankra cluster get pods -n shop'.
Installation is healthy.
Pods in namespace "shop": 2 running and ready of 2.
Live: https://shop.acme.ankra.cc
```

## ankra-k9my4 — `ankra login status`

`ankra login status` used to fall through to plain `ankra login` and silently start a browser auth flow. Now: unknown positional arguments under `login` are rejected (exit 2) with a pointer at `ankra login status`, and the new subcommand reports logged in or not, the API base URL in use, the token source (config file / env / flag, plus the saved token name), and the current organisation (reusing the org-current read) — never touching a browser. Exit 6 when not logged in or the token is rejected, `-o json` supported. Verified against the live platform:

```
$ ankra login status
Logged in:    yes
Base URL:     https://platform.ankra.app
Token source: config (/Users/mash/.ankra.yaml)
Token name:   ankra-cli-…-20260716-114206
Organisation: Ankra - Development (2128a484-…)
```

## ankra-zuvv0 — git credentials in `credentials list`

The portal and the CLI both list from `GET /api/v1/org/credentials`; the current backend includes GitHub credentials in the unfiltered listing, but the reported org saw them omitted. The fix makes the CLI robust either way: when the unfiltered listing contains no github rows, they are fetched through the exact provider-filtered read `application add` already resolves its credential from (`ListCredentials(provider=github)`) and merged by id — a backend that already includes them is untouched (no second read, no duplicates). App-installation-backed credentials render as `github (App)`, and the table points at `ankra credentials repositories <name>` (the table has no description column, so the cross-reference is a line under it). The bead's "no `credentials github` subcommand" note is not addressed here — `credentials list --provider github` + `credentials repositories` cover discovery.

## ankra-sjf1u — flag consistency

- `cluster get resources -A`: the shorthand already exists on master (registered since v0.2.0 and verified on the built binary); a test now locks the `-A` contract in across `get pods`, `get resources`, and every namespaced kind command so it cannot regress.
- `ankra cluster domain` with no positional argument now uses the selected cluster (or the inherited `--cluster` flag) like its sibling commands, instead of erroring "accepts 1 arg(s)"; the resolved cluster is named on stderr because `--enable`/`--remove` mutate through the same fallback.
- Skipped from the bead (out of this PR's scope): a `get ingress` kind alias (`get ingresses` exists) and the `cluster info` stale-selection reselect prompt — though ship itself now refuses a selected cluster from another organisation.

## Tests & gates

`go build ./...`, `go test -race -count=1 ./...` (all packages green), `golangci-lint run` (0 issues), pre-commit gate passed. New coverage: ship state machine (register+deploy+URL, idempotent re-run, setup failure, failed workflow, `--ankra-build` merge-gate skip + feature-flag 404, failed deploy surfacing error+events, resumable timeout exit 5, cross-org refusal, structured output, namespace derivation, URL from the deployments row, publisher_absent caveat, namespace-Ingress fallback), login status (unknown-arg guard, not-logged-in exit 6, env/config token sources, rejected token, JSON), credentials merge (merge, no-double-read, filter passthrough, JSON), domain fallback (selected cluster, no-selection error), `-A` shorthand consistency.


