### PR TITLE
feat(cluster): kubernetes write parity with the portal - delete, restart, cordon/drain, helm rollback/upgrade (ankra-ko7c8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@
   - `ankra cluster cordon|uncordon <node>` flip the node's scheduling;
     `ankra cluster drain <node>` cordons it and deletes the pods on it,
     leaving DaemonSet and static pods alone and printing the plan first
-    (`--dry-run` stops there).
+    (`--dry-run` stops there). It deletes rather than evicts - the agent has
+    no eviction relay yet - so PodDisruptionBudgets are not consulted; the
+    help says so and the plan names every pod before anything happens.
   - `ankra cluster helm get <release>` shows the chart, revision, values and
     notes (`-o values` dumps just the values as YAML), `helm history` lists
     the revisions, `helm rollback --revision N` rolls back and waits, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@
 
 ### Added
 
+- **The CLI can now change a cluster the way the portal can: `ankra cluster
+  delete|restart|cordon|uncordon|drain` and `ankra cluster helm
+  get|history|rollback|upgrade`.** The Kubernetes surface was read-only, so
+  every operational fix the portal offered with a button - delete a pod,
+  roll a deployment, drain a node, roll a Helm release back - needed a
+  kubeconfig and `kubectl` or `helm` from the terminal. Each of these goes
+  through the cluster's Ankra agent, the same relay and the same organisation
+  permissions the portal uses, after a `[y/N]` prompt (`--yes` skips it).
+  - `ankra cluster delete <kind> <name> [name...]` deletes any kind the
+    kubectl spellings resolve (`pod`, `pods`, `po`, `deploy`, `sts`, `cm`,
+    `namespace`, `node`, `pvc`, ...) and any custom resource with `--group`
+    and `--api-version`. `--grace-period 0` deletes immediately, `--dry-run`
+    reports what would go, and each object reports its own outcome: exit 0
+    when everything was deleted, 3 when one did not exist, 1 when the
+    cluster refused. Deleting a namespace, a node or a PersistentVolume says
+    what that takes with it before asking.
+  - `ankra cluster restart <deployment|statefulset|daemonset> <name>` is
+    `kubectl rollout restart`: a fresh `restartedAt` annotation on the pod
+    template, so the controller rolls every pod under its own strategy.
+  - `ankra cluster cordon|uncordon <node>` flip the node's scheduling;
+    `ankra cluster drain <node>` cordons it and deletes the pods on it,
+    leaving DaemonSet and static pods alone and printing the plan first
+    (`--dry-run` stops there).
+  - `ankra cluster helm get <release>` shows the chart, revision, values and
+    notes (`-o values` dumps just the values as YAML), `helm history` lists
+    the revisions, `helm rollback --revision N` rolls back and waits, and
+    `helm upgrade --chart <ref> --values <file>` runs an in-place upgrade
+    with the values file replacing the release's values wholesale. A
+    release an Ankra addon manages is refused by the platform so Git stays
+    the source of truth.
 - **`ankra security sbom` reads the fleet's software bill of materials.** Every
   package the scanner found in every container image, grouped by name,
   version and ecosystem, with how many images, workloads and clusters carry

--- a/cmd/cluster_delete.go
+++ b/cmd/cluster_delete.go
@@ -1,0 +1,210 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+var clusterDeleteCmd = &cobra.Command{
+	Use:   "delete <kind> <name> [name...]",
+	Short: "Delete Kubernetes resources from the active cluster",
+	Long: `Delete one or more Kubernetes resources from the active cluster.
+
+The kind takes the kubectl spellings - pod, pods, po, deployment, deploy,
+statefulset, sts, configmap, cm, namespace, node, pvc, ... - and a custom
+resource is reachable with --group and --api-version, exactly like
+'cluster get resources' and 'cluster describe'.
+
+A pod owned by a controller (Deployment, StatefulSet, DaemonSet, Job) is
+recreated by that controller, so deleting it is how you restart a single
+replica; 'cluster restart' rolls a whole workload. The delete goes through
+the cluster's Ankra agent: no kubeconfig is needed and the same organisation
+permissions as the portal apply.
+
+Each object reports its own outcome. The command exits 0 when everything was
+deleted, 3 when one of the objects did not exist, and 1 when the cluster
+refused a delete.
+
+Examples:
+  ankra cluster delete pod my-pod -n default
+  ankra cluster delete pods web-0 web-1 -n prod --yes
+  ankra cluster delete pod stuck-pod -n default --grace-period 0
+  ankra cluster delete deployment web -n prod --dry-run
+  ankra cluster delete namespace scratch
+  ankra cluster delete Certificate web-tls -n prod --group cert-manager.io --api-version v1`,
+	Args:        cobra.MinimumNArgs(2),
+	Annotations: map[string]string{"group": "kubernetes"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		namespace, _ := cmd.Flags().GetString("namespace")
+		yes, _ := cmd.Flags().GetBool("yes")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		apiGroup, _ := cmd.Flags().GetString("group")
+		apiVersion, _ := cmd.Flags().GetString("api-version")
+
+		resolvedKind, kindError := resolveK8sKind(args[0], apiGroup, apiVersion)
+		if kindError != nil {
+			return kindError
+		}
+		names := args[1:]
+		if !resolvedKind.clusterScoped && namespace == "" {
+			return withExitCode(exitUsage, fmt.Errorf("--namespace (-n) is required to delete a %s", resolvedKind.kind))
+		}
+		if resolvedKind.clusterScoped {
+			namespace = ""
+		}
+		var gracePeriodSeconds *int
+		if cmd.Flags().Changed("grace-period") {
+			gracePeriod, _ := cmd.Flags().GetInt("grace-period")
+			if gracePeriod < 0 {
+				return withExitCode(exitUsage, errors.New("--grace-period must be zero or a positive number of seconds"))
+			}
+			gracePeriodSeconds = &gracePeriod
+		}
+
+		cluster, err := resolveActiveCluster(cmd)
+		if err != nil {
+			return err
+		}
+
+		if !dryRun {
+			prompt := deleteResourcesPrompt(resolvedKind, names, namespace, cluster.Name)
+			if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(), prompt, yes); err != nil {
+				return err
+			}
+		}
+
+		return runResourceMutations(cmd, resolvedKind, names, namespace, deleteWording,
+			func(name string) (*client.ResourceMutationResponse, error) {
+				return apiClient.DeleteResource(cluster.ID, client.DeleteResourceRequest{
+					Kind:               resolvedKind.kind,
+					Group:              resolvedKind.group,
+					Version:            resolvedKind.version,
+					Resource:           resolvedKind.resource,
+					Namespace:          namespace,
+					Name:               name,
+					DryRun:             dryRun,
+					GracePeriodSeconds: gracePeriodSeconds,
+				})
+			})
+	},
+}
+
+// mutationWording names one write verb in the three forms the per-object
+// outcome lines and the error summary need.
+type mutationWording struct {
+	noun        string
+	pastTense   string
+	progressive string
+}
+
+var (
+	deleteWording  = mutationWording{noun: "delete", pastTense: "deleted", progressive: "deleting"}
+	restartWording = mutationWording{noun: "restart", pastTense: "restarted", progressive: "restarting"}
+)
+
+type resourceMutation func(name string) (*client.ResourceMutationResponse, error)
+
+// runResourceMutations applies one mutation per name and turns the agent's
+// per-object verdicts into the shared exit-code contract: every object
+// prints its own line, a transport failure stops the run where it is, an
+// "error" verdict exits 1 and a "not_found" verdict exits 3 once every
+// other object has been handled.
+func runResourceMutations(cmd *cobra.Command, kind k8sKind, names []string, namespace string,
+	wording mutationWording, mutate resourceMutation) error {
+	out := cmd.OutOrStdout()
+	label := strings.ToLower(kind.kind)
+	location := ""
+	if namespace != "" {
+		location = fmt.Sprintf(" in namespace %q", namespace)
+	}
+	missingCount := 0
+	var refused []string
+	for _, name := range names {
+		response, err := mutate(name)
+		if err != nil {
+			return fmt.Errorf("%s %s %q: %w", wording.progressive, label, name, err)
+		}
+		switch response.Status {
+		case "success":
+			_, _ = fmt.Fprintf(out, "%s %q %s%s\n", label, name, wording.pastTense, location)
+		case "dry_run":
+			_, _ = fmt.Fprintf(out, "%s %q would be %s%s (dry run)\n", label, name, wording.pastTense, location)
+		case "not_found":
+			missingCount++
+			_, _ = fmt.Fprintf(out, "%s %q not found%s\n", label, name, location)
+		default:
+			refused = append(refused, name+": "+mutationVerdictMessage(response))
+		}
+	}
+
+	if len(refused) > 0 {
+		return fmt.Errorf("%s refused for %d of %d %s:\n  %s",
+			wording.noun, len(refused), len(names), pluralKindLabel(kind), strings.Join(refused, "\n  "))
+	}
+	if missingCount > 0 {
+		return withExitCode(exitNotFound, fmt.Errorf("%d of %d %s not found%s",
+			missingCount, len(names), pluralKindLabel(kind), location))
+	}
+	return nil
+}
+
+func deleteResourcesPrompt(kind k8sKind, names []string, namespace, clusterName string) string {
+	where := fmt.Sprintf("on cluster %q", clusterName)
+	if namespace != "" {
+		where = fmt.Sprintf("in namespace %q on cluster %q", namespace, clusterName)
+	}
+	warning := deleteKindWarning(kind.kind)
+	if len(names) == 1 {
+		return fmt.Sprintf("%sDelete %s %q %s? [y/N]: ", warning, strings.ToLower(kind.kind), names[0], where)
+	}
+	return fmt.Sprintf("%sDelete %d %s (%s) %s? [y/N]: ",
+		warning, len(names), pluralKindLabel(kind), strings.Join(names, ", "), where)
+}
+
+// deleteKindWarning spells out the consequence a delete of this kind carries
+// beyond the object itself, so the prompt says it before the [y/N].
+func deleteKindWarning(kind string) string {
+	switch kind {
+	case "Namespace":
+		return "Deleting a namespace removes every object inside it.\n"
+	case "PersistentVolume":
+		return "Deleting a PersistentVolume releases its storage according to the reclaim policy.\n"
+	case "Node":
+		return "Deleting a Node removes it from the cluster; the machine itself is not touched.\n"
+	}
+	return ""
+}
+
+func pluralKindLabel(kind k8sKind) string {
+	if kind.resource != "" {
+		return kind.resource
+	}
+	return strings.ToLower(kind.kind) + "s"
+}
+
+// mutationVerdictMessage names the reason the agent gave for a non-converged
+// verdict; the relay answers HTTP 200 for every verdict, so the message is
+// the only thing that separates an RBAC deny from a wrong kind.
+func mutationVerdictMessage(response *client.ResourceMutationResponse) string {
+	if response.Message != nil && *response.Message != "" {
+		return *response.Message
+	}
+	return "status " + response.Status
+}
+
+func init() {
+	clusterDeleteCmd.Flags().StringP("namespace", "n", "", "Kubernetes namespace (required for namespaced kinds)")
+	clusterDeleteCmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
+	clusterDeleteCmd.Flags().Bool("dry-run", false, "Report what would be deleted without deleting anything")
+	clusterDeleteCmd.Flags().Int("grace-period", -1,
+		"Seconds the object gets to shut down cleanly; 0 deletes it immediately, -1 keeps the object's own grace period")
+	clusterDeleteCmd.Flags().String("group", "", "API group for a kind outside the built-in set (e.g. cert-manager.io)")
+	clusterDeleteCmd.Flags().String("api-version", "", "API version for a kind outside the built-in set (e.g. v1, v1beta1)")
+
+	clusterCmd.AddCommand(clusterDeleteCmd)
+}

