### PR TITLE
fix(chat): skip the pipeline's narrative status line (ankra-y8l44.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `ankra chat` no longer prints the pipeline's narrative status line - a truncated
+  echo of the answer in brackets - after the answer itself.
 - **`ankra chat` names the conversations it starts.** After the first
   completed turn of a new conversation the CLI asks the backend for a
   summarised title (the same call the portal makes), so a chat started from

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -24,6 +24,12 @@ func chatStatusText(data any) string {
 	case string:
 		return typed
 	case map[string]any:
+		// A narrative status is the model's own first sentence, relayed for
+		// the portal's activity ticker; the CLI already prints that sentence
+		// as content, so showing it again in brackets - truncated - is noise.
+		if source, _ := typed["intent_source"].(string); source == "narrative" {
+			return ""
+		}
 		intent, _ := typed["intent"].(string)
 		mechanism, _ := typed["mechanism"].(string)
 		switch {

--- a/cmd/chat_test.go
+++ b/cmd/chat_test.go
@@ -58,6 +58,8 @@ func TestChatStatusText(t *testing.T) {
 		{"object with intent only", map[string]any{"intent": "Processing...", "mechanism": nil}, "Processing..."},
 		{"object with nothing renderable", map[string]any{"elapsed_ms": float64(12)}, ""},
 		{"nil data", nil, ""},
+		{"narrative status echoes the answer", map[string]any{"intent": "Only demo-helsinki is online right now \u2014 playground is offl\u2026", "mechanism": nil, "intent_source": "narrative"}, ""},
+		{"registry status keeps rendering", map[string]any{"intent": "Listing clusters", "mechanism": nil, "intent_source": "registry"}, "Listing clusters"},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {


### PR DESCRIPTION
## What & why

With `ankra chat` on the sessions lane, the answer is followed by a bracketed, truncated copy of itself, e.g. `[Only demo-helsinki is online right now — playground is offl…]`. The pipeline relays a `status` frame with `intent_source: narrative` (the model's first sentence, for the portal's activity ticker) beside the registry statuses (`Processing...`, `Listing clusters`), and the CLI rendered every status intent in brackets. Narrative statuses are content the CLI already printed, so `chatStatusText` now skips them; registry statuses keep rendering.

Bead: ankra-y8l44.15

## Test plan

- `TestChatStatusText` gains the narrative and registry cases; pre-commit hook (`go test ./...`, `golangci-lint`) green.
- Live: the two-sentence cluster question no longer echoes its first line after the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)