### PR TITLE
fix(backups): stop telling the user to fix access keys that are fine (ankra-0xsdd.41)

### DIFF
--- a/cmd/backup_vaults.go
+++ b/cmd/backup_vaults.go
@@ -103,14 +103,27 @@ func resolveBackupVaultID(vaults APIClient, reference string) (string, error) {
 // keys, so there are none to fix and re-verifying cannot make the bucket
 // exist (the API answers 409 for exactly that) - the way out is to delete
 // it, which also clears whatever the run had already created, and provision
-// again. Anywhere else the keys are the user's own and re-verifying is the
-// point.
+// again.
+//
+// For a vault Ankra provisioned that HAS verified before, the cause is not
+// knowable from here: the keys may have been rotated, the bucket may be
+// gone, or a teardown may have failed and put the row back. Telling that
+// user to "fix the access keys" named a cause that is often wrong - a failed
+// teardown leaves perfectly good keys (ankra-0xsdd.41) - so the hint now
+// points at the error and gives both real ways out. A bring-your-own vault
+// is the one case where the keys really are the user's, and re-verifying
+// after fixing them is the point.
 func backupVaultVerifyHint(vault *client.BackupVault) string {
-	if vault.Kind == "ankra_provisioned" && (vault.LastVerifiedAt == nil || *vault.LastVerifiedAt == "") {
+	if vault.Kind != "ankra_provisioned" {
+		return fmt.Sprintf("fix the access keys, then run 'ankra backup vaults verify %s'", vault.Name)
+	}
+	if vault.LastVerifiedAt == nil || *vault.LastVerifiedAt == "" {
 		return fmt.Sprintf("provisioning did not finish, so run "+
 			"'ankra backup vaults delete %s --destroy-provider-resources' and provision again", vault.Name)
 	}
-	return fmt.Sprintf("fix the access keys, then run 'ankra backup vaults verify %s'", vault.Name)
+	return fmt.Sprintf("read the error above - if the bucket or its keys changed, run "+
+		"'ankra backup vaults verify %s'; if a teardown left resources behind, remove them with "+
+		"'ankra backup vaults delete %s --destroy-provider-resources'", vault.Name, vault.Name)
 }
 
 // backupVaultStatusError turns a vault whose verification failed into a

--- a/cmd/backup_vaults_test.go
+++ b/cmd/backup_vaults_test.go
@@ -214,9 +214,13 @@ func TestBackupVaultVerifyHintMatchesTheVaultKind(t *testing.T) {
 			vault:    client.BackupVault{Name: "offsite", Kind: "ankra_provisioned"},
 			expected: "--destroy-provider-resources",
 		},
+		// The cause is not knowable from here - rotated keys, a deleted
+		// bucket, or a failed teardown that put the row back - so the hint
+		// must not name one. It used to say "fix the access keys", which a
+		// failed teardown makes plainly wrong (ankra-0xsdd.41).
 		"provisioned but verified before": {
 			vault:    client.BackupVault{Name: "offsite", Kind: "ankra_provisioned", LastVerifiedAt: &verifiedAt},
-			expected: "fix the access keys",
+			expected: "if a teardown left resources behind",
 		},
 		"bring your own": {
 			vault:    client.BackupVault{Name: "offsite", Kind: "customer_s3"},
@@ -228,6 +232,13 @@ func TestBackupVaultVerifyHintMatchesTheVaultKind(t *testing.T) {
 		if !strings.Contains(hint, testCase.expected) {
 			t.Errorf("%s: hint %q does not contain %q", name, hint, testCase.expected)
 		}
+	}
+
+	// A vault Ankra provisioned and verified before must never be told its
+	// keys are the problem: a failed teardown leaves them working.
+	provisioned := client.BackupVault{Name: "offsite", Kind: "ankra_provisioned", LastVerifiedAt: &verifiedAt}
+	if hint := backupVaultVerifyHint(&provisioned); strings.Contains(hint, "fix the access keys") {
+		t.Errorf("hint still names the keys as the cause: %q", hint)
 	}
 }
 


### PR DESCRIPTION
Bead: ankra-0xsdd.41 (CLI half; the platform half is ankraio/cluster#2368)

A backup vault whose teardown failed comes back as an error row, and the CLI printed:

```
To recover: fix the access keys, then run 'ankra backup vaults verify demo-backups'
```

The keys are not the problem. A failed teardown leaves them working — what is left behind is a provider resource — so the advice named a wrong cause and sent the user to a command that cannot help. Observed live while provisioning a real vault on UpCloud.

## What changed

For a vault Ankra provisioned **that has verified before**, the cause genuinely is not knowable from the CLI: rotated keys, a deleted bucket, or a failed teardown that put the row back are all possible. That branch no longer asserts one. It points at the error the row already carries and offers both real ways out — re-verify, or delete with `--destroy-provider-resources`.

The two branches that *do* know are untouched:

- a bring-your-own vault's keys really are the user's → "fix the access keys, then verify";
- a provisioned vault that never verified never got as far as minting keys → "provisioning did not finish, delete and provision again".

## Why not something more specific

A typed error kind on the vault (`provisioning` / `verification` / `teardown`) would let this be specific again rather than merely honest. That needs a column, an API field and an `openapi.json` change, so it belongs with the restore-point work rather than bolted onto a hint fix. Noted on the bead.

## Tests

The provisioned-and-verified case now asserts the teardown route is offered, plus a guard that the hint can never name the keys as the cause again.

`gofmt`, `go vet ankra/cmd` and `go test ankra/cmd` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