--- a/cmd/cluster_delete_test.go
+++ b/cmd/cluster_delete_test.go
@@ -1,0 +1,262 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type deleteResourceMock struct {
+	baseMock
+	requests  []client.DeleteResourceRequest
+	responses map[string]*client.ResourceMutationResponse
+}
+
+func (m *deleteResourceMock) GetCluster(name string) (client.ClusterListItem, error) {
+	return client.ClusterListItem{ID: "cluster-abc", Name: name}, nil
+}
+
+func (m *deleteResourceMock) DeleteResource(clusterID string, request client.DeleteResourceRequest) (*client.ResourceMutationResponse, error) {
+	m.requests = append(m.requests, request)
+	if response, ok := m.responses[request.Name]; ok {
+		return response, nil
+	}
+	return &client.ResourceMutationResponse{Status: "success"}, nil
+}
+
+func runDelete(t *testing.T, mock APIClient, input string, extraArgs ...string) (string, error) {
+	t.Helper()
+	resetConfirmFlag(t, clusterDeleteCmd, clusterCmd)
+	args := append([]string{"cluster", "delete"}, extraArgs...)
+	return runWithInput(t, mock, input, args...)
+}
+
+func TestDelete_DeclineDoesNotCallAPI(t *testing.T) {
+	mock := &deleteResourceMock{}
+	_, err := runDelete(t, mock, "n\n", "pod", "web-0", "--namespace", "prod", "--cluster", "prod-cluster")
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled on decline, got %v", err)
+	}
+	if len(mock.requests) != 0 {
+		t.Errorf("expected no delete call when declined, got %d", len(mock.requests))
+	}
+}
+
+func TestDelete_PodSendsPodDelete(t *testing.T) {
+	mock := &deleteResourceMock{}
+	out, err := runDelete(t, mock, "", "pod", "web-0", "-n", "prod", "--cluster", "prod-cluster", "--yes")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if len(mock.requests) != 1 {
+		t.Fatalf("expected one delete call, got %d", len(mock.requests))
+	}
+	request := mock.requests[0]
+	if request.Kind != "Pod" || request.Version != "v1" || request.Group != "" || request.Namespace != "prod" || request.Name != "web-0" {
+		t.Errorf("request = %+v, want kind=Pod version=v1 namespace=prod name=web-0", request)
+	}
+	if request.DryRun {
+		t.Error("dry_run must be false without --dry-run")
+	}
+	if request.GracePeriodSeconds != nil {
+		t.Errorf("grace_period_seconds must stay unset without --grace-period, got %d", *request.GracePeriodSeconds)
+	}
+	if !strings.Contains(out, `pod "web-0" deleted in namespace "prod"`) {
+		t.Errorf("expected a deleted line, got: %s", out)
+	}
+}
+
+func TestDelete_KindSpellingsResolveGroupAndPlural(t *testing.T) {
+	mock := &deleteResourceMock{}
+	out, err := runDelete(t, mock, "", "deploy", "web", "-n", "prod", "--cluster", "prod-cluster", "--yes")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	request := mock.requests[0]
+	if request.Kind != "Deployment" || request.Group != "apps" || request.Version != "v1" {
+		t.Errorf("deploy should resolve to apps/v1 Deployment, got %+v", request)
+	}
+
+	mock = &deleteResourceMock{}
+	out, err = runDelete(t, mock, "", "ingresses", "web", "-n", "prod", "--cluster", "prod-cluster", "--yes")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	request = mock.requests[0]
+	if request.Kind != "Ingress" || request.Group != "networking.k8s.io" || request.Resource != "ingresses" {
+		t.Errorf("ingresses should pin the irregular plural, got %+v", request)
+	}
+}
+
+func TestDelete_ClusterScopedKindNeedsNoNamespaceAndWarns(t *testing.T) {
+	mock := &deleteResourceMock{}
+	out, err := runDelete(t, mock, "y\n", "namespace", "scratch", "--cluster", "prod-cluster")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if len(mock.requests) != 1 || mock.requests[0].Namespace != "" || mock.requests[0].Kind != "Namespace" {
+		t.Fatalf("expected one cluster-scoped Namespace delete, got %+v", mock.requests)
+	}
+	if !strings.Contains(out, "removes every object inside it") {
+		t.Errorf("namespace prompt should warn about the contents, got: %s", out)
+	}
+	if !strings.Contains(out, `namespace "scratch" deleted`) {
+		t.Errorf("expected a deleted line without a namespace suffix, got: %s", out)
+	}
+}
+
+func TestDelete_CustomResourcePassesGroupAndVersion(t *testing.T) {
+	mock := &deleteResourceMock{}
+	out, err := runDelete(t, mock, "", "Certificate", "web-tls", "-n", "prod", "--cluster", "prod-cluster", "--yes",
+		"--group", "cert-manager.io", "--api-version", "v1")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	request := mock.requests[0]
+	if request.Kind != "Certificate" || request.Group != "cert-manager.io" || request.Version != "v1" {
+		t.Errorf("custom resource should pass the overrides through, got %+v", request)
+	}
+}
+
+func TestDelete_UnknownKindExitsUsage(t *testing.T) {
+	mock := &deleteResourceMock{}
+	_, err := runDelete(t, mock, "", "Certificate", "web-tls", "-n", "prod", "--cluster", "prod-cluster", "--yes")
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("unknown kind without --group should exit %d, got %d (err=%v)", exitUsage, got, err)
+	}
+	if len(mock.requests) != 0 {
+		t.Error("unknown kind must be rejected before any API call")
+	}
+}
+
+func TestDelete_MissingNamespaceExitsUsage(t *testing.T) {
+	mock := &deleteResourceMock{}
+	_, err := runDelete(t, mock, "", "pod", "web-0", "--cluster", "prod-cluster", "--yes")
+	if err == nil {
+		t.Fatal("expected a usage error without --namespace")
+	}
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("missing namespace should exit %d, got %d", exitUsage, got)
+	}
+	if len(mock.requests) != 0 {
+		t.Error("missing namespace must be rejected before any API call")
+	}
+}
+
+func TestDelete_NegativeGracePeriodExitsUsage(t *testing.T) {
+	mock := &deleteResourceMock{}
+	_, err := runDelete(t, mock, "", "pod", "web-0", "-n", "prod", "--cluster", "prod-cluster", "--yes", "--grace-period", "-5")
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("negative grace period should exit %d, got %d (err=%v)", exitUsage, got, err)
+	}
+	if len(mock.requests) != 0 {
+		t.Error("negative grace period must be rejected before any API call")
+	}
+}
+
+func TestDelete_GracePeriodForwarded(t *testing.T) {
+	mock := &deleteResourceMock{}
+	out, err := runDelete(t, mock, "", "pod", "stuck", "-n", "prod", "--cluster", "prod-cluster", "--yes", "--grace-period", "0")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if len(mock.requests) != 1 || mock.requests[0].GracePeriodSeconds == nil || *mock.requests[0].GracePeriodSeconds != 0 {
+		t.Fatalf("expected grace_period_seconds=0 on the wire, got %+v", mock.requests)
+	}
+}
+
+func TestDelete_DryRunSkipsPromptAndSendsDryRun(t *testing.T) {
+	mock := &deleteResourceMock{responses: map[string]*client.ResourceMutationResponse{
+		"web-0": {Status: "dry_run"},
+	}}
+	out, err := runDelete(t, mock, "", "pod", "web-0", "-n", "prod", "--cluster", "prod-cluster", "--dry-run")
+	if err != nil {
+		t.Fatalf("dry run must not prompt or fail: %v\noutput: %s", err, out)
+	}
+	if len(mock.requests) != 1 || !mock.requests[0].DryRun {
+		t.Fatalf("expected one dry_run=true request, got %+v", mock.requests)
+	}
+	if strings.Contains(out, "[y/N]") {
+		t.Errorf("dry run must not show the confirmation prompt, got: %s", out)
+	}
+	if !strings.Contains(out, "would be deleted") {
+		t.Errorf("expected a dry-run line, got: %s", out)
+	}
+}
+
+func TestDelete_MultipleObjectsEachDeleted(t *testing.T) {
+	mock := &deleteResourceMock{}
+	out, err := runDelete(t, mock, "y\n", "pods", "web-0", "web-1", "-n", "prod", "--cluster", "prod-cluster")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if len(mock.requests) != 2 || mock.requests[0].Name != "web-0" || mock.requests[1].Name != "web-1" {
+		t.Fatalf("expected deletes for web-0 and web-1 in order, got %+v", mock.requests)
+	}
+	if !strings.Contains(out, "Delete 2 pods (web-0, web-1)") {
+		t.Errorf("expected the bulk prompt to name every pod, got: %s", out)
+	}
+}
+
+func TestDelete_NotFoundExitsNotFound(t *testing.T) {
+	mock := &deleteResourceMock{responses: map[string]*client.ResourceMutationResponse{
+		"gone": {Status: "not_found"},
+	}}
+	out, err := runDelete(t, mock, "", "pod", "web-0", "gone", "-n", "prod", "--cluster", "prod-cluster", "--yes")
+	if got := exitCodeFor(err); got != exitNotFound {
+		t.Fatalf("a missing pod should exit %d, got %d (err=%v)", exitNotFound, got, err)
+	}
+	if len(mock.requests) != 2 {
+		t.Errorf("a missing pod must not stop the remaining deletes, got %d requests", len(mock.requests))
+	}
+	if !strings.Contains(out, `pod "web-0" deleted`) || !strings.Contains(out, `pod "gone" not found`) {
+		t.Errorf("expected per-pod outcomes, got: %s", out)
+	}
+}
+
+func TestDelete_RefusedVerdictExitsError(t *testing.T) {
+	message := "pods is forbidden: User cannot delete resource"
+	mock := &deleteResourceMock{responses: map[string]*client.ResourceMutationResponse{
+		"web-0": {Status: "error", Message: &message},
+	}}
+	_, err := runDelete(t, mock, "", "pod", "web-0", "-n", "prod", "--cluster", "prod-cluster", "--yes")
+	if err == nil {
+		t.Fatal("an error verdict must not be reported as success")
+	}
+	if got := exitCodeFor(err); got != exitError {
+		t.Errorf("refused delete should exit %d, got %d", exitError, got)
+	}
+	if !strings.Contains(err.Error(), message) {
+		t.Errorf("error should carry the agent's reason, got: %v", err)
+	}
+}
+
+func TestDelete_TransportErrorStopsRun(t *testing.T) {
+	mock := &deleteTransportErrorMock{}
+	_, err := runDelete(t, mock, "", "pod", "web-0", "web-1", "-n", "prod", "--cluster", "prod-cluster", "--yes")
+	if err == nil {
+		t.Fatal("expected the cluster error to surface")
+	}
+	if !strings.Contains(err.Error(), "Cluster is offline") {
+		t.Errorf("expected the offline reason, got: %v", err)
+	}
+	if mock.calls != 1 {
+		t.Errorf("an offline cluster must stop the run after the first call, got %d calls", mock.calls)
+	}
+}
+
+type deleteTransportErrorMock struct {
+	baseMock
+	calls int
+}
+
+func (m *deleteTransportErrorMock) GetCluster(name string) (client.ClusterListItem, error) {
+	return client.ClusterListItem{ID: "cluster-abc", Name: name}, nil
+}
+
+func (m *deleteTransportErrorMock) DeleteResource(clusterID string, request client.DeleteResourceRequest) (*client.ResourceMutationResponse, error) {
+	m.calls++
+	return nil, &client.ClusterUnavailableError{ErrorCode: "CLUSTER_OFFLINE"}
+}

--- a/cmd/cluster_helm.go
+++ b/cmd/cluster_helm.go
@@ -4,19 +4,22 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 
 	"ankra/internal/client"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 var clusterHelmCmd = &cobra.Command{
 	Use:   "helm",
 	Short: "Manage Helm releases in the cluster",
-	Long:  "Commands to list and uninstall Helm releases running in the cluster.",
+	Long:  "Commands to list, inspect, roll back, upgrade and uninstall Helm releases running in the cluster.",
 }
 
 var clusterHelmReleasesCmd = &cobra.Command{
@@ -114,7 +117,7 @@ var clusterHelmUninstallCmd = &cobra.Command{
 			return err
 		}
 
-		result, err := apiClient.UninstallHelmRelease(cluster.ID, releaseName, namespace)
+		result, err := apiClient.UninstallHelmRelease(cluster.ID, namespace, releaseName)
 		if err != nil {
 			return err
 		}
@@ -127,6 +130,315 @@ var clusterHelmUninstallCmd = &cobra.Command{
 	},
 }
 
