### PR TITLE
feat(chat): run ankra chat on the durable sessions API (ankra-y8l44.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Ankra CLI Changelog
 
+## Unreleased
+
+### Changed
+
+- **`ankra chat` runs on the durable chat sessions API** (`/api/v1/chat/sessions`),
+  the successor the deprecated bearer stream has advertised since July. The
+  backend now owns the transcript: interactive turns continue one server-side
+  conversation instead of resending the whole history every turn, a one-shot
+  answer prints the conversation id it started, and `--conversation <id>`
+  continues any conversation from `ankra chat history` (or a previous answer)
+  - which also makes `ankra chat actions list <id>` usable after a one-shot.
+  A dropped reply stream is resumed from its last durable event instead of
+  ending the turn. Backends without the lane fall back to the deprecated
+  stream, whose deprecation warning now prints once per process instead of
+  on every interactive turn. Error frames name their stable code (for
+  example `ai_platform_billing`); set `ANKRA_DEBUG=1` to also print the
+  operator detail.
+
+### Fixed
+
+- A persisted `ankra cluster select` pointing at a cluster that no longer
+  exists made `ankra chat` fail with a bare `404 Cluster not found`. Chat now
+  says which selection is stale, how to clear it, and continues without
+  cluster context; `ankra chat health` explains the stale selection instead
+  of a bare 404.
+- `ankra chat show` and `ankra chat delete` refuse a value that is not a
+  conversation id with a hint, instead of surfacing the backend's 422.
+- The org-switch test no longer writes `~/.ankra/organisation.json` into the
+  developer's real home directory.
+
 ## v0.15.0-rc0 — 2026-09-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
   A dropped reply stream is resumed from its last durable event instead of
   ending the turn. Backends without the lane fall back to the deprecated
   stream, whose deprecation warning now prints once per process instead of
-  on every interactive turn. Error frames name their stable code (for
+  on every interactive turn, and which says when a conversation id cannot
+  be continued there. Error frames name their stable code (for
   example `ai_platform_billing`); set `ANKRA_DEBUG=1` to also print the
   operator detail.
 

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -119,12 +119,14 @@ func staleSelectionNotice(scope chatScope) string {
 
 // openChatTurn starts the turn in the given scope, degrading a stale
 // persisted selection to the global lane once with a notice. It returns the
-// scope the turn actually ran in so callers keep it for the next turn.
+// scope the turn actually ran in so callers keep it for the next turn. The
+// sessions lane reports the stale cluster as ErrClusterNotFound; the
+// deprecated per-cluster stream answers a bare 404, so both shapes count.
 func openChatTurn(scope chatScope, conversationID string, req client.ChatRequest,
 	interactionMode string, errOut io.Writer) (<-chan client.ChatStreamEvent, bool, chatScope, error) {
 	events, onSessions, err := startChatTurn(conversationID, scope.clusterID, req, interactionMode)
-	if err != nil && scope.fromSelection && errors.Is(err, client.ErrClusterNotFound) {
-		fmt.Fprintln(errOut, staleSelectionNotice(scope))
+	if err != nil && scope.fromSelection && isNotFoundResponse(err) {
+		_, _ = fmt.Fprintln(errOut, staleSelectionNotice(scope))
 		scope = chatScope{}
 		events, onSessions, err = startChatTurn(conversationID, nil, req, interactionMode)
 	}
@@ -157,6 +159,8 @@ func runChatMessage(scope chatScope, conversationID string, query string, intera
 		} else {
 			fmt.Fprintf(os.Stderr, "conversation %s\n", conversationID)
 		}
+	} else if !startedConversation {
+		legacyLaneNotice(os.Stderr, conversationID, true)
 	}
 	if outcome.errorMessage != "" {
 		return errors.New(outcome.errorMessage)
@@ -165,6 +169,7 @@ func runChatMessage(scope chatScope, conversationID string, query string, intera
 }
 
 func runInteractiveChat(stdin io.Reader, scope chatScope, conversationID string, interactionMode string) error {
+	continued := conversationID != ""
 	if conversationID == "" {
 		generated, err := newChatUUID()
 		if err != nil {
@@ -195,6 +200,7 @@ func runInteractiveChat(stdin io.Reader, scope chatScope, conversationID string,
 	// The legacy lane still needs the history the server does not keep;
 	// the sessions lane ignores it.
 	var history []client.ChatMessage
+	legacyNoticed := false
 	reader := bufio.NewReader(stdin)
 
 	for {
@@ -236,12 +242,16 @@ func runInteractiveChat(stdin io.Reader, scope chatScope, conversationID string,
 			InteractionMode:     interactionMode,
 		}
 
-		events, _, nextScope, err := openChatTurn(scope, conversationID, req, interactionMode, os.Stderr)
+		events, onSessions, nextScope, err := openChatTurn(scope, conversationID, req, interactionMode, os.Stderr)
 		if err != nil {
 			fmt.Printf("Error: %v\n", err)
 			continue
 		}
 		scope = nextScope
+		if !onSessions && !legacyNoticed {
+			legacyNoticed = true
+			legacyLaneNotice(os.Stderr, conversationID, continued)
+		}
 
 		fmt.Print(text.FgGreen.Sprint("\nAssistant: "))
 		outcome := renderChatTurn(events, os.Stdout, os.Stderr, true)

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"strings"
 
@@ -51,37 +52,46 @@ var chatCmd = &cobra.Command{
 	Short: "AI-powered chat for troubleshooting and assistance",
 	Long: `AI-powered chat for troubleshooting and assistance.
 
-If a message is provided, sends a one-shot question.
+If a message is provided, sends a one-shot question and prints the
+conversation id so a follow-up can continue it with --conversation.
 If no message is provided, enters interactive chat mode.
 
-Use --cluster to provide cluster context for better answers.`,
+Use --cluster to provide cluster context for better answers; without it the
+persisted 'ankra cluster select' applies, and with neither the chat reads
+across the whole organisation.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clusterName, _ := cmd.Flags().GetString("cluster")
 		mode, _ := cmd.Flags().GetString("mode")
+		conversationID, _ := cmd.Flags().GetString("conversation")
 		interactionMode, modeError := normalizeChatMode(mode)
 		if modeError != nil {
 			return modeError
 		}
+		if conversationID != "" {
+			if err := validateConversationID(conversationID); err != nil {
+				return err
+			}
+			conversationID = strings.TrimSpace(conversationID)
+		}
 
-		var clusterID *string
+		var scope chatScope
 		if clusterName != "" {
 			cluster, err := apiClient.GetCluster(clusterName)
 			if err != nil {
 				return fmt.Errorf("finding cluster %s: %w", clusterName, err)
 			}
-			clusterID = &cluster.ID
-		} else {
-			selected, err := loadSelectedCluster()
-			if err == nil {
-				clusterID = &selected.ID
-			}
+			scope.clusterID = &cluster.ID
+		} else if selected, err := loadSelectedCluster(); err == nil {
+			scope.clusterID = &selected.ID
+			scope.fromSelection = true
+			scope.selectedName = selected.Name
 		}
 
 		if len(args) > 0 {
-			return runChatMessage(clusterID, args[0], interactionMode)
+			return runChatMessage(scope, conversationID, args[0], interactionMode)
 		}
-		return runInteractiveChat(clusterID, interactionMode)
+		return runInteractiveChat(cmd.InOrStdin(), scope, conversationID, interactionMode)
 	},
 }
 
@@ -100,84 +110,76 @@ func normalizeChatMode(mode string) (string, error) {
 	}
 }
 
-func runChatMessage(clusterID *string, query string, interactionMode string) error {
+// staleSelectionNotice tells the user the persisted cluster selection points
+// at a cluster the backend no longer knows, and how to clear it.
+func staleSelectionNotice(scope chatScope) string {
+	return fmt.Sprintf("note: the selected cluster %q no longer exists; chatting without cluster context. "+
+		"Run 'ankra cluster clear' to drop the selection, or pass --cluster.", scope.selectedName)
+}
+
+// openChatTurn starts the turn in the given scope, degrading a stale
+// persisted selection to the global lane once with a notice. It returns the
+// scope the turn actually ran in so callers keep it for the next turn.
+func openChatTurn(scope chatScope, conversationID string, req client.ChatRequest,
+	interactionMode string, errOut io.Writer) (<-chan client.ChatStreamEvent, bool, chatScope, error) {
+	events, onSessions, err := startChatTurn(conversationID, scope.clusterID, req, interactionMode)
+	if err != nil && scope.fromSelection && errors.Is(err, client.ErrClusterNotFound) {
+		fmt.Fprintln(errOut, staleSelectionNotice(scope))
+		scope = chatScope{}
+		events, onSessions, err = startChatTurn(conversationID, nil, req, interactionMode)
+	}
+	return events, onSessions, scope, err
+}
+
+func runChatMessage(scope chatScope, conversationID string, query string, interactionMode string) error {
+	startedConversation := conversationID == ""
+	if startedConversation {
+		generated, err := newChatUUID()
+		if err != nil {
+			return err
+		}
+		conversationID = generated
+	}
 	req := client.ChatRequest{Query: query, InteractionMode: interactionMode}
-	events, err := apiClient.StreamChat(clusterID, req)
+	events, onSessions, _, err := openChatTurn(scope, conversationID, req, interactionMode, os.Stderr)
 	if err != nil {
 		return fmt.Errorf("chat: %w", err)
 	}
 
 	fmt.Print("\n")
-	var hasStartedContent bool
-	var hadStatus bool
-	var streamErrorMessage string
-	for event := range events {
-		switch event.Type {
-		case "content":
-			// Data can be string content
-			if str, ok := event.Data.(string); ok {
-				if !hasStartedContent {
-					if hadStatus {
-						fmt.Print("\n") // New line after status before content
-					}
-					hasStartedContent = true
-				}
-				fmt.Print(str)
-			} else if event.Content != "" {
-				if !hasStartedContent {
-					if hadStatus {
-						fmt.Print("\n")
-					}
-					hasStartedContent = true
-				}
-				fmt.Print(event.Content)
-			}
-		case "status":
-			if status := chatStatusText(event.Data); status != "" {
-				if hasStartedContent {
-					fmt.Printf("\n\n[%s]\n\n", status)
-				} else {
-					fmt.Printf("[%s]", status)
-					hadStatus = true
-				}
-			}
-		case "action_proposal":
-			proposal, decodeError := decodeActionProposal(event.Data)
-			if decodeError != nil {
-				fmt.Printf("\nAn action is awaiting confirmation but could not be read: %v\n", decodeError)
-				continue
-			}
-			renderActionProposal(proposal)
-			fmt.Println("This write has NOT run. Confirm it to proceed:")
-			fmt.Printf("  ankra chat actions confirm %s\n", proposal.ActionID)
-			fmt.Printf("  ankra chat actions reject %s\n\n", proposal.ActionID)
-		case "error":
-			// Fail the command once the stream drains: errors belong on
-			// stderr with a non-zero exit, not lost in the transcript.
-			if streamErrorMessage == "" {
-				streamErrorMessage = chatErrorMessage(event)
-			}
-		case "done", "complete":
-			fmt.Print("\n\n")
-		default:
-			// Ignore triage, context and other metadata events
+	outcome := renderChatTurn(events, os.Stdout, os.Stderr, false)
+	fmt.Print("\n\n")
+	if onSessions {
+		// The id goes to stderr so a piped answer stays clean.
+		if startedConversation {
+			fmt.Fprintf(os.Stderr, "conversation %s (continue with: ankra chat --conversation %s \"...\")\n",
+				conversationID, conversationID)
+		} else {
+			fmt.Fprintf(os.Stderr, "conversation %s\n", conversationID)
 		}
 	}
-	if streamErrorMessage != "" {
-		if hasStartedContent {
-			fmt.Print("\n")
-		}
-		return errors.New(streamErrorMessage)
+	if outcome.errorMessage != "" {
+		return errors.New(outcome.errorMessage)
 	}
 	return nil
 }
 
-func runInteractiveChat(clusterID *string, interactionMode string) error {
+func runInteractiveChat(stdin io.Reader, scope chatScope, conversationID string, interactionMode string) error {
+	if conversationID == "" {
+		generated, err := newChatUUID()
+		if err != nil {
+			return err
+		}
+		conversationID = generated
+	}
 	fmt.Println("Ankra AI Chat")
 	fmt.Println("─────────────")
-	if clusterID != nil {
+	switch {
+	case scope.clusterID != nil && scope.selectedName != "":
+		fmt.Printf("Cluster context: %s (selected)\n", scope.selectedName)
+	case scope.clusterID != nil:
 		fmt.Println("Cluster context: active")
-	} else {
+	default:
 		fmt.Println("Cluster context: none (use --cluster to set)")
 	}
 	switch interactionMode {
@@ -186,11 +188,14 @@ func runInteractiveChat(clusterID *string, interactionMode string) error {
 	case "agentic":
 		fmt.Println("Mode: agent (can act)")
 	}
-	fmt.Println("Type 'exit' or 'quit' to exit, 'clear' to clear history")
+	fmt.Printf("Conversation: %s\n", conversationID)
+	fmt.Println("Type 'exit' or 'quit' to exit, 'clear' to start a new conversation")
 	fmt.Println()
 
+	// The legacy lane still needs the history the server does not keep;
+	// the sessions lane ignores it.
 	var history []client.ChatMessage
-	reader := bufio.NewReader(os.Stdin)
+	reader := bufio.NewReader(stdin)
 
 	for {
 		fmt.Print(text.FgCyan.Sprint("You: "))
@@ -215,83 +220,36 @@ func runInteractiveChat(clusterID *string, interactionMode string) error {
 			return nil
 		case "clear":
 			history = nil
-			fmt.Println("Chat history cleared.")
+			generated, genErr := newChatUUID()
+			if genErr != nil {
+				return genErr
+			}
+			conversationID = generated
+			fmt.Printf("Started a new conversation: %s\n", conversationID)
 			continue
 		}
 
-		// Add user message to history
 		history = append(history, client.ChatMessage{Role: "user", Content: input})
-
 		req := client.ChatRequest{
 			Query:               input,
 			ConversationHistory: history,
 			InteractionMode:     interactionMode,
 		}
 
-		events, err := apiClient.StreamChat(clusterID, req)
+		events, _, nextScope, err := openChatTurn(scope, conversationID, req, interactionMode, os.Stderr)
 		if err != nil {
 			fmt.Printf("Error: %v\n", err)
 			continue
 		}
+		scope = nextScope
 
 		fmt.Print(text.FgGreen.Sprint("\nAssistant: "))
-		var response strings.Builder
-		var hasStartedContent bool
-		var hadStatus bool
-		var pendingProposals []*client.ChatActionProposal
-		for event := range events {
-			switch event.Type {
-			case "content":
-				// Data can be string content
-				if str, ok := event.Data.(string); ok {
-					if !hasStartedContent {
-						if hadStatus {
-							fmt.Print("\n") // New line after status before content
-						}
-						hasStartedContent = true
-					}
-					fmt.Print(str)
-					response.WriteString(str)
-				} else if event.Content != "" {
-					if !hasStartedContent {
-						if hadStatus {
-							fmt.Print("\n")
-						}
-						hasStartedContent = true
-					}
-					fmt.Print(event.Content)
-					response.WriteString(event.Content)
-				}
-			case "status":
-				// Show status, don't add to response
-				if status := chatStatusText(event.Data); status != "" {
-					if hasStartedContent {
-						fmt.Printf("\n\n[%s]\n\n", status)
-					} else {
-						fmt.Printf("[%s]", status)
-						hadStatus = true
-					}
-				}
-			case "action_proposal":
-				proposal, decodeError := decodeActionProposal(event.Data)
-				if decodeError != nil {
-					fmt.Printf("\nAn action is awaiting confirmation but could not be read: %v\n", decodeError)
-					continue
-				}
-				pendingProposals = append(pendingProposals, proposal)
-			case "error":
-				fmt.Fprintf(os.Stderr, "\nError: %s\n", chatErrorMessage(event))
-			case "done", "complete":
-				// Add assistant response to history
-				if response.Len() > 0 {
-					history = append(history, client.ChatMessage{Role: "assistant", Content: response.String()})
-				}
-			default:
-				// Ignore triage, context and other metadata events
-			}
+		outcome := renderChatTurn(events, os.Stdout, os.Stderr, true)
+		if outcome.response != "" {
+			history = append(history, client.ChatMessage{Role: "assistant", Content: outcome.response})
 		}
 		fmt.Print("\n\n")
-		resolvePendingProposals(reader, pendingProposals)
+		resolvePendingProposals(reader, outcome.proposals)
 	}
 }
 
@@ -364,6 +322,9 @@ var chatShowCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		conversationID := args[0]
+		if err := validateConversationLookupID(conversationID); err != nil {
+			return err
+		}
 
 		conv, err := apiClient.GetChatConversation(conversationID)
 		if err != nil {
@@ -401,6 +362,9 @@ var chatDeleteCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		conversationID := args[0]
+		if err := validateConversationLookupID(conversationID); err != nil {
+			return err
+		}
 		yes, _ := cmd.Flags().GetBool("yes")
 
 		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
@@ -434,6 +398,9 @@ var chatHealthCmd = &cobra.Command{
 
 		health, err := apiClient.GetClusterHealth(cluster.ID, includeAI)
 		if err != nil {
+			if clusterFlagOverride(cmd) == "" && isNotFoundResponse(err) {
+				return fmt.Errorf("the selected cluster %q no longer exists; run 'ankra cluster clear' to drop the selection, or pass --cluster", cluster.Name)
+			}
 			return fmt.Errorf("getting cluster health: %w", err)
 		}
 
@@ -490,6 +457,7 @@ var chatHealthCmd = &cobra.Command{
 func init() {
 	chatCmd.Flags().String("cluster", "", "Cluster name for context")
 	chatCmd.Flags().String("mode", "", "Safety mode: 'ask' (read-only + safe creations) or 'agent' (can act). Defaults to the server default.")
+	chatCmd.Flags().String("conversation", "", "Continue an existing conversation (id from 'ankra chat history' or a previous answer)")
 
 	chatHistoryCmd.Flags().String("cluster", "", "Filter by cluster")
 	chatHistoryCmd.Flags().Int("limit", 20, "Maximum number of conversations to show")
@@ -507,4 +475,23 @@ func init() {
 	chatCmd.AddCommand(chatHealthCmd)
 
 	rootCmd.AddCommand(chatCmd)
+}
+
+// validateConversationLookupID refuses a conversation id the history
+// endpoints would answer 422 for, with the hint the raw status lacks.
+func validateConversationLookupID(conversationID string) error {
+	if looksLikeUUID(strings.TrimSpace(conversationID)) {
+		return nil
+	}
+	return fmt.Errorf("invalid conversation id %q: pass the id shown by 'ankra chat history'", conversationID)
+}
+
+// isNotFoundResponse reports a 404 from the API, whichever error shape the
+// client wrapped it in.
+func isNotFoundResponse(err error) bool {
+	if errors.Is(err, client.ErrClusterNotFound) {
+		return true
+	}
+	var unexpected *client.UnexpectedResponseError
+	return errors.As(err, &unexpected) && unexpected.StatusCode == http.StatusNotFound
 }

--- a/cmd/chat_session.go
+++ b/cmd/chat_session.go
@@ -112,15 +112,36 @@ func startChatTurn(conversationID string, clusterID *string, req client.ChatRequ
 	req.ConversationHistory = nil
 	submitted, err := apiClient.SubmitChatTurn(session.ID, req)
 	if err != nil {
+		// The session opened two calls ago now carries no turn: release it
+		// instead of leaving it pending until it expires. Best-effort - the
+		// submit error is the one to report.
+		_ = apiClient.CancelChatSession(session.ID)
 		return nil, true, err
 	}
 	return tailChatSession(session.ID, submitted.LastSeq), true, nil
 }
 
+// retryableTailError reports whether a failed tail open is worth re-opening:
+// a transport failure or a 5xx is; a 4xx (the token rejected, the session
+// or the lane gone) answers the same way every time.
+func retryableTailError(err error) bool {
+	if errors.Is(err, client.ErrUnauthorized) || errors.Is(err, client.ErrChatSessionsUnavailable) ||
+		errors.Is(err, client.ErrClusterNotFound) {
+		return false
+	}
+	var unexpected *client.UnexpectedResponseError
+	if errors.As(err, &unexpected) && unexpected.StatusCode >= 400 && unexpected.StatusCode < 500 {
+		return false
+	}
+	return true
+}
+
 // tailChatSession follows the session's durable event log until the
 // terminal "end" frame, re-opening the tail from the last sequence it saw
 // when the connection drops (the runner keeps working server-side and the
-// log keeps every frame, so nothing is lost across a reconnect).
+// log keeps every frame, so nothing is lost across a reconnect). The
+// reconnect budget bounds consecutive failures: a re-opened tail that
+// delivers a durable frame has resumed, and a later drop starts over.
 func tailChatSession(sessionID string, since int64) <-chan client.ChatStreamEvent {
 	out := make(chan client.ChatStreamEvent, 100)
 	go func() {
@@ -129,7 +150,7 @@ func tailChatSession(sessionID string, since int64) <-chan client.ChatStreamEven
 		for {
 			events, err := apiClient.StreamChatSessionEvents(sessionID, since)
 			if err != nil {
-				if reconnects < chatTailMaxReconnects && !errors.Is(err, client.ErrUnauthorized) {
+				if reconnects < chatTailMaxReconnects && retryableTailError(err) {
 					reconnects++
 					time.Sleep(time.Duration(reconnects) * chatTailReconnectDelay)
 					continue
@@ -137,29 +158,31 @@ func tailChatSession(sessionID string, since int64) <-chan client.ChatStreamEven
 				out <- client.ChatStreamEvent{Type: "error", Error: err.Error()}
 				return
 			}
-			dropped := false
 			for event := range events {
-				if event.Sequence > since {
-					since = event.Sequence
-				}
 				// A local stream failure (read error, idle watchdog) carries
 				// Error and no payload: that is a drop to resume from, not a
 				// backend verdict to show.
 				if event.Type == "error" && event.Error != "" && event.Data == nil {
-					dropped = true
 					break
+				}
+				// The backend serves `since` exclusively (events strictly
+				// after the cursor), so a durable frame at or below it can
+				// only be a replay: skip it rather than render it twice.
+				if event.Sequence != 0 && event.Sequence <= since {
+					continue
+				}
+				if event.Sequence > since {
+					since = event.Sequence
+					reconnects = 0
 				}
 				out <- event
 				if event.Type == "end" {
 					return
 				}
 			}
-			if !dropped {
-				// The tail closed cleanly without an end frame: the server
-				// finished its response window; resume to catch the rest.
-				dropped = true
-			}
-			if dropped && reconnects >= chatTailMaxReconnects {
+			// Dropped, or closed cleanly without an end frame (the server
+			// finished its response window): resume from the cursor.
+			if reconnects >= chatTailMaxReconnects {
 				out <- client.ChatStreamEvent{Type: "error",
 					Error: "the reply stream dropped and could not be resumed; the turn may still finish - check 'ankra chat show'"}
 				return
@@ -169,6 +192,20 @@ func tailChatSession(sessionID string, since int64) <-chan client.ChatStreamEven
 		}
 	}()
 	return out
+}
+
+// legacyLaneNotice says what the deprecated stream cannot do with a
+// conversation id: that backend keeps no transcript to continue, so a
+// --conversation continuation runs without its earlier context, and the id
+// an interactive run prints cannot be continued later.
+func legacyLaneNotice(errOut io.Writer, conversationID string, continued bool) {
+	if continued {
+		_, _ = fmt.Fprintf(errOut, "note: this backend has no durable chat sessions; conversation %s "+
+			"cannot be continued here, so this turn runs without its earlier context.\n", conversationID)
+		return
+	}
+	_, _ = fmt.Fprintf(errOut, "note: this backend has no durable chat sessions; conversation %s "+
+		"is local to this run and cannot be continued with --conversation.\n", conversationID)
 }
 
 // chatErrorDetail renders the operator-facing detail a sessions-lane error
@@ -206,18 +243,18 @@ func renderChatTurn(events <-chan client.ChatStreamEvent, out io.Writer, errOut 
 		}
 		if !hasStartedContent {
 			if hadStatus {
-				fmt.Fprint(out, "\n")
+				_, _ = fmt.Fprint(out, "\n")
 			}
 			hasStartedContent = true
 		}
-		fmt.Fprint(out, text)
+		_, _ = fmt.Fprint(out, text)
 		response.WriteString(text)
 	}
 	printLine := func(line string) {
 		if hasStartedContent {
-			fmt.Fprintf(out, "\n\n[%s]\n\n", line)
+			_, _ = fmt.Fprintf(out, "\n\n[%s]\n\n", line)
 		} else {
-			fmt.Fprintf(out, "[%s]", line)
+			_, _ = fmt.Fprintf(out, "[%s]", line)
 			hadStatus = true
 		}
 	}
@@ -242,7 +279,7 @@ func renderChatTurn(events <-chan client.ChatStreamEvent, out io.Writer, errOut 
 		case "action_proposal":
 			proposal, decodeError := decodeActionProposal(event.Data)
 			if decodeError != nil {
-				fmt.Fprintf(out, "\nAn action is awaiting confirmation but could not be read: %v\n", decodeError)
+				_, _ = fmt.Fprintf(out, "\nAn action is awaiting confirmation but could not be read: %v\n", decodeError)
 				continue
 			}
 			if collectProposals {
@@ -250,9 +287,9 @@ func renderChatTurn(events <-chan client.ChatStreamEvent, out io.Writer, errOut 
 				continue
 			}
 			renderActionProposal(proposal)
-			fmt.Fprintln(out, "This write has NOT run. Confirm it to proceed:")
-			fmt.Fprintf(out, "  ankra chat actions confirm %s\n", proposal.ActionID)
-			fmt.Fprintf(out, "  ankra chat actions reject %s\n\n", proposal.ActionID)
+			_, _ = fmt.Fprintln(out, "This write has NOT run. Confirm it to proceed:")
+			_, _ = fmt.Fprintf(out, "  ankra chat actions confirm %s\n", proposal.ActionID)
+			_, _ = fmt.Fprintf(out, "  ankra chat actions reject %s\n\n", proposal.ActionID)
 		case "error":
 			message := chatErrorMessage(event)
 			if detail := chatErrorDetail(event); detail != "" {
@@ -262,7 +299,7 @@ func renderChatTurn(events <-chan client.ChatStreamEvent, out io.Writer, errOut 
 				outcome.errorMessage = message
 			}
 			if collectProposals {
-				fmt.Fprintf(errOut, "\nError: %s\n", message)
+				_, _ = fmt.Fprintf(errOut, "\nError: %s\n", message)
 			}
 		case "done", "complete", "end":
 			// The turn's text is complete; the session_complete/end frames

--- a/cmd/chat_session.go
+++ b/cmd/chat_session.go
@@ -1,0 +1,276 @@
+package cmd
+
+// One chat turn on the durable sessions lane (ankra-y8l44.2): create a
+// session on the conversation, submit the turn, tail the event log until the
+// terminal frame. The backend owns the transcript, so a conversation id is
+// all the CLI carries between turns - no more resending the whole history
+// every interactive turn, and a one-shot answer names the conversation it
+// started so the next `ankra chat --conversation <id>` continues it. A
+// backend without the lane (older self-hosted platforms) falls back to the
+// deprecated stream transparently.
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"ankra/internal/client"
+)
+
+// chatTailMaxReconnects bounds how many times a dropped event tail is
+// re-opened from its last durable sequence before the turn is given up.
+const chatTailMaxReconnects = 3
+
+// chatTailReconnectDelay is the base back-off between tail re-opens; a var
+// so tests do not wait.
+var chatTailReconnectDelay = time.Second
+
+// chatScope is the cluster context a chat runs in and where it came from:
+// a persisted `ankra cluster select` is advisory (a deleted cluster degrades
+// to the global lane with a notice), an explicit --cluster is not.
+type chatScope struct {
+	clusterID     *string
+	fromSelection bool
+	selectedName  string
+}
+
+// chatTurnOutcome is what one rendered turn leaves behind.
+type chatTurnOutcome struct {
+	response     string
+	proposals    []*client.ChatActionProposal
+	errorMessage string
+}
+
+// newChatUUID mints a random v4 UUID for conversation ids and idempotency
+// keys without a UUID dependency.
+func newChatUUID() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate id: %w", err)
+	}
+	raw[6] = (raw[6] & 0x0f) | 0x40
+	raw[8] = (raw[8] & 0x3f) | 0x80
+	encoded := hex.EncodeToString(raw[:])
+	return encoded[0:8] + "-" + encoded[8:12] + "-" + encoded[12:16] + "-" + encoded[16:20] + "-" + encoded[20:32], nil
+}
+
+// sessionModeForInteraction maps the turn's interaction_mode onto the
+// session safety-mode literal; empty leaves the server default.
+func sessionModeForInteraction(interactionMode string) string {
+	switch interactionMode {
+	case "ask":
+		return "ask"
+	case "agentic":
+		return "agent"
+	case "plan":
+		return "plan"
+	}
+	return ""
+}
+
+// validateConversationID checks a user-supplied --conversation value
+// against the backend's constraints (1-128 characters, no whitespace).
+func validateConversationID(conversationID string) error {
+	trimmed := strings.TrimSpace(conversationID)
+	if trimmed == "" || len(trimmed) > 128 || strings.ContainsAny(trimmed, " \t\r\n") {
+		return fmt.Errorf("invalid --conversation %q: pass a conversation id from 'ankra chat history'", conversationID)
+	}
+	return nil
+}
+
+// startChatTurn opens one turn and returns its event stream. The sessions
+// lane is tried first; a backend that does not serve it gets the deprecated
+// stream with the same request. The returned bool reports the sessions lane
+// (so callers know the conversation id is the server's too).
+func startChatTurn(conversationID string, clusterID *string, req client.ChatRequest,
+	interactionMode string) (<-chan client.ChatStreamEvent, bool, error) {
+	idempotencyKey, keyErr := newChatUUID()
+	if keyErr != nil {
+		return nil, false, keyErr
+	}
+	session, err := apiClient.CreateChatSession(client.CreateChatSessionRequest{
+		ConversationID: conversationID,
+		ClusterID:      clusterID,
+		Mode:           sessionModeForInteraction(interactionMode),
+		IdempotencyKey: idempotencyKey,
+	})
+	if errors.Is(err, client.ErrChatSessionsUnavailable) {
+		events, legacyErr := apiClient.StreamChat(clusterID, req)
+		return events, false, legacyErr
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	// The transcript is server-owned on this lane: send the conversation
+	// id, never the history.
+	req.ConversationID = &conversationID
+	req.ConversationHistory = nil
+	submitted, err := apiClient.SubmitChatTurn(session.ID, req)
+	if err != nil {
+		return nil, true, err
+	}
+	return tailChatSession(session.ID, submitted.LastSeq), true, nil
+}
+
+// tailChatSession follows the session's durable event log until the
+// terminal "end" frame, re-opening the tail from the last sequence it saw
+// when the connection drops (the runner keeps working server-side and the
+// log keeps every frame, so nothing is lost across a reconnect).
+func tailChatSession(sessionID string, since int64) <-chan client.ChatStreamEvent {
+	out := make(chan client.ChatStreamEvent, 100)
+	go func() {
+		defer close(out)
+		reconnects := 0
+		for {
+			events, err := apiClient.StreamChatSessionEvents(sessionID, since)
+			if err != nil {
+				if reconnects < chatTailMaxReconnects && !errors.Is(err, client.ErrUnauthorized) {
+					reconnects++
+					time.Sleep(time.Duration(reconnects) * chatTailReconnectDelay)
+					continue
+				}
+				out <- client.ChatStreamEvent{Type: "error", Error: err.Error()}
+				return
+			}
+			dropped := false
+			for event := range events {
+				if event.Sequence > since {
+					since = event.Sequence
+				}
+				// A local stream failure (read error, idle watchdog) carries
+				// Error and no payload: that is a drop to resume from, not a
+				// backend verdict to show.
+				if event.Type == "error" && event.Error != "" && event.Data == nil {
+					dropped = true
+					break
+				}
+				out <- event
+				if event.Type == "end" {
+					return
+				}
+			}
+			if !dropped {
+				// The tail closed cleanly without an end frame: the server
+				// finished its response window; resume to catch the rest.
+				dropped = true
+			}
+			if dropped && reconnects >= chatTailMaxReconnects {
+				out <- client.ChatStreamEvent{Type: "error",
+					Error: "the reply stream dropped and could not be resumed; the turn may still finish - check 'ankra chat show'"}
+				return
+			}
+			reconnects++
+			time.Sleep(time.Duration(reconnects) * chatTailReconnectDelay)
+		}
+	}()
+	return out
+}
+
+// chatErrorDetail renders the operator-facing detail a sessions-lane error
+// frame carries (the sanitised upstream error) - only when ANKRA_DEBUG is
+// set, because the message is the user-facing text.
+func chatErrorDetail(event client.ChatStreamEvent) string {
+	data, isMap := event.Data.(map[string]any)
+	if !isMap {
+		return ""
+	}
+	var parts []string
+	if code, ok := data["error_code"].(string); ok && code != "" {
+		parts = append(parts, "code: "+code)
+	}
+	if os.Getenv("ANKRA_DEBUG") != "" {
+		if detail, ok := data["detail"].(string); ok && detail != "" {
+			parts = append(parts, "detail: "+detail)
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
+// renderChatTurn prints a turn's events as they arrive and reports what the
+// turn left behind. Proposals are rendered inline (one-shot) or collected
+// for the caller to resolve (interactive) depending on collectProposals.
+func renderChatTurn(events <-chan client.ChatStreamEvent, out io.Writer, errOut io.Writer,
+	collectProposals bool) chatTurnOutcome {
+	var outcome chatTurnOutcome
+	var response strings.Builder
+	var hasStartedContent bool
+	var hadStatus bool
+	printContent := func(text string) {
+		if text == "" {
+			return
+		}
+		if !hasStartedContent {
+			if hadStatus {
+				fmt.Fprint(out, "\n")
+			}
+			hasStartedContent = true
+		}
+		fmt.Fprint(out, text)
+		response.WriteString(text)
+	}
+	printLine := func(line string) {
+		if hasStartedContent {
+			fmt.Fprintf(out, "\n\n[%s]\n\n", line)
+		} else {
+			fmt.Fprintf(out, "[%s]", line)
+			hadStatus = true
+		}
+	}
+	for event := range events {
+		switch event.Type {
+		case "content":
+			if text, ok := event.Data.(string); ok {
+				printContent(text)
+			} else {
+				printContent(event.Content)
+			}
+		case "status":
+			if status := chatStatusText(event.Data); status != "" {
+				printLine(status)
+			}
+		case "system_notice":
+			if data, ok := event.Data.(map[string]any); ok {
+				if message, ok := data["message"].(string); ok && message != "" {
+					printLine("note: " + message)
+				}
+			}
+		case "action_proposal":
+			proposal, decodeError := decodeActionProposal(event.Data)
+			if decodeError != nil {
+				fmt.Fprintf(out, "\nAn action is awaiting confirmation but could not be read: %v\n", decodeError)
+				continue
+			}
+			if collectProposals {
+				outcome.proposals = append(outcome.proposals, proposal)
+				continue
+			}
+			renderActionProposal(proposal)
+			fmt.Fprintln(out, "This write has NOT run. Confirm it to proceed:")
+			fmt.Fprintf(out, "  ankra chat actions confirm %s\n", proposal.ActionID)
+			fmt.Fprintf(out, "  ankra chat actions reject %s\n\n", proposal.ActionID)
+		case "error":
+			message := chatErrorMessage(event)
+			if detail := chatErrorDetail(event); detail != "" {
+				message += " (" + detail + ")"
+			}
+			if outcome.errorMessage == "" {
+				outcome.errorMessage = message
+			}
+			if collectProposals {
+				fmt.Fprintf(errOut, "\nError: %s\n", message)
+			}
+		case "done", "complete", "end":
+			// The turn's text is complete; the session_complete/end frames
+			// that follow carry no more content.
+		default:
+			// Triage, thinking, budgets, tool telemetry and other metadata.
+		}
+	}
+	outcome.response = response.String()
+	return outcome
+}

--- a/cmd/chat_session_test.go
+++ b/cmd/chat_session_test.go
@@ -1,0 +1,406 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"ankra/internal/client"
+)
+
+// chatSessionMock scripts the sessions lane: every created session gets the
+// next scripted tail, and every request is recorded for assertions.
+type chatSessionMock struct {
+	baseMock
+	mutex sync.Mutex
+
+	createErrors []error // consumed in order; nil means success
+	created      []client.CreateChatSessionRequest
+	submitted    []client.ChatRequest
+	tails        [][]client.ChatStreamEvent // one per StreamChatSessionEvents call
+	tailSince    []int64
+	legacyEvents []client.ChatStreamEvent
+	legacyCalls  int
+}
+
+func (m *chatSessionMock) CreateChatSession(request client.CreateChatSessionRequest) (*client.ChatSession, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.created = append(m.created, request)
+	if len(m.createErrors) > 0 {
+		err := m.createErrors[0]
+		m.createErrors = m.createErrors[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &client.ChatSession{ID: "sess-" + request.IdempotencyKey, ConversationID: request.ConversationID,
+		ClusterID: request.ClusterID, Mode: request.Mode, Status: "pending"}, nil
+}
+
+func (m *chatSessionMock) SubmitChatTurn(sessionID string, request client.ChatRequest) (*client.SubmitChatTurnResponse, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.submitted = append(m.submitted, request)
+	return &client.SubmitChatTurnResponse{SessionID: sessionID, LastSeq: 1}, nil
+}
+
+func (m *chatSessionMock) StreamChatSessionEvents(_ string, since int64) (<-chan client.ChatStreamEvent, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.tailSince = append(m.tailSince, since)
+	if len(m.tails) == 0 {
+		return nil, errors.New("no tail scripted")
+	}
+	tail := m.tails[0]
+	m.tails = m.tails[1:]
+	stream := make(chan client.ChatStreamEvent, len(tail))
+	for _, event := range tail {
+		stream <- event
+	}
+	close(stream)
+	return stream, nil
+}
+
+func (m *chatSessionMock) StreamChat(_ *string, _ client.ChatRequest) (<-chan client.ChatStreamEvent, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.legacyCalls++
+	stream := make(chan client.ChatStreamEvent, len(m.legacyEvents))
+	for _, event := range m.legacyEvents {
+		stream <- event
+	}
+	close(stream)
+	return stream, nil
+}
+
+
+// resetChatFlags clears the chat command's flag values after a test: cobra
+// keeps the last parsed value on the shared root command, so a
+// --conversation or --mode from one test would leak into the next.
+func resetChatFlags(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		for _, name := range []string{"conversation", "mode", "cluster"} {
+			_ = chatCmd.Flags().Set(name, "")
+		}
+	})
+}
+
+func endFrame() client.ChatStreamEvent {
+	return client.ChatStreamEvent{Type: "end", Data: map[string]any{"status": "completed"}, Done: true}
+}
+
+func contentFrame(sequence int64, text string) client.ChatStreamEvent {
+	return client.ChatStreamEvent{Type: "content", Data: text, Content: text, Sequence: sequence}
+}
+
+func TestChatOneShot_RunsOnSessionsAndNamesTheConversation(t *testing.T) {
+	resetChatFlags(t)
+	mock := &chatSessionMock{tails: [][]client.ChatStreamEvent{{
+		{Type: "status", Data: map[string]any{"intent": "Processing...", "mechanism": nil}, Sequence: 2},
+		contentFrame(3, "Hello"),
+		contentFrame(4, " world"),
+		{Type: "complete", Data: map[string]any{"response": "Hello world"}, Sequence: 5},
+		endFrame(),
+	}}}
+	var runErr error
+	var stderrOutput string
+	stdoutOutput := captureStdout(t, func() {
+		stderrOutput = captureStderr(t, func() {
+			_, runErr = runWithInput(t, mock, "", "chat", "--mode", "ask", "hello")
+		})
+	})
+	if runErr != nil {
+		t.Fatalf("chat failed: %v", runErr)
+	}
+	if !strings.Contains(stdoutOutput, "Hello world") {
+		t.Fatalf("stdout = %q, want the streamed answer", stdoutOutput)
+	}
+	if len(mock.created) != 1 || mock.created[0].Mode != "ask" || mock.created[0].ConversationID == "" {
+		t.Fatalf("created sessions = %+v, want one ask-mode session on a fresh conversation", mock.created)
+	}
+	if len(mock.submitted) != 1 || mock.submitted[0].ConversationID == nil ||
+		*mock.submitted[0].ConversationID != mock.created[0].ConversationID {
+		t.Fatalf("submitted = %+v, want the turn bound to the session's conversation", mock.submitted)
+	}
+	if mock.submitted[0].ConversationHistory != nil {
+		t.Fatal("the sessions lane must not resend history")
+	}
+	if len(mock.tailSince) != 1 || mock.tailSince[0] != 1 {
+		t.Fatalf("tail since = %v, want [1] (after the persisted user turn)", mock.tailSince)
+	}
+	if !strings.Contains(stderrOutput, "conversation "+mock.created[0].ConversationID) ||
+		!strings.Contains(stderrOutput, "--conversation "+mock.created[0].ConversationID) {
+		t.Fatalf("stderr = %q, want the conversation id and how to continue it", stderrOutput)
+	}
+	if strings.Contains(stdoutOutput, "conversation "+mock.created[0].ConversationID) {
+		t.Fatal("the conversation id must stay off stdout so piped answers stay clean")
+	}
+	if mock.legacyCalls != 0 {
+		t.Fatal("the deprecated stream must not be used when sessions work")
+	}
+}
+
+func TestChatOneShot_ContinuesTheGivenConversation(t *testing.T) {
+	resetChatFlags(t)
+	mock := &chatSessionMock{tails: [][]client.ChatStreamEvent{{contentFrame(2, "Sure."), endFrame()}}}
+	stderrOutput := captureStderr(t, func() {
+		captureStdout(t, func() {
+			if _, err := runWithInput(t, mock, "", "chat", "--conversation",
+				"a75c06a2-5100-41f2-bdde-778c5a74200c", "and then?"); err != nil {
+				t.Fatalf("chat failed: %v", err)
+			}
+		})
+	})
+	if mock.created[0].ConversationID != "a75c06a2-5100-41f2-bdde-778c5a74200c" {
+		t.Fatalf("conversation = %q, want the --conversation value", mock.created[0].ConversationID)
+	}
+	if strings.Contains(stderrOutput, "continue with") {
+		t.Fatalf("stderr = %q; a continued conversation needs no how-to-continue hint", stderrOutput)
+	}
+	if _, err := runWithInput(t, mock, "", "chat", "--conversation", "has space", "x"); err == nil ||
+		!strings.Contains(err.Error(), "invalid --conversation") {
+		t.Fatalf("err = %v, want the --conversation validation", err)
+	}
+}
+
+func TestChatOneShot_ErrorFrameFailsWithTheCode(t *testing.T) {
+	resetChatFlags(t)
+	mock := &chatSessionMock{tails: [][]client.ChatStreamEvent{{
+		{Type: "error", Data: map[string]any{
+			"message":    "The AI service is temporarily unavailable. Please try again shortly.",
+			"error_code": "ai_platform_billing",
+			"detail":     "messages API returned HTTP 400: credit balance is too low",
+		}, Sequence: 2},
+		endFrame(),
+	}}}
+	t.Setenv("ANKRA_DEBUG", "")
+	var runErr error
+	captureStdout(t, func() {
+		captureStderr(t, func() { _, runErr = runWithInput(t, mock, "", "chat", "hello") })
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "temporarily unavailable") ||
+		!strings.Contains(runErr.Error(), "ai_platform_billing") {
+		t.Fatalf("err = %v, want the message with its stable code", runErr)
+	}
+	if strings.Contains(runErr.Error(), "credit balance") {
+		t.Fatalf("err = %v; the operator detail must stay behind ANKRA_DEBUG", runErr)
+	}
+	t.Setenv("ANKRA_DEBUG", "1")
+	mock.tails = [][]client.ChatStreamEvent{{
+		{Type: "error", Data: map[string]any{"message": "unavailable", "detail": "credit balance is too low"}},
+		endFrame(),
+	}}
+	captureStdout(t, func() {
+		captureStderr(t, func() { _, runErr = runWithInput(t, mock, "", "chat", "hello") })
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "credit balance") {
+		t.Fatalf("err = %v, want the detail under ANKRA_DEBUG", runErr)
+	}
+}
+
+func TestChatOneShot_ResumesADroppedTailFromItsLastSequence(t *testing.T) {
+	resetChatFlags(t)
+	previous := chatTailReconnectDelay
+	chatTailReconnectDelay = time.Millisecond
+	t.Cleanup(func() { chatTailReconnectDelay = previous })
+	mock := &chatSessionMock{tails: [][]client.ChatStreamEvent{
+		{contentFrame(2, "Hello"), {Type: "error", Error: "read: connection reset"}},
+		{contentFrame(3, " world"), endFrame()},
+	}}
+	var runErr error
+	stdoutOutput := captureStdout(t, func() {
+		captureStderr(t, func() { _, runErr = runWithInput(t, mock, "", "chat", "hello") })
+	})
+	if runErr != nil {
+		t.Fatalf("chat failed: %v", runErr)
+	}
+	if !strings.Contains(stdoutOutput, "Hello world") {
+		t.Fatalf("stdout = %q, want the answer stitched across the reconnect", stdoutOutput)
+	}
+	if len(mock.tailSince) != 2 || mock.tailSince[1] != 2 {
+		t.Fatalf("tail since = %v, want the resume from the last durable sequence", mock.tailSince)
+	}
+}
+
+func TestChatOneShot_GivesUpAfterTooManyDrops(t *testing.T) {
+	resetChatFlags(t)
+	previous := chatTailReconnectDelay
+	chatTailReconnectDelay = time.Millisecond
+	t.Cleanup(func() { chatTailReconnectDelay = previous })
+	drop := []client.ChatStreamEvent{{Type: "error", Error: "read: connection reset"}}
+	mock := &chatSessionMock{tails: [][]client.ChatStreamEvent{drop, drop, drop, drop, drop}}
+	var runErr error
+	captureStdout(t, func() {
+		captureStderr(t, func() { _, runErr = runWithInput(t, mock, "", "chat", "hello") })
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "could not be resumed") {
+		t.Fatalf("err = %v, want the resume give-up", runErr)
+	}
+	if len(mock.tailSince) != chatTailMaxReconnects+1 {
+		t.Fatalf("tail opens = %d, want the initial open plus %d reconnects", len(mock.tailSince), chatTailMaxReconnects)
+	}
+}
+
+func TestChatOneShot_FallsBackToTheDeprecatedStreamWithoutSessions(t *testing.T) {
+	resetChatFlags(t)
+	mock := &chatSessionMock{
+		createErrors: []error{client.ErrChatSessionsUnavailable},
+		legacyEvents: []client.ChatStreamEvent{{Type: "content", Content: "Legacy answer."}, {Type: "complete"}},
+	}
+	var runErr error
+	stdoutOutput := captureStdout(t, func() {
+		captureStderr(t, func() { _, runErr = runWithInput(t, mock, "", "chat", "hello") })
+	})
+	if runErr != nil {
+		t.Fatalf("chat failed: %v", runErr)
+	}
+	if mock.legacyCalls != 1 || !strings.Contains(stdoutOutput, "Legacy answer.") {
+		t.Fatalf("legacy calls = %d, stdout = %q", mock.legacyCalls, stdoutOutput)
+	}
+}
+
+func writeStaleSelection(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, ".ankra"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	selection, _ := json.Marshal(client.ClusterListItem{ID: "b765f99a-ec5c-48ab-98a9-9b4f1857eff2", Name: "tael-ops"})
+	if err := os.WriteFile(filepath.Join(home, ".ankra", "selected.json"), selection, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestChatOneShot_StaleSelectionDegradesToGlobalWithANotice(t *testing.T) {
+	resetChatFlags(t)
+	writeStaleSelection(t)
+	mock := &chatSessionMock{
+		createErrors: []error{client.ErrClusterNotFound},
+		tails:        [][]client.ChatStreamEvent{{contentFrame(2, "Global answer."), endFrame()}},
+	}
+	var runErr error
+	var stderrOutput string
+	stdoutOutput := captureStdout(t, func() {
+		stderrOutput = captureStderr(t, func() { _, runErr = runWithInput(t, mock, "", "chat", "hello") })
+	})
+	if runErr != nil {
+		t.Fatalf("chat failed: %v", runErr)
+	}
+	if !strings.Contains(stdoutOutput, "Global answer.") {
+		t.Fatalf("stdout = %q", stdoutOutput)
+	}
+	if !strings.Contains(stderrOutput, `selected cluster "tael-ops" no longer exists`) ||
+		!strings.Contains(stderrOutput, "ankra cluster clear") {
+		t.Fatalf("stderr = %q, want the stale-selection notice with the fix", stderrOutput)
+	}
+	if len(mock.created) != 2 || mock.created[0].ClusterID == nil || mock.created[1].ClusterID != nil {
+		t.Fatalf("created = %+v, want the selected cluster first, then the global lane", mock.created)
+	}
+}
+
+func TestChatOneShot_StaleSelectionDegradesOnlyOnce(t *testing.T) {
+	resetChatFlags(t)
+	writeStaleSelection(t)
+	// The degrade is a single step: a not-found on the global retry is a
+	// real failure and surfaces.
+	mock := &chatSessionMock{createErrors: []error{client.ErrClusterNotFound, client.ErrClusterNotFound}}
+	var runErr error
+	captureStdout(t, func() {
+		captureStderr(t, func() { _, runErr = runWithInput(t, mock, "", "chat", "hello") })
+	})
+	if runErr == nil || !errors.Is(runErr, client.ErrClusterNotFound) {
+		t.Fatalf("err = %v, want the cluster-not-found surfaced after one degrade", runErr)
+	}
+}
+
+func TestChatInteractive_KeepsOneConversationAcrossTurns(t *testing.T) {
+	resetChatFlags(t)
+	mock := &chatSessionMock{tails: [][]client.ChatStreamEvent{
+		{contentFrame(2, "pong"), endFrame()},
+		{contentFrame(2, "ping"), endFrame()},
+	}}
+	var runErr error
+	stdoutOutput := captureStdout(t, func() {
+		captureStderr(t, func() {
+			_, runErr = runWithInput(t, mock, "say pong\nsay ping\nexit\n", "chat")
+		})
+	})
+	if runErr != nil {
+		t.Fatalf("chat failed: %v", runErr)
+	}
+	if len(mock.created) != 2 || mock.created[0].ConversationID != mock.created[1].ConversationID {
+		t.Fatalf("created = %+v, want two sessions on one conversation", mock.created)
+	}
+	for index, request := range mock.submitted {
+		if request.ConversationHistory != nil {
+			t.Fatalf("turn %d resent history; the server owns the transcript", index)
+		}
+	}
+	if !strings.Contains(stdoutOutput, "Conversation: "+mock.created[0].ConversationID) {
+		t.Fatalf("stdout = %q, want the conversation id in the header", stdoutOutput)
+	}
+	if !strings.Contains(stdoutOutput, "pong") || !strings.Contains(stdoutOutput, "ping") {
+		t.Fatalf("stdout = %q, want both answers", stdoutOutput)
+	}
+}
+
+func TestChatInteractive_ClearStartsANewConversation(t *testing.T) {
+	resetChatFlags(t)
+	mock := &chatSessionMock{tails: [][]client.ChatStreamEvent{
+		{contentFrame(2, "one"), endFrame()},
+		{contentFrame(2, "two"), endFrame()},
+	}}
+	captureStdout(t, func() {
+		captureStderr(t, func() {
+			if _, err := runWithInput(t, mock, "first\nclear\nsecond\nexit\n", "chat"); err != nil {
+				t.Fatalf("chat failed: %v", err)
+			}
+		})
+	})
+	if len(mock.created) != 2 || mock.created[0].ConversationID == mock.created[1].ConversationID {
+		t.Fatalf("created = %+v, want 'clear' to start a fresh conversation", mock.created)
+	}
+}
+
+func TestChatShow_RefusesANonConversationID(t *testing.T) {
+	resetChatFlags(t)
+	_, err := runWithInput(t, &baseMock{}, "", "chat", "show", "not-a-uuid")
+	if err == nil || !strings.Contains(err.Error(), "invalid conversation id") {
+		t.Fatalf("err = %v, want the id validation", err)
+	}
+	_, err = runWithInput(t, &baseMock{}, "", "chat", "delete", "--yes", "not-a-uuid")
+	if err == nil || !strings.Contains(err.Error(), "invalid conversation id") {
+		t.Fatalf("delete err = %v, want the id validation", err)
+	}
+}
+
+func TestSessionModeForInteraction(t *testing.T) {
+	cases := map[string]string{"": "", "ask": "ask", "agentic": "agent", "plan": "plan", "other": ""}
+	for interaction, want := range cases {
+		if got := sessionModeForInteraction(interaction); got != want {
+			t.Errorf("sessionModeForInteraction(%q) = %q, want %q", interaction, got, want)
+		}
+	}
+}
+
+func TestNewChatUUIDIsV4(t *testing.T) {
+	id, err := newChatUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !looksLikeUUID(id) || id[14] != '4' || !strings.ContainsRune("89ab", rune(id[19])) {
+		t.Fatalf("id = %q, want a v4 UUID", id)
+	}
+	other, _ := newChatUUID()
+	if other == id {
+		t.Fatal("two ids must differ")
+	}
+}

--- a/cmd/chat_session_test.go
+++ b/cmd/chat_session_test.go
@@ -19,25 +19,37 @@ type chatSessionMock struct {
 	baseMock
 	mutex sync.Mutex
 
-	createErrors []error // consumed in order; nil means success
-	created      []client.CreateChatSessionRequest
-	submitted    []client.ChatRequest
-	tails        [][]client.ChatStreamEvent // one per StreamChatSessionEvents call
-	tailSince    []int64
-	legacyEvents []client.ChatStreamEvent
-	legacyCalls  int
+	// The error queues are consumed one per call; a nil entry (or an empty
+	// queue) means that call succeeds with the scripted data.
+	createErrors   []error
+	submitErrors   []error
+	tailErrors     []error
+	legacyErrors   []error
+	created        []client.CreateChatSessionRequest
+	submitted      []client.ChatRequest
+	cancelled      []string
+	tails          [][]client.ChatStreamEvent // one per StreamChatSessionEvents call
+	tailSince      []int64
+	legacyEvents   []client.ChatStreamEvent
+	legacyCalls    int
+	legacyClusters []*string // the cluster each StreamChat call was scoped to
+}
+
+func popScriptedError(queue *[]error) error {
+	if len(*queue) == 0 {
+		return nil
+	}
+	err := (*queue)[0]
+	*queue = (*queue)[1:]
+	return err
 }
 
 func (m *chatSessionMock) CreateChatSession(request client.CreateChatSessionRequest) (*client.ChatSession, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.created = append(m.created, request)
-	if len(m.createErrors) > 0 {
-		err := m.createErrors[0]
-		m.createErrors = m.createErrors[1:]
-		if err != nil {
-			return nil, err
-		}
+	if err := popScriptedError(&m.createErrors); err != nil {
+		return nil, err
 	}
 	return &client.ChatSession{ID: "sess-" + request.IdempotencyKey, ConversationID: request.ConversationID,
 		ClusterID: request.ClusterID, Mode: request.Mode, Status: "pending"}, nil
@@ -47,13 +59,26 @@ func (m *chatSessionMock) SubmitChatTurn(sessionID string, request client.ChatRe
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.submitted = append(m.submitted, request)
+	if err := popScriptedError(&m.submitErrors); err != nil {
+		return nil, err
+	}
 	return &client.SubmitChatTurnResponse{SessionID: sessionID, LastSeq: 1}, nil
+}
+
+func (m *chatSessionMock) CancelChatSession(sessionID string) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.cancelled = append(m.cancelled, sessionID)
+	return nil
 }
 
 func (m *chatSessionMock) StreamChatSessionEvents(_ string, since int64) (<-chan client.ChatStreamEvent, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.tailSince = append(m.tailSince, since)
+	if err := popScriptedError(&m.tailErrors); err != nil {
+		return nil, err
+	}
 	if len(m.tails) == 0 {
 		return nil, errors.New("no tail scripted")
 	}
@@ -67,10 +92,14 @@ func (m *chatSessionMock) StreamChatSessionEvents(_ string, since int64) (<-chan
 	return stream, nil
 }
 
-func (m *chatSessionMock) StreamChat(_ *string, _ client.ChatRequest) (<-chan client.ChatStreamEvent, error) {
+func (m *chatSessionMock) StreamChat(clusterID *string, _ client.ChatRequest) (<-chan client.ChatStreamEvent, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.legacyCalls++
+	m.legacyClusters = append(m.legacyClusters, clusterID)
+	if err := popScriptedError(&m.legacyErrors); err != nil {
+		return nil, err
+	}
 	stream := make(chan client.ChatStreamEvent, len(m.legacyEvents))
 	for _, event := range m.legacyEvents {
 		stream <- event
@@ -78,7 +107,6 @@ func (m *chatSessionMock) StreamChat(_ *string, _ client.ChatRequest) (<-chan cl
 	close(stream)
 	return stream, nil
 }
-
 
 // resetChatFlags clears the chat command's flag values after a test: cobra
 // keeps the last parsed value on the shared root command, so a
@@ -248,6 +276,153 @@ func TestChatOneShot_GivesUpAfterTooManyDrops(t *testing.T) {
 	}
 }
 
+func TestChatOneShot_ReconnectBudgetBoundsConsecutiveDropsOnly(t *testing.T) {
+	resetChatFlags(t)
+	previous := chatTailReconnectDelay
+	chatTailReconnectDelay = time.Millisecond
+	t.Cleanup(func() { chatTailReconnectDelay = previous })
+	drop := client.ChatStreamEvent{Type: "error", Error: "read: connection reset"}
+	// More drops than the budget, but every re-opened tail makes progress:
+	// the budget bounds failures in a row, not over the turn's lifetime.
+	mock := &chatSessionMock{tails: [][]client.ChatStreamEvent{
+		{contentFrame(2, "a"), drop},
+		{contentFrame(3, "b"), drop},
+		{contentFrame(4, "c"), drop},
+		{contentFrame(5, "d"), drop},
+		{contentFrame(6, "e"), endFrame()},
+	}}
+	var runErr error
+	stdoutOutput := captureStdout(t, func() {
+		captureStderr(t, func() { _, runErr = runWithInput(t, mock, "", "chat", "hello") })
+	})
+	if runErr != nil {
+		t.Fatalf("chat failed: %v", runErr)
+	}
+	if !strings.Contains(stdoutOutput, "abcde") {
+		t.Fatalf("stdout = %q, want the answer stitched across every reconnect", stdoutOutput)
+	}
+	if len(mock.tailSince) != 5 || mock.tailSince[4] != 5 {
+		t.Fatalf("tail since = %v, want five opens resuming from each last sequence", mock.tailSince)
+	}
+}
+
+func TestChatOneShot_SkipsFramesReplayedOnResume(t *testing.T) {
+	resetChatFlags(t)
+	previous := chatTailReconnectDelay
+	chatTailReconnectDelay = time.Millisecond
+	t.Cleanup(func() { chatTailReconnectDelay = previous })
+	mock := &chatSessionMock{tails: [][]client.ChatStreamEvent{
+		{contentFrame(2, "Hello"), {Type: "error", Error: "read: connection reset"}},
+		{contentFrame(2, "Hello"), contentFrame(3, " world"), endFrame()},
+	}}
+	var runErr error
+	stdoutOutput := captureStdout(t, func() {
+		captureStderr(t, func() { _, runErr = runWithInput(t, mock, "", "chat", "hello") })
+	})
+	if runErr != nil {
+		t.Fatalf("chat failed: %v", runErr)
+	}
+	if strings.Count(stdoutOutput, "Hello") != 1 || !strings.Contains(stdoutOutput, "Hello world") {
+		t.Fatalf("stdout = %q, want the replayed frame rendered once", stdoutOutput)
+	}
+}
+
+func TestChatOneShot_TailOpenRetriesOnlyTransientFailures(t *testing.T) {
+	resetChatFlags(t)
+	previous := chatTailReconnectDelay
+	chatTailReconnectDelay = time.Millisecond
+	t.Cleanup(func() { chatTailReconnectDelay = previous })
+	terminal := []error{
+		client.ErrChatSessionsUnavailable,
+		client.NewUnexpectedResponseError(403, "forbidden"),
+	}
+	for _, tailErr := range terminal {
+		mock := &chatSessionMock{tailErrors: []error{tailErr}}
+		var runErr error
+		captureStdout(t, func() {
+			captureStderr(t, func() { _, runErr = runWithInput(t, mock, "", "chat", "hello") })
+		})
+		if runErr == nil || !strings.Contains(runErr.Error(), tailErr.Error()) {
+			t.Fatalf("err = %v, want %v surfaced", runErr, tailErr)
+		}
+		if len(mock.tailSince) != 1 {
+			t.Fatalf("tail opens = %d for %v, want no retry of a 4xx", len(mock.tailSince), tailErr)
+		}
+	}
+	mock := &chatSessionMock{
+		tailErrors: []error{client.NewUnexpectedResponseError(503, "upstream unavailable")},
+		tails:      [][]client.ChatStreamEvent{{contentFrame(2, "Recovered."), endFrame()}},
+	}
+	var runErr error
+	stdoutOutput := captureStdout(t, func() {
+		captureStderr(t, func() { _, runErr = runWithInput(t, mock, "", "chat", "hello") })
+	})
+	if runErr != nil || !strings.Contains(stdoutOutput, "Recovered.") {
+		t.Fatalf("err = %v, stdout = %q; want a 5xx retried", runErr, stdoutOutput)
+	}
+	if len(mock.tailSince) != 2 {
+		t.Fatalf("tail opens = %d, want the failed open plus one retry", len(mock.tailSince))
+	}
+}
+
+func TestChatOneShot_CancelsTheSessionWhenTheTurnIsRefused(t *testing.T) {
+	resetChatFlags(t)
+	mock := &chatSessionMock{submitErrors: []error{client.NewUnexpectedResponseError(402, "AI allowance exhausted")}}
+	var runErr error
+	captureStdout(t, func() {
+		captureStderr(t, func() { _, runErr = runWithInput(t, mock, "", "chat", "hello") })
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "allowance exhausted") {
+		t.Fatalf("err = %v, want the refusal surfaced", runErr)
+	}
+	if len(mock.created) != 1 || len(mock.cancelled) != 1 || mock.cancelled[0] != "sess-"+mock.created[0].IdempotencyKey {
+		t.Fatalf("cancelled = %v, want the session that never got its turn", mock.cancelled)
+	}
+	if len(mock.tailSince) != 0 {
+		t.Fatal("a refused turn has nothing to tail")
+	}
+}
+
+func TestChatOneShot_LegacyFallbackSaysTheConversationIsNotContinued(t *testing.T) {
+	resetChatFlags(t)
+	mock := &chatSessionMock{
+		createErrors: []error{client.ErrChatSessionsUnavailable},
+		legacyEvents: []client.ChatStreamEvent{{Type: "content", Content: "Legacy answer."}, {Type: "complete"}},
+	}
+	var runErr error
+	var stderrOutput string
+	stdoutOutput := captureStdout(t, func() {
+		stderrOutput = captureStderr(t, func() {
+			_, runErr = runWithInput(t, mock, "", "chat", "--conversation",
+				"a75c06a2-5100-41f2-bdde-778c5a74200c", "and then?")
+		})
+	})
+	if runErr != nil || !strings.Contains(stdoutOutput, "Legacy answer.") {
+		t.Fatalf("err = %v, stdout = %q", runErr, stdoutOutput)
+	}
+	if !strings.Contains(stderrOutput, "conversation a75c06a2-5100-41f2-bdde-778c5a74200c cannot be continued here") {
+		t.Fatalf("stderr = %q, want the note that the deprecated stream ignored --conversation", stderrOutput)
+	}
+}
+
+func TestChatInteractive_LegacyFallbackNotesTheLocalConversationOnce(t *testing.T) {
+	resetChatFlags(t)
+	mock := &chatSessionMock{
+		createErrors: []error{client.ErrChatSessionsUnavailable, client.ErrChatSessionsUnavailable},
+		legacyEvents: []client.ChatStreamEvent{{Type: "content", Content: "ok"}, {Type: "complete"}},
+	}
+	var runErr error
+	stderrOutput := captureStderr(t, func() {
+		captureStdout(t, func() { _, runErr = runWithInput(t, mock, "one\ntwo\nexit\n", "chat") })
+	})
+	if runErr != nil || mock.legacyCalls != 2 {
+		t.Fatalf("err = %v, legacy calls = %d", runErr, mock.legacyCalls)
+	}
+	if strings.Count(stderrOutput, "is local to this run") != 1 {
+		t.Fatalf("stderr = %q, want exactly one note that the printed conversation id is local", stderrOutput)
+	}
+}
+
 func TestChatOneShot_FallsBackToTheDeprecatedStreamWithoutSessions(t *testing.T) {
 	resetChatFlags(t)
 	mock := &chatSessionMock{
@@ -303,6 +478,32 @@ func TestChatOneShot_StaleSelectionDegradesToGlobalWithANotice(t *testing.T) {
 	}
 	if len(mock.created) != 2 || mock.created[0].ClusterID == nil || mock.created[1].ClusterID != nil {
 		t.Fatalf("created = %+v, want the selected cluster first, then the global lane", mock.created)
+	}
+}
+
+func TestChatOneShot_StaleSelectionDegradesOnTheDeprecatedStreamToo(t *testing.T) {
+	resetChatFlags(t)
+	writeStaleSelection(t)
+	// A backend without the lane answers the stale cluster with a bare 404
+	// from the per-cluster stream, not the sessions sentinel.
+	mock := &chatSessionMock{
+		createErrors: []error{client.ErrChatSessionsUnavailable, client.ErrChatSessionsUnavailable},
+		legacyErrors: []error{client.NewUnexpectedResponseError(404, "Cluster not found")},
+		legacyEvents: []client.ChatStreamEvent{{Type: "content", Content: "Legacy global."}, {Type: "complete"}},
+	}
+	var runErr error
+	var stderrOutput string
+	stdoutOutput := captureStdout(t, func() {
+		stderrOutput = captureStderr(t, func() { _, runErr = runWithInput(t, mock, "", "chat", "hello") })
+	})
+	if runErr != nil || !strings.Contains(stdoutOutput, "Legacy global.") {
+		t.Fatalf("err = %v, stdout = %q", runErr, stdoutOutput)
+	}
+	if !strings.Contains(stderrOutput, `selected cluster "tael-ops" no longer exists`) {
+		t.Fatalf("stderr = %q, want the stale-selection notice", stderrOutput)
+	}
+	if len(mock.legacyClusters) != 2 || mock.legacyClusters[0] == nil || mock.legacyClusters[1] != nil {
+		t.Fatalf("legacy clusters = %v, want the selected cluster first, then the global lane", mock.legacyClusters)
 	}
 }
 

--- a/cmd/chat_test.go
+++ b/cmd/chat_test.go
@@ -23,7 +23,7 @@ func (m *chatDeleteMock) DeleteChatConversation(conversationID string) (*client.
 func TestChatDelete_DeclineDoesNotCallAPI(t *testing.T) {
 	mock := &chatDeleteMock{}
 	resetConfirmFlag(t, chatDeleteCmd)
-	_, err := runWithInput(t, mock, "n\n", "chat", "delete", "conv-1")
+	_, err := runWithInput(t, mock, "n\n", "chat", "delete", "0f7c9a2e-3b1d-4c5e-8f6a-7b8c9d0e1f2a")
 	if !errors.Is(err, errCancelled) {
 		t.Fatalf("expected errCancelled on decline, got %v", err)
 	}
@@ -35,14 +35,14 @@ func TestChatDelete_DeclineDoesNotCallAPI(t *testing.T) {
 func TestChatDelete_YesProceeds(t *testing.T) {
 	mock := &chatDeleteMock{}
 	resetConfirmFlag(t, chatDeleteCmd)
-	out, err := runWithInput(t, mock, "", "chat", "delete", "conv-1", "--yes")
+	out, err := runWithInput(t, mock, "", "chat", "delete", "0f7c9a2e-3b1d-4c5e-8f6a-7b8c9d0e1f2a", "--yes")
 	if err != nil {
 		t.Fatalf("execute failed: %v\noutput: %s", err, out)
 	}
 	if !mock.called {
 		t.Fatal("expected delete call with --yes")
 	}
-	if mock.gotConversationID != "conv-1" {
+	if mock.gotConversationID != "0f7c9a2e-3b1d-4c5e-8f6a-7b8c9d0e1f2a" {
 		t.Errorf("conversation id = %q, want conv-1", mock.gotConversationID)
 	}
 }

--- a/cmd/chat_test.go
+++ b/cmd/chat_test.go
@@ -43,7 +43,7 @@ func TestChatDelete_YesProceeds(t *testing.T) {
 		t.Fatal("expected delete call with --yes")
 	}
 	if mock.gotConversationID != "0f7c9a2e-3b1d-4c5e-8f6a-7b8c9d0e1f2a" {
-		t.Errorf("conversation id = %q, want conv-1", mock.gotConversationID)
+		t.Errorf("conversation id = %q, want the id passed on the command line", mock.gotConversationID)
 	}
 }
 

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -21,6 +21,22 @@ type baseMock struct{}
 
 func (m baseMock) SetOrganisationOverride(string) {}
 
+// The sessions lane is absent on the base mock so every existing chat test
+// keeps exercising the legacy StreamChat path it scripts.
+func (m baseMock) CreateChatSession(client.CreateChatSessionRequest) (*client.ChatSession, error) {
+	return nil, client.ErrChatSessionsUnavailable
+}
+
+func (m baseMock) SubmitChatTurn(string, client.ChatRequest) (*client.SubmitChatTurnResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) StreamChatSessionEvents(string, int64) (<-chan client.ChatStreamEvent, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) CancelChatSession(string) error { return errors.New("not implemented") }
+
 func (m baseMock) OrganisationOverride() string { return "" }
 
 func (m baseMock) UpdateUpcloudZonePool(context.Context, string, []string, bool) (*client.UpdateUpcloudZonePoolResult, bool, error) {
@@ -3287,6 +3303,8 @@ func TestTokensListEmptyCommand(t *testing.T) {
 }
 
 func TestOrgSwitchCommand(t *testing.T) {
+	// The switch persists ~/.ankra/organisation.json; keep it out of the real home.
+	t.Setenv("HOME", t.TempDir())
 	mock := &orgSwitchMock{}
 	setMockClient(t, mock)
 

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -281,6 +281,10 @@ type APIClient interface {
 	DeleteAPIToken(tokenID string) (*client.DeleteAPITokenResponse, error)
 
 	StreamChat(clusterID *string, chatReq client.ChatRequest) (<-chan client.ChatStreamEvent, error)
+	CreateChatSession(request client.CreateChatSessionRequest) (*client.ChatSession, error)
+	SubmitChatTurn(sessionID string, request client.ChatRequest) (*client.SubmitChatTurnResponse, error)
+	StreamChatSessionEvents(sessionID string, since int64) (<-chan client.ChatStreamEvent, error)
+	CancelChatSession(sessionID string) error
 	ConfirmChatAction(request client.ConfirmChatActionRequest) (*client.ConfirmChatActionResult, error)
 	ListPendingChatActions(conversationID string) (*client.PendingChatActionsResult, error)
 	ListChatHistory(clusterID *string, limit, offset int) (*client.ListConversationsResponse, error)

--- a/internal/client/chat.go
+++ b/internal/client/chat.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -92,6 +93,10 @@ type ChatStreamEvent struct {
 	Content string `json:"content,omitempty"`
 	Error   string `json:"error,omitempty"`
 	Done    bool   `json:"done,omitempty"`
+	// Sequence is the durable event log position of a sessions-lane frame
+	// (the SSE id), the cursor a dropped tail resumes from; zero on the
+	// legacy stream and on id-less frames.
+	Sequence int64 `json:"-"`
 }
 
 // ErrorMessage extracts the human message from an error event. Backend
@@ -120,6 +125,10 @@ func (event ChatStreamEvent) ErrorMessage() string {
 // tests can shorten it.
 var chatStreamIdleTimeout = 3 * time.Minute
 
+// deprecatedChatWarningOnce rate-limits the legacy lane's deprecation
+// warning to one per process.
+var deprecatedChatWarningOnce sync.Once
+
 func (c *Client) StreamChat(clusterID *string, chatReq ChatRequest) (<-chan ChatStreamEvent, error) {
 	var url string
 	if clusterID != nil && *clusterID != "" {
@@ -147,12 +156,16 @@ func (c *Client) StreamChat(clusterID *string, chatReq ChatRequest) (<-chan Chat
 	}
 
 	if resp.Header.Get("Deprecation") == "true" {
+		// Once per process: the interactive loop calls this per turn, and a
+		// warning re-printed mid-prompt on every turn is noise, not a signal.
 		sunsetMessage := resp.Header.Get("Sunset")
-		fmt.Fprintf(os.Stderr,
-			"warning: this chat endpoint is deprecated and will be removed (sunset: %s).\n"+
-				"         Upgrade ankra-cli to a newer release.\n",
-			sunsetMessage,
-		)
+		deprecatedChatWarningOnce.Do(func() {
+			fmt.Fprintf(os.Stderr,
+				"warning: this backend serves chat over a deprecated endpoint (sunset: %s).\n"+
+					"         Upgrade the Ankra platform to one that offers /api/v1/chat/sessions.\n",
+				sunsetMessage,
+			)
+		})
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/internal/client/chat_sessions.go
+++ b/internal/client/chat_sessions.go
@@ -1,0 +1,259 @@
+package client
+
+// The durable chat sessions lane (/api/v1/chat/sessions): the successor the
+// deprecated bearer stream (POST /api/v1/chat/general and the per-cluster
+// twin) has advertised in its Link header since 2026-07. A turn is three
+// calls: create a session bound to a conversation id, submit the turn, and
+// tail the session's durable event log over SSE until the terminal "end"
+// frame. The server hydrates the conversation from its own transcript, so
+// the client never resends history, and every frame carries a sequence
+// number the tail can resume from after a dropped connection.
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// ChatSession mirrors the backend's AISession (the members the CLI uses).
+type ChatSession struct {
+	ID                   string  `json:"id"`
+	ConversationID       string  `json:"conversation_id"`
+	ClusterID            *string `json:"cluster_id"`
+	Mode                 string  `json:"mode"`
+	Status               string  `json:"status"`
+	LatestSequenceNumber int64   `json:"latest_sequence_number"`
+	Error                *string `json:"error"`
+}
+
+// CreateChatSessionRequest is the POST /api/v1/chat/sessions body. Mode is
+// the session safety mode ("ask", "agent", "plan"); empty leaves the server
+// default. IdempotencyKey lets a retried create find its own session.
+type CreateChatSessionRequest struct {
+	ConversationID string  `json:"conversation_id"`
+	ClusterID      *string `json:"cluster_id,omitempty"`
+	Mode           string  `json:"mode,omitempty"`
+	IdempotencyKey string  `json:"idempotency_key,omitempty"`
+}
+
+// SubmitChatTurnResponse mirrors the backend's SubmitTurnResponse: LastSeq
+// is the sequence number of the persisted user turn, so tailing from it
+// yields exactly the assistant's side of the turn.
+type SubmitChatTurnResponse struct {
+	SessionID string `json:"session_id"`
+	LastSeq   int64  `json:"last_seq"`
+}
+
+// ErrChatSessionsUnavailable marks a backend without the bearer sessions
+// lane (a 404 on the route itself, not on a resource it names), so callers
+// can fall back to the deprecated stream.
+var ErrChatSessionsUnavailable = errors.New("chat sessions are not available on this backend")
+
+// liveDeltaFrame reports the id-less live-plane mirror frames the session
+// tail relays ahead of the durable log (content_delta, thinking_delta,
+// tool_input_delta, tool_start_live). The durable frames carry the same
+// bytes, so the CLI renders those and skips the mirrors; the terminal "end"
+// frame is also id-less and is the one id-less frame that matters.
+func liveDeltaFrame(eventName string) bool {
+	return strings.HasSuffix(eventName, "_delta") || eventName == "tool_start_live"
+}
+
+// CreateChatSession opens a session on the conversation.
+func (c *Client) CreateChatSession(request CreateChatSessionRequest) (*ChatSession, error) {
+	var session ChatSession
+	if err := c.sendJSON(http.MethodPost, c.BaseURL+"/api/v1/chat/sessions", request, &session); err != nil {
+		return nil, classifyChatSessionError(err)
+	}
+	return &session, nil
+}
+
+// SubmitChatTurn persists the user turn on the session; the runner picks it
+// up and the events tail carries the reply.
+func (c *Client) SubmitChatTurn(sessionID string, request ChatRequest) (*SubmitChatTurnResponse, error) {
+	payload := struct {
+		Request ChatRequest `json:"request"`
+	}{Request: request}
+	var response SubmitChatTurnResponse
+	if err := c.sendJSON(http.MethodPost,
+		fmt.Sprintf("%s/api/v1/chat/sessions/%s/turns", c.BaseURL, url.PathEscape(sessionID)),
+		payload, &response); err != nil {
+		return nil, classifyChatSessionError(err)
+	}
+	return &response, nil
+}
+
+// CancelChatSession asks the runner to stop the session's in-flight turn.
+func (c *Client) CancelChatSession(sessionID string) error {
+	return classifyChatSessionError(c.sendJSON(http.MethodPost,
+		fmt.Sprintf("%s/api/v1/chat/sessions/%s/cancel", c.BaseURL, url.PathEscape(sessionID)), nil, nil))
+}
+
+// classifyChatSessionError maps the two 404s the sessions lane can answer
+// onto sentinel errors: the route missing altogether (older backend) and a
+// cluster the backend does not know. Everything else passes through with
+// the backend's detail (allowance exhausted, rate limited, AI paused).
+func classifyChatSessionError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var unexpected *UnexpectedResponseError
+	if !errors.As(err, &unexpected) || unexpected.StatusCode != http.StatusNotFound {
+		return err
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "cluster not found") {
+		return fmt.Errorf("%w: %v", ErrClusterNotFound, err)
+	}
+	return fmt.Errorf("%w: %v", ErrChatSessionsUnavailable, err)
+}
+
+// StreamChatSessionEvents tails the session's event log from the given
+// sequence number (exclusive) until the terminal "end" frame or the
+// connection drops; the channel closes either way. Every durable frame is
+// delivered as a ChatStreamEvent whose Type is the SSE event name, Data the
+// decoded JSON payload, and Sequence the frame's id; id-less live-plane
+// mirrors are skipped. Heartbeat comments reset the same idle watchdog the
+// legacy stream uses.
+func (c *Client) StreamChatSessionEvents(sessionID string, since int64) (<-chan ChatStreamEvent, error) {
+	eventsURL := fmt.Sprintf("%s/api/v1/chat/sessions/%s/events?stream=true&since=%d",
+		c.BaseURL, url.PathEscape(sessionID), since)
+	httpReq, err := http.NewRequest(http.MethodGet, eventsURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+c.Token)
+	httpReq.Header.Set("Accept", "text/event-stream")
+
+	resp, err := c.StreamingHTTP.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, readErr := readResponseBody(resp)
+		closeBody(resp)
+		if readErr != nil {
+			return nil, fmt.Errorf("read response: %w", readErr)
+		}
+		if resp.StatusCode == http.StatusUnauthorized {
+			return nil, ErrUnauthorized
+		}
+		if detail := detailFromBody(body); detail != "" {
+			return nil, classifyChatSessionError(newUnexpectedResponseErrorWithMessage(resp.StatusCode, detail))
+		}
+		return nil, classifyChatSessionError(newUnexpectedResponseError("chat events failed", resp.StatusCode,
+			redactedBodyForError(body, 500)))
+	}
+
+	events := make(chan ChatStreamEvent, 100)
+	go func() {
+		defer closeBody(resp)
+		defer close(events)
+
+		var idleTimedOut atomic.Bool
+		watchdog := time.AfterFunc(chatStreamIdleTimeout, func() {
+			idleTimedOut.Store(true)
+			closeBody(resp)
+		})
+		defer watchdog.Stop()
+
+		reader := bufio.NewReader(resp.Body)
+		var frame sseFrame
+		for {
+			line, readErr := reader.ReadString('\n')
+			watchdog.Reset(chatStreamIdleTimeout)
+			if readErr != nil {
+				if idleTimedOut.Load() {
+					events <- ChatStreamEvent{Type: "error",
+						Error: fmt.Sprintf("stream idle timeout: no data received for %s", chatStreamIdleTimeout)}
+				} else if readErr != io.EOF {
+					events <- ChatStreamEvent{Type: "error", Error: readErr.Error()}
+				}
+				return
+			}
+			line = strings.TrimRight(line, "\r\n")
+			if line == "" {
+				if event, ok := frame.event(); ok {
+					events <- event
+					if event.Type == "end" {
+						return
+					}
+				}
+				frame = sseFrame{}
+				continue
+			}
+			frame.addLine(line)
+		}
+	}()
+	return events, nil
+}
+
+// sseFrame accumulates one server-sent event's fields until the blank line
+// that ends it.
+type sseFrame struct {
+	id        string
+	eventName string
+	data      []string
+	hasData   bool
+}
+
+func (frame *sseFrame) addLine(line string) {
+	if strings.HasPrefix(line, ":") {
+		return // comment / heartbeat
+	}
+	field, value, _ := strings.Cut(line, ":")
+	value = strings.TrimPrefix(value, " ")
+	switch field {
+	case "id":
+		frame.id = value
+	case "event":
+		frame.eventName = value
+	case "data":
+		frame.data = append(frame.data, value)
+		frame.hasData = true
+	}
+}
+
+// event renders the accumulated frame; false for frames the CLI skips
+// (empty frames and the live-plane mirrors).
+func (frame *sseFrame) event() (ChatStreamEvent, bool) {
+	if !frame.hasData && frame.eventName == "" {
+		return ChatStreamEvent{}, false
+	}
+	name := frame.eventName
+	if name == "" {
+		name = "message"
+	}
+	if frame.id == "" && liveDeltaFrame(name) {
+		return ChatStreamEvent{}, false
+	}
+	event := ChatStreamEvent{Type: name}
+	if frame.id != "" {
+		if sequence, parseErr := strconv.ParseInt(frame.id, 10, 64); parseErr == nil {
+			event.Sequence = sequence
+		}
+	}
+	raw := strings.Join(frame.data, "\n")
+	if raw == "" {
+		return event, true
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		event.Data = raw
+		return event, true
+	}
+	event.Data = decoded
+	if name == "content" {
+		if text, isString := decoded.(string); isString {
+			event.Content = text
+		}
+	}
+	event.Done = name == "end"
+	return event, true
+}

--- a/internal/client/chat_sessions.go
+++ b/internal/client/chat_sessions.go
@@ -108,15 +108,20 @@ func classifyChatSessionError(err error) error {
 	if !errors.As(err, &unexpected) || unexpected.StatusCode != http.StatusNotFound {
 		return err
 	}
-	// "Cluster not found" is the literal the backend writes for an unknown
-	// or foreign cluster on this route family (chatapi's
-	// verifyClusterInOrganisation and authoriseSessionOr404); it carries no
-	// error_code, so the text is the only signal. The other 404 the family
-	// answers is the route itself, on a backend that predates the lane.
-	if strings.Contains(strings.ToLower(err.Error()), "cluster not found") {
+	// The shape of the 404 tells the two apart: a backend that predates the
+	// lane answers the router's bare not-found (no JSON detail), while the
+	// lane itself always answers {"detail": ...}. Among the lane's own
+	// not-founds, "Cluster not found" (chatapi's verifyClusterInOrganisation
+	// and authoriseSessionOr404) is the one callers act on; anything else
+	// (a session that expired or was deleted) is a real not-found and stays
+	// the error it is.
+	if unexpected.Detail == "" {
+		return fmt.Errorf("%w: %v", ErrChatSessionsUnavailable, err)
+	}
+	if strings.Contains(strings.ToLower(unexpected.Detail), "cluster not found") {
 		return fmt.Errorf("%w: %v", ErrClusterNotFound, err)
 	}
-	return fmt.Errorf("%w: %v", ErrChatSessionsUnavailable, err)
+	return err
 }
 
 // StreamChatSessionEvents tails the session's event log from the given
@@ -150,7 +155,7 @@ func (c *Client) StreamChatSessionEvents(sessionID string, since int64) (<-chan 
 			return nil, ErrUnauthorized
 		}
 		if detail := detailFromBody(body); detail != "" {
-			return nil, classifyChatSessionError(newUnexpectedResponseErrorWithMessage(resp.StatusCode, detail))
+			return nil, classifyChatSessionError(newBackendDetailError(resp.StatusCode, detail))
 		}
 		return nil, classifyChatSessionError(newUnexpectedResponseError("chat events failed", resp.StatusCode,
 			redactedBodyForError(body, 500)))

--- a/internal/client/chat_sessions.go
+++ b/internal/client/chat_sessions.go
@@ -108,6 +108,11 @@ func classifyChatSessionError(err error) error {
 	if !errors.As(err, &unexpected) || unexpected.StatusCode != http.StatusNotFound {
 		return err
 	}
+	// "Cluster not found" is the literal the backend writes for an unknown
+	// or foreign cluster on this route family (chatapi's
+	// verifyClusterInOrganisation and authoriseSessionOr404); it carries no
+	// error_code, so the text is the only signal. The other 404 the family
+	// answers is the route itself, on a backend that predates the lane.
 	if strings.Contains(strings.ToLower(err.Error()), "cluster not found") {
 		return fmt.Errorf("%w: %v", ErrClusterNotFound, err)
 	}

--- a/internal/client/chat_sessions_test.go
+++ b/internal/client/chat_sessions_test.go
@@ -1,0 +1,219 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCreateChatSession_PostsTheConversationAndDecodesTheSession(t *testing.T) {
+	var captured map[string]any
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/chat/sessions" {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &captured)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"sess-1","conversation_id":"conv-1","cluster_id":null,"mode":"ask","status":"pending","latest_sequence_number":0,"error":null}`)
+	}
+	testClient := newTestClient(t, handler)
+	session, err := testClient.CreateChatSession(CreateChatSessionRequest{
+		ConversationID: "conv-1", Mode: "ask", IdempotencyKey: "key-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateChatSession: %v", err)
+	}
+	if session.ID != "sess-1" || session.ConversationID != "conv-1" || session.Mode != "ask" {
+		t.Fatalf("session = %+v", session)
+	}
+	if captured["conversation_id"] != "conv-1" || captured["mode"] != "ask" || captured["idempotency_key"] != "key-1" {
+		t.Fatalf("request body = %v", captured)
+	}
+	if _, hasCluster := captured["cluster_id"]; hasCluster {
+		t.Fatalf("a nil cluster must be omitted, body = %v", captured)
+	}
+}
+
+func TestCreateChatSession_ClassifiesTheTwo404s(t *testing.T) {
+	routeMissing := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "404 page not found", http.StatusNotFound)
+	})
+	_, err := routeMissing.CreateChatSession(CreateChatSessionRequest{ConversationID: "conv-1"})
+	if !errors.Is(err, ErrChatSessionsUnavailable) {
+		t.Fatalf("route 404 = %v, want ErrChatSessionsUnavailable", err)
+	}
+	clusterMissing := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, `{"detail":"Cluster not found"}`)
+	})
+	clusterID := "gone"
+	_, err = clusterMissing.CreateChatSession(CreateChatSessionRequest{ConversationID: "conv-1", ClusterID: &clusterID})
+	if !errors.Is(err, ErrClusterNotFound) {
+		t.Fatalf("cluster 404 = %v, want ErrClusterNotFound", err)
+	}
+	if errors.Is(err, ErrChatSessionsUnavailable) {
+		t.Fatal("a cluster 404 must not read as a missing lane")
+	}
+}
+
+func TestSubmitChatTurn_WrapsTheRequestAndSurfacesBackendDetail(t *testing.T) {
+	var captured map[string]any
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/chat/sessions/sess-1/turns" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &captured)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"session_id":"sess-1","last_seq":1}`)
+	}
+	testClient := newTestClient(t, handler)
+	conversationID := "conv-1"
+	submitted, err := testClient.SubmitChatTurn("sess-1", ChatRequest{
+		Query: "hello", ConversationID: &conversationID, InteractionMode: "ask",
+	})
+	if err != nil {
+		t.Fatalf("SubmitChatTurn: %v", err)
+	}
+	if submitted.LastSeq != 1 || submitted.SessionID != "sess-1" {
+		t.Fatalf("submitted = %+v", submitted)
+	}
+	request, _ := captured["request"].(map[string]any)
+	if request["query"] != "hello" || request["conversation_id"] != "conv-1" || request["interaction_mode"] != "ask" {
+		t.Fatalf("wrapped request = %v", captured)
+	}
+
+	exhausted := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusPaymentRequired)
+		_, _ = fmt.Fprint(w, `{"error_code":"AI_ALLOWANCE_EXHAUSTED","detail":"Your monthly free AI allowance is used up."}`)
+	})
+	_, err = exhausted.SubmitChatTurn("sess-1", ChatRequest{Query: "hello"})
+	if err == nil || !strings.Contains(err.Error(), "monthly free AI allowance") {
+		t.Fatalf("402 error = %v, want the backend detail", err)
+	}
+}
+
+func TestStreamChatSessionEvents_ParsesDurableFramesAndSkipsLiveMirrors(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/chat/sessions/sess-1/events" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("stream") != "true" || r.URL.Query().Get("since") != "1" {
+			t.Errorf("query = %s", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		frames := []string{
+			": heartbeat\n\n",
+			"id: 2\nevent: status\ndata: {\"intent\": \"Processing...\", \"mechanism\": null}\n\n",
+			"event: content_delta\ndata: {\"kind\":\"content_delta\",\"offset\":0,\"text\":\"Hel\"}\n\n",
+			"id: 3\nevent: content\ndata: \"Hello\"\n\n",
+			"id: 4\nevent: content\ndata: \" world\"\n\n",
+			"id: 5\nevent: complete\ndata: {\"response\": \"Hello world\"}\n\n",
+			"id: 6\nevent: session_complete\ndata: {\"status\": \"completed\"}\n\n",
+			"event: end\ndata: {\"status\": \"completed\", \"was_resumed\": false}\n\n",
+		}
+		for _, frame := range frames {
+			_, _ = fmt.Fprint(w, frame)
+			flusher.Flush()
+		}
+	}
+	testClient := newTestClient(t, handler)
+	events, err := testClient.StreamChatSessionEvents("sess-1", 1)
+	if err != nil {
+		t.Fatalf("StreamChatSessionEvents: %v", err)
+	}
+	var received []ChatStreamEvent
+	for event := range events {
+		received = append(received, event)
+	}
+	types := make([]string, 0, len(received))
+	for _, event := range received {
+		types = append(types, event.Type)
+	}
+	want := []string{"status", "content", "content", "complete", "session_complete", "end"}
+	if strings.Join(types, ",") != strings.Join(want, ",") {
+		t.Fatalf("event types = %v, want %v", types, want)
+	}
+	if received[0].Sequence != 2 || received[1].Sequence != 3 || received[5].Sequence != 0 {
+		t.Fatalf("sequences = %d/%d/%d, want 2/3/0", received[0].Sequence, received[1].Sequence, received[5].Sequence)
+	}
+	if received[1].Content != "Hello" || received[2].Content != " world" {
+		t.Fatalf("content = %q / %q", received[1].Content, received[2].Content)
+	}
+	if status := chatStatus(received[0]); status != "Processing..." {
+		t.Fatalf("status intent = %q", status)
+	}
+	if !received[5].Done {
+		t.Fatal("the end frame must be marked done")
+	}
+}
+
+func chatStatus(event ChatStreamEvent) string {
+	data, _ := event.Data.(map[string]any)
+	intent, _ := data["intent"].(string)
+	return intent
+}
+
+func TestStreamChatSessionEvents_DropWithoutEndClosesWithoutAnError(t *testing.T) {
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "id: 2\nevent: content\ndata: \"partial\"\n\n")
+	}
+	testClient := newTestClient(t, handler)
+	events, err := testClient.StreamChatSessionEvents("sess-1", 1)
+	if err != nil {
+		t.Fatalf("StreamChatSessionEvents: %v", err)
+	}
+	var received []ChatStreamEvent
+	for event := range events {
+		received = append(received, event)
+	}
+	if len(received) != 1 || received[0].Type != "content" {
+		t.Fatalf("events = %+v, want just the partial content (a clean EOF is the caller's resume cue)", received)
+	}
+}
+
+func TestStreamChatSessionEvents_IdleTimeoutSurfacesALocalError(t *testing.T) {
+	previous := chatStreamIdleTimeout
+	chatStreamIdleTimeout = 150 * time.Millisecond
+	t.Cleanup(func() { chatStreamIdleTimeout = previous })
+	release := make(chan struct{})
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.(http.Flusher).Flush()
+		<-release
+	}
+	testClient := newTestClient(t, handler)
+	t.Cleanup(func() { close(release) })
+	events, err := testClient.StreamChatSessionEvents("sess-1", 0)
+	if err != nil {
+		t.Fatalf("StreamChatSessionEvents: %v", err)
+	}
+	var received []ChatStreamEvent
+	for event := range events {
+		received = append(received, event)
+	}
+	if len(received) != 1 || received[0].Type != "error" || received[0].Data != nil ||
+		!strings.Contains(received[0].Error, "idle timeout") {
+		t.Fatalf("events = %+v, want one local idle-timeout error", received)
+	}
+}
+
+func TestStreamChatSessionEvents_NotFoundClassifies(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "404 page not found", http.StatusNotFound)
+	})
+	_, err := testClient.StreamChatSessionEvents("sess-1", 0)
+	if !errors.Is(err, ErrChatSessionsUnavailable) {
+		t.Fatalf("err = %v, want ErrChatSessionsUnavailable", err)
+	}
+}

--- a/internal/client/chat_sessions_test.go
+++ b/internal/client/chat_sessions_test.go
@@ -61,6 +61,18 @@ func TestCreateChatSession_ClassifiesTheTwo404s(t *testing.T) {
 	if errors.Is(err, ErrChatSessionsUnavailable) {
 		t.Fatal("a cluster 404 must not read as a missing lane")
 	}
+	sessionGone := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, `{"detail":"AI session not found"}`)
+	})
+	_, err = sessionGone.SubmitChatTurn("sess-gone", ChatRequest{Query: "hello"})
+	if err == nil || errors.Is(err, ErrChatSessionsUnavailable) || errors.Is(err, ErrClusterNotFound) {
+		t.Fatalf("a JSON not-found from the lane itself must stay a plain not-found, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "AI session not found") {
+		t.Fatalf("err = %v, want the backend detail", err)
+	}
 }
 
 func TestSubmitChatTurn_WrapsTheRequestAndSurfacesBackendDetail(t *testing.T) {

--- a/internal/client/csrf.go
+++ b/internal/client/csrf.go
@@ -87,7 +87,7 @@ func (c *Client) doJSONWithClient(
 	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusCreated {
 		detail := detailFromBody(body)
 		if detail != "" {
-			return newUnexpectedResponseErrorWithMessage(response.StatusCode, detail)
+			return newBackendDetailError(response.StatusCode, detail)
 		}
 		return newUnexpectedResponseError(operation, response.StatusCode, redactedBodyForError(body, 500))
 	}

--- a/internal/client/helpers.go
+++ b/internal/client/helpers.go
@@ -118,7 +118,7 @@ func (c *Client) sendJSON(method string, url string, payload any, target any) er
 			return denied
 		}
 		if detail := detailFromBody(body); detail != "" {
-			return newUnexpectedResponseErrorWithMessage(response.StatusCode, detail)
+			return newBackendDetailError(response.StatusCode, detail)
 		}
 		return newUnexpectedResponseError("request failed", response.StatusCode, redactedBodyForError(body, 500))
 	}

--- a/internal/client/unexpected_response.go
+++ b/internal/client/unexpected_response.go
@@ -13,6 +13,12 @@ import (
 type UnexpectedResponseError struct {
 	StatusCode int
 	message    string
+	// Detail is the backend's JSON `detail` string when the response carried
+	// one, and empty when the body was not the API's error shape (a bare
+	// router 404, a proxy page). Callers that must tell "the route does not
+	// exist" from "the route answered not-found" key on it instead of on
+	// message text.
+	Detail string
 }
 
 func (e *UnexpectedResponseError) Error() string {
@@ -26,6 +32,17 @@ func newUnexpectedResponseError(operation string, statusCode int, bodyForDisplay
 	return &UnexpectedResponseError{
 		StatusCode: statusCode,
 		message:    fmt.Sprintf("%s: status %d, body: %s", operation, statusCode, bodyForDisplay),
+	}
+}
+
+// newBackendDetailError wraps an API error body's `detail` string: the
+// message is the detail itself (what users see) and Detail records that the
+// backend, not a router or proxy, produced the status.
+func newBackendDetailError(statusCode int, detail string) *UnexpectedResponseError {
+	return &UnexpectedResponseError{
+		StatusCode: statusCode,
+		message:    detail,
+		Detail:     detail,
 	}
 }
 


### PR DESCRIPTION
## What & why

`ankra chat` ran on the two bearer stream endpoints the backend deprecated in July (`POST /api/v1/chat/general` and the per-cluster twin): both are `Deprecation: true` with a 2026-12-31 sunset and a `Link: </api/v1/chat/sessions>; rel="successor-version"`, both pin the platform Anthropic key with no org routing, both persist only the user's message (every CLI conversation in prod today has exactly one message), both hide the failure cause behind one generic sentence, and the interactive loop resent the whole transcript on every turn. On 2026-09-01, with the platform Anthropic account out of credits, every `ankra chat` turn failed while the portal (on sessions) kept working.

This PR moves `ankra chat` onto the durable sessions lane (bead **ankra-y8l44.2**) and fixes the stale-selection UX around it (bead **ankra-y8l44.3**):

- **Sessions lane** (`internal/client/chat_sessions.go`): create a session on a conversation id, submit the turn, tail `GET /sessions/{id}/events?stream=true&since=N` with a real SSE frame parser (id / event / data, heartbeat comments reset the idle watchdog, id-less live-plane mirrors skipped, terminal `end` frame). The backend owns the transcript, so the CLI carries only a conversation id between turns.
- **Continuity**: a one-shot answer prints `conversation <id> (continue with: ankra chat --conversation <id> "...")` on **stderr** (piped answers stay clean); `--conversation <id>` continues any conversation from `ankra chat history`; interactive mode keeps one conversation and `clear` starts a fresh one. This also makes `ankra chat actions list <id>` usable after a one-shot.
- **Resilience**: a dropped tail resumes from its last durable sequence (bounded reconnects with back-off); a backend without the lane (older self-hosted platforms) falls back to the deprecated stream transparently, whose deprecation warning now prints once per process instead of mid-prompt on every turn.
- **Errors**: error frames show their stable code (`ai_platform_billing`, …); `ANKRA_DEBUG=1` adds the operator detail the sessions lane carries.
- **Stale `ankra cluster select`**: a persisted selection pointing at a deleted cluster used to turn `ankra chat` and `ankra chat health` into a bare `404 Cluster not found`. Chat now names the stale selection, says how to clear it, and continues without cluster context (one degrade only); `chat health` explains it instead of the bare 404. An explicit `--cluster` is never degraded.
- **Small ones**: `chat show`/`chat delete` refuse a non-UUID id with a hint instead of the backend's 422; interactive mode reads the command's configured stdin; `TestOrgSwitchCommand` no longer writes `~/.ankra/organisation.json` into the developer's real home directory (it did - found on this machine).

Beads: ankra-y8l44.2, ankra-y8l44.3 (parent ankra-y8l44, the 2026-09-01 AI chat review).

## Test plan

- `go test -race -count=1 ./...` green; `gofmt` clean on the touched files.
- New client tests: session create (body shape, nil cluster omitted), the two 404 classifications (route missing → legacy fallback sentinel, `Cluster not found` → cluster sentinel), turn submit wrapping and 402 detail surfacing, SSE parsing (sequences, content, live mirrors skipped, `end`), clean drop without `end`, idle-timeout local error, 404 on the tail.
- New command tests: one-shot on sessions (ask mode, conversation id on stderr only, no history resent, tail from `last_seq`), `--conversation` continuation and validation, error frame with code (detail only under `ANKRA_DEBUG`), resume across a dropped tail from the last sequence, give-up after the reconnect budget, legacy fallback, stale-selection degrade with notice (and only once), interactive continuity across turns and `clear`, `show`/`delete` id validation, session-mode mapping, UUID v4 minting.
- Live against `platform.ankra.app` (george@ankra.io, demo org) with the built binary: see the PR comments for the transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3h8p8qQLeNgirDRARzkuf
