### PR TITLE
fix(backups): stop reporting a failure for an UpCloud provision that is still succeeding (ankra-0xsdd.42)

### DIFF
--- a/cmd/async_write.go
+++ b/cmd/async_write.go
@@ -12,8 +12,17 @@ import (
 const defaultAsyncWriteTimeout = 10 * time.Minute
 
 func registerAsyncWriteFlags(command *cobra.Command) {
+	registerAsyncWriteFlagsWithTimeout(command, defaultAsyncWriteTimeout)
+}
+
+// registerAsyncWriteFlagsWithTimeout is for operations the platform itself
+// allows longer than the shared default. A --wait shorter than the bound the
+// platform works to reports a failure for a run that is still succeeding, so
+// a command whose lane can legitimately outlast ten minutes sets its own
+// default here rather than leaving users to discover it (ankra-0xsdd.42).
+func registerAsyncWriteFlagsWithTimeout(command *cobra.Command, defaultTimeout time.Duration) {
 	command.Flags().Bool("wait", false, "Wait for the operation to finish and report success or failure (default: submit and return immediately)")
-	command.Flags().Duration("timeout", defaultAsyncWriteTimeout, "Maximum time to wait when --wait is set")
+	command.Flags().Duration("timeout", defaultTimeout, "Maximum time to wait when --wait is set")
 }
 
 func asyncWriteWaitFlag(command *cobra.Command) (bool, error) {

--- a/cmd/backup_vaults.go
+++ b/cmd/backup_vaults.go
@@ -413,6 +413,27 @@ func resolveProvisionCredential(reference string) (client.Credential, error) {
 	return client.Credential{}, fmt.Errorf("multiple credentials are named %q; pass the credential ID instead", reference)
 }
 
+// backupVaultProvisionWaitTimeout is the default --timeout for provisioning.
+// It has to exceed the bound the platform itself works to: UpCloud's Managed
+// Object Storage service alone is allowed 15 minutes to reach "running"
+// (upcloudServiceReadyWithin in the scheduler), and the bucket, the access key
+// and the verification come after it. The shared 10-minute default sat below
+// that, so a perfectly healthy UpCloud provision reported "context deadline
+// exceeded" while it was still succeeding - and a user who believed it would
+// delete a service that was about to come up (ankra-0xsdd.42).
+const backupVaultProvisionWaitTimeout = 25 * time.Minute
+
+// backupVaultWaitTimeoutFor reports the --timeout actually in force, so the
+// message names the bound the user hit rather than a hard-coded default they
+// may have overridden.
+func backupVaultWaitTimeoutFor(command *cobra.Command) time.Duration {
+	timeout, timeoutError := command.Flags().GetDuration("timeout")
+	if timeoutError != nil {
+		return backupVaultProvisionWaitTimeout
+	}
+	return timeout
+}
+
 // waitForBackupVaultProvisioning polls the vault until it leaves
 // "provisioning" or the context expires.
 func waitForBackupVaultProvisioning(ctx context.Context, vaults APIClient, vaultID string) (*client.BackupVault, error) {
@@ -563,6 +584,13 @@ Examples:
 		fmt.Printf("Provisioning backup vault '%s' on %s...\n", vault.Name, vault.Provider)
 		final, waitError := waitForBackupVaultProvisioning(ctx, apiClient, vault.ID)
 		if waitError != nil {
+			// Giving up waiting is not the run failing. Say so, or the user
+			// deletes a vault that is still on its way up (ankra-0xsdd.42).
+			if errors.Is(waitError, context.DeadlineExceeded) {
+				fmt.Printf("\nStopped waiting after %s. Provisioning is still running on %s - "+
+					"it has not failed.\nCheck on it with 'ankra backup vaults get %s'.\n",
+					backupVaultWaitTimeoutFor(cmd), vault.Provider, vault.Name)
+			}
 			return asyncWriteError("provisioning backup vault", true, waitError)
 		}
 		printBackupVault(final)
@@ -667,7 +695,7 @@ func init() {
 	backupVaultsProvisionCmd.Flags().String("bucket", "", "Bucket name (default: a unique name derived from the vault name)")
 	backupVaultsProvisionCmd.Flags().String("access-key-id", "", "Hetzner Object Storage access key (Hetzner only; prompted for when omitted)")
 	backupVaultsProvisionCmd.Flags().String("secret-access-key", "", "Hetzner Object Storage secret key (Hetzner only; prompted for hidden when omitted)")
-	registerAsyncWriteFlags(backupVaultsProvisionCmd)
+	registerAsyncWriteFlagsWithTimeout(backupVaultsProvisionCmd, backupVaultProvisionWaitTimeout)
 
 	backupVaultsDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 	backupVaultsDeleteCmd.Flags().Bool("destroy-provider-resources", false,

--- a/cmd/backup_vaults_test.go
+++ b/cmd/backup_vaults_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"ankra/internal/client"
 )
@@ -463,5 +464,31 @@ func TestBackupVaultsDeleteYesSkipsThePrompt(t *testing.T) {
 	}
 	if !strings.Contains(stdoutOutput, "deleted") {
 		t.Errorf("expected a deletion confirmation, got: %s", stdoutOutput)
+	}
+}
+
+// The provision --wait deadline has to outlast the bound the PLATFORM works
+// to, or a healthy run reports "context deadline exceeded" while it is still
+// succeeding. UpCloud's object storage service alone is allowed 15 minutes to
+// reach running, before the bucket, the key and the verification (ankra-0xsdd.42).
+func TestBackupVaultProvisionWaitOutlastsThePlatformBound(t *testing.T) {
+	const platformServiceReadyBound = 15 * time.Minute
+
+	if backupVaultProvisionWaitTimeout <= platformServiceReadyBound {
+		t.Fatalf("provision --wait default is %s, at or below the platform's own %s bound",
+			backupVaultProvisionWaitTimeout, platformServiceReadyBound)
+	}
+	if backupVaultProvisionWaitTimeout <= defaultAsyncWriteTimeout {
+		t.Fatalf("provision --wait default %s is no longer than the shared default %s, "+
+			"so registering its own timeout achieves nothing",
+			backupVaultProvisionWaitTimeout, defaultAsyncWriteTimeout)
+	}
+
+	flag := backupVaultsProvisionCmd.Flags().Lookup("timeout")
+	if flag == nil {
+		t.Fatal("provision has no --timeout flag")
+	}
+	if flag.DefValue != backupVaultProvisionWaitTimeout.String() {
+		t.Fatalf("--timeout default is %q, want %q", flag.DefValue, backupVaultProvisionWaitTimeout)
 	}
 }


### PR DESCRIPTION
Bead: ankra-0xsdd.42

`ankra backup vaults provision <name> --credential <upcloud> --wait` printed:

```
Error: provisioning backup vault: context deadline exceeded
```

after ten minutes — on a run that had **not** failed. The vault reached `ready` shortly afterwards with a real Managed Object Storage service and a verified bucket. Observed live.

## Cause

The shared `--timeout` default sat *below* the bound the platform itself works to. UpCloud's object storage service alone is allowed 15 minutes to reach running (`upcloudServiceReadyWithin` in the scheduler), and the bucket, the access key and the verification all come after it. A ten-minute client deadline could therefore never see a normal UpCloud provision finish.

That is worse than a wrong message. A user who believes it deletes a vault whose service is on its way up — and on UpCloud, creating one is slow enough that they hit the same wall on the retry.

## Changes

- `provision` registers its own **25-minute** default via the new `registerAsyncWriteFlagsWithTimeout`, comfortably past the platform's bound. Every other async write keeps the shared 10-minute default.
- **Giving up waiting no longer reads as the run failing.** On a deadline the command says provisioning is still running, names the timeout actually in force, and points at `ankra backup vaults get <name>`. The distinct wait-timeout exit code is unchanged, so scripts still tell "gave up waiting" from "the write was rejected".

## Tests

The default is pinned above both the platform's 15-minute bound and the shared default, and the flag is asserted to actually carry it — the regression here would be someone tidying the call back to `registerAsyncWriteFlags`.

`gofmt`, `go vet ankra/cmd` and `go test ankra/cmd` are clean. The CLI reference regenerates from the live command tree on tag, so the published `--timeout` default follows automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