+var clusterHelmGetCmd = &cobra.Command{
+	Use:   "get <release_name>",
+	Short: "Show a Helm release: chart, status, values and notes",
+	Long: `Show one Helm release - the chart and revision it is on, when it was
+deployed, the values it was installed with and the chart's notes.
+
+'-o values' prints only the values the release was installed with, as YAML:
+edit that file and hand it back to 'cluster helm upgrade --values'.
+
+Examples:
+  ankra cluster helm get traefik -n traefik
+  ankra cluster helm get traefik -n traefik -o values > traefik-values.yaml`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		releaseName := args[0]
+		namespace, _ := cmd.Flags().GetString("namespace")
+		outputFormat, _ := cmd.Flags().GetString("output")
+		if namespace == "" {
+			return withExitCode(exitUsage, errors.New("--namespace (-n) is required for helm get"))
+		}
+		switch outputFormat {
+		case "table", "json", "yaml", "values":
+		default:
+			return withExitCode(exitUsage, fmt.Errorf("unsupported output format %q: use table, json, yaml or values", outputFormat))
+		}
+
+		cluster, err := resolveActiveCluster(cmd)
+		if err != nil {
+			return err
+		}
+		detail, err := apiClient.GetHelmReleaseDetail(cluster.ID, namespace, releaseName)
+		if err != nil {
+			return err
+		}
+
+		out := cmd.OutOrStdout()
+		switch outputFormat {
+		case "json":
+			encoded, marshalError := json.MarshalIndent(detail, "", "  ")
+			if marshalError != nil {
+				return fmt.Errorf("marshalling to JSON: %w", marshalError)
+			}
+			_, _ = fmt.Fprintln(out, string(encoded))
+			return nil
+		case "yaml":
+			encoded, marshalError := yaml.Marshal(detail)
+			if marshalError != nil {
+				return fmt.Errorf("marshalling to YAML: %w", marshalError)
+			}
+			_, _ = fmt.Fprint(out, string(encoded))
+			return nil
+		case "values":
+			return writeHelmValuesYAML(out, detail.UserValues)
+		}
+
+		metadata := detail.Metadata
+		_, _ = fmt.Fprintf(out, "Name:           %s\n", metadata.Name)
+		_, _ = fmt.Fprintf(out, "Namespace:      %s\n", metadata.Namespace)
+		_, _ = fmt.Fprintf(out, "Revision:       %d\n", metadata.Revision)
+		_, _ = fmt.Fprintf(out, "Status:         %s\n", metadata.Status)
+		_, _ = fmt.Fprintf(out, "Chart:          %s\n", stringFromPointer(metadata.Chart))
+		_, _ = fmt.Fprintf(out, "Chart version:  %s\n", stringFromPointer(metadata.ChartVersion))
+		_, _ = fmt.Fprintf(out, "App version:    %s\n", stringFromPointer(metadata.AppVersion))
+		_, _ = fmt.Fprintf(out, "First deployed: %s\n", stringFromPointer(metadata.FirstDeployed))
+		_, _ = fmt.Fprintf(out, "Last deployed:  %s\n", stringFromPointer(metadata.LastDeployed))
+		_, _ = fmt.Fprintf(out, "Description:    %s\n", stringFromPointer(metadata.Description))
+		_, _ = fmt.Fprintf(out, "\nUser values:\n")
+		if len(detail.UserValues) == 0 {
+			_, _ = fmt.Fprintln(out, "  (chart defaults)")
+		} else if err := writeHelmValuesYAML(out, detail.UserValues); err != nil {
+			return err
+		}
+		if detail.Notes != nil && strings.TrimSpace(*detail.Notes) != "" {
+			_, _ = fmt.Fprintf(out, "\nNotes:\n%s\n", strings.TrimRight(*detail.Notes, "\n"))
+		}
+		return nil
+	},
+}
+
+var clusterHelmHistoryCmd = &cobra.Command{
+	Use:   "history <release_name>",
+	Short: "List the revisions of a Helm release",
+	Long: `List a Helm release's revisions, newest first, with the chart and status of
+each - the revision numbers 'cluster helm rollback --revision' takes.
+
+Example:
+  ankra cluster helm history traefik -n traefik`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		releaseName := args[0]
+		namespace, _ := cmd.Flags().GetString("namespace")
+		limit, _ := cmd.Flags().GetInt("limit")
+		outputFormat, _ := cmd.Flags().GetString("output")
+		if namespace == "" {
+			return withExitCode(exitUsage, errors.New("--namespace (-n) is required for helm history"))
+		}
+		if limit < 1 || limit > 200 {
+			return withExitCode(exitUsage, errors.New("--limit must be between 1 and 200"))
+		}
+
+		cluster, err := resolveActiveCluster(cmd)
+		if err != nil {
+			return err
+		}
+		history, err := apiClient.GetHelmReleaseHistory(cluster.ID, namespace, releaseName, limit)
+		if err != nil {
+			return err
+		}
+
+		out := cmd.OutOrStdout()
+		if outputFormat == "json" {
+			encoded, marshalError := json.MarshalIndent(history, "", "  ")
+			if marshalError != nil {
+				return fmt.Errorf("marshalling to JSON: %w", marshalError)
+			}
+			_, _ = fmt.Fprintln(out, string(encoded))
+			return nil
+		}
+		if len(history.Revisions) == 0 {
+			_, _ = fmt.Fprintf(out, "No revisions found for release %q in namespace %q.\n", releaseName, namespace)
+			return nil
+		}
+
+		t := table.NewWriter()
+		t.SetOutputMirror(out)
+		t.SetStyle(table.StyleRounded)
+		t.AppendHeader(table.Row{"Revision", "Updated", "Status", "Chart", "App Version", "Description"})
+		for _, revision := range history.Revisions {
+			status := revision.Status
+			switch status {
+			case "deployed":
+				status = text.FgGreen.Sprint(status)
+			case "failed":
+				status = text.FgRed.Sprint(status)
+			case "superseded":
+				status = text.FgHiBlack.Sprint(status)
+			}
+			t.AppendRow(table.Row{
+				revision.Revision,
+				stringFromPointer(revision.Updated),
+				status,
+				stringFromPointer(revision.Chart),
+				stringFromPointer(revision.AppVersion),
+				stringFromPointer(revision.Description),
+			})
+		}
+		t.Render()
+		return nil
+	},
+}
+
+var clusterHelmRollbackCmd = &cobra.Command{
+	Use:   "rollback <release_name>",
+	Short: "Roll a Helm release back to an earlier revision",
+	Long: `Roll a Helm release back to one of its earlier revisions, as listed by
+'cluster helm history'. The rollback runs on the cluster's Ankra agent and,
+by default, waits for the rolled-back resources to become ready before
+returning. A release that an Ankra addon manages is refused: change the
+addon's values in the stack instead, so Git stays the source of truth.
+
+Examples:
+  ankra cluster helm rollback traefik -n traefik --revision 3
+  ankra cluster helm rollback traefik -n traefik --revision 3 --wait=false --yes`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		releaseName := args[0]
+		namespace, _ := cmd.Flags().GetString("namespace")
+		revision, _ := cmd.Flags().GetInt("revision")
+		wait, _ := cmd.Flags().GetBool("wait")
+		timeoutSeconds, _ := cmd.Flags().GetInt("timeout")
+		yes, _ := cmd.Flags().GetBool("yes")
+		if namespace == "" {
+			return withExitCode(exitUsage, errors.New("--namespace (-n) is required for helm rollback"))
+		}
+		if revision < 1 {
+			return withExitCode(exitUsage, errors.New("--revision is required and must be 1 or higher (see 'cluster helm history')"))
+		}
+		if timeoutSeconds < 1 || timeoutSeconds > 3600 {
+			return withExitCode(exitUsage, errors.New("--timeout must be between 1 and 3600 seconds"))
+		}
+
+		cluster, err := resolveActiveCluster(cmd)
+		if err != nil {
+			return err
+		}
+		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Roll back Helm release %q (namespace %q) on cluster %q to revision %d? [y/N]: ",
+				releaseName, namespace, cluster.Name, revision),
+			yes); err != nil {
+			return err
+		}
+
+		result, err := apiClient.RollbackHelmRelease(cluster.ID, namespace, releaseName, client.RollbackHelmReleaseRequest{
+			Revision:       revision,
+			Wait:           wait,
+			TimeoutSeconds: timeoutSeconds,
+		})
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Helm release %q rolled back to revision %d; it is now revision %d (%s).\n",
+			releaseName, revision, result.Revision, formatElapsedMilliseconds(result.ElapsedMS))
+		return nil
+	},
+}
+
+var clusterHelmUpgradeCmd = &cobra.Command{
+	Use:   "upgrade <release_name>",
+	Short: "Upgrade a Helm release in place with a chart and a values file",
+	Long: `Upgrade a Helm release in place: the agent runs 'helm upgrade' with the
+chart reference and the values file you pass. The values file REPLACES the
+release's values wholesale - start from 'cluster helm get <release> -o values'
+so nothing you did not mean to change resets to a chart default. Without
+--version the release stays on the chart version it already runs.
+
+A release that an Ankra addon manages is refused: change the addon in the
+stack instead, so Git stays the source of truth.
+
+Examples:
+  ankra cluster helm get traefik -n traefik -o values > traefik-values.yaml
+  ankra cluster helm upgrade traefik -n traefik --chart traefik/traefik --values traefik-values.yaml
+  ankra cluster helm upgrade traefik -n traefik --chart traefik --repo https://traefik.github.io/charts --version 30.0.0 --values traefik-values.yaml`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		releaseName := args[0]
+		namespace, _ := cmd.Flags().GetString("namespace")
+		chartReference, _ := cmd.Flags().GetString("chart")
+		repositoryURL, _ := cmd.Flags().GetString("repo")
+		chartVersion, _ := cmd.Flags().GetString("version")
+		valuesPath, _ := cmd.Flags().GetString("values")
+		wait, _ := cmd.Flags().GetBool("wait")
+		timeoutSeconds, _ := cmd.Flags().GetInt("timeout")
+		yes, _ := cmd.Flags().GetBool("yes")
+		if namespace == "" {
+			return withExitCode(exitUsage, errors.New("--namespace (-n) is required for helm upgrade"))
+		}
+		if chartReference == "" {
+			return withExitCode(exitUsage, errors.New("--chart is required (e.g. traefik/traefik, or a chart name with --repo)"))
+		}
+		if valuesPath == "" {
+			return withExitCode(exitUsage, errors.New("--values <file> is required: the file replaces the release's values, start from 'cluster helm get <release> -o values'"))
+		}
+		if timeoutSeconds < 1 || timeoutSeconds > 3600 {
+			return withExitCode(exitUsage, errors.New("--timeout must be between 1 and 3600 seconds"))
+		}
+		valuesYAML, readError := os.ReadFile(valuesPath)
+		if readError != nil {
+			return withExitCode(exitUsage, fmt.Errorf("reading --values file: %w", readError))
+		}
+		var parsedValues interface{}
+		if parseError := yaml.Unmarshal(valuesYAML, &parsedValues); parseError != nil {
+			return withExitCode(exitUsage, fmt.Errorf("--values file %s is not valid YAML: %w", valuesPath, parseError))
+		}
+
+		cluster, err := resolveActiveCluster(cmd)
+		if err != nil {
+			return err
+		}
+		chartLabel := chartReference
+		if chartVersion != "" {
+			chartLabel += " " + chartVersion
+		}
+		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Upgrade Helm release %q (namespace %q) on cluster %q with chart %s and the values in %s? [y/N]: ",
+				releaseName, namespace, cluster.Name, chartLabel, valuesPath),
+			yes); err != nil {
+			return err
+		}
+
+		result, err := apiClient.UpgradeHelmRelease(cluster.ID, namespace, releaseName, client.UpgradeHelmReleaseRequest{
+			ChartRef:       chartReference,
+			RepoURL:        repositoryURL,
+			ChartVersion:   chartVersion,
+			ValuesYAML:     string(valuesYAML),
+			Wait:           wait,
+			TimeoutSeconds: timeoutSeconds,
+		})
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Helm release %q upgraded; it is now revision %d (%s).\n",
+			releaseName, result.Revision, formatElapsedMilliseconds(result.ElapsedMS))
+		return nil
+	},
+}
+
+func writeHelmValuesYAML(out io.Writer, values map[string]interface{}) error {
+	if values == nil {
+		values = map[string]interface{}{}
+	}
+	encoded, marshalError := yaml.Marshal(values)
+	if marshalError != nil {
+		return fmt.Errorf("marshalling values to YAML: %w", marshalError)
+	}
+	_, _ = fmt.Fprint(out, string(encoded))
+	return nil
+}
+
+func stringFromPointer(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func formatElapsedMilliseconds(elapsedMilliseconds int) string {
+	return fmt.Sprintf("%.1fs", float64(elapsedMilliseconds)/1000)
+}
+
 func init() {
 	clusterHelmReleasesCmd.Flags().StringP("namespace", "n", "", "Kubernetes namespace")
 	clusterHelmReleasesCmd.Flags().BoolP("all-namespaces", "A", false, "List across all namespaces (default)")
@@ -135,7 +447,33 @@ func init() {
 	clusterHelmUninstallCmd.Flags().StringP("namespace", "n", "", "Kubernetes namespace (required)")
 	clusterHelmUninstallCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 
+	clusterHelmGetCmd.Flags().StringP("namespace", "n", "", "Kubernetes namespace (required)")
+	clusterHelmGetCmd.Flags().StringP("output", "o", "table", "Output format: table, json, yaml, values")
+
+	clusterHelmHistoryCmd.Flags().StringP("namespace", "n", "", "Kubernetes namespace (required)")
+	clusterHelmHistoryCmd.Flags().Int("limit", 25, "Number of revisions to show (1-200)")
+	clusterHelmHistoryCmd.Flags().StringP("output", "o", "table", "Output format: table, json")
+
+	clusterHelmRollbackCmd.Flags().StringP("namespace", "n", "", "Kubernetes namespace (required)")
+	clusterHelmRollbackCmd.Flags().Int("revision", 0, "Revision to roll back to (required, see 'cluster helm history')")
+	clusterHelmRollbackCmd.Flags().Bool("wait", true, "Wait for the rolled-back resources to become ready")
+	clusterHelmRollbackCmd.Flags().Int("timeout", 600, "Seconds to wait for the rollback (1-3600)")
+	clusterHelmRollbackCmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
+
+	clusterHelmUpgradeCmd.Flags().StringP("namespace", "n", "", "Kubernetes namespace (required)")
+	clusterHelmUpgradeCmd.Flags().String("chart", "", "Chart reference (required): repo/name, an OCI reference, or a name with --repo")
+	clusterHelmUpgradeCmd.Flags().String("repo", "", "Chart repository URL when --chart is a bare chart name")
+	clusterHelmUpgradeCmd.Flags().String("version", "", "Chart version to upgrade to (default: the version the release already runs)")
+	clusterHelmUpgradeCmd.Flags().StringP("values", "f", "", "Values file that replaces the release's values (required)")
+	clusterHelmUpgradeCmd.Flags().Bool("wait", true, "Wait for the upgraded resources to become ready")
+	clusterHelmUpgradeCmd.Flags().Int("timeout", 600, "Seconds to wait for the upgrade (1-3600)")
+	clusterHelmUpgradeCmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
+
 	clusterHelmCmd.AddCommand(clusterHelmReleasesCmd)
+	clusterHelmCmd.AddCommand(clusterHelmGetCmd)
+	clusterHelmCmd.AddCommand(clusterHelmHistoryCmd)
+	clusterHelmCmd.AddCommand(clusterHelmRollbackCmd)
+	clusterHelmCmd.AddCommand(clusterHelmUpgradeCmd)
 	clusterHelmCmd.AddCommand(clusterHelmUninstallCmd)
 
 	clusterCmd.AddCommand(clusterHelmCmd)

--- a/cmd/cluster_helm.go
+++ b/cmd/cluster_helm.go
@@ -229,6 +229,9 @@ Example:
 		if limit < 1 || limit > 200 {
 			return withExitCode(exitUsage, errors.New("--limit must be between 1 and 200"))
 		}
+		if outputFormat != "table" && outputFormat != "json" {
+			return withExitCode(exitUsage, fmt.Errorf("unsupported output format %q: use table or json", outputFormat))
+		}
 
 		cluster, err := resolveActiveCluster(cmd)
 		if err != nil {

--- a/cmd/cluster_helm.go
+++ b/cmd/cluster_helm.go
@@ -117,7 +117,7 @@ var clusterHelmUninstallCmd = &cobra.Command{
 			return err
 		}
 
-		result, err := apiClient.UninstallHelmRelease(cluster.ID, namespace, releaseName)
+		result, err := apiClient.UninstallHelmRelease(cluster.ID, releaseName, namespace)
 		if err != nil {
 			return err
 		}
@@ -175,7 +175,7 @@ Examples:
 			_, _ = fmt.Fprintln(out, string(encoded))
 			return nil
 		case "yaml":
-			encoded, marshalError := yaml.Marshal(detail)
+			encoded, marshalError := yamlWithWireKeys(detail)
 			if marshalError != nil {
 				return fmt.Errorf("marshalling to YAML: %w", marshalError)
 			}
@@ -414,6 +414,22 @@ Examples:
 			releaseName, result.Revision, formatElapsedMilliseconds(result.ElapsedMS))
 		return nil
 	},
+}
+
+// yamlWithWireKeys renders a value with the same keys '-o json' prints. The
+// client structs carry json tags only, so marshalling them straight to YAML
+// would emit lower-cased Go field names ("uservalues") instead of the wire
+// names ("user_values") and the two machine-readable formats would disagree.
+func yamlWithWireKeys(value interface{}) ([]byte, error) {
+	encoded, marshalError := json.Marshal(value)
+	if marshalError != nil {
+		return nil, marshalError
+	}
+	var generic interface{}
+	if unmarshalError := json.Unmarshal(encoded, &generic); unmarshalError != nil {
+		return nil, unmarshalError
+	}
+	return yaml.Marshal(generic)
 }
 
 func writeHelmValuesYAML(out io.Writer, values map[string]interface{}) error {

--- a/cmd/cluster_helm_test.go
+++ b/cmd/cluster_helm_test.go
@@ -22,7 +22,7 @@ func (m *helmUninstallMock) GetCluster(name string) (client.ClusterListItem, err
 	return client.ClusterListItem{ID: "cluster-abc", Name: name}, nil
 }
 
-func (m *helmUninstallMock) UninstallHelmRelease(clusterID, namespace, releaseName string) (*client.UninstallHelmReleaseResponse, error) {
+func (m *helmUninstallMock) UninstallHelmRelease(clusterID, releaseName, namespace string) (*client.UninstallHelmReleaseResponse, error) {
 	m.called = true
 	m.gotClusterID = clusterID
 	m.gotReleaseName = releaseName
@@ -258,5 +258,20 @@ func TestHelmUpgrade_InvalidValuesFileExitsUsage(t *testing.T) {
 	}
 	if len(mock.upgrades) != 0 {
 		t.Error("invalid values must be rejected before any API call")
+	}
+}
+
+func TestHelmGet_YamlOutputUsesWireKeys(t *testing.T) {
+	mock := &helmReleaseOpsMock{}
+	resetConfirmFlag(t, clusterHelmGetCmd, clusterCmd)
+	out, err := runWithInput(t, mock, "", "cluster", "helm", "get", "traefik", "-n", "traefik", "--cluster", "prod-cluster", "-o", "yaml")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, "user_values:") || !strings.Contains(out, "chart_version:") {
+		t.Errorf("-o yaml should use the JSON wire keys, got: %s", out)
+	}
+	if strings.Contains(out, "uservalues") || strings.Contains(out, "chartversion") {
+		t.Errorf("-o yaml must not leak Go field names, got: %s", out)
 	}
 }

--- a/cmd/cluster_helm_test.go
+++ b/cmd/cluster_helm_test.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"ankra/internal/client"
@@ -19,7 +22,7 @@ func (m *helmUninstallMock) GetCluster(name string) (client.ClusterListItem, err
 	return client.ClusterListItem{ID: "cluster-abc", Name: name}, nil
 }
 
-func (m *helmUninstallMock) UninstallHelmRelease(clusterID, releaseName, namespace string) (*client.UninstallHelmReleaseResponse, error) {
+func (m *helmUninstallMock) UninstallHelmRelease(clusterID, namespace, releaseName string) (*client.UninstallHelmReleaseResponse, error) {
 	m.called = true
 	m.gotClusterID = clusterID
 	m.gotReleaseName = releaseName
@@ -54,5 +57,206 @@ func TestHelmUninstall_YesProceeds(t *testing.T) {
 	if mock.gotClusterID != "cluster-abc" || mock.gotReleaseName != "my-release" || mock.gotNamespace != "prod" {
 		t.Errorf("got cluster=%q release=%q ns=%q, want cluster-abc/my-release/prod",
 			mock.gotClusterID, mock.gotReleaseName, mock.gotNamespace)
+	}
+}
+
+type helmReleaseOpsMock struct {
+	baseMock
+	rollbacks   []client.RollbackHelmReleaseRequest
+	upgrades    []client.UpgradeHelmReleaseRequest
+	gotRelease  string
+	gotNS       string
+	historyCall int
+	historyMax  int
+}
+
+func (m *helmReleaseOpsMock) GetCluster(name string) (client.ClusterListItem, error) {
+	return client.ClusterListItem{ID: "cluster-abc", Name: name}, nil
+}
+
+func (m *helmReleaseOpsMock) GetHelmReleaseDetail(clusterID, namespace, releaseName string) (*client.HelmReleaseDetail, error) {
+	m.gotRelease, m.gotNS = releaseName, namespace
+	chart := "traefik-30.0.0"
+	notes := "Traefik is up.\n"
+	return &client.HelmReleaseDetail{
+		Metadata:   client.HelmReleaseMetadata{Name: releaseName, Namespace: namespace, Revision: 4, Status: "deployed", Chart: &chart},
+		UserValues: map[string]interface{}{"deployment": map[string]interface{}{"replicas": 2}},
+		Notes:      &notes,
+	}, nil
+}
+
+func (m *helmReleaseOpsMock) GetHelmReleaseHistory(clusterID, namespace, releaseName string, limit int) (*client.HelmReleaseHistory, error) {
+	m.historyCall++
+	m.historyMax = limit
+	m.gotRelease, m.gotNS = releaseName, namespace
+	chart := "traefik-30.0.0"
+	return &client.HelmReleaseHistory{Revisions: []client.HelmReleaseHistoryEntry{
+		{Revision: 4, Status: "deployed", Chart: &chart},
+		{Revision: 3, Status: "superseded", Chart: &chart},
+	}}, nil
+}
+
+func (m *helmReleaseOpsMock) RollbackHelmRelease(clusterID, namespace, releaseName string, request client.RollbackHelmReleaseRequest) (*client.HelmReleaseMutationResult, error) {
+	m.rollbacks = append(m.rollbacks, request)
+	m.gotRelease, m.gotNS = releaseName, namespace
+	return &client.HelmReleaseMutationResult{ReleaseName: releaseName, Namespace: namespace, Revision: 5, ElapsedMS: 1500}, nil
+}
+
+func (m *helmReleaseOpsMock) UpgradeHelmRelease(clusterID, namespace, releaseName string, request client.UpgradeHelmReleaseRequest) (*client.HelmReleaseMutationResult, error) {
+	m.upgrades = append(m.upgrades, request)
+	m.gotRelease, m.gotNS = releaseName, namespace
+	return &client.HelmReleaseMutationResult{ReleaseName: releaseName, Namespace: namespace, Revision: 5, ElapsedMS: 2500}, nil
+}
+
+func TestHelmGet_ValuesOutputPrintsUserValuesYAML(t *testing.T) {
+	mock := &helmReleaseOpsMock{}
+	resetConfirmFlag(t, clusterHelmGetCmd, clusterCmd)
+	out, err := runWithInput(t, mock, "", "cluster", "helm", "get", "traefik", "-n", "traefik", "--cluster", "prod-cluster", "-o", "values")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if strings.TrimSpace(out) != "deployment:\n    replicas: 2" {
+		t.Errorf("-o values should print only the user values as YAML, got: %q", out)
+	}
+	if mock.gotRelease != "traefik" || mock.gotNS != "traefik" {
+		t.Errorf("detail should be fetched for traefik/traefik, got %s/%s", mock.gotNS, mock.gotRelease)
+	}
+}
+
+func TestHelmGet_TableShowsMetadataValuesAndNotes(t *testing.T) {
+	mock := &helmReleaseOpsMock{}
+	resetConfirmFlag(t, clusterHelmGetCmd, clusterCmd)
+	out, err := runWithInput(t, mock, "", "cluster", "helm", "get", "traefik", "-n", "traefik", "--cluster", "prod-cluster")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	for _, want := range []string{"Revision:       4", "Chart:          traefik-30.0.0", "replicas: 2", "Traefik is up."} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in the rendering, got: %s", want, out)
+		}
+	}
+}
+
+func TestHelmHistory_RendersRevisionsWithLimit(t *testing.T) {
+	mock := &helmReleaseOpsMock{}
+	resetConfirmFlag(t, clusterHelmHistoryCmd, clusterCmd)
+	out, err := runWithInput(t, mock, "", "cluster", "helm", "history", "traefik", "-n", "traefik", "--cluster", "prod-cluster", "--limit", "10")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if mock.historyMax != 10 {
+		t.Errorf("--limit should reach the API, got %d", mock.historyMax)
+	}
+	plain := stripANSICodes(out)
+	if !strings.Contains(plain, "deployed") || !strings.Contains(plain, "superseded") {
+		t.Errorf("expected both revisions in the table, got: %s", plain)
+	}
+}
+
+func TestHelmRollback_DeclineDoesNotCallAPI(t *testing.T) {
+	mock := &helmReleaseOpsMock{}
+	resetConfirmFlag(t, clusterHelmRollbackCmd, clusterCmd)
+	_, err := runWithInput(t, mock, "n\n", "cluster", "helm", "rollback", "traefik", "-n", "traefik", "--revision", "3", "--cluster", "prod-cluster")
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled on decline, got %v", err)
+	}
+	if len(mock.rollbacks) != 0 {
+		t.Error("expected no rollback call when declined")
+	}
+}
+
+func TestHelmRollback_YesSendsRevision(t *testing.T) {
+	mock := &helmReleaseOpsMock{}
+	resetConfirmFlag(t, clusterHelmRollbackCmd, clusterCmd)
+	out, err := runWithInput(t, mock, "", "cluster", "helm", "rollback", "traefik", "-n", "traefik", "--revision", "3", "--cluster", "prod-cluster", "--yes")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if len(mock.rollbacks) != 1 {
+		t.Fatalf("expected one rollback call, got %d", len(mock.rollbacks))
+	}
+	request := mock.rollbacks[0]
+	if request.Revision != 3 || !request.Wait || request.TimeoutSeconds != 600 {
+		t.Errorf("request = %+v, want revision=3 wait=true timeout=600", request)
+	}
+	if !strings.Contains(out, "rolled back to revision 3; it is now revision 5 (1.5s)") {
+		t.Errorf("expected the rollback summary, got: %s", out)
+	}
+}
+
+func TestHelmRollback_MissingRevisionExitsUsage(t *testing.T) {
+	mock := &helmReleaseOpsMock{}
+	resetConfirmFlag(t, clusterHelmRollbackCmd, clusterCmd)
+	_, err := runWithInput(t, mock, "", "cluster", "helm", "rollback", "traefik", "-n", "traefik", "--cluster", "prod-cluster", "--yes")
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("missing --revision should exit %d, got %d (err=%v)", exitUsage, got, err)
+	}
+	if len(mock.rollbacks) != 0 {
+		t.Error("missing revision must be rejected before any API call")
+	}
+}
+
+func TestHelmUpgrade_RequiresChartAndValues(t *testing.T) {
+	mock := &helmReleaseOpsMock{}
+	resetConfirmFlag(t, clusterHelmUpgradeCmd, clusterCmd)
+	_, err := runWithInput(t, mock, "", "cluster", "helm", "upgrade", "traefik", "-n", "traefik", "--cluster", "prod-cluster", "--yes")
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("missing --chart should exit %d, got %d (err=%v)", exitUsage, got, err)
+	}
+	resetConfirmFlag(t, clusterHelmUpgradeCmd, clusterCmd)
+	_, err = runWithInput(t, mock, "", "cluster", "helm", "upgrade", "traefik", "-n", "traefik", "--chart", "traefik/traefik", "--cluster", "prod-cluster", "--yes")
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("missing --values should exit %d, got %d (err=%v)", exitUsage, got, err)
+	}
+	if len(mock.upgrades) != 0 {
+		t.Error("missing flags must be rejected before any API call")
+	}
+}
+
+func TestHelmUpgrade_YesSendsChartAndValuesFile(t *testing.T) {
+	valuesPath := filepath.Join(t.TempDir(), "values.yaml")
+	if err := os.WriteFile(valuesPath, []byte("deployment:\n  replicas: 3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mock := &helmReleaseOpsMock{}
+	resetConfirmFlag(t, clusterHelmUpgradeCmd, clusterCmd)
+	out, err := runWithInput(t, mock, "", "cluster", "helm", "upgrade", "traefik", "-n", "traefik",
+		"--chart", "traefik", "--repo", "https://traefik.github.io/charts", "--version", "30.0.0",
+		"--values", valuesPath, "--cluster", "prod-cluster", "--yes")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if len(mock.upgrades) != 1 {
+		t.Fatalf("expected one upgrade call, got %d", len(mock.upgrades))
+	}
+	request := mock.upgrades[0]
+	if request.ChartRef != "traefik" || request.RepoURL != "https://traefik.github.io/charts" || request.ChartVersion != "30.0.0" {
+		t.Errorf("request = %+v, want chart=traefik repo=https://traefik.github.io/charts version=30.0.0", request)
+	}
+	if request.ValuesYAML != "deployment:\n  replicas: 3\n" {
+		t.Errorf("values_yaml should be the file verbatim, got %q", request.ValuesYAML)
+	}
+	if !request.Wait || request.TimeoutSeconds != 600 {
+		t.Errorf("wait/timeout defaults should be true/600, got %+v", request)
+	}
+	if !strings.Contains(out, "upgraded; it is now revision 5 (2.5s)") {
+		t.Errorf("expected the upgrade summary, got: %s", out)
+	}
+}
+
+func TestHelmUpgrade_InvalidValuesFileExitsUsage(t *testing.T) {
+	valuesPath := filepath.Join(t.TempDir(), "values.yaml")
+	if err := os.WriteFile(valuesPath, []byte("deployment: [unclosed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mock := &helmReleaseOpsMock{}
+	resetConfirmFlag(t, clusterHelmUpgradeCmd, clusterCmd)
+	_, err := runWithInput(t, mock, "", "cluster", "helm", "upgrade", "traefik", "-n", "traefik",
+		"--chart", "traefik/traefik", "--values", valuesPath, "--cluster", "prod-cluster", "--yes")
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("invalid YAML should exit %d, got %d (err=%v)", exitUsage, got, err)
+	}
+	if len(mock.upgrades) != 0 {
+		t.Error("invalid values must be rejected before any API call")
 	}
 }

--- a/cmd/cluster_helm_test.go
+++ b/cmd/cluster_helm_test.go
@@ -275,3 +275,15 @@ func TestHelmGet_YamlOutputUsesWireKeys(t *testing.T) {
 		t.Errorf("-o yaml must not leak Go field names, got: %s", out)
 	}
 }
+
+func TestHelmHistory_UnsupportedOutputExitsUsage(t *testing.T) {
+	mock := &helmReleaseOpsMock{}
+	resetConfirmFlag(t, clusterHelmHistoryCmd, clusterCmd)
+	_, err := runWithInput(t, mock, "", "cluster", "helm", "history", "traefik", "-n", "traefik", "--cluster", "prod-cluster", "-o", "wide")
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("-o wide should exit %d, got %d (err=%v)", exitUsage, got, err)
+	}
+	if mock.historyCall != 0 {
+		t.Error("an unsupported output format must be rejected before any API call")
+	}
+}

--- a/cmd/cluster_node_scheduling.go
+++ b/cmd/cluster_node_scheduling.go
@@ -52,13 +52,19 @@ Example:
 
 var clusterDrainCmd = &cobra.Command{
 	Use:   "drain <node>",
-	Short: "Cordon a node and delete the pods running on it",
+	Short: "Cordon a node and delete the pods running on it (deletes, does not evict)",
 	Long: `Cordon a node, then delete every pod scheduled on it so its controller
 reschedules the pod elsewhere. DaemonSet pods are left alone (they would
 come straight back on the same node) and so are the static pods the kubelet
 runs from disk. A pod without a controller is deleted like any other and is
 not recreated - the plan names every pod before anything happens, and
 --dry-run stops after printing it.
+
+Unlike 'kubectl drain', the pods are deleted rather than evicted: the Ankra
+agent has no eviction relay yet, so PodDisruptionBudgets are not consulted
+and a budget at its limit does not hold the drain back. Check the budgets in
+the namespaces you care about ('cluster get resources PodDisruptionBudget
+--group policy') before draining a node that carries a quorum member.
 
 The node stays cordoned afterwards; run 'cluster uncordon' to put it back
 into service.
@@ -124,8 +130,10 @@ Examples:
 				return fmt.Errorf("deleting pod %s: %w", pod, err)
 			}
 			switch response.Status {
-			case "success", "not_found":
+			case "success":
 				_, _ = fmt.Fprintf(out, "pod %s deleted\n", pod)
+			case "not_found":
+				_, _ = fmt.Fprintf(out, "pod %s already gone\n", pod)
 			default:
 				refused = append(refused, pod.String()+": "+mutationVerdictMessage(response))
 			}

--- a/cmd/cluster_node_scheduling.go
+++ b/cmd/cluster_node_scheduling.go
@@ -1,0 +1,285 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+var clusterCordonCmd = &cobra.Command{
+	Use:   "cordon <node>",
+	Short: "Mark a node unschedulable",
+	Long: `Mark a node unschedulable so no new pods land on it. Pods already running
+stay where they are; 'cluster drain' moves them off. 'cluster uncordon' puts
+the node back into service.
+
+Example:
+  ankra cluster cordon worker-3`,
+	Args:        cobra.ExactArgs(1),
+	Annotations: map[string]string{"group": "kubernetes"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cluster, err := resolveActiveCluster(cmd)
+		if err != nil {
+			return err
+		}
+		return setNodeUnschedulable(cmd, cluster.ID, args[0], true)
+	},
+}
+
+var clusterUncordonCmd = &cobra.Command{
+	Use:   "uncordon <node>",
+	Short: "Mark a node schedulable again",
+	Long: `Clear the unschedulable mark 'cluster cordon' or 'cluster drain' set, so the
+scheduler can place pods on the node again.
+
+Example:
+  ankra cluster uncordon worker-3`,
+	Args:        cobra.ExactArgs(1),
+	Annotations: map[string]string{"group": "kubernetes"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cluster, err := resolveActiveCluster(cmd)
+		if err != nil {
+			return err
+		}
+		return setNodeUnschedulable(cmd, cluster.ID, args[0], false)
+	},
+}
+
+var clusterDrainCmd = &cobra.Command{
+	Use:   "drain <node>",
+	Short: "Cordon a node and delete the pods running on it",
+	Long: `Cordon a node, then delete every pod scheduled on it so its controller
+reschedules the pod elsewhere. DaemonSet pods are left alone (they would
+come straight back on the same node) and so are the static pods the kubelet
+runs from disk. A pod without a controller is deleted like any other and is
+not recreated - the plan names every pod before anything happens, and
+--dry-run stops after printing it.
+
+The node stays cordoned afterwards; run 'cluster uncordon' to put it back
+into service.
+
+Examples:
+  ankra cluster drain worker-3
+  ankra cluster drain worker-3 --grace-period 30 --yes
+  ankra cluster drain worker-3 --dry-run`,
+	Args:        cobra.ExactArgs(1),
+	Annotations: map[string]string{"group": "kubernetes"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		nodeName := args[0]
+		yes, _ := cmd.Flags().GetBool("yes")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		var gracePeriodSeconds *int
+		if cmd.Flags().Changed("grace-period") {
+			gracePeriod, _ := cmd.Flags().GetInt("grace-period")
+			if gracePeriod < 0 {
+				return withExitCode(exitUsage, fmt.Errorf("--grace-period must be zero or a positive number of seconds"))
+			}
+			gracePeriodSeconds = &gracePeriod
+		}
+
+		cluster, err := resolveActiveCluster(cmd)
+		if err != nil {
+			return err
+		}
+
+		plan, err := planNodeDrain(cluster.ID, nodeName)
+		if err != nil {
+			return err
+		}
+		out := cmd.OutOrStdout()
+		printDrainPlan(out, nodeName, plan)
+		if dryRun {
+			return nil
+		}
+
+		prompt := fmt.Sprintf("Drain node %q on cluster %q (cordon it and delete %d pods)? [y/N]: ",
+			nodeName, cluster.Name, len(plan.evictable))
+		if err := confirmPrompt(cmd.InOrStdin(), out, prompt, yes); err != nil {
+			return err
+		}
+
+		if err := setNodeUnschedulable(cmd, cluster.ID, nodeName, true); err != nil {
+			return err
+		}
+		if len(plan.evictable) == 0 {
+			_, _ = fmt.Fprintf(out, "node %q drained: nothing to delete\n", nodeName)
+			return nil
+		}
+
+		var refused []string
+		for _, pod := range plan.evictable {
+			response, err := apiClient.DeleteResource(cluster.ID, client.DeleteResourceRequest{
+				Kind:               "Pod",
+				Version:            "v1",
+				Namespace:          pod.namespace,
+				Name:               pod.name,
+				GracePeriodSeconds: gracePeriodSeconds,
+			})
+			if err != nil {
+				return fmt.Errorf("deleting pod %s: %w", pod, err)
+			}
+			switch response.Status {
+			case "success", "not_found":
+				_, _ = fmt.Fprintf(out, "pod %s deleted\n", pod)
+			default:
+				refused = append(refused, pod.String()+": "+mutationVerdictMessage(response))
+			}
+		}
+		if len(refused) > 0 {
+			return fmt.Errorf("node %q is cordoned but %d of %d pods could not be deleted:\n  %s",
+				nodeName, len(refused), len(plan.evictable), strings.Join(refused, "\n  "))
+		}
+		_, _ = fmt.Fprintf(out, "node %q drained: %d pods deleted\n", nodeName, len(plan.evictable))
+		return nil
+	},
+}
+
+// setNodeUnschedulable flips spec.unschedulable through the patch relay -
+// the same call the portal's cordon toggle makes.
+func setNodeUnschedulable(cmd *cobra.Command, clusterID, nodeName string, unschedulable bool) error {
+	verb := "cordoned"
+	if !unschedulable {
+		verb = "uncordoned"
+	}
+	response, err := apiClient.PatchResource(clusterID, client.PatchResourceRequest{
+		Kind:      "Node",
+		Version:   "v1",
+		Name:      nodeName,
+		Patch:     map[string]interface{}{"spec": map[string]interface{}{"unschedulable": unschedulable}},
+		PatchType: "strategic",
+	})
+	if err != nil {
+		return fmt.Errorf("updating node %q: %w", nodeName, err)
+	}
+	switch response.Status {
+	case "success":
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "node %q %s\n", nodeName, verb)
+		return nil
+	case "not_found":
+		return withExitCode(exitNotFound, fmt.Errorf("node %q not found", nodeName))
+	default:
+		return fmt.Errorf("node %q could not be %s: %s", nodeName, verb, mutationVerdictMessage(response))
+	}
+}
+
+type podReference struct {
+	namespace string
+	name      string
+}
+
+func (reference podReference) String() string {
+	return reference.namespace + "/" + reference.name
+}
+
+// drainPlan splits the pods on a node into the ones a drain deletes and the
+// ones it leaves in place, with the reason for each skip.
+type drainPlan struct {
+	evictable []podReference
+	skipped   map[string][]podReference
+}
+
+func planNodeDrain(clusterID, nodeName string) (drainPlan, error) {
+	response, err := apiClient.GetResources(clusterID, client.GetResourcesRequest{
+		ResourceRequests: []client.ResourceRequestItem{{
+			Kind:           "Pod",
+			Version:        "v1",
+			FieldSelectors: []client.FieldSelector{{Field: "spec.nodeName", Value: nodeName}},
+		}},
+		SkipCache: true,
+	})
+	if err != nil {
+		return drainPlan{}, fmt.Errorf("listing pods on node %q: %w", nodeName, err)
+	}
+	plan := drainPlan{skipped: map[string][]podReference{}}
+	if len(response.ResourceResponses) == 0 {
+		return plan, nil
+	}
+	for _, item := range response.ResourceResponses[0].Items {
+		pod, isObject := item.(map[string]interface{})
+		if !isObject || getNestedString(pod, "spec", "nodeName") != nodeName {
+			continue
+		}
+		reference := podReference{
+			namespace: getNestedString(pod, "metadata", "namespace"),
+			name:      getNestedString(pod, "metadata", "name"),
+		}
+		if reason := drainSkipReason(pod); reason != "" {
+			plan.skipped[reason] = append(plan.skipped[reason], reference)
+			continue
+		}
+		plan.evictable = append(plan.evictable, reference)
+	}
+	return plan, nil
+}
+
+// drainSkipReason mirrors kubectl drain's defaults: a DaemonSet pod is
+// recreated on the same node the moment it is deleted, and a static pod
+// belongs to the kubelet, not the API server.
+func drainSkipReason(pod map[string]interface{}) string {
+	metadata, hasMetadata := getNestedMap(pod, "metadata")
+	if !hasMetadata {
+		return ""
+	}
+	if annotations, hasAnnotations := getNestedMap(metadata, "annotations"); hasAnnotations {
+		if _, isMirror := annotations["kubernetes.io/config.mirror"]; isMirror {
+			return "static pod"
+		}
+	}
+	owners, hasOwners := metadata["ownerReferences"].([]interface{})
+	if !hasOwners {
+		return ""
+	}
+	for _, rawOwner := range owners {
+		owner, isObject := rawOwner.(map[string]interface{})
+		if !isObject {
+			continue
+		}
+		switch getNestedString(owner, "kind") {
+		case "DaemonSet":
+			return "DaemonSet pod"
+		case "Node":
+			return "static pod"
+		}
+	}
+	return ""
+}
+
+func printDrainPlan(out io.Writer, nodeName string, plan drainPlan) {
+	if len(plan.evictable) == 0 {
+		_, _ = fmt.Fprintf(out, "No pods to delete on node %q.\n", nodeName)
+	} else {
+		_, _ = fmt.Fprintf(out, "%d pods on node %q will be deleted:\n", len(plan.evictable), nodeName)
+		for _, pod := range plan.evictable {
+			_, _ = fmt.Fprintf(out, "  %s\n", pod)
+		}
+	}
+	reasons := make([]string, 0, len(plan.skipped))
+	for reason := range plan.skipped {
+		reasons = append(reasons, reason)
+	}
+	sort.Strings(reasons)
+	for _, reason := range reasons {
+		pods := plan.skipped[reason]
+		names := make([]string, 0, len(pods))
+		for _, pod := range pods {
+			names = append(names, pod.String())
+		}
+		_, _ = fmt.Fprintf(out, "Skipping %d (%s): %s\n", len(pods), reason, strings.Join(names, ", "))
+	}
+}
+
+func init() {
+	clusterDrainCmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
+	clusterDrainCmd.Flags().Bool("dry-run", false, "Print the plan without cordoning or deleting anything")
+	clusterDrainCmd.Flags().Int("grace-period", -1,
+		"Seconds each pod gets to shut down cleanly; 0 deletes immediately, -1 keeps each pod's own grace period")
+
+	clusterCmd.AddCommand(clusterCordonCmd)
+	clusterCmd.AddCommand(clusterUncordonCmd)
+	clusterCmd.AddCommand(clusterDrainCmd)
+}

--- a/cmd/cluster_node_scheduling.go
+++ b/cmd/cluster_node_scheduling.go
@@ -195,11 +195,18 @@ func planNodeDrain(clusterID, nodeName string) (drainPlan, error) {
 	if err != nil {
 		return drainPlan{}, fmt.Errorf("listing pods on node %q: %w", nodeName, err)
 	}
-	plan := drainPlan{skipped: map[string][]podReference{}}
+	// A refused or errored list is an unknown, not an empty node: draining on
+	// it would cordon the node and report "nothing to delete" while the pods
+	// keep running there.
 	if len(response.ResourceResponses) == 0 {
-		return plan, nil
+		return drainPlan{}, fmt.Errorf("listing pods on node %q: the cluster returned no answer for the pod list; nothing was cordoned", nodeName)
 	}
-	for _, item := range response.ResourceResponses[0].Items {
+	responseItem := response.ResourceResponses[0]
+	if responseItem.Status != "" && responseItem.Status != "success" {
+		return drainPlan{}, fmt.Errorf("listing pods on node %q: the cluster could not answer the pod list (status %q); nothing was cordoned", nodeName, responseItem.Status)
+	}
+	plan := drainPlan{skipped: map[string][]podReference{}}
+	for _, item := range responseItem.Items {
 		pod, isObject := item.(map[string]interface{})
 		if !isObject || getNestedString(pod, "spec", "nodeName") != nodeName {
 			continue

--- a/cmd/cluster_node_scheduling_test.go
+++ b/cmd/cluster_node_scheduling_test.go
@@ -1,0 +1,188 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type nodeSchedulingMock struct {
+	baseMock
+	patches []client.PatchResourceRequest
+	deletes []client.DeleteResourceRequest
+	pods    []interface{}
+}
+
+func (m *nodeSchedulingMock) GetCluster(name string) (client.ClusterListItem, error) {
+	return client.ClusterListItem{ID: "cluster-abc", Name: name}, nil
+}
+
+func (m *nodeSchedulingMock) PatchResource(clusterID string, request client.PatchResourceRequest) (*client.ResourceMutationResponse, error) {
+	m.patches = append(m.patches, request)
+	return &client.ResourceMutationResponse{Status: "success"}, nil
+}
+
+func (m *nodeSchedulingMock) DeleteResource(clusterID string, request client.DeleteResourceRequest) (*client.ResourceMutationResponse, error) {
+	m.deletes = append(m.deletes, request)
+	return &client.ResourceMutationResponse{Status: "success"}, nil
+}
+
+func (m *nodeSchedulingMock) GetResources(clusterID string, request client.GetResourcesRequest) (*client.GetResourcesResponse, error) {
+	return &client.GetResourcesResponse{ResourceResponses: []client.ResourceResponseItem{
+		{Status: "ok", Kind: "Pod", Version: "v1", Items: m.pods},
+	}}, nil
+}
+
+func podOnNode(namespace, name, nodeName string, ownerKind string, annotations map[string]interface{}) map[string]interface{} {
+	metadata := map[string]interface{}{"name": name, "namespace": namespace}
+	if ownerKind != "" {
+		metadata["ownerReferences"] = []interface{}{map[string]interface{}{"kind": ownerKind, "name": "owner"}}
+	}
+	if annotations != nil {
+		metadata["annotations"] = annotations
+	}
+	return map[string]interface{}{
+		"metadata": metadata,
+		"spec":     map[string]interface{}{"nodeName": nodeName},
+	}
+}
+
+func unschedulableFromPatch(t *testing.T, patch interface{}) (bool, bool) {
+	t.Helper()
+	spec, _ := patch.(map[string]interface{})["spec"].(map[string]interface{})
+	value, isBool := spec["unschedulable"].(bool)
+	return value, isBool
+}
+
+func TestCordon_PatchesNodeUnschedulable(t *testing.T) {
+	mock := &nodeSchedulingMock{}
+	out, err := runWithInput(t, mock, "", "cluster", "cordon", "worker-3", "--cluster", "prod-cluster")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if len(mock.patches) != 1 {
+		t.Fatalf("expected one patch, got %d", len(mock.patches))
+	}
+	request := mock.patches[0]
+	if request.Kind != "Node" || request.Version != "v1" || request.Name != "worker-3" || request.Namespace != "" {
+		t.Errorf("request = %+v, want cluster-scoped v1 Node worker-3", request)
+	}
+	if value, isBool := unschedulableFromPatch(t, request.Patch); !isBool || !value {
+		t.Errorf("cordon must set spec.unschedulable=true, got %+v", request.Patch)
+	}
+	if !strings.Contains(out, `node "worker-3" cordoned`) {
+		t.Errorf("expected a cordoned line, got: %s", out)
+	}
+}
+
+func TestUncordon_PatchesNodeSchedulable(t *testing.T) {
+	mock := &nodeSchedulingMock{}
+	out, err := runWithInput(t, mock, "", "cluster", "uncordon", "worker-3", "--cluster", "prod-cluster")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if value, isBool := unschedulableFromPatch(t, mock.patches[0].Patch); !isBool || value {
+		t.Errorf("uncordon must set spec.unschedulable=false, got %+v", mock.patches[0].Patch)
+	}
+	if !strings.Contains(out, `node "worker-3" uncordoned`) {
+		t.Errorf("expected an uncordoned line, got: %s", out)
+	}
+}
+
+func drainPods() []interface{} {
+	return []interface{}{
+		podOnNode("prod", "web-7d9f-2xkvp", "worker-3", "ReplicaSet", nil),
+		podOnNode("monitoring", "node-exporter-abc12", "worker-3", "DaemonSet", nil),
+		podOnNode("kube-system", "kube-apiserver-worker-3", "worker-3", "Node", nil),
+		podOnNode("kube-system", "etcd-worker-3", "worker-3", "", map[string]interface{}{"kubernetes.io/config.mirror": "abc"}),
+		podOnNode("prod", "web-7d9f-other", "worker-1", "ReplicaSet", nil),
+		podOnNode("batch", "one-off", "worker-3", "", nil),
+	}
+}
+
+func TestDrain_CordonsThenDeletesOnlyEvictablePods(t *testing.T) {
+	mock := &nodeSchedulingMock{pods: drainPods()}
+	resetConfirmFlag(t, clusterDrainCmd, clusterCmd)
+	out, err := runWithInput(t, mock, "y\n", "cluster", "drain", "worker-3", "--cluster", "prod-cluster", "--grace-period", "10")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if len(mock.patches) != 1 {
+		t.Fatalf("expected the node to be cordoned once, got %d patches", len(mock.patches))
+	}
+	if value, isBool := unschedulableFromPatch(t, mock.patches[0].Patch); !isBool || !value {
+		t.Errorf("drain must cordon first, got %+v", mock.patches[0].Patch)
+	}
+	if len(mock.deletes) != 2 {
+		t.Fatalf("expected exactly the two evictable pods to be deleted, got %+v", mock.deletes)
+	}
+	deleted := map[string]bool{}
+	for _, request := range mock.deletes {
+		deleted[request.Namespace+"/"+request.Name] = true
+		if request.Kind != "Pod" || request.GracePeriodSeconds == nil || *request.GracePeriodSeconds != 10 {
+			t.Errorf("each delete should be a Pod with grace_period_seconds=10, got %+v", request)
+		}
+	}
+	if !deleted["prod/web-7d9f-2xkvp"] || !deleted["batch/one-off"] {
+		t.Errorf("expected prod/web-7d9f-2xkvp and batch/one-off, got %v", deleted)
+	}
+	if !strings.Contains(out, "Skipping 1 (DaemonSet pod): monitoring/node-exporter-abc12") {
+		t.Errorf("expected the DaemonSet skip to be reported, got: %s", out)
+	}
+	if !strings.Contains(out, "Skipping 2 (static pod)") {
+		t.Errorf("expected both static pods to be reported, got: %s", out)
+	}
+	if !strings.Contains(out, "Drain node \"worker-3\" on cluster \"prod-cluster\" (cordon it and delete 2 pods)") {
+		t.Errorf("expected the prompt to state the count, got: %s", out)
+	}
+	if !strings.Contains(out, `node "worker-3" drained: 2 pods deleted`) {
+		t.Errorf("expected a drained summary, got: %s", out)
+	}
+}
+
+func TestDrain_DeclineLeavesNodeUntouched(t *testing.T) {
+	mock := &nodeSchedulingMock{pods: drainPods()}
+	resetConfirmFlag(t, clusterDrainCmd, clusterCmd)
+	_, err := runWithInput(t, mock, "n\n", "cluster", "drain", "worker-3", "--cluster", "prod-cluster")
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled on decline, got %v", err)
+	}
+	if len(mock.patches) != 0 || len(mock.deletes) != 0 {
+		t.Errorf("a declined drain must neither cordon nor delete, got %d patches %d deletes", len(mock.patches), len(mock.deletes))
+	}
+}
+
+func TestDrain_DryRunPrintsPlanOnly(t *testing.T) {
+	mock := &nodeSchedulingMock{pods: drainPods()}
+	resetConfirmFlag(t, clusterDrainCmd, clusterCmd)
+	out, err := runWithInput(t, mock, "", "cluster", "drain", "worker-3", "--cluster", "prod-cluster", "--dry-run")
+	if err != nil {
+		t.Fatalf("dry run must not prompt or fail: %v\noutput: %s", err, out)
+	}
+	if len(mock.patches) != 0 || len(mock.deletes) != 0 {
+		t.Errorf("dry run must not cordon or delete, got %d patches %d deletes", len(mock.patches), len(mock.deletes))
+	}
+	if !strings.Contains(out, `2 pods on node "worker-3" will be deleted:`) || !strings.Contains(out, "  prod/web-7d9f-2xkvp") {
+		t.Errorf("expected the plan to list the evictable pods, got: %s", out)
+	}
+	if strings.Contains(out, "[y/N]") {
+		t.Errorf("dry run must not prompt, got: %s", out)
+	}
+}
+
+func TestDrain_EmptyNodeStillCordons(t *testing.T) {
+	mock := &nodeSchedulingMock{}
+	resetConfirmFlag(t, clusterDrainCmd, clusterCmd)
+	out, err := runWithInput(t, mock, "", "cluster", "drain", "worker-3", "--cluster", "prod-cluster", "--yes")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if len(mock.patches) != 1 || len(mock.deletes) != 0 {
+		t.Errorf("an empty node should be cordoned and nothing deleted, got %d patches %d deletes", len(mock.patches), len(mock.deletes))
+	}
+	if !strings.Contains(out, "nothing to delete") {
+		t.Errorf("expected the empty summary, got: %s", out)
+	}
+}

--- a/cmd/cluster_node_scheduling_test.go
+++ b/cmd/cluster_node_scheduling_test.go
@@ -10,9 +10,10 @@ import (
 
 type nodeSchedulingMock struct {
 	baseMock
-	patches []client.PatchResourceRequest
-	deletes []client.DeleteResourceRequest
-	pods    []interface{}
+	patches    []client.PatchResourceRequest
+	deletes    []client.DeleteResourceRequest
+	pods       []interface{}
+	listStatus string
 }
 
 func (m *nodeSchedulingMock) GetCluster(name string) (client.ClusterListItem, error) {
@@ -30,8 +31,12 @@ func (m *nodeSchedulingMock) DeleteResource(clusterID string, request client.Del
 }
 
 func (m *nodeSchedulingMock) GetResources(clusterID string, request client.GetResourcesRequest) (*client.GetResourcesResponse, error) {
+	status := m.listStatus
+	if status == "" {
+		status = "success"
+	}
 	return &client.GetResourcesResponse{ResourceResponses: []client.ResourceResponseItem{
-		{Status: "ok", Kind: "Pod", Version: "v1", Items: m.pods},
+		{Status: status, Kind: "Pod", Version: "v1", Items: m.pods},
 	}}, nil
 }
 
@@ -184,5 +189,20 @@ func TestDrain_EmptyNodeStillCordons(t *testing.T) {
 	}
 	if !strings.Contains(out, "nothing to delete") {
 		t.Errorf("expected the empty summary, got: %s", out)
+	}
+}
+
+func TestDrain_RefusedPodListStopsBeforeCordon(t *testing.T) {
+	mock := &nodeSchedulingMock{listStatus: "error"}
+	resetConfirmFlag(t, clusterDrainCmd, clusterCmd)
+	_, err := runWithInput(t, mock, "", "cluster", "drain", "worker-3", "--cluster", "prod-cluster", "--yes")
+	if err == nil {
+		t.Fatal("a refused pod list must fail the drain, not read as an empty node")
+	}
+	if !strings.Contains(err.Error(), `status "error"`) || !strings.Contains(err.Error(), "nothing was cordoned") {
+		t.Errorf("error should name the status and say the node is untouched, got: %v", err)
+	}
+	if len(mock.patches) != 0 || len(mock.deletes) != 0 {
+		t.Errorf("a refused list must neither cordon nor delete, got %d patches %d deletes", len(mock.patches), len(mock.deletes))
 	}
 }

--- a/cmd/cluster_node_scheduling_test.go
+++ b/cmd/cluster_node_scheduling_test.go
@@ -10,10 +10,11 @@ import (
 
 type nodeSchedulingMock struct {
 	baseMock
-	patches    []client.PatchResourceRequest
-	deletes    []client.DeleteResourceRequest
-	pods       []interface{}
-	listStatus string
+	patches      []client.PatchResourceRequest
+	deletes      []client.DeleteResourceRequest
+	pods         []interface{}
+	listStatus   string
+	deleteStatus map[string]string
 }
 
 func (m *nodeSchedulingMock) GetCluster(name string) (client.ClusterListItem, error) {
@@ -27,6 +28,11 @@ func (m *nodeSchedulingMock) PatchResource(clusterID string, request client.Patc
 
 func (m *nodeSchedulingMock) DeleteResource(clusterID string, request client.DeleteResourceRequest) (*client.ResourceMutationResponse, error) {
 	m.deletes = append(m.deletes, request)
+	if m.deleteStatus != nil {
+		if status, ok := m.deleteStatus[request.Name]; ok {
+			return &client.ResourceMutationResponse{Status: status}, nil
+		}
+	}
 	return &client.ResourceMutationResponse{Status: "success"}, nil
 }
 
@@ -204,5 +210,17 @@ func TestDrain_RefusedPodListStopsBeforeCordon(t *testing.T) {
 	}
 	if len(mock.patches) != 0 || len(mock.deletes) != 0 {
 		t.Errorf("a refused list must neither cordon nor delete, got %d patches %d deletes", len(mock.patches), len(mock.deletes))
+	}
+}
+
+func TestDrain_ReportsAlreadyGonePodsHonestly(t *testing.T) {
+	mock := &nodeSchedulingMock{pods: drainPods(), deleteStatus: map[string]string{"one-off": "not_found"}}
+	resetConfirmFlag(t, clusterDrainCmd, clusterCmd)
+	out, err := runWithInput(t, mock, "", "cluster", "drain", "worker-3", "--cluster", "prod-cluster", "--yes")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, "pod batch/one-off already gone") || strings.Contains(out, "pod batch/one-off deleted") {
+		t.Errorf("a not_found verdict must read as already gone, not deleted, got: %s", out)
 	}
 }

--- a/cmd/cluster_restart.go
+++ b/cmd/cluster_restart.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// restartedAtAnnotation is the annotation kubectl rollout restart writes into
+// the pod template; changing it is what makes the controller roll every pod.
+const restartedAtAnnotation = "kubectl.kubernetes.io/restartedAt"
+
+var clusterRestartCmd = &cobra.Command{
+	Use:   "restart <kind> <name> [name...]",
+	Short: "Rolling-restart a Deployment, StatefulSet or DaemonSet",
+	Long: `Rolling-restart one or more workloads in the active cluster.
+
+This is 'kubectl rollout restart': the pod template gets a fresh
+kubectl.kubernetes.io/restartedAt annotation, so the controller replaces
+every pod under its own rollout strategy - no downtime for a Deployment with
+more than one replica, one pod at a time for a StatefulSet. Nothing else in
+the spec changes. The kind is deployment, statefulset or daemonset; the
+kubectl short and plural spellings work too.
+
+Examples:
+  ankra cluster restart deployment web -n prod
+  ankra cluster restart sts postgres -n data --yes
+  ankra cluster restart daemonset node-exporter -n monitoring --dry-run`,
+	Args:        cobra.MinimumNArgs(2),
+	Annotations: map[string]string{"group": "kubernetes"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		namespace, _ := cmd.Flags().GetString("namespace")
+		yes, _ := cmd.Flags().GetBool("yes")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+		resolvedKind, kindError := resolveK8sKind(args[0], "", "")
+		if kindError != nil {
+			return kindError
+		}
+		if !isRestartableKind(resolvedKind.kind) {
+			return withExitCode(exitUsage, fmt.Errorf(
+				"%s cannot be rolling-restarted: the kind must be deployment, statefulset or daemonset", resolvedKind.kind))
+		}
+		names := args[1:]
+		if namespace == "" {
+			return withExitCode(exitUsage, fmt.Errorf("--namespace (-n) is required to restart a %s", resolvedKind.kind))
+		}
+
+		cluster, err := resolveActiveCluster(cmd)
+		if err != nil {
+			return err
+		}
+
+		if !dryRun {
+			prompt := restartPrompt(resolvedKind, names, namespace, cluster.Name)
+			if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(), prompt, yes); err != nil {
+				return err
+			}
+		}
+
+		restartedAt := time.Now().UTC().Format(time.RFC3339)
+		return runResourceMutations(cmd, resolvedKind, names, namespace, restartWording,
+			func(name string) (*client.ResourceMutationResponse, error) {
+				return apiClient.PatchResource(cluster.ID, client.PatchResourceRequest{
+					Kind:      resolvedKind.kind,
+					Group:     resolvedKind.group,
+					Version:   resolvedKind.version,
+					Namespace: namespace,
+					Name:      name,
+					Patch:     restartPatch(restartedAt),
+					PatchType: "strategic",
+					DryRun:    dryRun,
+				})
+			})
+	},
+}
+
+func isRestartableKind(kind string) bool {
+	switch kind {
+	case "Deployment", "StatefulSet", "DaemonSet":
+		return true
+	}
+	return false
+}
+
+func restartPatch(restartedAt string) map[string]interface{} {
+	return map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						restartedAtAnnotation: restartedAt,
+					},
+				},
+			},
+		},
+	}
+}
+
+func restartPrompt(kind k8sKind, names []string, namespace, clusterName string) string {
+	if len(names) == 1 {
+		return fmt.Sprintf("Rolling-restart %s %q in namespace %q on cluster %q? [y/N]: ",
+			kind.kind, names[0], namespace, clusterName)
+	}
+	return fmt.Sprintf("Rolling-restart %d %s in namespace %q on cluster %q? [y/N]: ",
+		len(names), pluralKindLabel(kind), namespace, clusterName)
+}
+
+func init() {
+	clusterRestartCmd.Flags().StringP("namespace", "n", "", "Kubernetes namespace (required)")
+	clusterRestartCmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
+	clusterRestartCmd.Flags().Bool("dry-run", false, "Report what would be restarted without changing anything")
+
+	clusterCmd.AddCommand(clusterRestartCmd)
+}

--- a/cmd/cluster_restart_test.go
+++ b/cmd/cluster_restart_test.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type patchResourceMock struct {
+	baseMock
+	requests  []client.PatchResourceRequest
+	responses map[string]*client.ResourceMutationResponse
+}
+
+func (m *patchResourceMock) GetCluster(name string) (client.ClusterListItem, error) {
+	return client.ClusterListItem{ID: "cluster-abc", Name: name}, nil
+}
+
+func (m *patchResourceMock) PatchResource(clusterID string, request client.PatchResourceRequest) (*client.ResourceMutationResponse, error) {
+	m.requests = append(m.requests, request)
+	if response, ok := m.responses[request.Name]; ok {
+		return response, nil
+	}
+	return &client.ResourceMutationResponse{Status: "success"}, nil
+}
+
+func runRestart(t *testing.T, mock APIClient, input string, extraArgs ...string) (string, error) {
+	t.Helper()
+	resetConfirmFlag(t, clusterRestartCmd, clusterCmd)
+	args := append([]string{"cluster", "restart"}, extraArgs...)
+	return runWithInput(t, mock, input, args...)
+}
+
+func restartedAtFromPatch(t *testing.T, patch interface{}) string {
+	t.Helper()
+	spec, _ := patch.(map[string]interface{})["spec"].(map[string]interface{})
+	template, _ := spec["template"].(map[string]interface{})
+	metadata, _ := template["metadata"].(map[string]interface{})
+	annotations, _ := metadata["annotations"].(map[string]interface{})
+	value, _ := annotations[restartedAtAnnotation].(string)
+	return value
+}
+
+func TestRestart_DeclineDoesNotCallAPI(t *testing.T) {
+	mock := &patchResourceMock{}
+	_, err := runRestart(t, mock, "n\n", "deployment", "web", "-n", "prod", "--cluster", "prod-cluster")
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled on decline, got %v", err)
+	}
+	if len(mock.requests) != 0 {
+		t.Errorf("expected no patch when declined, got %d", len(mock.requests))
+	}
+}
+
+func TestRestart_YesPatchesRestartedAtAnnotation(t *testing.T) {
+	mock := &patchResourceMock{}
+	out, err := runRestart(t, mock, "", "sts", "postgres", "-n", "data", "--cluster", "prod-cluster", "--yes")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if len(mock.requests) != 1 {
+		t.Fatalf("expected one patch, got %d", len(mock.requests))
+	}
+	request := mock.requests[0]
+	if request.Kind != "StatefulSet" || request.Group != "apps" || request.Version != "v1" || request.Namespace != "data" || request.Name != "postgres" {
+		t.Errorf("request = %+v, want apps/v1 StatefulSet data/postgres", request)
+	}
+	if request.PatchType != "strategic" {
+		t.Errorf("patch_type should be strategic, got %q", request.PatchType)
+	}
+	if restartedAtFromPatch(t, request.Patch) == "" {
+		t.Errorf("patch should set the %s annotation, got %+v", restartedAtAnnotation, request.Patch)
+	}
+	if !strings.Contains(out, `statefulset "postgres" restarted in namespace "data"`) {
+		t.Errorf("expected a restarted line, got: %s", out)
+	}
+}
+
+func TestRestart_UnsupportedKindExitsUsage(t *testing.T) {
+	mock := &patchResourceMock{}
+	_, err := runRestart(t, mock, "", "pod", "web-0", "-n", "prod", "--cluster", "prod-cluster", "--yes")
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("restarting a pod should exit %d, got %d (err=%v)", exitUsage, got, err)
+	}
+	if len(mock.requests) != 0 {
+		t.Error("an unsupported kind must be rejected before any API call")
+	}
+}
+
+func TestRestart_MissingNamespaceExitsUsage(t *testing.T) {
+	mock := &patchResourceMock{}
+	_, err := runRestart(t, mock, "", "deployment", "web", "--cluster", "prod-cluster", "--yes")
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("missing namespace should exit %d, got %d (err=%v)", exitUsage, got, err)
+	}
+}
+
+func TestRestart_DryRunSkipsPrompt(t *testing.T) {
+	mock := &patchResourceMock{responses: map[string]*client.ResourceMutationResponse{"web": {Status: "dry_run"}}}
+	out, err := runRestart(t, mock, "", "deployment", "web", "-n", "prod", "--cluster", "prod-cluster", "--dry-run")
+	if err != nil {
+		t.Fatalf("dry run must not prompt or fail: %v\noutput: %s", err, out)
+	}
+	if len(mock.requests) != 1 || !mock.requests[0].DryRun {
+		t.Fatalf("expected one dry_run=true patch, got %+v", mock.requests)
+	}
+	if !strings.Contains(out, "would be restarted") {
+		t.Errorf("expected a dry-run line, got: %s", out)
+	}
+}
+
+func TestRestart_NotFoundExitsNotFound(t *testing.T) {
+	mock := &patchResourceMock{responses: map[string]*client.ResourceMutationResponse{"gone": {Status: "not_found"}}}
+	_, err := runRestart(t, mock, "", "deployment", "gone", "-n", "prod", "--cluster", "prod-cluster", "--yes")
+	if got := exitCodeFor(err); got != exitNotFound {
+		t.Errorf("a missing deployment should exit %d, got %d (err=%v)", exitNotFound, got, err)
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1170,6 +1170,30 @@ func (m baseMock) UninstallHelmRelease(clusterID, releaseName, namespace string)
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) DeleteResource(clusterID string, req client.DeleteResourceRequest) (*client.ResourceMutationResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) PatchResource(clusterID string, req client.PatchResourceRequest) (*client.ResourceMutationResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetHelmReleaseDetail(clusterID, namespace, releaseName string) (*client.HelmReleaseDetail, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetHelmReleaseHistory(clusterID, namespace, releaseName string, limit int) (*client.HelmReleaseHistory, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) RollbackHelmRelease(clusterID, namespace, releaseName string, req client.RollbackHelmReleaseRequest) (*client.HelmReleaseMutationResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) UpgradeHelmRelease(clusterID, namespace, releaseName string, req client.UpgradeHelmReleaseRequest) (*client.HelmReleaseMutationResult, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) QueryPrometheusInstant(clusterID, query string, timeoutSeconds int) (*client.PrometheusQueryResult, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -355,6 +355,12 @@ type APIClient interface {
 	OpenPodTerminal(ctx context.Context, clusterID string, request client.PodTerminalRequest) (client.PodTerminal, error)
 	ListHelmReleases(clusterID string, opts *client.HelmReleasesOptions) (*client.HelmReleasesResponse, error)
 	UninstallHelmRelease(clusterID, releaseName, namespace string) (*client.UninstallHelmReleaseResponse, error)
+	DeleteResource(clusterID string, req client.DeleteResourceRequest) (*client.ResourceMutationResponse, error)
+	PatchResource(clusterID string, req client.PatchResourceRequest) (*client.ResourceMutationResponse, error)
+	GetHelmReleaseDetail(clusterID, namespace, releaseName string) (*client.HelmReleaseDetail, error)
+	GetHelmReleaseHistory(clusterID, namespace, releaseName string, limit int) (*client.HelmReleaseHistory, error)
+	RollbackHelmRelease(clusterID, namespace, releaseName string, req client.RollbackHelmReleaseRequest) (*client.HelmReleaseMutationResult, error)
+	UpgradeHelmRelease(clusterID, namespace, releaseName string, req client.UpgradeHelmReleaseRequest) (*client.HelmReleaseMutationResult, error)
 	QueryPrometheusInstant(clusterID, query string, timeoutSeconds int) (*client.PrometheusQueryResult, error)
 	QueryPrometheusRange(clusterID string, opts client.PrometheusRangeOptions) (*client.PrometheusQueryResult, error)
 

--- a/internal/client/kubernetes.go
+++ b/internal/client/kubernetes.go
@@ -711,12 +711,11 @@ func (c *Client) doKubernetesRelay(method, endpoint string, payload []byte, targ
 	if payload != nil {
 		httpReq.Header.Set("Content-Type", "application/json")
 	}
-	// A relay write presents the double-submit CSRF token the way the Helm
-	// mutations and the browser do, so the delete and patch lanes keep
+	httpReq.Header.Set("Authorization", "Bearer "+c.Token)
+	// A relay write also presents the double-submit CSRF token the way the
+	// Helm mutations and the browser do, so the delete and patch lanes keep
 	// working the day the backend guards them the same way.
-	if method == http.MethodGet {
-		httpReq.Header.Set("Authorization", "Bearer "+c.Token)
-	} else {
+	if method != http.MethodGet {
 		c.applyAuthAndCSRFHeaders(httpReq)
 	}
 

--- a/internal/client/kubernetes.go
+++ b/internal/client/kubernetes.go
@@ -519,6 +519,226 @@ func (c *Client) UninstallHelmRelease(clusterID, releaseName, namespace string) 
 	return &response, nil
 }
 
+type DeleteResourceRequest struct {
+	Kind               string `json:"kind"`
+	Namespace          string `json:"namespace,omitempty"`
+	Name               string `json:"name"`
+	Group              string `json:"group,omitempty"`
+	Version            string `json:"version"`
+	Resource           string `json:"resource,omitempty"`
+	DryRun             bool   `json:"dry_run"`
+	GracePeriodSeconds *int   `json:"grace_period_seconds,omitempty"`
+}
+
+type PatchResourceRequest struct {
+	Kind      string      `json:"kind"`
+	Namespace string      `json:"namespace,omitempty"`
+	Name      string      `json:"name"`
+	Group     string      `json:"group,omitempty"`
+	Version   string      `json:"version"`
+	Resource  string      `json:"resource,omitempty"`
+	Patch     interface{} `json:"patch"`
+	PatchType string      `json:"patch_type"`
+	DryRun    bool        `json:"dry_run"`
+}
+
+// ResourceMutationResponse is the agent's verdict on a delete or a patch.
+// The relay answers HTTP 200 for every verdict: "success", "not_found"
+// (already gone), "dry_run" (nothing touched, Preview describes the outcome)
+// and "error" (RBAC deny, wrong kind, failure inside the cluster) - only
+// Status says whether the change landed.
+type ResourceMutationResponse struct {
+	Status  string                 `json:"status"`
+	Message *string                `json:"message"`
+	Preview map[string]interface{} `json:"preview,omitempty"`
+}
+
+func (c *Client) DeleteResource(clusterID string, req DeleteResourceRequest) (*ResourceMutationResponse, error) {
+	var response ResourceMutationResponse
+	if err := c.postKubernetesRelay(clusterID, "resources/delete", req, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) PatchResource(clusterID string, req PatchResourceRequest) (*ResourceMutationResponse, error) {
+	var response ResourceMutationResponse
+	if err := c.postKubernetesRelay(clusterID, "resources/patch", req, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+type HelmReleaseMetadata struct {
+	Name          string  `json:"name"`
+	Namespace     string  `json:"namespace"`
+	Revision      int     `json:"revision"`
+	Status        string  `json:"status"`
+	Description   *string `json:"description"`
+	Chart         *string `json:"chart"`
+	ChartVersion  *string `json:"chart_version"`
+	AppVersion    *string `json:"app_version"`
+	FirstDeployed *string `json:"first_deployed"`
+	LastDeployed  *string `json:"last_deployed"`
+}
+
+type HelmReleaseDetail struct {
+	Metadata          HelmReleaseMetadata      `json:"metadata"`
+	UserValues        map[string]interface{}   `json:"user_values"`
+	ComputedValues    map[string]interface{}   `json:"computed_values"`
+	ManifestResources []map[string]interface{} `json:"manifest_resources"`
+	Hooks             []map[string]interface{} `json:"hooks"`
+	Notes             *string                  `json:"notes"`
+}
+
+type HelmReleaseHistoryEntry struct {
+	Revision    int     `json:"revision"`
+	Updated     *string `json:"updated"`
+	Status      string  `json:"status"`
+	Chart       *string `json:"chart"`
+	AppVersion  *string `json:"app_version"`
+	Description *string `json:"description"`
+}
+
+type HelmReleaseHistory struct {
+	Revisions []HelmReleaseHistoryEntry `json:"revisions"`
+}
+
+type RollbackHelmReleaseRequest struct {
+	Revision       int  `json:"revision"`
+	Wait           bool `json:"wait"`
+	TimeoutSeconds int  `json:"timeout_seconds"`
+}
+
+// UpgradeHelmReleaseRequest carries the whole values document: the agent
+// replaces the release's values with exactly ValuesYAML, so an empty string
+// resets every override to the chart defaults. An empty ChartVersion keeps
+// the installed chart version rather than floating to the repository's
+// latest.
+type UpgradeHelmReleaseRequest struct {
+	ChartRef       string `json:"chart_ref"`
+	RepoURL        string `json:"repo_url"`
+	ChartVersion   string `json:"chart_version"`
+	ValuesYAML     string `json:"values_yaml"`
+	Wait           bool   `json:"wait"`
+	TimeoutSeconds int    `json:"timeout_seconds"`
+}
+
+// HelmReleaseMutationResult is what a rollback or an upgrade returns once
+// the agent has run it.
+type HelmReleaseMutationResult struct {
+	ReleaseName string `json:"release_name"`
+	Namespace   string `json:"namespace"`
+	Revision    int    `json:"revision"`
+	ElapsedMS   int    `json:"elapsed_ms"`
+}
+
+func (c *Client) helmReleaseURL(clusterID, namespace, releaseName string) string {
+	return fmt.Sprintf("%s/api/v1/clusters/%s/kubernetes/helm/releases/%s/%s",
+		c.BaseURL, url.PathEscape(clusterID), url.PathEscape(namespace), url.PathEscape(releaseName))
+}
+
+func (c *Client) GetHelmReleaseDetail(clusterID, namespace, releaseName string) (*HelmReleaseDetail, error) {
+	var detail HelmReleaseDetail
+	if err := c.doKubernetesRelay(http.MethodGet, c.helmReleaseURL(clusterID, namespace, releaseName), nil, &detail); err != nil {
+		return nil, err
+	}
+	return &detail, nil
+}
+
+func (c *Client) GetHelmReleaseHistory(clusterID, namespace, releaseName string, limit int) (*HelmReleaseHistory, error) {
+	endpoint := c.helmReleaseURL(clusterID, namespace, releaseName) + "/history"
+	if limit > 0 {
+		endpoint += "?limit=" + fmt.Sprintf("%d", limit)
+	}
+	var history HelmReleaseHistory
+	if err := c.doKubernetesRelay(http.MethodGet, endpoint, nil, &history); err != nil {
+		return nil, err
+	}
+	return &history, nil
+}
+
+// RollbackHelmRelease waits for the rollback by default, which can outlast
+// the shared client's response-header deadline, so it rides the slow-write
+// lane: a timeout is reported as an unknown outcome, not a failure.
+func (c *Client) RollbackHelmRelease(clusterID, namespace, releaseName string, req RollbackHelmReleaseRequest) (*HelmReleaseMutationResult, error) {
+	var result HelmReleaseMutationResult
+	err := c.postCSRFJSONSlowWrite(c.helmReleaseURL(clusterID, namespace, releaseName)+"/rollback", req, &result,
+		"roll back Helm release "+releaseName,
+		fmt.Sprintf("ankra cluster helm history %s -n %s", releaseName, namespace),
+		"a second rollback to the same revision adds another revision to the release history")
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *Client) UpgradeHelmRelease(clusterID, namespace, releaseName string, req UpgradeHelmReleaseRequest) (*HelmReleaseMutationResult, error) {
+	var result HelmReleaseMutationResult
+	err := c.postCSRFJSONSlowWrite(c.helmReleaseURL(clusterID, namespace, releaseName)+"/upgrade", req, &result,
+		"upgrade Helm release "+releaseName,
+		fmt.Sprintf("ankra cluster helm history %s -n %s", releaseName, namespace),
+		"a second upgrade with the same chart and values adds another revision to the release history")
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *Client) postKubernetesRelay(clusterID, relayPath string, req interface{}, target interface{}) error {
+	endpoint := fmt.Sprintf("%s/api/v1/clusters/%s/kubernetes/%s", c.BaseURL, url.PathEscape(clusterID), relayPath)
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+	return c.doKubernetesRelay(http.MethodPost, endpoint, payload, target)
+}
+
+// doKubernetesRelay issues one request against the kubernetes relay and
+// maps its replies the way the read paths above do: a 503 becomes a
+// ClusterUnavailableError with the agent's reason, any other non-200 keeps
+// the backend's detail so a 404 or 409 names the release or the lock.
+func (c *Client) doKubernetesRelay(method, endpoint string, payload []byte, target interface{}) error {
+	var body io.Reader
+	if payload != nil {
+		body = bytes.NewReader(payload)
+	}
+	httpReq, err := http.NewRequest(method, endpoint, body)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	if payload != nil {
+		httpReq.Header.Set("Content-Type", "application/json")
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+c.Token)
+
+	resp, err := c.HTTP.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer closeBody(resp)
+
+	responseBody, err := readResponseBody(resp)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		return parseClusterError(responseBody)
+	}
+	if resp.StatusCode != http.StatusOK {
+		if detail := detailFromBody(responseBody); detail != "" {
+			return newBackendDetailError(resp.StatusCode, detail)
+		}
+		return newUnexpectedResponseErrorWithMessage(resp.StatusCode, fmt.Sprintf("request failed: status %d: %s", resp.StatusCode, redactedBodyForError(responseBody, 500)))
+	}
+
+	if err := json.Unmarshal(responseBody, target); err != nil {
+		return fmt.Errorf("parse response: %w", err)
+	}
+	return nil
+}
+
 type ApiErrorResponse struct {
 	ErrorCode  string `json:"error_code"`
 	Detail     string `json:"detail"`

--- a/internal/client/kubernetes.go
+++ b/internal/client/kubernetes.go
@@ -697,7 +697,8 @@ func (c *Client) postKubernetesRelay(clusterID, relayPath string, req interface{
 // doKubernetesRelay issues one request against the kubernetes relay and
 // maps its replies the way the read paths above do: a 503 becomes a
 // ClusterUnavailableError with the agent's reason, any other non-200 keeps
-// the backend's detail so a 404 or 409 names the release or the lock.
+// the backend's detail so a 404 or 409 names the release or the lock. A
+// write carries the CSRF header alongside the bearer token.
 func (c *Client) doKubernetesRelay(method, endpoint string, payload []byte, target interface{}) error {
 	var body io.Reader
 	if payload != nil {
@@ -710,7 +711,14 @@ func (c *Client) doKubernetesRelay(method, endpoint string, payload []byte, targ
 	if payload != nil {
 		httpReq.Header.Set("Content-Type", "application/json")
 	}
-	httpReq.Header.Set("Authorization", "Bearer "+c.Token)
+	// A relay write presents the double-submit CSRF token the way the Helm
+	// mutations and the browser do, so the delete and patch lanes keep
+	// working the day the backend guards them the same way.
+	if method == http.MethodGet {
+		httpReq.Header.Set("Authorization", "Bearer "+c.Token)
+	} else {
+		c.applyAuthAndCSRFHeaders(httpReq)
+	}
 
 	resp, err := c.HTTP.Do(httpReq)
 	if err != nil {

--- a/internal/client/kubernetes_test.go
+++ b/internal/client/kubernetes_test.go
@@ -432,6 +432,9 @@ func TestDeleteResource(t *testing.T) {
 				if reqBody["dry_run"] != false {
 					t.Errorf("dry_run should be false on the wire, got %v", reqBody["dry_run"])
 				}
+				if r.Header.Get(csrfHeaderName) == "" || r.Header.Get("Authorization") != "Bearer "+testToken {
+					t.Error("a relay delete must carry the CSRF header alongside the bearer token")
+				}
 				jsonResponse(t, w, http.StatusOK, ResourceMutationResponse{Status: "success"})
 			},
 			wantStatus: "success",
@@ -509,6 +512,9 @@ func TestPatchResource(t *testing.T) {
 		spec, _ := patch["spec"].(map[string]interface{})
 		if spec["unschedulable"] != true {
 			t.Errorf("patch should carry spec.unschedulable=true, got %v", reqBody["patch"])
+		}
+		if r.Header.Get(csrfHeaderName) == "" {
+			t.Error("a relay patch must carry the CSRF header alongside the bearer token")
 		}
 		jsonResponse(t, w, http.StatusOK, ResourceMutationResponse{Status: "success"})
 	})

--- a/internal/client/kubernetes_test.go
+++ b/internal/client/kubernetes_test.go
@@ -398,6 +398,269 @@ func TestUninstallHelmRelease(t *testing.T) {
 	}
 }
 
+func TestDeleteResource(t *testing.T) {
+	gracePeriod := 0
+	tests := []struct {
+		name       string
+		request    DeleteResourceRequest
+		handler    http.HandlerFunc
+		wantStatus string
+		wantErr    bool
+	}{
+		{
+			name:    "success forwards the pod address and grace period",
+			request: DeleteResourceRequest{Kind: "pods", Version: "v1", Namespace: "default", Name: "web-0", GracePeriodSeconds: &gracePeriod},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				if !strings.HasSuffix(r.URL.Path, "/kubernetes/resources/delete") {
+					t.Errorf("unexpected path %s", r.URL.Path)
+				}
+				var reqBody map[string]interface{}
+				if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				if reqBody["kind"] != "pods" || reqBody["name"] != "web-0" || reqBody["namespace"] != "default" || reqBody["version"] != "v1" {
+					t.Errorf("unexpected body %v", reqBody)
+				}
+				if reqBody["grace_period_seconds"] != float64(0) {
+					t.Errorf("grace_period_seconds should be 0 on the wire, got %v", reqBody["grace_period_seconds"])
+				}
+				if reqBody["dry_run"] != false {
+					t.Errorf("dry_run should be false on the wire, got %v", reqBody["dry_run"])
+				}
+				jsonResponse(t, w, http.StatusOK, ResourceMutationResponse{Status: "success"})
+			},
+			wantStatus: "success",
+		},
+		{
+			name:    "unset grace period stays off the wire",
+			request: DeleteResourceRequest{Kind: "pods", Version: "v1", Namespace: "default", Name: "web-0"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var reqBody map[string]interface{}
+				if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				if _, isPresent := reqBody["grace_period_seconds"]; isPresent {
+					t.Errorf("grace_period_seconds must be omitted when unset, got %v", reqBody["grace_period_seconds"])
+				}
+				message := "already gone"
+				jsonResponse(t, w, http.StatusOK, ResourceMutationResponse{Status: "not_found", Message: &message})
+			},
+			wantStatus: "not_found",
+		},
+		{
+			name:    "503 cluster unavailable",
+			request: DeleteResourceRequest{Kind: "pods", Version: "v1", Namespace: "default", Name: "web-0"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = w.Write([]byte(`{"error_code":"CLUSTER_OFFLINE","detail":"offline"}`))
+			},
+			wantErr: true,
+		},
+		{
+			name:    "403 sandbox mode",
+			request: DeleteResourceRequest{Kind: "pods", Version: "v1", Namespace: "default", Name: "web-0"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"error_code":"SANDBOX_MODE","detail":"writes are disabled"}`))
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testClient := newTestClient(t, tt.handler)
+			got, err := testClient.DeleteResource("cluster-id", tt.request)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeleteResource() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got.Status != tt.wantStatus {
+				t.Errorf("DeleteResource() got.Status = %v, want %v", got.Status, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestPatchResource(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/kubernetes/resources/patch") {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		var reqBody map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if reqBody["kind"] != "Node" || reqBody["name"] != "worker-3" || reqBody["patch_type"] != "strategic" {
+			t.Errorf("unexpected body %v", reqBody)
+		}
+		if _, hasNamespace := reqBody["namespace"]; hasNamespace {
+			t.Errorf("a cluster-scoped patch must omit namespace, got %v", reqBody["namespace"])
+		}
+		patch, _ := reqBody["patch"].(map[string]interface{})
+		spec, _ := patch["spec"].(map[string]interface{})
+		if spec["unschedulable"] != true {
+			t.Errorf("patch should carry spec.unschedulable=true, got %v", reqBody["patch"])
+		}
+		jsonResponse(t, w, http.StatusOK, ResourceMutationResponse{Status: "success"})
+	})
+	got, err := testClient.PatchResource("cluster-id", PatchResourceRequest{
+		Kind: "Node", Version: "v1", Name: "worker-3", PatchType: "strategic",
+		Patch: map[string]interface{}{"spec": map[string]interface{}{"unschedulable": true}},
+	})
+	if err != nil {
+		t.Fatalf("PatchResource() error = %v", err)
+	}
+	if got.Status != "success" {
+		t.Errorf("PatchResource() status = %q, want success", got.Status)
+	}
+}
+
+func TestGetHelmReleaseDetail(t *testing.T) {
+	t.Run("success addresses namespace then release", func(t *testing.T) {
+		chart := "traefik-30.0.0"
+		testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/kubernetes/helm/releases/traefik-ns/traefik") {
+				t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			}
+			jsonResponse(t, w, http.StatusOK, HelmReleaseDetail{
+				Metadata:   HelmReleaseMetadata{Name: "traefik", Namespace: "traefik-ns", Revision: 4, Status: "deployed", Chart: &chart},
+				UserValues: map[string]interface{}{"replicas": float64(2)},
+			})
+		})
+		got, err := testClient.GetHelmReleaseDetail("cluster-id", "traefik-ns", "traefik")
+		if err != nil {
+			t.Fatalf("GetHelmReleaseDetail() error = %v", err)
+		}
+		if got.Metadata.Revision != 4 || got.UserValues["replicas"] != float64(2) {
+			t.Errorf("unexpected detail %+v", got)
+		}
+	})
+	t.Run("404 keeps the backend detail", func(t *testing.T) {
+		testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"detail":"release traefik not found in namespace traefik-ns"}`))
+		})
+		_, err := testClient.GetHelmReleaseDetail("cluster-id", "traefik-ns", "traefik")
+		var unexpected *UnexpectedResponseError
+		if !errors.As(err, &unexpected) || unexpected.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected a 404 UnexpectedResponseError, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "release traefik not found") {
+			t.Errorf("error should carry the backend detail, got %v", err)
+		}
+	})
+	t.Run("503 cluster offline", func(t *testing.T) {
+		testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error_code":"CLUSTER_OFFLINE","detail":"offline"}`))
+		})
+		_, err := testClient.GetHelmReleaseDetail("cluster-id", "traefik-ns", "traefik")
+		var unavailable *ClusterUnavailableError
+		if !errors.As(err, &unavailable) || unavailable.ErrorCode != "CLUSTER_OFFLINE" {
+			t.Fatalf("expected ClusterUnavailableError, got %v", err)
+		}
+	})
+}
+
+func TestGetHelmReleaseHistory(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/kubernetes/helm/releases/traefik-ns/traefik/history") {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("limit") != "10" {
+			t.Errorf("limit should be forwarded, got %q", r.URL.Query().Get("limit"))
+		}
+		jsonResponse(t, w, http.StatusOK, HelmReleaseHistory{Revisions: []HelmReleaseHistoryEntry{{Revision: 4, Status: "deployed"}}})
+	})
+	got, err := testClient.GetHelmReleaseHistory("cluster-id", "traefik-ns", "traefik", 10)
+	if err != nil {
+		t.Fatalf("GetHelmReleaseHistory() error = %v", err)
+	}
+	if len(got.Revisions) != 1 || got.Revisions[0].Revision != 4 {
+		t.Errorf("unexpected history %+v", got)
+	}
+}
+
+func TestRollbackHelmRelease(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/kubernetes/helm/releases/traefik-ns/traefik/rollback") {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get(csrfHeaderName) == "" {
+			t.Error("rollback must carry the CSRF header the backend requires")
+		}
+		var reqBody RollbackHelmReleaseRequest
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if reqBody.Revision != 3 || !reqBody.Wait || reqBody.TimeoutSeconds != 600 {
+			t.Errorf("unexpected body %+v", reqBody)
+		}
+		jsonResponse(t, w, http.StatusOK, HelmReleaseMutationResult{ReleaseName: "traefik", Namespace: "traefik-ns", Revision: 5, ElapsedMS: 1200})
+	})
+	got, err := testClient.RollbackHelmRelease("cluster-id", "traefik-ns", "traefik", RollbackHelmReleaseRequest{Revision: 3, Wait: true, TimeoutSeconds: 600})
+	if err != nil {
+		t.Fatalf("RollbackHelmRelease() error = %v", err)
+	}
+	if got.Revision != 5 {
+		t.Errorf("RollbackHelmRelease() revision = %d, want 5", got.Revision)
+	}
+}
+
+func TestUpgradeHelmRelease(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/kubernetes/helm/releases/traefik-ns/traefik/upgrade") {
+				t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			}
+			if r.Header.Get(csrfHeaderName) == "" {
+				t.Error("upgrade must carry the CSRF header the backend requires")
+			}
+			var reqBody UpgradeHelmReleaseRequest
+			if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			if reqBody.ChartRef != "traefik/traefik" || reqBody.ValuesYAML != "replicas: 3\n" || reqBody.ChartVersion != "" {
+				t.Errorf("unexpected body %+v", reqBody)
+			}
+			jsonResponse(t, w, http.StatusOK, HelmReleaseMutationResult{ReleaseName: "traefik", Namespace: "traefik-ns", Revision: 6, ElapsedMS: 3000})
+		})
+		got, err := testClient.UpgradeHelmRelease("cluster-id", "traefik-ns", "traefik", UpgradeHelmReleaseRequest{
+			ChartRef: "traefik/traefik", ValuesYAML: "replicas: 3\n", Wait: true, TimeoutSeconds: 600,
+		})
+		if err != nil {
+			t.Fatalf("UpgradeHelmRelease() error = %v", err)
+		}
+		if got.Revision != 6 {
+			t.Errorf("UpgradeHelmRelease() revision = %d, want 6", got.Revision)
+		}
+	})
+	t.Run("409 managed by addon keeps the detail", func(t *testing.T) {
+		testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"detail":"release traefik is managed by the Ankra addon traefik"}`))
+		})
+		_, err := testClient.UpgradeHelmRelease("cluster-id", "traefik-ns", "traefik", UpgradeHelmReleaseRequest{ChartRef: "traefik/traefik", ValuesYAML: ""})
+		if err == nil || !strings.Contains(err.Error(), "managed by the Ankra addon") {
+			t.Fatalf("expected the 409 detail to surface, got %v", err)
+		}
+	})
+}
+
 func TestClusterUnavailableError(t *testing.T) {
 	tests := []struct {
 		errorCode string

--- a/internal/client/kubernetes_test.go
+++ b/internal/client/kubernetes_test.go
@@ -537,6 +537,9 @@ func TestGetHelmReleaseDetail(t *testing.T) {
 			if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/kubernetes/helm/releases/traefik-ns/traefik") {
 				t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 			}
+			if r.Header.Get("Authorization") != "Bearer "+testToken {
+				t.Errorf("a relay read must carry the bearer token, got %q", r.Header.Get("Authorization"))
+			}
 			jsonResponse(t, w, http.StatusOK, HelmReleaseDetail{
 				Metadata:   HelmReleaseMetadata{Name: "traefik", Namespace: "traefik-ns", Revision: 4, Status: "deployed", Chart: &chart},
 				UserValues: map[string]interface{}{"replicas": float64(2)},

--- a/internal/skills/embedded/skills/ankra-cli/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-cli/SKILL.md
@@ -108,6 +108,8 @@ ankra cluster helm rollback <release> -n <ns> --revision <n>
 ankra cluster helm upgrade <release> -n <ns> --chart <repo/name> --values values.yaml
 ```
 
+`drain` deletes pods rather than evicting them (the agent has no eviction relay yet), so
+PodDisruptionBudgets are not consulted - check them first on a node that carries a quorum member.
 A pod owned by a controller comes straight back after `delete pod` - that is the single-replica
 restart. `delete` exits 3 when an object did not exist and 1 when the cluster refused, so scripts
 can tell the two apart. A Helm release an Ankra addon manages is refused by `rollback`/`upgrade`:

--- a/internal/skills/embedded/skills/ankra-cli/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-cli/SKILL.md
@@ -90,6 +90,29 @@ ankra cluster metrics query '<promql>'
 
 `--follow` defaults to true on `logs`; pass `--follow=false` for anything scripted or it will hang.
 
+## Changing a cluster
+
+These act through the cluster's Ankra agent - no kubeconfig - and prompt before changing anything
+(`--yes` skips the prompt, `--dry-run` reports without changing). They are for operational fixes;
+anything declarative (a new workload, a changed addon) belongs in the stack YAML and `ankra cluster apply`.
+
+```bash
+ankra cluster delete pod <pod> -n <ns>                 # any kind: deployment, cm, secret, namespace, node, ...
+ankra cluster delete Certificate web-tls -n <ns> --group cert-manager.io --api-version v1
+ankra cluster restart deployment <name> -n <ns>        # kubectl rollout restart; also statefulset, daemonset
+ankra cluster cordon <node> / uncordon <node>
+ankra cluster drain <node> --dry-run                   # prints the plan; without --dry-run cordons + deletes pods
+ankra cluster helm get <release> -n <ns> -o values > values.yaml
+ankra cluster helm history <release> -n <ns>
+ankra cluster helm rollback <release> -n <ns> --revision <n>
+ankra cluster helm upgrade <release> -n <ns> --chart <repo/name> --values values.yaml
+```
+
+A pod owned by a controller comes straight back after `delete pod` - that is the single-replica
+restart. `delete` exits 3 when an object did not exist and 1 when the cluster refused, so scripts
+can tell the two apart. A Helm release an Ankra addon manages is refused by `rollback`/`upgrade`:
+change the addon in the stack instead.
+
 ## Triage
 
 ```bash


### PR DESCRIPTION
Bead: ankra-ko7c8

## Why

The portal has had a delete button on every pod (and on every other kind), a restart action on workloads, cordon/drain on nodes and rollback/upgrade on Helm releases for a long time. The CLI's Kubernetes surface was read-only, so any of those from the terminal meant a kubeconfig plus `kubectl`/`helm`. Every one of them already had a backend relay (`resources/delete`, `resources/patch`, `helm/releases/*`) that the CLI never called.

## What

- **`ankra cluster delete <kind> <name> [name...]`** - kubectl spellings resolve through the existing `resolveK8sKind` table (`pod`, `pods`, `po`, `deploy`, `sts`, `cm`, `namespace`, `node`, `pvc`, ...); custom resources via `--group`/`--api-version`. `--grace-period`, `--dry-run`, `[y/N]` prompt with `--yes`. Each object reports its own verdict: exit 0 all deleted, 3 when one did not exist, 1 when the cluster refused. Namespace / Node / PersistentVolume prompts say what the delete takes with it.
- **`ankra cluster restart <deployment|statefulset|daemonset> <name...>`** - `kubectl rollout restart` (fresh `restartedAt` annotation on the pod template via the strategic patch relay).
- **`ankra cluster cordon|uncordon <node>`** and **`ankra cluster drain <node>`** - drain cordons, lists the pods on the node, skips DaemonSet and static pods (the portal's drain deletes those too and they come straight back), prints the plan, then deletes. `--dry-run` stops at the plan.
- **`ankra cluster helm get|history|rollback|upgrade`** - `get -o values` dumps the release's user values as YAML for editing; `rollback --revision N` and `upgrade --chart <ref> --values <file>` ride the slow-write lane (they wait up to 600s by default) and send the CSRF header those routes require. A release an Ankra addon manages is refused by the backend (409), surfaced with the backend's detail.

Client side: one `doKubernetesRelay` helper maps 503 to `ClusterUnavailableError` and keeps the backend `detail` on every other non-200 (so a 404/409 names the release or the lock), shared by the new `DeleteResource`, `PatchResource` and Helm detail/history methods.

## Deliberately left out

- Raw manifest apply (`resources/apply`, the portal's YAML editor) and a generic `patch` verb: both bypass the GitOps path the platform is built on (`ankra cluster apply` + stack manifests). Say the word if you want a break-glass `apply-manifest`.
- Workload scale: the portal does not offer it, and `ankra cluster scale` is already the worker-count verb.

## Tests

- `cmd`: delete (kind resolution, cluster-scoped, custom resource, unknown kind, grace period, dry-run, multi-object, not_found, refused verdict, transport error stops the run), restart, cordon/uncordon, drain (plan, skips, decline, dry-run, empty node), helm get/history/rollback/upgrade (flag validation, values file verbatim, decline).
- `internal/client`: `DeleteResource`, `PatchResource`, helm detail (200/404 detail/503), history limit, rollback + upgrade (CSRF header, body, 409 detail).
- `make test` (race) green, `golangci-lint run` 0 issues.

Docs: `CHANGELOG.md` Unreleased entry; the embedded `ankra-cli` skill gained a "Changing a cluster" section (mirrored into the monorepo `ankra-skills/` copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
