### PR TITLE
feat(chat): name the conversations ankra chat starts (ankra-y8l44.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Changed
 
+- **`ankra chat` names the conversations it starts.** After the first
+  completed turn of a new conversation the CLI asks the backend for a
+  summarised title (the same call the portal makes), so a chat started from
+  the terminal no longer keeps its raw first question as its title in
+  `ankra chat history` and the portal sidebar. Best-effort: an older backend
+  or a title you already set are left alone.
 - **`ankra chat` runs on the durable chat sessions API** (`/api/v1/chat/sessions`),
   the successor the deprecated bearer stream has advertised since July. The
   backend now owns the transcript: interactive turns continue one server-side

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -151,6 +151,9 @@ func runChatMessage(scope chatScope, conversationID string, query string, intera
 	fmt.Print("\n")
 	outcome := renderChatTurn(events, os.Stdout, os.Stderr, false)
 	fmt.Print("\n\n")
+	if onSessions && startedConversation && outcome.errorMessage == "" {
+		requestConversationTitle(conversationID)
+	}
 	if onSessions {
 		// The id goes to stderr so a piped answer stays clean.
 		if startedConversation {
@@ -170,6 +173,9 @@ func runChatMessage(scope chatScope, conversationID string, query string, intera
 
 func runInteractiveChat(stdin io.Reader, scope chatScope, conversationID string, interactionMode string) error {
 	continued := conversationID != ""
+	// A continued conversation is not this session's to name; one started
+	// here is named after its first completed turn, like the portal does.
+	titled := continued
 	if conversationID == "" {
 		generated, err := newChatUUID()
 		if err != nil {
@@ -231,6 +237,7 @@ func runInteractiveChat(stdin io.Reader, scope chatScope, conversationID string,
 				return genErr
 			}
 			conversationID = generated
+			titled = false
 			fmt.Printf("Started a new conversation: %s\n", conversationID)
 			continue
 		}
@@ -257,6 +264,10 @@ func runInteractiveChat(stdin io.Reader, scope chatScope, conversationID string,
 		outcome := renderChatTurn(events, os.Stdout, os.Stderr, true)
 		if outcome.response != "" {
 			history = append(history, client.ChatMessage{Role: "assistant", Content: outcome.response})
+		}
+		if onSessions && !titled && outcome.errorMessage == "" {
+			requestConversationTitle(conversationID)
+			titled = true
 		}
 		fmt.Print("\n\n")
 		resolvePendingProposals(reader, outcome.proposals)

--- a/cmd/chat_session.go
+++ b/cmd/chat_session.go
@@ -311,3 +311,12 @@ func renderChatTurn(events <-chan client.ChatStreamEvent, out io.Writer, errOut 
 	outcome.response = response.String()
 	return outcome
 }
+
+// requestConversationTitle asks the backend to name a conversation this
+// command started, once its first exchange exists - the same call the portal
+// makes after the first reply. Best-effort by design: a backend without the
+// route, a title the user already set, or a summariser outage all leave the
+// first question as the title, and none of them is worth a line of output.
+func requestConversationTitle(conversationID string) {
+	_ = apiClient.RegenerateChatTitle(conversationID)
+}

--- a/cmd/chat_session_test.go
+++ b/cmd/chat_session_test.go
@@ -32,6 +32,7 @@ type chatSessionMock struct {
 	tailSince      []int64
 	legacyEvents   []client.ChatStreamEvent
 	legacyCalls    int
+	titleCalls     []string
 	legacyClusters []*string // the cluster each StreamChat call was scoped to
 }
 
@@ -42,6 +43,13 @@ func popScriptedError(queue *[]error) error {
 	err := (*queue)[0]
 	*queue = (*queue)[1:]
 	return err
+}
+
+func (m *chatSessionMock) RegenerateChatTitle(conversationID string) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.titleCalls = append(m.titleCalls, conversationID)
+	return nil
 }
 
 func (m *chatSessionMock) CreateChatSession(request client.CreateChatSessionRequest) (*client.ChatSession, error) {
@@ -603,5 +611,73 @@ func TestNewChatUUIDIsV4(t *testing.T) {
 	other, _ := newChatUUID()
 	if other == id {
 		t.Fatal("two ids must differ")
+	}
+}
+
+func TestChatOneShot_NamesTheConversationItStarted(t *testing.T) {
+	resetChatFlags(t)
+	mock := &chatSessionMock{tails: [][]client.ChatStreamEvent{{contentFrame(2, "Hello"), endFrame()}}}
+	captureStdout(t, func() {
+		captureStderr(t, func() {
+			if _, err := runWithInput(t, mock, "", "chat", "hello"); err != nil {
+				t.Fatalf("chat failed: %v", err)
+			}
+		})
+	})
+	if len(mock.titleCalls) != 1 || mock.titleCalls[0] != mock.created[0].ConversationID {
+		t.Fatalf("title calls = %v, want one for the started conversation %s", mock.titleCalls, mock.created[0].ConversationID)
+	}
+}
+
+func TestChatOneShot_DoesNotRenameAContinuedOrFailedConversation(t *testing.T) {
+	resetChatFlags(t)
+	continued := &chatSessionMock{tails: [][]client.ChatStreamEvent{{contentFrame(2, "Sure."), endFrame()}}}
+	captureStdout(t, func() {
+		captureStderr(t, func() {
+			_, _ = runWithInput(t, continued, "", "chat", "--conversation", "a75c06a2-5100-41f2-bdde-778c5a74200c", "and then?")
+		})
+	})
+	if len(continued.titleCalls) != 0 {
+		t.Fatalf("a continued conversation must keep its title; calls = %v", continued.titleCalls)
+	}
+	resetChatFlags(t)
+	failed := &chatSessionMock{tails: [][]client.ChatStreamEvent{{
+		{Type: "error", Data: map[string]any{"message": "unavailable"}, Sequence: 2}, endFrame()}}}
+	captureStdout(t, func() {
+		captureStderr(t, func() { _, _ = runWithInput(t, failed, "", "chat", "hello") })
+	})
+	if len(failed.titleCalls) != 0 {
+		t.Fatalf("a failed first turn has nothing to summarise; calls = %v", failed.titleCalls)
+	}
+	legacy := &chatSessionMock{createErrors: []error{client.ErrChatSessionsUnavailable},
+		legacyEvents: []client.ChatStreamEvent{{Type: "content", Content: "Legacy."}, {Type: "complete"}}}
+	captureStdout(t, func() {
+		captureStderr(t, func() { _, _ = runWithInput(t, legacy, "", "chat", "hello") })
+	})
+	if len(legacy.titleCalls) != 0 {
+		t.Fatalf("the deprecated lane has no server-side conversation to name; calls = %v", legacy.titleCalls)
+	}
+}
+
+func TestChatInteractive_NamesEachConversationOnceAfterItsFirstTurn(t *testing.T) {
+	resetChatFlags(t)
+	mock := &chatSessionMock{tails: [][]client.ChatStreamEvent{
+		{contentFrame(2, "one"), endFrame()},
+		{contentFrame(2, "two"), endFrame()},
+		{contentFrame(2, "three"), endFrame()},
+	}}
+	captureStdout(t, func() {
+		captureStderr(t, func() {
+			if _, err := runWithInput(t, mock, "first\nsecond\nclear\nthird\nexit\n", "chat"); err != nil {
+				t.Fatalf("chat failed: %v", err)
+			}
+		})
+	})
+	if len(mock.titleCalls) != 2 {
+		t.Fatalf("title calls = %v, want one per conversation started (before and after 'clear')", mock.titleCalls)
+	}
+	if mock.titleCalls[0] != mock.created[0].ConversationID || mock.titleCalls[1] != mock.created[2].ConversationID {
+		t.Fatalf("title calls = %v, want the first and the post-clear conversation ids (%s, %s)",
+			mock.titleCalls, mock.created[0].ConversationID, mock.created[2].ConversationID)
 	}
 }

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -37,6 +37,8 @@ func (m baseMock) StreamChatSessionEvents(string, int64) (<-chan client.ChatStre
 
 func (m baseMock) CancelChatSession(string) error { return errors.New("not implemented") }
 
+func (m baseMock) RegenerateChatTitle(string) error { return errors.New("not implemented") }
+
 func (m baseMock) OrganisationOverride() string { return "" }
 
 func (m baseMock) UpdateUpcloudZonePool(context.Context, string, []string, bool) (*client.UpdateUpcloudZonePoolResult, bool, error) {

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -285,6 +285,7 @@ type APIClient interface {
 	SubmitChatTurn(sessionID string, request client.ChatRequest) (*client.SubmitChatTurnResponse, error)
 	StreamChatSessionEvents(sessionID string, since int64) (<-chan client.ChatStreamEvent, error)
 	CancelChatSession(sessionID string) error
+	RegenerateChatTitle(conversationID string) error
 	ConfirmChatAction(request client.ConfirmChatActionRequest) (*client.ConfirmChatActionResult, error)
 	ListPendingChatActions(conversationID string) (*client.PendingChatActionsResult, error)
 	ListChatHistory(clusterID *string, limit, offset int) (*client.ListConversationsResponse, error)

--- a/internal/client/chat_sessions.go
+++ b/internal/client/chat_sessions.go
@@ -90,6 +90,18 @@ func (c *Client) SubmitChatTurn(sessionID string, request ChatRequest) (*SubmitC
 	return &response, nil
 }
 
+// RegenerateChatTitle asks the backend to summarise a conversation's
+// placeholder title from its first exchange - what the portal does after
+// the first reply, and what a conversation started here would otherwise
+// never get. Callers treat every failure as best-effort: an older backend
+// without the route (404), a title the user already set (409), or a
+// summariser outage (502) all leave the first question as the title.
+func (c *Client) RegenerateChatTitle(conversationID string) error {
+	return classifyChatSessionError(c.sendJSON(http.MethodPost,
+		fmt.Sprintf("%s/api/v1/chat/conversations/%s/title/regenerate", c.BaseURL, url.PathEscape(conversationID)),
+		nil, nil))
+}
+
 // CancelChatSession asks the runner to stop the session's in-flight turn.
 func (c *Client) CancelChatSession(sessionID string) error {
 	return classifyChatSessionError(c.sendJSON(http.MethodPost,

--- a/internal/client/chat_sessions_test.go
+++ b/internal/client/chat_sessions_test.go
@@ -229,3 +229,30 @@ func TestStreamChatSessionEvents_NotFoundClassifies(t *testing.T) {
 		t.Fatalf("err = %v, want ErrChatSessionsUnavailable", err)
 	}
 }
+
+func TestRegenerateChatTitle_PostsAndClassifies(t *testing.T) {
+	var method, path string
+	ok := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		method, path = r.Method, r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"conversation_id":"a75c06a2-5100-41f2-bdde-778c5a74200c","title":"Diagnose Failing Nats"}`)
+	})
+	if err := ok.RegenerateChatTitle("a75c06a2-5100-41f2-bdde-778c5a74200c"); err != nil {
+		t.Fatalf("RegenerateChatTitle: %v", err)
+	}
+	if method != http.MethodPost || path != "/api/v1/chat/conversations/a75c06a2-5100-41f2-bdde-778c5a74200c/title/regenerate" {
+		t.Fatalf("request = %s %s", method, path)
+	}
+	custom := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = fmt.Fprint(w, `{"detail":"Conversation already has a custom title"}`)
+	})
+	if err := custom.RegenerateChatTitle("a75c06a2-5100-41f2-bdde-778c5a74200c"); err == nil || !strings.Contains(err.Error(), "custom title") {
+		t.Fatalf("409 = %v, want the backend detail surfaced for the caller to ignore", err)
+	}
+	older := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) { http.Error(w, "404 page not found", http.StatusNotFound) })
+	if err := older.RegenerateChatTitle("a75c06a2-5100-41f2-bdde-778c5a74200c"); !errors.Is(err, ErrChatSessionsUnavailable) {
+		t.Fatalf("route 404 = %v, want ErrChatSessionsUnavailable", err)
+	}
+}


### PR DESCRIPTION
## What & why

Only the portal asks the backend for a conversation title (after the first reply), so every conversation started from `ankra chat` kept its raw first question as its title in `ankra chat history` and in the portal sidebar (seen live on 2026-09-01: the portal's new chat got "Kubernetes Namespace Definition", the CLI's stayed "Reply with exactly the word pong.").

After the first completed turn of a conversation this command started (a one-shot, or each conversation in interactive mode including after `clear`) the CLI now calls the new bearer twin `POST /api/v1/chat/conversations/{id}/title/regenerate` (ankraio/cluster#2379). Best-effort by design: an older backend without the route, a title the user already set (409), or a summariser outage (502) leave the first question in place with no output. A continued (`--conversation`) or failed turn never triggers it, and the deprecated lane has no server-side conversation to name.

Bead: ankra-y8l44.14 (parent ankra-y8l44, the 2026-09-01 AI chat review).

## Test plan

- Client: `TestRegenerateChatTitle_PostsAndClassifies` (method/path, 409 detail surfaced, route-missing 404 classified).
- Command: `TestChatOneShot_NamesTheConversationItStarted`, `TestChatOneShot_DoesNotRenameAContinuedOrFailedConversation` (continued, failed, legacy lane), `TestChatInteractive_NamesEachConversationOnceAfterItsFirstTurn` (two turns name once; `clear` names the new one).
- Pre-commit hook: `go test ./...` and `golangci-lint` green.
- Live verification pending the platform AI accounts being funded again and cluster#2379 deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
