### PR TITLE
feat(security): sbom, namespaces and pods reads (ankra-j9kec)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+### Added
+
+- **`ankra security sbom` reads the fleet's software bill of materials.** Every
+  package the scanner found in every container image, grouped by name,
+  version and ecosystem, with how many images, workloads and clusters carry
+  it and the findings that name that exact package and version - so a new CVE
+  is answered with `ankra security sbom --search <package>` instead of a
+  rescan. `--type`, `--vulnerable true|false`, `--cluster`, `--namespace` and
+  `--image` narrow it; `ankra security sbom images` lists the images with a
+  bill of materials and `ankra security sbom image <digest>` opens one with
+  the workloads running it and its full component list. The coverage line
+  says how many scanned clusters publish a bill of materials; the platform
+  keeps it off by default, and the input to switch on per cluster is named
+  when none do.
+- **`ankra security namespaces` and `ankra security pods` break findings down
+  by namespace and pod.** `namespaces` lists every namespace on every cluster
+  with its scanned workloads and images, the pods running there now, the
+  actionable findings by severity and the known-exploited count (cluster-scoped
+  reports keep a `(cluster-scoped)` row so the totals still add up). `pods
+  --cluster <c> --namespace <ns>` lists the namespace's running pods, each
+  container joined to its scanned workload's findings through the pod's owner
+  chain; narrow to one workload with `--workload-uid` or
+  `--workload-kind`/`--workload-name`. A container the scanner never covered
+  reads `not scanned`, never clean.
+
 ### Changed
 
 - `ankra chat` no longer prints the pipeline's narrative status line - a truncated

--- a/cmd/confirm_core_test.go
+++ b/cmd/confirm_core_test.go
@@ -20,15 +20,33 @@ func resetTreeFlags(t *testing.T, cmds ...*cobra.Command) {
 	t.Helper()
 	cmds = append(cmds, clusterCmd)
 	for _, command := range cmds {
-		command.Flags().VisitAll(func(flag *pflag.Flag) {
-			_ = flag.Value.Set(flag.DefValue)
-			flag.Changed = false
-		})
-		command.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
-			_ = flag.Value.Set(flag.DefValue)
-			flag.Changed = false
-		})
+		command.Flags().VisitAll(resetFlagToDefault)
+		command.PersistentFlags().VisitAll(resetFlagToDefault)
 	}
