### PR TITLE
release: cut v0.15.0-rc0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Ankra CLI Changelog
 
-## Unreleased
+## v0.15.0-rc0 — 2026-09-01
 
 ### Added
 
@@ -53,6 +53,30 @@
   like its sibling cluster commands, instead of failing with
   "accepts 1 arg(s)"; the resolved cluster is named on stderr since
   `--enable`/`--remove` mutate through the same fallback.
+
+- **A deferred GitOps commit is no longer reported as a failed deploy.** When
+  the values repository has commits the platform has not synced yet, a stack
+  write is applied to the cluster and is live, and only the commit back to
+  Git waits on the background sync - the platform says so explicitly, with
+  "do not re-apply". The CLI still exited 1 on that answer, so CI marked
+  successful deploys red and retry wrappers re-applied the change the message
+  warns against. The CLI now reads the machine-readable `error_code` the
+  platform attaches (`GIT_PUSH_DEFERRED` vs `GIT_PUSH_FAILED`) and treats a
+  deferral as success: exit 0, the platform's message printed verbatim, and
+  `git_push_deferred`/`git_push_message` fields in `-o json`. This covers
+  every write that can defer - addons upgrade/uninstall/update, manifests
+  upgrade/disconnect, encrypt, stack variables, stack rename, and
+  `cluster apply` (including `migrate up`). Genuine push failures and older
+  platforms that send no `error_code` keep the non-zero exit they have today.
+  One deliberate exception: `cluster draft`'s bootstrap import needs the new
+  cluster's ID from the response, which a deferral does not carry, so it
+  reports the saved-but-deferred state and asks you to re-run instead of
+  staging drafts against an empty cluster.
+- **`ankra cluster info` finds clusters past the first page.** The name
+  lookup behind `cluster info` (and the selected-cluster fallback) only read
+  the first page of the organisation's clusters, so a cluster beyond it
+  reported "cluster not found" even though `cluster list` showed it; the
+  lookup now walks every page.
 
 ## v0.14.0 — 2026-08-31
 
@@ -136,24 +160,6 @@ The rc sections below carry the full detail.
 
 ### Fixed
 
-- **A deferred GitOps commit is no longer reported as a failed deploy.** When
-  the values repository has commits the platform has not synced yet, a stack
-  write is applied to the cluster and is live, and only the commit back to
-  Git waits on the background sync - the platform says so explicitly, with
-  "do not re-apply". The CLI still exited 1 on that answer, so CI marked
-  successful deploys red and retry wrappers re-applied the change the message
-  warns against. The CLI now reads the machine-readable `error_code` the
-  platform attaches (`GIT_PUSH_DEFERRED` vs `GIT_PUSH_FAILED`) and treats a
-  deferral as success: exit 0, the platform's message printed verbatim, and
-  `git_push_deferred`/`git_push_message` fields in `-o json`. This covers
-  every write that can defer - addons upgrade/uninstall/update, manifests
-  upgrade/disconnect, encrypt, stack variables, stack rename, and
-  `cluster apply` (including `migrate up`). Genuine push failures and older
-  platforms that send no `error_code` keep the non-zero exit they have today.
-  One deliberate exception: `cluster draft`'s bootstrap import needs the new
-  cluster's ID from the response, which a deferral does not carry, so it
-  reports the saved-but-deferred state and asks you to re-run instead of
-  staging drafts against an empty cluster.
 - **`control-plane get` answers the count and the instance type separately.**
   The platform can now resize a running cluster's controllers one at a time,
   so the two controls stopped having the same answer - but the CLI still


### PR DESCRIPTION
Cuts v0.15.0-rc0 (beta channel). Headline: `ankra application ship` — the one-shot idea-to-live command — plus `ankra login status`, GitHub credentials in `credentials list`, and `cluster domain` on the selected cluster (#216).

Changelog housekeeping per the placement-trap protocol: #210's deferred-GitOps entry moved out of the already-tagged rc8 section into this one (its notes never shipped it), and an entry written for #215 (cluster info pagination), which shipped none.

Extractor dry-run verified for `0.15.0-rc0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
