### PR TITLE
ci: put Depot runner labels behind org variables CI_RUNNER_2/4/8 (ankra-e249l.1)

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   sync-docs:
     name: Generate and PR CLI reference
-    runs-on: depot-ubuntu-24.04
+    runs-on: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
     steps:
       - name: Checkout ankra-cli
         uses: actions/checkout@v6

--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   lint-test-build:
-    runs-on: depot-ubuntu-24.04
+    runs-on: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Create release
     permissions:
       contents: write
-    runs-on: depot-ubuntu-24.04
+    runs-on: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -67,16 +67,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: depot-ubuntu-24.04
+          - os: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
             goos: linux
             goarch: amd64
-          - os: depot-ubuntu-24.04
+          - os: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
             goos: linux
             goarch: arm64
-          - os: depot-ubuntu-24.04
+          - os: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
             goos: windows
             goarch: amd64
-          - os: depot-ubuntu-24.04
+          - os: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
             goos: windows
             goarch: arm64
           - os: macos-latest
@@ -156,7 +156,7 @@ jobs:
     if: ${{ !contains(github.ref_name, '-') }}
     permissions:
       contents: read
-    runs-on: depot-ubuntu-24.04
+    runs-on: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/systemtest.yml
+++ b/.github/workflows/systemtest.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   lifecycle-system-test:
     name: Cloud lifecycle system test
-    runs-on: depot-ubuntu-24.04
+    runs-on: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
     timeout-minutes: 240
     env:
       ANKRA_SYSTEMTEST_CONFIRM: 'yes'


### PR DESCRIPTION
Every `runs-on` that named a Depot label now reads `${{ vars.CI_RUNNER_<n> || '<same Depot label>' }}` (n = 2/4/8 vCPU). **No behaviour change until the org variables exist**: an unset variable evaluates to the empty string, so the expression falls back to today's label.

Once `CI_RUNNER_2/4/8` are created at the org level, a single variable edit re-routes CI for the whole org (Ubicloud, the ARC scale sets, or back to Depot) without touching any repo.

Context: the August 2026 Depot invoice (~22k SEK) is ~88% hosted-runner minutes. This is step 1 of epic ankra-e249l; the same change lands in every ankraio repo that uses a Depot label.

Bead: ankra-e249l.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dgar45i9fMhLXFw4hFBRkV