+}
+
+// resetFlagToDefault restores one flag. A slice flag's Set appends once the
+// flag has been touched, so re-applying its "[a,b]" default through Set
+// would grow it by one entry per reset; Replace puts the parsed default
+// back instead.
+func resetFlagToDefault(flag *pflag.Flag) {
+	if sliceValue, isSlice := flag.Value.(pflag.SliceValue); isSlice {
+		_ = sliceValue.Replace(defaultSliceEntries(flag.DefValue))
+	} else {
+		_ = flag.Value.Set(flag.DefValue)
+	}
+	flag.Changed = false
+}
+
+func defaultSliceEntries(defaultValue string) []string {
+	trimmed := strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(defaultValue), "["), "]")
+	entries := []string{}
+	for _, entry := range strings.Split(trimmed, ",") {
+		if entry = strings.TrimSpace(entry); entry != "" {
+			entries = append(entries, entry)
+		}
+	}
+	return entries
 }
 
 // runConfirmCommand executes rootCmd end-to-end with the given stdin, capturing

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -982,6 +982,26 @@ func (m baseMock) ListSecurityClusters(client.SecurityClustersOptions) (*client.
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) ListSecurityNamespaces(client.SecurityNamespacesOptions) (*client.SecurityNamespaceList, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ListSecurityPods(client.SecurityPodsOptions) (*client.SecurityPodList, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ListSecuritySBOMComponents(client.SecuritySBOMComponentsOptions) (*client.SecuritySBOMComponentList, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ListSecuritySBOMImages(client.SecuritySBOMImagesOptions) (*client.SecuritySBOMImageList, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetSecuritySBOMImage(client.SecuritySBOMImageOptions) (*client.SecuritySBOMImageDetail, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) CreateAPIToken(name string, expiresAt *string, scopes []string) (*client.CreateAPITokenResponse, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/security_sbom.go
+++ b/cmd/security_sbom.go
@@ -1,0 +1,517 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+)
+
+var securityNamespacesCmd = &cobra.Command{
+	Use:   "namespaces",
+	Short: "Security posture by cluster and namespace: workloads, pods and actionable findings",
+	Long: `Break the fleet's findings down the way a platform team owns it: cluster,
+then namespace. Each row carries the scanned workloads and images in the
+namespace, the pods the cluster runs there right now, the actionable
+findings by severity and the known-exploited count. Cluster-scoped reports
+(node and control-plane images) keep a row of their own so the rows still
+add up to the cluster.
+
+Drill further with 'ankra security pods --cluster <cluster> --namespace <ns>'.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		page, _ := cmd.Flags().GetInt("page")
+		pageSize, _ := cmd.Flags().GetInt("page-size")
+		search, _ := cmd.Flags().GetString("search")
+		clusterFlag, _ := cmd.Flags().GetString("cluster")
+		sort, _ := cmd.Flags().GetString("sort")
+		order, _ := cmd.Flags().GetString("order")
+		options := client.SecurityNamespacesOptions{Page: page, PageSize: pageSize, Search: search, Sort: sort, Order: order}
+		if clusterFlag != "" {
+			clusterID, err := resolveClusterID(clusterFlag)
+			if err != nil {
+				return err
+			}
+			options.ClusterID = clusterID
+		}
+		list, err := apiClient.ListSecurityNamespaces(options)
+		if err != nil {
+			return fmt.Errorf("listing namespace security posture: %w", err)
+		}
+		if rendered, err := renderStructured(cmd, list); rendered || err != nil {
+			return err
+		}
+		renderSecurityNamespaces(cmd, list)
+		return nil
+	},
+}
+
+var securityPodsCmd = &cobra.Command{
+	Use:   "pods",
+	Short: "The pods of one namespace, each container joined to its scanned workload's findings",
+	Long: `List the pods a namespace runs right now with the findings of the scanned
+workload container behind each of their containers. The owner chain is
+resolved one level up (Pod -> ReplicaSet -> Deployment, Pod -> Job -> CronJob),
+so narrow to one workload with --workload-uid or --workload-kind/--workload-name.
+
+A container the scanner has no report for is marked "not scanned", which is
+not the same as clean.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		page, _ := cmd.Flags().GetInt("page")
+		pageSize, _ := cmd.Flags().GetInt("page-size")
+		clusterFlag, _ := cmd.Flags().GetString("cluster")
+		namespace, _ := cmd.Flags().GetString("namespace")
+		workloadUID, _ := cmd.Flags().GetString("workload-uid")
+		workloadKind, _ := cmd.Flags().GetString("workload-kind")
+		workloadName, _ := cmd.Flags().GetString("workload-name")
+		if strings.TrimSpace(clusterFlag) == "" || strings.TrimSpace(namespace) == "" {
+			return withExitCode(exitUsage, fmt.Errorf("--cluster and --namespace are required"))
+		}
+		clusterID, err := resolveClusterID(clusterFlag)
+		if err != nil {
+			return err
+		}
+		list, err := apiClient.ListSecurityPods(client.SecurityPodsOptions{
+			ClusterID:    clusterID,
+			Namespace:    namespace,
+			WorkloadUID:  workloadUID,
+			WorkloadKind: workloadKind,
+			WorkloadName: workloadName,
+			Page:         page,
+			PageSize:     pageSize,
+		})
+		if err != nil {
+			return fmt.Errorf("listing namespace pods: %w", err)
+		}
+		if rendered, err := renderStructured(cmd, list); rendered || err != nil {
+			return err
+		}
+		renderSecurityPods(cmd, list)
+		return nil
+	},
+}
+
+var securitySbomCmd = &cobra.Command{
+	Use:   "sbom",
+	Short: "The fleet's software bill of materials: every package in every image, and where it runs",
+	Long: `List every package the scanner found in the fleet's container images,
+grouped by name, version and ecosystem, with how many images, workloads and
+clusters carry it and the findings that name that exact package and version.
+Search a package to answer "where do we run this" without a rescan.
+
+The bill of materials is opt-in per cluster: set the security baseline input
+trivy_sbom_generation_enabled to true on a cluster with control-plane
+headroom. The coverage line says how many scanned clusters publish one.
+
+Subcommands list the images ('ankra security sbom images') and open one
+image's full component list ('ankra security sbom image <digest or reference>').`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		options, err := securitySbomComponentsOptionsFromFlags(cmd)
+		if err != nil {
+			return err
+		}
+		list, err := apiClient.ListSecuritySBOMComponents(options)
+		if err != nil {
+			return fmt.Errorf("listing the software bill of materials: %w", err)
+		}
+		if rendered, err := renderStructured(cmd, list); rendered || err != nil {
+			return err
+		}
+		renderSecuritySbomComponents(cmd, list)
+		return nil
+	},
+}
+
+var securitySbomImagesCmd = &cobra.Command{
+	Use:   "images",
+	Short: "Images with a bill of materials: OS, component count, where they run and their findings",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		page, _ := cmd.Flags().GetInt("page")
+		pageSize, _ := cmd.Flags().GetInt("page-size")
+		search, _ := cmd.Flags().GetString("search")
+		clusterFlag, _ := cmd.Flags().GetString("cluster")
+		namespace, _ := cmd.Flags().GetString("namespace")
+		sort, _ := cmd.Flags().GetString("sort")
+		order, _ := cmd.Flags().GetString("order")
+		options := client.SecuritySBOMImagesOptions{
+			Page: page, PageSize: pageSize, Search: search, Namespace: namespace, Sort: sort, Order: order,
+		}
+		if clusterFlag != "" {
+			clusterID, err := resolveClusterID(clusterFlag)
+			if err != nil {
+				return err
+			}
+			options.ClusterID = clusterID
+		}
+		list, err := apiClient.ListSecuritySBOMImages(options)
+		if err != nil {
+			return fmt.Errorf("listing images with a bill of materials: %w", err)
+		}
+		if rendered, err := renderStructured(cmd, list); rendered || err != nil {
+			return err
+		}
+		renderSecuritySbomImages(cmd, list)
+		return nil
+	},
+}
+
+var securitySbomImageCmd = &cobra.Command{
+	Use:   "image <digest or reference>",
+	Short: "One image's bill of materials: its identity, the workloads running it and every component",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		page, _ := cmd.Flags().GetInt("page")
+		pageSize, _ := cmd.Flags().GetInt("page-size")
+		search, _ := cmd.Flags().GetString("search")
+		packageTypes, _ := cmd.Flags().GetStringSlice("type")
+		sort, _ := cmd.Flags().GetString("sort")
+		order, _ := cmd.Flags().GetString("order")
+		detail, err := apiClient.GetSecuritySBOMImage(client.SecuritySBOMImageOptions{
+			ImageIdentity: strings.TrimSpace(args[0]),
+			Page:          page,
+			PageSize:      pageSize,
+			Search:        search,
+			PackageTypes:  packageTypes,
+			Sort:          sort,
+			Order:         order,
+		})
+		if err != nil {
+			return fmt.Errorf("reading the image's bill of materials: %w", err)
+		}
+		if rendered, err := renderStructured(cmd, detail); rendered || err != nil {
+			return err
+		}
+		renderSecuritySbomImageDetail(cmd, detail)
+		return nil
+	},
+}
+
+// securitySbomComponentsOptionsFromFlags maps the component flags. --vulnerable
+// accepts true, false or any so the inventory can be narrowed to packages a
+// finding names, or to the ones nothing names.
+func securitySbomComponentsOptionsFromFlags(cmd *cobra.Command) (client.SecuritySBOMComponentsOptions, error) {
+	page, _ := cmd.Flags().GetInt("page")
+	pageSize, _ := cmd.Flags().GetInt("page-size")
+	search, _ := cmd.Flags().GetString("search")
+	packageTypes, _ := cmd.Flags().GetStringSlice("type")
+	clusterFlag, _ := cmd.Flags().GetString("cluster")
+	namespace, _ := cmd.Flags().GetString("namespace")
+	image, _ := cmd.Flags().GetString("image")
+	vulnerableRaw, _ := cmd.Flags().GetString("vulnerable")
+	sort, _ := cmd.Flags().GetString("sort")
+	order, _ := cmd.Flags().GetString("order")
+	options := client.SecuritySBOMComponentsOptions{
+		Page:          page,
+		PageSize:      pageSize,
+		Search:        search,
+		PackageTypes:  packageTypes,
+		Namespace:     namespace,
+		ImageIdentity: image,
+		Sort:          sort,
+		Order:         order,
+	}
+	switch strings.ToLower(strings.TrimSpace(vulnerableRaw)) {
+	case "", "any":
+	case "true", "yes":
+		vulnerable := true
+		options.Vulnerable = &vulnerable
+	case "false", "no":
+		vulnerable := false
+		options.Vulnerable = &vulnerable
+	default:
+		return options, withExitCode(exitUsage, fmt.Errorf("--vulnerable must be true, false or any, got %q", vulnerableRaw))
+	}
+	if clusterFlag != "" {
+		clusterID, err := resolveClusterID(clusterFlag)
+		if err != nil {
+			return options, err
+		}
+		options.ClusterID = clusterID
+	}
+	return options, nil
+}
+
+func namespaceCell(namespace client.SecurityNamespace) string {
+	if namespace.ReportScope == "cluster" {
+		return "(cluster-scoped)"
+	}
+	return namespace.Namespace
+}
+
+func redIfPositive(value int) string {
+	rendered := fmt.Sprintf("%d", value)
+	if value > 0 {
+		return text.FgRed.Sprint(rendered)
+	}
+	return rendered
+}
+
+func renderSecurityNamespaces(cmd *cobra.Command, list *client.SecurityNamespaceList) {
+	out := cmd.OutOrStdout()
+	if len(list.Result) == 0 {
+		_, _ = fmt.Fprintln(out, "No scanned namespaces match these filters.")
+		return
+	}
+	writer := newSecurityTable(out)
+	writer.AppendHeader(table.Row{"Cluster", "Namespace", "Workloads", "Images", "Pods", "Actionable", "Critical", "High", "Known exploited", "Fixable severe", "Last scan"})
+	for _, namespace := range list.Result {
+		writer.AppendRow(table.Row{
+			namespace.ClusterName,
+			namespaceCell(namespace),
+			namespace.Workloads,
+			namespace.Images,
+			namespace.Pods,
+			namespace.ActionableTotal,
+			namespace.Actionable.Critical,
+			namespace.Actionable.High,
+			redIfPositive(namespace.KnownExploited),
+			namespace.FixableSevere,
+			formatTimeAgo(namespace.LastScan),
+		})
+	}
+	writer.Render()
+	_, _ = fmt.Fprintf(out, "Page %d of %d · %d namespaces\n", list.Pagination.Page, list.Pagination.TotalPages, list.Pagination.TotalCount)
+}
+
+func podContainerCell(container client.SecurityPodContainer) string {
+	parts := []string{container.Name + ": not scanned"}
+	if container.Scanned {
+		parts = []string{fmt.Sprintf("%s: %d critical, %d high", container.Name, container.Actionable.Critical, container.Actionable.High)}
+		if container.KnownExploited > 0 {
+			parts = append(parts, text.FgRed.Sprintf("%d known exploited", container.KnownExploited))
+		}
+	}
+	if !container.Ready {
+		parts = append(parts, "not ready")
+	}
+	return strings.Join(parts, ", ")
+}
+
+func renderSecurityPods(cmd *cobra.Command, list *client.SecurityPodList) {
+	out := cmd.OutOrStdout()
+	if len(list.Result) == 0 {
+		_, _ = fmt.Fprintln(out, "No running pods match this workload.")
+		return
+	}
+	if list.Capped {
+		_, _ = fmt.Fprintln(out, text.FgYellow.Sprint("The namespace holds more pods than one read loads; this listing is capped."))
+	}
+	writer := newSecurityTable(out)
+	writer.AppendHeader(table.Row{"Pod", "Workload", "Node", "Phase", "Priority", "Observed", "Critical", "High", "Known exploited", "Containers"})
+	for _, pod := range list.Result {
+		workload := "-"
+		if pod.WorkloadName != nil {
+			workload = stringOrEmpty(pod.WorkloadKind) + " " + *pod.WorkloadName
+		}
+		containers := make([]string, 0, len(pod.Containers))
+		for _, container := range pod.Containers {
+			containers = append(containers, podContainerCell(container))
+		}
+		priority := pod.Priority
+		if priority == "unscanned" {
+			priority = text.FgYellow.Sprint("not scanned")
+		}
+		writer.AppendRow(table.Row{
+			pod.Name,
+			strings.TrimSpace(workload),
+			stringOrEmpty(pod.Node),
+			stringOrEmpty(pod.Phase),
+			priority,
+			pod.Observed,
+			pod.Actionable.Critical,
+			pod.Actionable.High,
+			redIfPositive(pod.KnownExploited),
+			strings.Join(containers, "\n"),
+		})
+	}
+	writer.Render()
+	_, _ = fmt.Fprintf(out, "Page %d of %d · %d pods\n", list.Pagination.Page, list.Pagination.TotalPages, list.Pagination.TotalCount)
+}
+
+func renderSbomCoverage(cmd *cobra.Command, coverage client.SecuritySBOMCoverage) {
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "Bill of materials: %d images, %d components, %d workloads · %d of %d scanned clusters publish one",
+		coverage.Images, coverage.Components, coverage.Workloads, coverage.ClustersWithSBOM, coverage.ScannedClusters)
+	if coverage.LatestGeneratedAt != nil && *coverage.LatestGeneratedAt != "" {
+		_, _ = fmt.Fprintf(out, " · latest %s", formatTimeAgo(*coverage.LatestGeneratedAt))
+	}
+	_, _ = fmt.Fprintln(out)
+	if coverage.ClustersWithSBOM < coverage.ScannedClusters {
+		_, _ = fmt.Fprintln(out, text.FgYellow.Sprint("Clusters without a bill of materials have SBOM generation off: set the security baseline input trivy_sbom_generation_enabled to true to publish one."))
+	}
+}
+
+func componentFindingsCell(component client.SecuritySBOMComponent) string {
+	if component.VulnerableFindings == 0 {
+		return "-"
+	}
+	rendered := fmt.Sprintf("%d (%d actionable)", component.VulnerableFindings, component.ActionableFindings)
+	if component.KnownExploited > 0 {
+		rendered += " " + text.FgRed.Sprint("KEV")
+	}
+	return rendered
+}
+
+func renderSecuritySbomComponents(cmd *cobra.Command, list *client.SecuritySBOMComponentList) {
+	out := cmd.OutOrStdout()
+	renderSbomCoverage(cmd, list.Coverage)
+	if len(list.Result) == 0 {
+		_, _ = fmt.Fprintln(out, "No components match these filters.")
+		return
+	}
+	writer := newSecurityTable(out)
+	writer.AppendHeader(table.Row{"Package", "Version", "Type", "Licence", "Images", "Workloads", "Clusters", "Findings"})
+	for _, component := range list.Result {
+		writer.AppendRow(table.Row{
+			component.Name,
+			component.Version,
+			component.PackageType,
+			strings.Join(component.Licenses, ", "),
+			component.Images,
+			component.Workloads,
+			component.Clusters,
+			componentFindingsCell(component),
+		})
+	}
+	writer.Render()
+	_, _ = fmt.Fprintf(out, "Page %d of %d · %d components\n", list.Pagination.Page, list.Pagination.TotalPages, list.Pagination.TotalCount)
+}
+
+func renderSecuritySbomImages(cmd *cobra.Command, list *client.SecuritySBOMImageList) {
+	out := cmd.OutOrStdout()
+	renderSbomCoverage(cmd, list.Coverage)
+	if len(list.Result) == 0 {
+		_, _ = fmt.Fprintln(out, "No images match these filters.")
+		return
+	}
+	writer := newSecurityTable(out)
+	writer.AppendHeader(table.Row{"Image", "OS", "Components", "Workloads", "Clusters", "Namespaces", "Critical", "High", "Known exploited", "Generated"})
+	for _, image := range list.Result {
+		writer.AppendRow(table.Row{
+			image.ImageRef,
+			stringOrEmpty(image.OSName),
+			image.ComponentCount,
+			image.Workloads,
+			image.Clusters,
+			strings.Join(image.Namespaces, ", "),
+			image.Actionable.Critical,
+			image.Actionable.High,
+			redIfPositive(image.KnownExploited),
+			optionalTimeAgo(image.GeneratedAt),
+		})
+	}
+	writer.Render()
+	_, _ = fmt.Fprintf(out, "Page %d of %d · %d images\n", list.Pagination.Page, list.Pagination.TotalPages, list.Pagination.TotalCount)
+}
+
+func renderSecuritySbomImageDetail(cmd *cobra.Command, detail *client.SecuritySBOMImageDetail) {
+	out := cmd.OutOrStdout()
+	image := detail.Image
+	_, _ = fmt.Fprintln(out, text.Bold.Sprint(image.ImageRef))
+	if image.ImageDigest != nil {
+		_, _ = fmt.Fprintf(out, "Digest:      %s\n", *image.ImageDigest)
+	}
+	if image.Registry != nil {
+		_, _ = fmt.Fprintf(out, "Registry:    %s\n", *image.Registry)
+	}
+	_, _ = fmt.Fprintf(out, "OS:          %s\n", stringOrEmpty(image.OSName))
+	if image.BomFormat != nil {
+		_, _ = fmt.Fprintf(out, "Format:      %s %s\n", *image.BomFormat, stringOrEmpty(image.SpecVersion))
+	}
+	_, _ = fmt.Fprintf(out, "Components:  %d (%d dependencies)\n", image.ComponentCount, image.DependencyCount)
+	_, _ = fmt.Fprintf(out, "Findings:    %d observed, %d critical, %d high actionable, %s known exploited\n",
+		image.Observed, image.Actionable.Critical, image.Actionable.High, redIfPositive(image.KnownExploited))
+	_, _ = fmt.Fprintf(out, "Generated:   %s\n", optionalTimeAgo(image.GeneratedAt))
+
+	_, _ = fmt.Fprintln(out)
+	if len(detail.Workloads) == 0 {
+		_, _ = fmt.Fprintln(out, "No workload currently runs this image; the bill of materials is kept from the last scan that saw it.")
+	} else {
+		_, _ = fmt.Fprintf(out, "Running in %d workload container(s) on %d cluster(s):\n", image.Workloads, image.Clusters)
+		for _, workload := range detail.Workloads {
+			label := "cluster-scoped image"
+			if workload.WorkloadName != nil {
+				label = strings.TrimSpace(stringOrEmpty(workload.WorkloadKind) + " " + *workload.WorkloadName)
+				if workload.WorkloadNamespace != nil {
+					label += " in " + *workload.WorkloadNamespace
+				}
+			}
+			if workload.ContainerName != nil {
+				label += " (container " + *workload.ContainerName + ")"
+			}
+			_, _ = fmt.Fprintf(out, "  - %s on %s\n", label, workload.ClusterName)
+		}
+	}
+
+	_, _ = fmt.Fprintln(out)
+	if len(detail.Components) == 0 {
+		_, _ = fmt.Fprintln(out, "No components match these filters.")
+		return
+	}
+	writer := newSecurityTable(out)
+	writer.AppendHeader(table.Row{"Package", "Version", "Type", "Licence", "Findings"})
+	for _, component := range detail.Components {
+		writer.AppendRow(table.Row{
+			component.Name,
+			component.Version,
+			component.PackageType,
+			strings.Join(component.Licenses, ", "),
+			componentFindingsCell(component),
+		})
+	}
+	writer.Render()
+	_, _ = fmt.Fprintf(out, "Page %d of %d · %d components\n", detail.Pagination.Page, detail.Pagination.TotalPages, detail.Pagination.TotalCount)
+}
+
+func init() {
+	securityCmd.AddCommand(securityNamespacesCmd, securityPodsCmd, securitySbomCmd)
+	securitySbomCmd.AddCommand(securitySbomImagesCmd, securitySbomImageCmd)
+
+	securityNamespacesCmd.Flags().String("search", "", "Match namespace or cluster name")
+	securityNamespacesCmd.Flags().String("cluster", "", "Only namespaces on one cluster (name or id)")
+	securityNamespacesCmd.Flags().String("sort", "actionable", "Sort key: actionable, severity, known_exploited, fixable_severe, workloads, images, pods, observed, namespace, cluster_name, last_scan")
+	securityNamespacesCmd.Flags().String("order", "desc", "Sort order: asc or desc")
+	securityNamespacesCmd.Flags().Int("page", 1, "Page number")
+	securityNamespacesCmd.Flags().Int("page-size", 50, "Namespaces per page (max 100)")
+
+	securityPodsCmd.Flags().String("cluster", "", "The cluster (name or id); required")
+	securityPodsCmd.Flags().String("namespace", "", "The namespace; required")
+	securityPodsCmd.Flags().String("workload-uid", "", "Only pods owned by the workload with this uid")
+	securityPodsCmd.Flags().String("workload-kind", "", "With --workload-name: only pods owned by this workload kind")
+	securityPodsCmd.Flags().String("workload-name", "", "Only pods owned by the workload with this name")
+	securityPodsCmd.Flags().Int("page", 1, "Page number")
+	securityPodsCmd.Flags().Int("page-size", 50, "Pods per page (max 100)")
+
+	securitySbomCmd.Flags().String("search", "", "Match package name or package URL")
+	securitySbomCmd.Flags().StringSlice("type", nil, "Ecosystem filter, repeatable: deb, apk, rpm, npm, pypi, golang, maven, ...")
+	securitySbomCmd.Flags().String("cluster", "", "Only packages in images running on one cluster (name or id)")
+	securitySbomCmd.Flags().String("namespace", "", "Only packages in images running in one namespace")
+	securitySbomCmd.Flags().String("image", "", "Only packages in one image (digest or reference)")
+	securitySbomCmd.Flags().String("vulnerable", "any", "Findings filter: true (a finding names the package), false or any")
+	securitySbomCmd.Flags().String("sort", "images", "Sort key: images, workloads, clusters, vulnerable, actionable, name, version, package_type")
+	securitySbomCmd.Flags().String("order", "desc", "Sort order: asc or desc")
+	securitySbomCmd.Flags().Int("page", 1, "Page number")
+	securitySbomCmd.Flags().Int("page-size", 50, "Components per page (max 100)")
+
+	securitySbomImagesCmd.Flags().String("search", "", "Match image reference, digest or OS")
+	securitySbomImagesCmd.Flags().String("cluster", "", "Only images running on one cluster (name or id)")
+	securitySbomImagesCmd.Flags().String("namespace", "", "Only images running in one namespace")
+	securitySbomImagesCmd.Flags().String("sort", "actionable", "Sort key: actionable, known_exploited, workloads, clusters, components, image_ref, generated_at, last_seen_at")
+	securitySbomImagesCmd.Flags().String("order", "desc", "Sort order: asc or desc")
+	securitySbomImagesCmd.Flags().Int("page", 1, "Page number")
+	securitySbomImagesCmd.Flags().Int("page-size", 50, "Images per page (max 100)")
+
+	securitySbomImageCmd.Flags().String("search", "", "Match package name or package URL")
+	securitySbomImageCmd.Flags().StringSlice("type", nil, "Ecosystem filter, repeatable")
+	securitySbomImageCmd.Flags().String("sort", "vulnerable", "Sort key: vulnerable, actionable, name, version, package_type")
+	securitySbomImageCmd.Flags().String("order", "desc", "Sort order: asc or desc")
+	securitySbomImageCmd.Flags().Int("page", 1, "Page number")
+	securitySbomImageCmd.Flags().Int("page-size", 100, "Components per page (max 100)")
+}

--- a/cmd/security_sbom_test.go
+++ b/cmd/security_sbom_test.go
@@ -1,0 +1,182 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type securitySbomMock struct {
+	baseMock
+	namespaces        *client.SecurityNamespaceList
+	pods              *client.SecurityPodList
+	podsOptions       *client.SecurityPodsOptions
+	components        *client.SecuritySBOMComponentList
+	componentsOptions *client.SecuritySBOMComponentsOptions
+	images            *client.SecuritySBOMImageList
+	detail            *client.SecuritySBOMImageDetail
+	detailOptions     *client.SecuritySBOMImageOptions
+}
+
+func (m *securitySbomMock) ListSecurityNamespaces(client.SecurityNamespacesOptions) (*client.SecurityNamespaceList, error) {
+	return m.namespaces, nil
+}
+
+func (m *securitySbomMock) ListSecurityPods(options client.SecurityPodsOptions) (*client.SecurityPodList, error) {
+	m.podsOptions = &options
+	return m.pods, nil
+}
+
+func (m *securitySbomMock) ListSecuritySBOMComponents(options client.SecuritySBOMComponentsOptions) (*client.SecuritySBOMComponentList, error) {
+	m.componentsOptions = &options
+	return m.components, nil
+}
+
+func (m *securitySbomMock) ListSecuritySBOMImages(client.SecuritySBOMImagesOptions) (*client.SecuritySBOMImageList, error) {
+	return m.images, nil
+}
+
+func (m *securitySbomMock) GetSecuritySBOMImage(options client.SecuritySBOMImageOptions) (*client.SecuritySBOMImageDetail, error) {
+	m.detailOptions = &options
+	return m.detail, nil
+}
+
+func sbomCoverage() client.SecuritySBOMCoverage {
+	return client.SecuritySBOMCoverage{ScannedClusters: 3, ClustersWithSBOM: 1, Images: 12, Components: 1840, Workloads: 20}
+}
+
+func sbomComponent() client.SecuritySBOMComponent {
+	purl := "pkg:deb/debian/openssl@3.0.14"
+	return client.SecuritySBOMComponent{
+		Name: "openssl", Version: "3.0.14", PackageType: "deb", ComponentType: "library", PURL: &purl,
+		Licenses: []string{"Apache-2.0"}, Images: 4, Workloads: 7, Clusters: 2,
+		VulnerableFindings: 2, ActionableFindings: 1, KnownExploited: 1,
+	}
+}
+
+func TestSecurityNamespacesRendersClusterScopedRowsAndCounts(t *testing.T) {
+	namespaces := &client.SecurityNamespaceList{
+		Result: []client.SecurityNamespace{
+			{ClusterName: "prod", Namespace: "backend", ReportScope: "namespaced", Workloads: 3, Images: 2, Pods: 5,
+				ActionableTotal: 9, Actionable: client.SecuritySeverityCounts{Critical: 2, High: 4}, KnownExploited: 1,
+				FixableSevere: 4, LastScan: "2026-08-28T20:25:14Z"},
+			{ClusterName: "prod", Namespace: "", ReportScope: "cluster", Workloads: 1, Images: 1,
+				ActionableTotal: 2, Actionable: client.SecuritySeverityCounts{High: 1, Medium: 1}, LastScan: "2026-08-28T20:25:14Z"},
+		},
+		Pagination: client.SecurityPagination{Page: 1, PageSize: 50, TotalPages: 1, TotalCount: 2},
+	}
+	output, executeError := runSecurityCommand(t, &securitySbomMock{namespaces: namespaces}, "security", "namespaces")
+	if executeError != nil {
+		t.Fatalf("security namespaces failed: %v", executeError)
+	}
+	for _, expected := range []string{"backend", "(cluster-scoped)", "KNOWN EXPLOITED", "Page 1 of 1 · 2 namespaces"} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("output lacks %q:\n%s", expected, output)
+		}
+	}
+}
+
+func TestSecurityPodsRequiresClusterAndNamespaceAndMapsTheWorkloadFilters(t *testing.T) {
+	if _, executeError := runSecurityCommand(t, &securitySbomMock{}, "security", "pods", "--namespace", "backend"); executeError == nil {
+		t.Fatal("expected an error without --cluster")
+	}
+	node, phase, kind, name := "worker-1", "Running", "deployment", "api"
+	pods := &client.SecurityPodList{
+		Result: []client.SecurityPod{{
+			Name: "api-7d9f8-abcde", Namespace: "backend", Node: &node, Phase: &phase,
+			WorkloadKind: &kind, WorkloadName: &name, Scanned: true, Observed: 3,
+			Actionable: client.SecuritySeverityCounts{Critical: 1, High: 1}, KnownExploited: 1, Priority: "critical",
+			Containers: []client.SecurityPodContainer{
+				{Name: "api", Scanned: true, Ready: true, Actionable: client.SecuritySeverityCounts{Critical: 1, High: 1}, KnownExploited: 1},
+				{Name: "sidecar", Scanned: false, Ready: false},
+			},
+		}},
+		Pagination: client.SecurityPagination{Page: 1, PageSize: 50, TotalPages: 1, TotalCount: 1},
+		Capped:     true,
+	}
+	mock := &securitySbomMock{pods: pods}
+	output, executeError := runSecurityCommand(t, mock, "security", "pods",
+		"--cluster", "00000000-0000-0000-0000-000000000001", "--namespace", "backend",
+		"--workload-kind", "Deployment", "--workload-name", "api")
+	if executeError != nil {
+		t.Fatalf("security pods failed: %v", executeError)
+	}
+	if mock.podsOptions == nil || mock.podsOptions.Namespace != "backend" || mock.podsOptions.WorkloadKind != "Deployment" || mock.podsOptions.WorkloadName != "api" {
+		t.Fatalf("pods options = %+v", mock.podsOptions)
+	}
+	for _, expected := range []string{"api-7d9f8-abcde", "deployment api", "sidecar: not scanned", "not ready", "capped", "Page 1 of 1 · 1 pods"} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("output lacks %q:\n%s", expected, output)
+		}
+	}
+}
+
+func TestSecuritySbomMapsFlagsAndRendersCoverage(t *testing.T) {
+	mock := &securitySbomMock{components: &client.SecuritySBOMComponentList{
+		Result:     []client.SecuritySBOMComponent{sbomComponent()},
+		Pagination: client.SecurityPagination{Page: 1, PageSize: 50, TotalPages: 1, TotalCount: 1},
+		Coverage:   sbomCoverage(),
+	}}
+	output, executeError := runSecurityCommand(t, mock, "security", "sbom",
+		"--search", "openssl", "--type", "deb", "--type", "apk", "--vulnerable", "true", "--namespace", "backend", "--sort", "vulnerable")
+	if executeError != nil {
+		t.Fatalf("security sbom failed: %v", executeError)
+	}
+	options := mock.componentsOptions
+	if options == nil || options.Search != "openssl" || len(options.PackageTypes) != 2 || options.Vulnerable == nil || !*options.Vulnerable ||
+		options.Namespace != "backend" || options.Sort != "vulnerable" {
+		t.Fatalf("component options = %+v", options)
+	}
+	for _, expected := range []string{"1 of 3 scanned clusters publish one", "trivy_sbom_generation_enabled", "openssl", "2 (1 actionable)", "KEV", "Page 1 of 1 · 1 components"} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("output lacks %q:\n%s", expected, output)
+		}
+	}
+	if _, executeError := runSecurityCommand(t, mock, "security", "sbom", "--vulnerable", "maybe"); executeError == nil {
+		t.Fatal("expected --vulnerable maybe to be refused")
+	}
+}
+
+func TestSecuritySbomImagesAndImageDetail(t *testing.T) {
+	digest, osName := "sha256:abc", "debian 12.7"
+	image := client.SecuritySBOMImage{
+		ImageIdentity: digest, ImageRef: "registry.example.com/backend/api:1.0.0", ImageDigest: &digest, OSName: &osName,
+		ComponentCount: 212, DependencyCount: 180, Workloads: 2, Clusters: 1, Namespaces: []string{"backend"},
+		Observed: 5, Actionable: client.SecuritySeverityCounts{Critical: 1, High: 2}, KnownExploited: 1,
+	}
+	mock := &securitySbomMock{
+		images: &client.SecuritySBOMImageList{
+			Result:     []client.SecuritySBOMImage{image},
+			Pagination: client.SecurityPagination{Page: 1, PageSize: 50, TotalPages: 1, TotalCount: 1},
+			Coverage:   sbomCoverage(),
+		},
+		detail: &client.SecuritySBOMImageDetail{
+			Image:      image,
+			Components: []client.SecuritySBOMComponent{sbomComponent()},
+			Pagination: client.SecurityPagination{Page: 1, PageSize: 100, TotalPages: 1, TotalCount: 1},
+			Workloads:  []client.SecuritySBOMWorkload{},
+		},
+	}
+	output, executeError := runSecurityCommand(t, mock, "security", "sbom", "images")
+	if executeError != nil {
+		t.Fatalf("security sbom images failed: %v", executeError)
+	}
+	for _, expected := range []string{"registry.example.com/backend/api:1.0.0", "debian 12.7", "backend", "Page 1 of 1 · 1 images"} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("images output lacks %q:\n%s", expected, output)
+		}
+	}
+	output, executeError = runSecurityCommand(t, mock, "security", "sbom", "image", digest, "--type", "deb")
+	if executeError != nil {
+		t.Fatalf("security sbom image failed: %v", executeError)
+	}
+	if mock.detailOptions == nil || mock.detailOptions.ImageIdentity != digest || len(mock.detailOptions.PackageTypes) != 1 {
+		t.Fatalf("detail options = %+v", mock.detailOptions)
+	}
+	for _, expected := range []string{"Digest:      sha256:abc", "212 (180 dependencies)", "No workload currently runs this image", "openssl", "Page 1 of 1 · 1 components"} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("detail output lacks %q:\n%s", expected, output)
+		}
+	}
+}

--- a/cmd/security_test.go
+++ b/cmd/security_test.go
@@ -43,7 +43,10 @@ func (m *securityMock) ListSecurityClusters(client.SecurityClustersOptions) (*cl
 }
 
 func securityCommandTree() []*cobra.Command {
-	return []*cobra.Command{securityOverviewCmd, securityFindingsCmd, securityFindingCmd, securityAdvisoryCmd, securityClustersCmd}
+	return []*cobra.Command{
+		securityOverviewCmd, securityFindingsCmd, securityFindingCmd, securityAdvisoryCmd, securityClustersCmd,
+		securityNamespacesCmd, securityPodsCmd, securitySbomCmd, securitySbomImagesCmd, securitySbomImageCmd,
+	}
 }
 
 func runSecurityCommand(t *testing.T, mock APIClient, args ...string) (string, error) {

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -43,6 +43,11 @@ type APIClient interface {
 	GetSecurityFinding(findingID string) (*client.SecurityFindingDetail, error)
 	GetSecurityAdvisory(cveID string) (*client.SecurityAdvisory, error)
 	ListSecurityClusters(options client.SecurityClustersOptions) (*client.SecurityClusterList, error)
+	ListSecurityNamespaces(options client.SecurityNamespacesOptions) (*client.SecurityNamespaceList, error)
+	ListSecurityPods(options client.SecurityPodsOptions) (*client.SecurityPodList, error)
+	ListSecuritySBOMComponents(options client.SecuritySBOMComponentsOptions) (*client.SecuritySBOMComponentList, error)
+	ListSecuritySBOMImages(options client.SecuritySBOMImagesOptions) (*client.SecuritySBOMImageList, error)
+	GetSecuritySBOMImage(options client.SecuritySBOMImageOptions) (*client.SecuritySBOMImageDetail, error)
 
 	ListPowerSchedules(clusterID string) (*client.PowerScheduleListResult, error)
 	CreatePowerSchedule(clusterID string, request client.PowerScheduleRequest) (*client.PowerScheduleListResult, error)

--- a/internal/client/security_sbom.go
+++ b/internal/client/security_sbom.go
@@ -1,0 +1,375 @@
+package client
+
+import (
+	"fmt"
+	neturl "net/url"
+	"strconv"
+	"strings"
+)
+
+// SecurityNamespace is one namespace on one cluster in the Security Center's
+// breakdown: its scanned workloads and images, the pods the cluster runs
+// there now, and the actionable findings by severity. ReportScope "cluster"
+// with an empty Namespace carries the cluster-scoped reports (node and
+// control-plane images) so the rows still add up to the cluster.
+type SecurityNamespace struct {
+	ClusterID       string                 `json:"cluster_id" yaml:"cluster_id"`
+	ClusterName     string                 `json:"cluster_name" yaml:"cluster_name"`
+	Namespace       string                 `json:"namespace" yaml:"namespace"`
+	ReportScope     string                 `json:"report_scope" yaml:"report_scope"`
+	Workloads       int                    `json:"workloads" yaml:"workloads"`
+	Images          int                    `json:"images" yaml:"images"`
+	Pods            int                    `json:"pods" yaml:"pods"`
+	Observed        int                    `json:"observed" yaml:"observed"`
+	Actionable      SecuritySeverityCounts `json:"actionable" yaml:"actionable"`
+	ActionableTotal int                    `json:"actionable_total" yaml:"actionable_total"`
+	AcceptedRisk    int                    `json:"accepted_risk" yaml:"accepted_risk"`
+	FixableSevere   int                    `json:"fixable_severe" yaml:"fixable_severe"`
+	KnownExploited  int                    `json:"known_exploited" yaml:"known_exploited"`
+	Priority        string                 `json:"priority" yaml:"priority"`
+	LastScan        string                 `json:"last_scan" yaml:"last_scan"`
+	ScannerStatus   string                 `json:"scanner_status" yaml:"scanner_status"`
+}
+
+// SecurityNamespaceList is the paginated namespace breakdown.
+type SecurityNamespaceList struct {
+	Result     []SecurityNamespace `json:"result" yaml:"result"`
+	Pagination SecurityPagination  `json:"pagination" yaml:"pagination"`
+	Scanner    SecurityScanner     `json:"scanner" yaml:"scanner"`
+}
+
+// SecurityPodContainer is one container of a pod with the findings of the
+// scanned workload container behind it. Scanned false means no report
+// covers the container, which is not the same as a clean one.
+type SecurityPodContainer struct {
+	Name           string                 `json:"name" yaml:"name"`
+	Image          string                 `json:"image" yaml:"image"`
+	ImageDigest    *string                `json:"image_digest" yaml:"image_digest"`
+	Ready          bool                   `json:"ready" yaml:"ready"`
+	RestartCount   int                    `json:"restart_count" yaml:"restart_count"`
+	Scanned        bool                   `json:"scanned" yaml:"scanned"`
+	Observed       int                    `json:"observed" yaml:"observed"`
+	Actionable     SecuritySeverityCounts `json:"actionable" yaml:"actionable"`
+	KnownExploited int                    `json:"known_exploited" yaml:"known_exploited"`
+	FixableSevere  int                    `json:"fixable_severe" yaml:"fixable_severe"`
+}
+
+// SecurityPod is one running pod resolved to the scanned workload that owns
+// it, with the findings summed over its containers.
+type SecurityPod struct {
+	Name           string                 `json:"name" yaml:"name"`
+	UID            *string                `json:"uid" yaml:"uid"`
+	Namespace      string                 `json:"namespace" yaml:"namespace"`
+	Node           *string                `json:"node" yaml:"node"`
+	Phase          *string                `json:"phase" yaml:"phase"`
+	OwnerKind      *string                `json:"owner_kind" yaml:"owner_kind"`
+	OwnerName      *string                `json:"owner_name" yaml:"owner_name"`
+	WorkloadKind   *string                `json:"workload_kind" yaml:"workload_kind"`
+	WorkloadName   *string                `json:"workload_name" yaml:"workload_name"`
+	CreatedAt      *string                `json:"created_at" yaml:"created_at"`
+	Containers     []SecurityPodContainer `json:"containers" yaml:"containers"`
+	Scanned        bool                   `json:"scanned" yaml:"scanned"`
+	Observed       int                    `json:"observed" yaml:"observed"`
+	Actionable     SecuritySeverityCounts `json:"actionable" yaml:"actionable"`
+	KnownExploited int                    `json:"known_exploited" yaml:"known_exploited"`
+	FixableSevere  int                    `json:"fixable_severe" yaml:"fixable_severe"`
+	Priority       string                 `json:"priority" yaml:"priority"`
+}
+
+// SecurityPodList is the paginated pod breakdown of one namespace; Capped
+// says the namespace held more pods than one read loads.
+type SecurityPodList struct {
+	Result     []SecurityPod      `json:"result" yaml:"result"`
+	Pagination SecurityPagination `json:"pagination" yaml:"pagination"`
+	Capped     bool               `json:"capped" yaml:"capped"`
+}
+
+// SecuritySBOMComponent is one package name, version and ecosystem across
+// every image that carries it, with where it runs and the findings that name
+// that exact package and version on those images.
+type SecuritySBOMComponent struct {
+	Name               string   `json:"name" yaml:"name"`
+	Version            string   `json:"version" yaml:"version"`
+	PackageType        string   `json:"package_type" yaml:"package_type"`
+	ComponentType      string   `json:"component_type" yaml:"component_type"`
+	PURL               *string  `json:"purl" yaml:"purl"`
+	Licenses           []string `json:"licenses" yaml:"licenses"`
+	Images             int      `json:"images" yaml:"images"`
+	Workloads          int      `json:"workloads" yaml:"workloads"`
+	Clusters           int      `json:"clusters" yaml:"clusters"`
+	VulnerableFindings int      `json:"vulnerable_findings" yaml:"vulnerable_findings"`
+	ActionableFindings int      `json:"actionable_findings" yaml:"actionable_findings"`
+	KnownExploited     int      `json:"known_exploited" yaml:"known_exploited"`
+}
+
+// SecuritySBOMCoverage says how much of the scanned fleet publishes a bill
+// of materials. ClustersWithSBOM below ScannedClusters means the rest have
+// SBOM generation switched off, not that they run nothing.
+type SecuritySBOMCoverage struct {
+	ScannedClusters   int     `json:"scanned_clusters" yaml:"scanned_clusters"`
+	ClustersWithSBOM  int     `json:"clusters_with_sbom" yaml:"clusters_with_sbom"`
+	Images            int     `json:"images" yaml:"images"`
+	Components        int     `json:"components" yaml:"components"`
+	Workloads         int     `json:"workloads" yaml:"workloads"`
+	LatestGeneratedAt *string `json:"latest_generated_at" yaml:"latest_generated_at"`
+}
+
+// SecuritySBOMComponentFacets mirrors the component filters.
+type SecuritySBOMComponentFacets struct {
+	PackageType []SecurityFacetCount `json:"package_type" yaml:"package_type"`
+}
+
+// SecuritySBOMComponentList is the paginated component inventory.
+type SecuritySBOMComponentList struct {
+	Result     []SecuritySBOMComponent     `json:"result" yaml:"result"`
+	Pagination SecurityPagination          `json:"pagination" yaml:"pagination"`
+	Facets     SecuritySBOMComponentFacets `json:"facets" yaml:"facets"`
+	Coverage   SecuritySBOMCoverage        `json:"coverage" yaml:"coverage"`
+}
+
+// SecuritySBOMImage is one image with a bill of materials, where it runs and
+// the actionable findings the scanner attributes to it.
+type SecuritySBOMImage struct {
+	ImageIdentity   string                 `json:"image_identity" yaml:"image_identity"`
+	ImageRef        string                 `json:"image_ref" yaml:"image_ref"`
+	ImageRepository *string                `json:"image_repository" yaml:"image_repository"`
+	ImageTag        *string                `json:"image_tag" yaml:"image_tag"`
+	ImageDigest     *string                `json:"image_digest" yaml:"image_digest"`
+	Registry        *string                `json:"registry" yaml:"registry"`
+	OSFamily        *string                `json:"os_family" yaml:"os_family"`
+	OSName          *string                `json:"os_name" yaml:"os_name"`
+	BomFormat       *string                `json:"bom_format" yaml:"bom_format"`
+	SpecVersion     *string                `json:"spec_version" yaml:"spec_version"`
+	ComponentCount  int                    `json:"component_count" yaml:"component_count"`
+	DependencyCount int                    `json:"dependency_count" yaml:"dependency_count"`
+	Workloads       int                    `json:"workloads" yaml:"workloads"`
+	Clusters        int                    `json:"clusters" yaml:"clusters"`
+	Namespaces      []string               `json:"namespaces" yaml:"namespaces"`
+	Observed        int                    `json:"observed" yaml:"observed"`
+	Actionable      SecuritySeverityCounts `json:"actionable" yaml:"actionable"`
+	KnownExploited  int                    `json:"known_exploited" yaml:"known_exploited"`
+	GeneratedAt     *string                `json:"generated_at" yaml:"generated_at"`
+	FirstSeenAt     string                 `json:"first_seen_at" yaml:"first_seen_at"`
+	LastSeenAt      string                 `json:"last_seen_at" yaml:"last_seen_at"`
+}
+
+// SecuritySBOMImageList is the paginated image inventory.
+type SecuritySBOMImageList struct {
+	Result     []SecuritySBOMImage  `json:"result" yaml:"result"`
+	Pagination SecurityPagination   `json:"pagination" yaml:"pagination"`
+	Coverage   SecuritySBOMCoverage `json:"coverage" yaml:"coverage"`
+}
+
+// SecuritySBOMWorkload is one workload container currently running an image.
+type SecuritySBOMWorkload struct {
+	ClusterID         string  `json:"cluster_id" yaml:"cluster_id"`
+	ClusterName       string  `json:"cluster_name" yaml:"cluster_name"`
+	ReportScope       string  `json:"report_scope" yaml:"report_scope"`
+	WorkloadKind      *string `json:"workload_kind" yaml:"workload_kind"`
+	WorkloadNamespace *string `json:"workload_namespace" yaml:"workload_namespace"`
+	WorkloadName      *string `json:"workload_name" yaml:"workload_name"`
+	ContainerName     *string `json:"container_name" yaml:"container_name"`
+	LastSeenAt        string  `json:"last_seen_at" yaml:"last_seen_at"`
+}
+
+// SecuritySBOMImageDetail is one image, a page of its components and every
+// workload container running it.
+type SecuritySBOMImageDetail struct {
+	Image      SecuritySBOMImage           `json:"image" yaml:"image"`
+	Components []SecuritySBOMComponent     `json:"components" yaml:"components"`
+	Pagination SecurityPagination          `json:"pagination" yaml:"pagination"`
+	Facets     SecuritySBOMComponentFacets `json:"facets" yaml:"facets"`
+	Workloads  []SecuritySBOMWorkload      `json:"workloads" yaml:"workloads"`
+}
+
+// SecurityNamespacesOptions mirrors the namespace breakdown controls.
+type SecurityNamespacesOptions struct {
+	Page      int
+	PageSize  int
+	Search    string
+	ClusterID string
+	Sort      string
+	Order     string
+}
+
+// SecurityPodsOptions selects the pods of one namespace on one cluster,
+// optionally only those a scanned workload owns.
+type SecurityPodsOptions struct {
+	ClusterID    string
+	Namespace    string
+	WorkloadUID  string
+	WorkloadKind string
+	WorkloadName string
+	Page         int
+	PageSize     int
+}
+
+// SecuritySBOMComponentsOptions mirrors the component inventory filters.
+// Vulnerable is tri-state: nil keeps every component.
+type SecuritySBOMComponentsOptions struct {
+	Page          int
+	PageSize      int
+	Search        string
+	PackageTypes  []string
+	ClusterID     string
+	Namespace     string
+	ImageIdentity string
+	Vulnerable    *bool
+	Sort          string
+	Order         string
+}
+
+// SecuritySBOMImagesOptions mirrors the image inventory filters.
+type SecuritySBOMImagesOptions struct {
+	Page      int
+	PageSize  int
+	Search    string
+	ClusterID string
+	Namespace string
+	Sort      string
+	Order     string
+}
+
+// SecuritySBOMImageOptions pages the components of one image.
+type SecuritySBOMImageOptions struct {
+	ImageIdentity string
+	Page          int
+	PageSize      int
+	Search        string
+	PackageTypes  []string
+	Sort          string
+	Order         string
+}
+
+func setListControls(query neturl.Values, search string, sort string, order string) {
+	if trimmed := strings.TrimSpace(search); trimmed != "" {
+		query.Set("search", trimmed)
+	}
+	if sort != "" {
+		query.Set("sort", sort)
+	}
+	if order != "" {
+		query.Set("order", order)
+	}
+}
+
+// ListSecurityNamespaces pages through the fleet's per-namespace posture.
+func (c *Client) ListSecurityNamespaces(options SecurityNamespacesOptions) (*SecurityNamespaceList, error) {
+	query := neturl.Values{}
+	setPaging(query, options.Page, options.PageSize)
+	setListControls(query, options.Search, options.Sort, options.Order)
+	if options.ClusterID != "" {
+		query.Set("cluster_id", options.ClusterID)
+	}
+	var list SecurityNamespaceList
+	if err := c.getJSON(securityURL(c.BaseURL, "/namespaces", query), &list); err != nil {
+		return nil, fmt.Errorf("security namespaces request failed: %w", err)
+	}
+	if list.Result == nil {
+		list.Result = []SecurityNamespace{}
+	}
+	return &list, nil
+}
+
+// ListSecurityPods lists the pods of one namespace joined to their scanned
+// workload's findings.
+func (c *Client) ListSecurityPods(options SecurityPodsOptions) (*SecurityPodList, error) {
+	query := neturl.Values{}
+	setPaging(query, options.Page, options.PageSize)
+	query.Set("cluster_id", options.ClusterID)
+	query.Set("namespace", options.Namespace)
+	if options.WorkloadUID != "" {
+		query.Set("workload_uid", options.WorkloadUID)
+	}
+	if options.WorkloadKind != "" {
+		query.Set("workload_kind", options.WorkloadKind)
+	}
+	if options.WorkloadName != "" {
+		query.Set("workload_name", options.WorkloadName)
+	}
+	var list SecurityPodList
+	if err := c.getJSON(securityURL(c.BaseURL, "/pods", query), &list); err != nil {
+		return nil, fmt.Errorf("security pods request failed: %w", err)
+	}
+	if list.Result == nil {
+		list.Result = []SecurityPod{}
+	}
+	return &list, nil
+}
+
+// ListSecuritySBOMComponents pages through the fleet's package inventory.
+func (c *Client) ListSecuritySBOMComponents(options SecuritySBOMComponentsOptions) (*SecuritySBOMComponentList, error) {
+	query := neturl.Values{}
+	setPaging(query, options.Page, options.PageSize)
+	setListControls(query, options.Search, options.Sort, options.Order)
+	for _, packageType := range options.PackageTypes {
+		if trimmed := strings.TrimSpace(packageType); trimmed != "" {
+			query.Add("package_type", trimmed)
+		}
+	}
+	if options.ClusterID != "" {
+		query.Set("cluster_id", options.ClusterID)
+	}
+	if options.Namespace != "" {
+		query.Set("namespace", options.Namespace)
+	}
+	if options.ImageIdentity != "" {
+		query.Set("image", options.ImageIdentity)
+	}
+	if options.Vulnerable != nil {
+		query.Set("vulnerable", strconv.FormatBool(*options.Vulnerable))
+	}
+	var list SecuritySBOMComponentList
+	if err := c.getJSON(securityURL(c.BaseURL, "/sbom", query), &list); err != nil {
+		return nil, fmt.Errorf("security sbom request failed: %w", err)
+	}
+	if list.Result == nil {
+		list.Result = []SecuritySBOMComponent{}
+	}
+	return &list, nil
+}
+
+// ListSecuritySBOMImages pages through the images with a bill of materials.
+func (c *Client) ListSecuritySBOMImages(options SecuritySBOMImagesOptions) (*SecuritySBOMImageList, error) {
+	query := neturl.Values{}
+	setPaging(query, options.Page, options.PageSize)
+	setListControls(query, options.Search, options.Sort, options.Order)
+	if options.ClusterID != "" {
+		query.Set("cluster_id", options.ClusterID)
+	}
+	if options.Namespace != "" {
+		query.Set("namespace", options.Namespace)
+	}
+	var list SecuritySBOMImageList
+	if err := c.getJSON(securityURL(c.BaseURL, "/sbom/images", query), &list); err != nil {
+		return nil, fmt.Errorf("security sbom images request failed: %w", err)
+	}
+	if list.Result == nil {
+		list.Result = []SecuritySBOMImage{}
+	}
+	return &list, nil
+}
+
+// GetSecuritySBOMImage reads one image's bill of materials.
+func (c *Client) GetSecuritySBOMImage(options SecuritySBOMImageOptions) (*SecuritySBOMImageDetail, error) {
+	query := neturl.Values{}
+	setPaging(query, options.Page, options.PageSize)
+	setListControls(query, options.Search, options.Sort, options.Order)
+	query.Set("image", options.ImageIdentity)
+	for _, packageType := range options.PackageTypes {
+		if trimmed := strings.TrimSpace(packageType); trimmed != "" {
+			query.Add("package_type", trimmed)
+		}
+	}
+	var detail SecuritySBOMImageDetail
+	if err := c.getJSON(securityURL(c.BaseURL, "/sbom/image", query), &detail); err != nil {
+		return nil, fmt.Errorf("security sbom image request failed: %w", err)
+	}
+	if detail.Components == nil {
+		detail.Components = []SecuritySBOMComponent{}
+	}
+	if detail.Workloads == nil {
+		detail.Workloads = []SecuritySBOMWorkload{}
+	}
+	return &detail, nil
+}

--- a/internal/client/security_sbom_test.go
+++ b/internal/client/security_sbom_test.go
@@ -1,0 +1,101 @@
+package client
+
+import (
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func TestListSecurityNamespacesAndPodsEncodeTheirControls(t *testing.T) {
+	var captured http.Request
+	_, apiClient := newSecurityTestServer(t, `{"result": [{"cluster_id": "c1", "cluster_name": "prod", "namespace": "backend",
+        "report_scope": "namespaced", "workloads": 3, "images": 2, "pods": 5, "observed": 12,
+        "actionable": {"critical": 2, "high": 4, "medium": 3, "low": 0, "unknown": 0}, "actionable_total": 9,
+        "accepted_risk": 3, "fixable_severe": 4, "known_exploited": 1, "priority": "critical",
+        "last_scan": "2026-08-28T20:25:14Z", "scanner_status": "fresh"}],
+        "pagination": {"page": 1, "page_size": 50, "total_pages": 1, "total_count": 1},
+        "scanner": {"status": "fresh", "last_scan": null, "fresh_clusters": 1, "stale_clusters": 0, "unscanned_clusters": 0, "stale_after_seconds": 7200}}`, &captured)
+
+	list, listError := apiClient.ListSecurityNamespaces(SecurityNamespacesOptions{Page: 2, PageSize: 25, Search: " prod ", ClusterID: "c1", Sort: "pods", Order: "asc"})
+	if listError != nil {
+		t.Fatalf("ListSecurityNamespaces returned an error: %v", listError)
+	}
+	expectedQuery := url.Values{"page": {"2"}, "page_size": {"25"}, "search": {"prod"}, "cluster_id": {"c1"}, "sort": {"pods"}, "order": {"asc"}}
+	if captured.URL.Path != "/api/v1/org/security/namespaces" || !reflect.DeepEqual(captured.URL.Query(), expectedQuery) {
+		t.Fatalf("request = %s?%s", captured.URL.Path, captured.URL.RawQuery)
+	}
+	if len(list.Result) != 1 || list.Result[0].Pods != 5 || list.Result[0].Actionable.High != 4 {
+		t.Fatalf("namespaces not decoded: %+v", list)
+	}
+
+	_, apiClient = newSecurityTestServer(t, `{"result": [], "pagination": {"page": 1, "page_size": 50, "total_pages": 0, "total_count": 0}, "capped": false}`, &captured)
+	pods, podsError := apiClient.ListSecurityPods(SecurityPodsOptions{ClusterID: "c1", Namespace: "backend", WorkloadUID: "uid-1", WorkloadKind: "Deployment", WorkloadName: "api", PageSize: 100})
+	if podsError != nil {
+		t.Fatalf("ListSecurityPods returned an error: %v", podsError)
+	}
+	expectedQuery = url.Values{"page_size": {"100"}, "cluster_id": {"c1"}, "namespace": {"backend"}, "workload_uid": {"uid-1"}, "workload_kind": {"Deployment"}, "workload_name": {"api"}}
+	if captured.URL.Path != "/api/v1/org/security/pods" || !reflect.DeepEqual(captured.URL.Query(), expectedQuery) {
+		t.Fatalf("request = %s?%s", captured.URL.Path, captured.URL.RawQuery)
+	}
+	if pods.Result == nil || len(pods.Result) != 0 || pods.Capped {
+		t.Fatalf("empty pod list must decode to an empty slice: %+v", pods)
+	}
+}
+
+func TestSecuritySBOMReadsEncodeFiltersAndDecodeCoverage(t *testing.T) {
+	var captured http.Request
+	_, apiClient := newSecurityTestServer(t, `{"result": [{"name": "openssl", "version": "3.0.14", "package_type": "deb",
+        "component_type": "library", "purl": "pkg:deb/debian/openssl@3.0.14", "licenses": ["Apache-2.0"],
+        "images": 4, "workloads": 7, "clusters": 2, "vulnerable_findings": 2, "actionable_findings": 1, "known_exploited": 1}],
+        "pagination": {"page": 1, "page_size": 50, "total_pages": 1, "total_count": 1},
+        "facets": {"package_type": [{"value": "deb", "count": 1}]},
+        "coverage": {"scanned_clusters": 3, "clusters_with_sbom": 1, "images": 12, "components": 1840, "workloads": 20, "latest_generated_at": null}}`, &captured)
+	vulnerable := false
+	list, listError := apiClient.ListSecuritySBOMComponents(SecuritySBOMComponentsOptions{
+		Search: "openssl", PackageTypes: []string{"deb", " ", "apk"}, ClusterID: "c1", Namespace: "backend",
+		ImageIdentity: "sha256:abc", Vulnerable: &vulnerable, Sort: "vulnerable", Order: "desc",
+	})
+	if listError != nil {
+		t.Fatalf("ListSecuritySBOMComponents returned an error: %v", listError)
+	}
+	expectedQuery := url.Values{
+		"search": {"openssl"}, "package_type": {"deb", "apk"}, "cluster_id": {"c1"}, "namespace": {"backend"},
+		"image": {"sha256:abc"}, "vulnerable": {"false"}, "sort": {"vulnerable"}, "order": {"desc"},
+	}
+	if captured.URL.Path != "/api/v1/org/security/sbom" || !reflect.DeepEqual(captured.URL.Query(), expectedQuery) {
+		t.Fatalf("request = %s?%s", captured.URL.Path, captured.URL.RawQuery)
+	}
+	if list.Coverage.ClustersWithSBOM != 1 || list.Coverage.ScannedClusters != 3 || list.Result[0].KnownExploited != 1 {
+		t.Fatalf("components not decoded: %+v", list)
+	}
+
+	_, apiClient = newSecurityTestServer(t, `{"result": [], "pagination": {"page": 1, "page_size": 50, "total_pages": 0, "total_count": 0},
+        "coverage": {"scanned_clusters": 3, "clusters_with_sbom": 0, "images": 0, "components": 0, "workloads": 0, "latest_generated_at": null}}`, &captured)
+	images, imagesError := apiClient.ListSecuritySBOMImages(SecuritySBOMImagesOptions{Search: "api", ClusterID: "c1", Sort: "components"})
+	if imagesError != nil {
+		t.Fatalf("ListSecuritySBOMImages returned an error: %v", imagesError)
+	}
+	if captured.URL.Path != "/api/v1/org/security/sbom/images" || captured.URL.Query().Get("sort") != "components" || len(images.Result) != 0 {
+		t.Fatalf("images request = %s?%s %+v", captured.URL.Path, captured.URL.RawQuery, images)
+	}
+
+	_, apiClient = newSecurityTestServer(t, `{"image": {"image_identity": "sha256:abc", "image_ref": "registry.test/api:1.0.0",
+        "image_repository": null, "image_tag": null, "image_digest": "sha256:abc", "registry": null, "os_family": null, "os_name": null,
+        "bom_format": null, "spec_version": null, "component_count": 1, "dependency_count": 0, "workloads": 0, "clusters": 0,
+        "namespaces": [], "observed": 0, "actionable": {"critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0},
+        "known_exploited": 0, "generated_at": null, "first_seen_at": "2026-08-28T20:25:14Z", "last_seen_at": "2026-08-28T20:25:14Z"},
+        "components": null, "pagination": {"page": 1, "page_size": 100, "total_pages": 0, "total_count": 0},
+        "facets": {"package_type": []}, "workloads": null}`, &captured)
+	detail, detailError := apiClient.GetSecuritySBOMImage(SecuritySBOMImageOptions{ImageIdentity: "sha256:abc", PackageTypes: []string{"deb"}, Sort: "name", Order: "asc"})
+	if detailError != nil {
+		t.Fatalf("GetSecuritySBOMImage returned an error: %v", detailError)
+	}
+	expectedQuery = url.Values{"image": {"sha256:abc"}, "package_type": {"deb"}, "sort": {"name"}, "order": {"asc"}}
+	if captured.URL.Path != "/api/v1/org/security/sbom/image" || !reflect.DeepEqual(captured.URL.Query(), expectedQuery) {
+		t.Fatalf("detail request = %s?%s", captured.URL.Path, captured.URL.RawQuery)
+	}
+	if detail.Components == nil || detail.Workloads == nil {
+		t.Fatalf("null lists must decode to empty slices: %+v", detail)
+	}
+}


### PR DESCRIPTION
Bead: ankra-j9kec

Reads for the two Security Center additions (backend in the cluster PR under the same bead, UI in the portal PR):

- `ankra security sbom` — the fleet's software bill of materials: every package in every image grouped by name/version/ecosystem, with images/workloads/clusters carrying it and the findings that name that exact package and version. `--search`, `--type`, `--vulnerable true|false`, `--cluster`, `--namespace`, `--image`. Prints the coverage line (how many scanned clusters publish one) and names the `trivy_sbom_generation_enabled` input when some do not.
- `ankra security sbom images` and `ankra security sbom image <digest or reference>` — the images with a bill of materials, and one image with its workloads and full component list.
- `ankra security namespaces` — findings by cluster and namespace (workloads, images, live pods, actionable severity, known exploited; cluster-scoped reports keep a `(cluster-scoped)` row).
- `ankra security pods --cluster <c> --namespace <ns> [--workload-uid | --workload-kind/--workload-name]` — the namespace's running pods joined through their owner chain to the scanned workload's findings; uncovered containers read `not scanned`, never clean.

All five take `-o json|yaml` for the raw API document. `APIClient`, `baseMock` and the client package move together as the repo rules require.

Also fixes the shared test flag reset: `flag.Value.Set(DefValue)` appends on a touched slice flag, so every reset grew `--severity`/`--status` by one `[]` entry and any test file sorting before `security_test.go` made the findings-defaults test fail. Slice flags now reset through `Replace` with the parsed default.

Verification: `go build`, `go vet`, `go test ./...` (pre-commit hook: full suite + golangci-lint, 0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJvVAaraF7bVywkD9M6Lwb
