### PR TITLE
feat(pipeline): ankra pipeline run|list|get|logs|cancel|rerun|artifacts|validate|schedules over the pipeline runs API (ankra-vn0bd.2.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ### Added
 
+- **`ankra pipeline` drives Ankra Pipelines from the terminal.** `ankra pipeline
+  run` dispatches a run of a repository's `.ankra/pipeline.yaml` (with
+  `--input k=v` for declared inputs and `--wait` to follow it to a conclusion
+  and exit non-zero on failure, the way a CI step should); `list` and `get`
+  read runs and their step DAG; `logs --follow` streams a step's log live and
+  resumes from where it left off when the relay drops; `cancel` and `rerun`
+  (with `--failed-only`) act on a run; `artifacts` lists a run's step logs and
+  artifacts and `artifacts download` fetches one; `validate` checks a
+  pipeline file against the server's validator and prints each diagnostic
+  with its file and line; `definition get|put` reads and replaces the stored
+  definition; and `schedules list|create|update|delete` manage cron
+  schedules. `ankra application pipeline …` offers the same commands
+  addressed by application. Tables by default, `-o json` verbatim, and an id
+  from another organisation reads exactly like an absent one.
+
 - **`ankra security sbom` reads the fleet's software bill of materials.** Every
   package the scanner found in every container image, grouped by name,
   version and ecosystem, with how many images, workloads and clusters carry

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ per command family:
 | [ankra logout](https://docs.ankra.ai/reference/cli/logout) | Revoke the login token and remove saved credentials |
 | [ankra openclaw](https://docs.ankra.ai/reference/cli/openclaw) | Integrate Ankra with the OpenClaw assistant |
 | [ankra org](https://docs.ankra.ai/reference/cli/org) | Manage organisations, members, roles, org variables, DNS, and MCP tool servers |
+| [ankra pipeline](https://docs.ankra.ai/reference/cli/pipeline) | Run, watch and manage Ankra Pipelines: dispatch a run, list and inspect runs, follow step logs, cancel or re-run, download artifacts, validate `.ankra/pipeline.yaml`, and manage the definition and its schedules |
 | [ankra profile](https://docs.ankra.ai/reference/cli/profile) | Open profile authentication settings (MFA, passkeys) in the browser |
 | [ankra skills](https://docs.ankra.ai/reference/cli/skills) | Install Ankra Agent Skills into Cursor or Claude Code |
 | [ankra migrate](https://docs.ankra.ai/reference/cli/migrate) | Convert a docker-compose file, Dockerfile, or running containers into Ankra cluster and stack definitions, and export their databases for a restore into the cluster; extensible with `ankra-module-<name>` executables |

--- a/cmd/application_pipeline.go
+++ b/cmd/application_pipeline.go
@@ -1,0 +1,317 @@
+package cmd
+
+// `ankra application pipeline …`: the by-application twin of `ankra
+// pipeline …` (cmd/pipeline.go and its siblings). Every leaf here resolves
+// the leading <application-id> argument the way every other
+// `application <subcommand> <application-id>` command does
+// (resolveApplicationArgument) and then calls the exact same runPipeline*
+// function the top-level command calls, forcing the selector from the
+// resolved application id - there is exactly one place each behaviour is
+// implemented.
+
+import (
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+func newApplicationPipelineCommand() *cobra.Command {
+	pipelineCommand := &cobra.Command{
+		Use:     "pipeline",
+		Aliases: []string{"pipelines"},
+		Short:   "Manage the application's pipeline",
+	}
+	pipelineCommand.AddCommand(
+		newApplicationPipelineRunCommand(),
+		newApplicationPipelineListCommand(),
+		newApplicationPipelineGetCommand(),
+		newApplicationPipelineCancelCommand(),
+		newApplicationPipelineRerunCommand(),
+		newApplicationPipelineLogsCommand(),
+		newApplicationPipelineArtifactsCommand(),
+		newApplicationPipelineValidateCommand(),
+		newApplicationPipelineDefinitionCommand(),
+		newApplicationPipelineSchedulesCommand(),
+	)
+	return pipelineCommand
+}
+
+func newApplicationPipelineRunCommand() *cobra.Command {
+	runCommand := &cobra.Command{
+		Use:   "run <application-id>",
+		Short: "Dispatch a manual run of the application's pipeline",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			return runPipelineDispatch(command, client.PipelineSelector{ApplicationID: applicationID})
+		},
+	}
+	registerPipelineRunDispatchFlags(runCommand)
+	registerStructuredOutputFlags(runCommand)
+	return runCommand
+}
+
+func newApplicationPipelineListCommand() *cobra.Command {
+	listCommand := &cobra.Command{
+		Use:     "list <application-id>",
+		Aliases: []string{"ls"},
+		Short:   "List the application's pipeline runs",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			return runPipelineList(command, client.PipelineSelector{ApplicationID: applicationID})
+		},
+	}
+	registerPipelineListFlags(listCommand)
+	registerStructuredOutputFlags(listCommand)
+	return listCommand
+}
+
+func newApplicationPipelineGetCommand() *cobra.Command {
+	getCommand := &cobra.Command{
+		Use:   "get <application-id> <run>",
+		Short: "Show a pipeline run's detail",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			return runPipelineGet(command, client.PipelineSelector{ApplicationID: applicationID}, arguments[1])
+		},
+	}
+	registerStructuredOutputFlags(getCommand)
+	return getCommand
+}
+
+func newApplicationPipelineCancelCommand() *cobra.Command {
+	cancelCommand := &cobra.Command{
+		Use:     "cancel <application-id> <run>",
+		Aliases: []string{"stop"},
+		Short:   "Cancel a pipeline run that has not concluded",
+		Args:    cobra.ExactArgs(2),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			return runPipelineCancel(command, client.PipelineSelector{ApplicationID: applicationID}, arguments[1])
+		},
+	}
+	registerStructuredOutputFlags(cancelCommand)
+	return cancelCommand
+}
+
+func newApplicationPipelineRerunCommand() *cobra.Command {
+	rerunCommand := &cobra.Command{
+		Use:   "rerun <application-id> <run>",
+		Short: "Re-run a concluded pipeline run",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			return runPipelineRerun(command, client.PipelineSelector{ApplicationID: applicationID}, arguments[1])
+		},
+	}
+	rerunCommand.Flags().Bool("failed-only", false, "Re-run only the steps that did not succeed, and whatever depends on them")
+	rerunCommand.Flags().Bool("wait", false, "Wait for the new run to conclude before returning")
+	registerStructuredOutputFlags(rerunCommand)
+	return rerunCommand
+}
+
+func newApplicationPipelineLogsCommand() *cobra.Command {
+	logsCommand := &cobra.Command{
+		Use:   "logs <application-id> <run>",
+		Short: "Show a pipeline step's live output",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			return runPipelineLogs(command, client.PipelineSelector{ApplicationID: applicationID}, arguments[1])
+		},
+	}
+	registerPipelineLogsFlags(logsCommand)
+	return logsCommand
+}
+
+func newApplicationPipelineArtifactsCommand() *cobra.Command {
+	artifactsCommand := &cobra.Command{
+		Use:   "artifacts <application-id> <run>",
+		Short: "List a pipeline run's stored artifacts",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			return runPipelineArtifactsList(command, client.PipelineSelector{ApplicationID: applicationID}, arguments[1])
+		},
+	}
+	registerStructuredOutputFlags(artifactsCommand)
+	artifactsCommand.AddCommand(newApplicationPipelineArtifactsDownloadCommand())
+	return artifactsCommand
+}
+
+func newApplicationPipelineArtifactsDownloadCommand() *cobra.Command {
+	downloadCommand := &cobra.Command{
+		Use:   "download <application-id> <artifact-id>",
+		Short: "Download a stored artifact",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			return runPipelineArtifactsDownload(command, client.PipelineSelector{ApplicationID: applicationID}, arguments[1])
+		},
+	}
+	downloadCommand.Flags().String("out", "", "Local file to write the artifact to (default: the artifact id, in the current directory)")
+	return downloadCommand
+}
+
+func newApplicationPipelineValidateCommand() *cobra.Command {
+	validateCommand := &cobra.Command{
+		Use:   "validate <application-id> [file]",
+		Short: "Dry-run a pipeline definition without writing anything",
+		Args:  cobra.RangeArgs(1, 2),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			filePath := defaultPipelineDefinitionPath
+			if len(arguments) == 2 {
+				filePath = arguments[1]
+			}
+			return runPipelineValidate(command, client.PipelineSelector{ApplicationID: applicationID}, filePath)
+		},
+	}
+	registerStructuredOutputFlags(validateCommand)
+	return validateCommand
+}
+
+func newApplicationPipelineDefinitionCommand() *cobra.Command {
+	definitionCommand := &cobra.Command{
+		Use:   "definition",
+		Short: "Manage the application pipeline's definition of record",
+	}
+	definitionCommand.AddCommand(
+		&cobra.Command{
+			Use:   "get <application-id>",
+			Short: "Show the pipeline definition of record",
+			Args:  cobra.ExactArgs(1),
+			RunE: func(command *cobra.Command, arguments []string) error {
+				applicationID, resolveError := resolveApplicationArgument(command, arguments)
+				if resolveError != nil {
+					return resolveError
+				}
+				return runPipelineDefinitionGet(command, client.PipelineSelector{ApplicationID: applicationID})
+			},
+		},
+		&cobra.Command{
+			Use:   "put <application-id> <file>",
+			Short: "Store a pipeline definition as the definition of record",
+			Args:  cobra.ExactArgs(2),
+			RunE: func(command *cobra.Command, arguments []string) error {
+				applicationID, resolveError := resolveApplicationArgument(command, arguments)
+				if resolveError != nil {
+					return resolveError
+				}
+				return runPipelineDefinitionPut(command, client.PipelineSelector{ApplicationID: applicationID}, arguments[1])
+			},
+		},
+	)
+	for _, subcommand := range definitionCommand.Commands() {
+		registerStructuredOutputFlags(subcommand)
+	}
+	return definitionCommand
+}
+
+func newApplicationPipelineSchedulesCommand() *cobra.Command {
+	schedulesCommand := &cobra.Command{
+		Use:   "schedules",
+		Short: "Manage the application pipeline's cron schedules",
+	}
+
+	listCommand := &cobra.Command{
+		Use:     "list <application-id>",
+		Aliases: []string{"ls"},
+		Short:   "List the pipeline's cron schedules",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			return runPipelineSchedulesList(command, client.PipelineSelector{ApplicationID: applicationID})
+		},
+	}
+	registerStructuredOutputFlags(listCommand)
+
+	createCommand := &cobra.Command{
+		Use:   "create <application-id>",
+		Short: "Add a cron schedule",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			return runPipelineSchedulesCreate(command, client.PipelineSelector{ApplicationID: applicationID})
+		},
+	}
+	createCommand.Flags().String("cron", "", "Cron expression (required)")
+	createCommand.Flags().String("timezone", "", "IANA timezone the cron is evaluated in (default UTC)")
+	createCommand.Flags().String("ref", "", "Git reference the schedule runs at (default the repository's default branch)")
+	createCommand.Flags().StringArray("input", nil, "Dispatch input as key=value (repeatable)")
+	createCommand.Flags().Bool("enabled", true, "Whether the schedule fires")
+	registerStructuredOutputFlags(createCommand)
+
+	updateCommand := &cobra.Command{
+		Use:   "update <application-id> <schedule-id>",
+		Short: "Change a cron schedule",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			return runPipelineSchedulesUpdate(command, client.PipelineSelector{ApplicationID: applicationID}, arguments[1])
+		},
+	}
+	updateCommand.Flags().String("cron", "", "New cron expression")
+	updateCommand.Flags().String("timezone", "", "New IANA timezone")
+	updateCommand.Flags().String("ref", "", "New git reference")
+	updateCommand.Flags().StringArray("input", nil, "Replace the dispatch inputs entirely, as key=value (repeatable)")
+	updateCommand.Flags().Bool("enabled", false, "Enable the schedule")
+	updateCommand.Flags().Bool("disabled", false, "Disable the schedule")
+	registerStructuredOutputFlags(updateCommand)
+
+	deleteCommand := &cobra.Command{
+		Use:     "delete <application-id> <schedule-id>",
+		Aliases: []string{"rm"},
+		Short:   "Remove a cron schedule",
+		Args:    cobra.ExactArgs(2),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			applicationID, resolveError := resolveApplicationArgument(command, arguments)
+			if resolveError != nil {
+				return resolveError
+			}
+			return runPipelineSchedulesDelete(command, client.PipelineSelector{ApplicationID: applicationID}, arguments[1])
+		},
+	}
+	deleteCommand.Flags().Bool("yes", false, "Skip the confirmation prompt")
+
+	schedulesCommand.AddCommand(listCommand, createCommand, updateCommand, deleteCommand)
+	return schedulesCommand
+}

--- a/cmd/application_resources.go
+++ b/cmd/application_resources.go
@@ -138,6 +138,7 @@ func registerApplicationResourceCommands(applicationCommand *cobra.Command) {
 	applicationCommand.AddCommand(newApplicationBuildCommand())
 	applicationCommand.AddCommand(newApplicationSettingsCommand())
 	applicationCommand.AddCommand(newApplicationManifestAddonCommand())
+	applicationCommand.AddCommand(newApplicationPipelineCommand())
 }
 
 func newApplicationDeleteCommand() *cobra.Command {

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -2398,6 +2398,66 @@ func (m baseMock) DisableClusterDNSZone(clusterID string) (*client.ClusterDNSZon
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) ListPipelineRuns(ctx context.Context, selector client.PipelineSelector, options client.ListPipelineRunsOptions) (*client.PipelineRunList, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) CreatePipelineRun(ctx context.Context, selector client.PipelineSelector, request client.CreatePipelineRunRequest) (*client.CreatePipelineRunResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) GetPipelineRun(ctx context.Context, selector client.PipelineSelector, runID string) (*client.PipelineRunDetail, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) RerunPipelineRun(ctx context.Context, selector client.PipelineSelector, runID string, failedOnly bool) (*client.CreatePipelineRunResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) CancelPipelineRun(ctx context.Context, selector client.PipelineSelector, runID string) (*client.PipelineRun, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) StreamPipelineStepLogs(ctx context.Context, selector client.PipelineSelector, runID string, stepID string, fromSequence int64) (<-chan client.PipelineLogEvent, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ListPipelineArtifacts(ctx context.Context, selector client.PipelineSelector, runID string) (*client.PipelineArtifactList, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) DownloadPipelineArtifact(ctx context.Context, selector client.PipelineSelector, artifactID string, destination io.Writer) error {
+	return errors.New("not implemented")
+}
+
+func (m baseMock) GetPipelineDefinition(ctx context.Context, selector client.PipelineSelector) (*client.PipelineDefinition, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) PutPipelineDefinition(ctx context.Context, selector client.PipelineSelector, specYAML string) (*client.PipelineDefinition, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ValidatePipelineDefinition(ctx context.Context, selector client.PipelineSelector, specYAML string) (*client.PipelineValidation, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ListPipelineSchedules(ctx context.Context, selector client.PipelineSelector) (*client.PipelineScheduleList, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) CreatePipelineSchedule(ctx context.Context, selector client.PipelineSelector, request client.CreatePipelineScheduleRequest) (*client.PipelineSchedule, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) UpdatePipelineSchedule(ctx context.Context, selector client.PipelineSelector, scheduleID string, request client.UpdatePipelineScheduleRequest) (*client.PipelineSchedule, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) DeletePipelineSchedule(ctx context.Context, selector client.PipelineSelector, scheduleID string) error {
+	return errors.New("not implemented")
+}
+
 type clusterListMock struct {
 	baseMock
 	clusters []client.ClusterListItem

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -1,0 +1,152 @@
+package cmd
+
+// The `ankra pipeline` family (ankra-vn0bd.2.8, WS-B item B8): the CLI
+// surface over go/internal/pipelineapi's four route trees. Every leaf command
+// here addresses one pipeline through a PipelineSelector - a repository or
+// the application it is linked to - resolved from the shared --application /
+// --repository flag pair. `ankra application pipeline …`
+// (cmd/application_pipeline.go) is the by-application twin: it forces the
+// selector from a leading <application-id> argument instead of a flag, and
+// otherwise calls the exact same run* functions this file and its siblings
+// define.
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+func newPipelineCommand() *cobra.Command {
+	pipelineCommand := &cobra.Command{
+		Use:     "pipeline",
+		Aliases: []string{"pipelines"},
+		Short:   "Manage Ankra Pipelines",
+		Long: `Manage Ankra Pipelines: in-cluster CI/CD runs, the pipeline definition of
+record, and its cron schedules.
+
+Every command addresses one pipeline with exactly one of:
+
+  --application <name-or-id>   the application the pipeline builds and deploys
+  --repository <repository-id> the pipeline repository directly
+
+There is no lookup route yet for a repository by "owner/name" - only by-id and
+by-application addressing exist - so --repository takes the repository's id
+(for example, the "repository.id" field 'ankra pipeline definition get'
+returns). Most invocations want --application instead.
+
+A run is addressed by its id (the RUN ID column, not the "run_id" field a
+JSON/YAML response also carries - that second field is the cross-lifecycle
+umbrella run this pipeline run belongs to, useful for correlating with
+'ankra cluster operations', but not what these commands accept).`,
+	}
+	pipelineCommand.AddCommand(
+		newPipelineRunCommand(),
+		newPipelineListCommand(),
+		newPipelineGetCommand(),
+		newPipelineCancelCommand(),
+		newPipelineRerunCommand(),
+		newPipelineLogsCommand(),
+		newPipelineArtifactsCommand(),
+		newPipelineValidateCommand(),
+		newPipelineDefinitionCommand(),
+		newPipelineSchedulesCommand(),
+	)
+	return pipelineCommand
+}
+
+func init() {
+	rootCmd.AddCommand(newPipelineCommand())
+}
+
+// registerPipelineSelectorFlags adds the shared --application / --repository
+// pair to a pipeline command.
+func registerPipelineSelectorFlags(command *cobra.Command) {
+	command.Flags().String("application", "", "Application name or id whose pipeline to act on")
+	command.Flags().String("repository", "", "Pipeline repository id to act on (mutually exclusive with --application)")
+}
+
+// resolvePipelineSelector reads --application / --repository and resolves
+// them into the PipelineSelector every pipeline client call takes. Exactly
+// one of the two must be given.
+func resolvePipelineSelector(command *cobra.Command) (client.PipelineSelector, error) {
+	applicationReference, _ := command.Flags().GetString("application")
+	repositoryID, _ := command.Flags().GetString("repository")
+	applicationReference = strings.TrimSpace(applicationReference)
+	repositoryID = strings.TrimSpace(repositoryID)
+
+	switch {
+	case applicationReference != "" && repositoryID != "":
+		return client.PipelineSelector{}, withExitCode(exitUsage,
+			errors.New("--application and --repository are mutually exclusive"))
+	case applicationReference != "":
+		applicationID, resolveError := resolveApplicationID(command.Context(), apiClient, applicationReference)
+		if resolveError != nil {
+			return client.PipelineSelector{}, resolveError
+		}
+		return client.PipelineSelector{ApplicationID: applicationID}, nil
+	case repositoryID != "":
+		if !looksLikeUUID(repositoryID) {
+			return client.PipelineSelector{}, withExitCode(exitUsage, fmt.Errorf(
+				"--repository %q must be the pipeline repository id - there is no lookup by owner/name yet, "+
+					"so pass the id from 'ankra pipeline definition get --application <name>' "+
+					"(its repository.id field), or use --application instead", repositoryID))
+		}
+		return client.PipelineSelector{RepositoryID: repositoryID}, nil
+	default:
+		return client.PipelineSelector{}, withExitCode(exitUsage,
+			errors.New("one of --application or --repository is required"))
+	}
+}
+
+// parsePipelineInputFlags parses repeated --input key=value flags into the
+// dispatch input map. A missing '=' or a repeated key is a usage error rather
+// than a silently dropped or overwritten input.
+func parsePipelineInputFlags(rawInputs []string) (map[string]string, error) {
+	if len(rawInputs) == 0 {
+		return nil, nil
+	}
+	inputs := make(map[string]string, len(rawInputs))
+	for _, rawInput := range rawInputs {
+		key, value, found := strings.Cut(rawInput, "=")
+		key = strings.TrimSpace(key)
+		if !found || key == "" {
+			return nil, withExitCode(exitUsage, fmt.Errorf("--input %q is not key=value", rawInput))
+		}
+		if _, isDuplicate := inputs[key]; isDuplicate {
+			return nil, withExitCode(exitUsage,
+				fmt.Errorf("--input %s given more than once: name each input at most once", key))
+		}
+		inputs[key] = value
+	}
+	return inputs, nil
+}
+
+// pipelineOutcomeLabel renders a run or step's status/outcome pair as one
+// word for a table cell: the outcome once the work has concluded, the status
+// while it has not.
+func pipelineOutcomeLabel(status string, outcome *string) string {
+	if outcome != nil && *outcome != "" {
+		return *outcome
+	}
+	return status
+}
+
+func pipelineOptionalString(value *string) string {
+	if value == nil || *value == "" {
+		return "-"
+	}
+	return *value
+}
+
+// pipelineShortSHA renders a commit for a table cell: short enough to scan,
+// long enough that two commits on the same branch stay distinguishable.
+func pipelineShortSHA(sha string) string {
+	if len(sha) <= 12 {
+		return sha
+	}
+	return sha[:12]
+}

--- a/cmd/pipeline_artifacts.go
+++ b/cmd/pipeline_artifacts.go
@@ -102,6 +102,15 @@ func runPipelineArtifactsDownload(command *cobra.Command, selector client.Pipeli
 	if outputPath == "" {
 		outputPath = artifactID
 	}
+	// The default destination is the artifact id the server chose, and --out
+	// is whatever the caller typed; neither may walk out of the directory the
+	// command was run in, so a path that escapes after cleaning is refused
+	// rather than written.
+	outputPath = filepath.Clean(outputPath)
+	if outputPath == ".." || strings.HasPrefix(outputPath, ".."+string(filepath.Separator)) {
+		return withExitCode(exitUsage,
+			fmt.Errorf("refusing to write outside the current directory: %q", outputPath))
+	}
 	if directory := filepath.Dir(outputPath); directory != "." {
 		if mkdirError := os.MkdirAll(directory, 0o755); mkdirError != nil {
 			return fmt.Errorf("creating %q: %w", directory, mkdirError)

--- a/cmd/pipeline_artifacts.go
+++ b/cmd/pipeline_artifacts.go
@@ -1,0 +1,123 @@
+package cmd
+
+// Artifacts: the store behind these routes is WS-C item C1 and does not
+// exist yet, so the list always answers empty and the download always
+// answers 404 today (go/internal/pipelineapi/artifacts.go). Both commands are
+// wired to the real contract now so nothing about them changes once the
+// store lands.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+func newPipelineArtifactsCommand() *cobra.Command {
+	artifactsCommand := &cobra.Command{
+		Use:   "artifacts <run>",
+		Short: "List a pipeline run's stored artifacts",
+		Long: `List a pipeline run's stored artifacts.
+
+The artifact store has not shipped yet, so every run answers an empty list
+until it does - this is not a sign that a run produced nothing.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			selector, selectorError := resolvePipelineSelector(command)
+			if selectorError != nil {
+				return selectorError
+			}
+			return runPipelineArtifactsList(command, selector, arguments[0])
+		},
+	}
+	registerPipelineSelectorFlags(artifactsCommand)
+	registerStructuredOutputFlags(artifactsCommand)
+	artifactsCommand.AddCommand(newPipelineArtifactsDownloadCommand())
+	return artifactsCommand
+}
+
+func runPipelineArtifactsList(command *cobra.Command, selector client.PipelineSelector, runID string) error {
+	format, formatError := structuredFormatFromFlags(command)
+	if formatError != nil {
+		return formatError
+	}
+	list, listError := apiClient.ListPipelineArtifacts(command.Context(), selector, strings.TrimSpace(runID))
+	if listError != nil {
+		return listError
+	}
+	if format != outputDefault {
+		return encodeStructured(command.OutOrStdout(), format, list)
+	}
+	if len(list.Artifacts) == 0 {
+		_, _ = fmt.Fprintln(command.OutOrStdout(), "No artifacts stored for this run.")
+		return nil
+	}
+	writer := table.NewWriter()
+	writer.SetOutputMirror(command.OutOrStdout())
+	writer.SetStyle(table.StyleRounded)
+	writer.AppendHeader(table.Row{"ID", "NAME", "STEP", "CONTENT TYPE", "SIZE", "CREATED"})
+	for _, artifact := range list.Artifacts {
+		writer.AppendRow(table.Row{
+			artifact.ID,
+			artifact.Name,
+			artifact.StepID,
+			artifact.ContentType,
+			artifact.SizeBytes,
+			formatTimeAgo(artifact.CreatedAt),
+		})
+	}
+	writer.Render()
+	return nil
+}
+
+func newPipelineArtifactsDownloadCommand() *cobra.Command {
+	downloadCommand := &cobra.Command{
+		Use:   "download <artifact-id>",
+		Short: "Download a stored artifact",
+		Long: `Download a stored artifact, following the platform's redirect to its
+presigned storage URL and streaming it to disk.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			selector, selectorError := resolvePipelineSelector(command)
+			if selectorError != nil {
+				return selectorError
+			}
+			return runPipelineArtifactsDownload(command, selector, arguments[0])
+		},
+	}
+	registerPipelineSelectorFlags(downloadCommand)
+	downloadCommand.Flags().String("out", "", "Local file to write the artifact to (default: the artifact id, in the current directory)")
+	return downloadCommand
+}
+
+func runPipelineArtifactsDownload(command *cobra.Command, selector client.PipelineSelector, artifactID string) error {
+	artifactID = strings.TrimSpace(artifactID)
+	outputPath, _ := command.Flags().GetString("out")
+	outputPath = strings.TrimSpace(outputPath)
+	if outputPath == "" {
+		outputPath = artifactID
+	}
+	if directory := filepath.Dir(outputPath); directory != "." {
+		if mkdirError := os.MkdirAll(directory, 0o755); mkdirError != nil {
+			return fmt.Errorf("creating %q: %w", directory, mkdirError)
+		}
+	}
+
+	destination, createError := os.Create(outputPath) // #nosec G304 -- user-supplied download destination, by design
+	if createError != nil {
+		return fmt.Errorf("creating %q: %w", outputPath, createError)
+	}
+	defer func() { _ = destination.Close() }()
+
+	if downloadError := apiClient.DownloadPipelineArtifact(command.Context(), selector, artifactID, destination); downloadError != nil {
+		_ = os.Remove(outputPath)
+		return downloadError
+	}
+	_, _ = fmt.Fprintf(command.OutOrStdout(), "Downloaded artifact %s to %s\n", artifactID, outputPath)
+	return nil
+}

--- a/cmd/pipeline_artifacts.go
+++ b/cmd/pipeline_artifacts.go
@@ -100,12 +100,20 @@ func runPipelineArtifactsDownload(command *cobra.Command, selector client.Pipeli
 	outputPath, _ := command.Flags().GetString("out")
 	outputPath = strings.TrimSpace(outputPath)
 	if outputPath == "" {
-		outputPath = artifactID
+		// The default destination is derived from the artifact id, which the
+		// server chose: only its base name is used, so an id carrying a
+		// separator or an absolute path cannot decide where this command
+		// writes. --out, by contrast, is the caller's own choice of
+		// destination and may name a subdirectory.
+		outputPath = filepath.Base(filepath.Clean(artifactID))
+		if outputPath == "." || outputPath == ".." || outputPath == string(filepath.Separator) {
+			return withExitCode(exitUsage,
+				fmt.Errorf("the artifact id %q does not name a file to write; pass --out", artifactID))
+		}
 	}
-	// The default destination is the artifact id the server chose, and --out
-	// is whatever the caller typed; neither may walk out of the directory the
-	// command was run in, so a path that escapes after cleaning is refused
-	// rather than written.
+	// Neither destination may walk out of the directory the command was run
+	// in, so a path that escapes after cleaning is refused rather than
+	// written.
 	outputPath = filepath.Clean(outputPath)
 	if outputPath == ".." || strings.HasPrefix(outputPath, ".."+string(filepath.Separator)) {
 		return withExitCode(exitUsage,

--- a/cmd/pipeline_definition.go
+++ b/cmd/pipeline_definition.go
@@ -1,0 +1,230 @@
+package cmd
+
+// The definition of record and its dry-run validation
+// (go/internal/pipelineapi/definition.go).
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+// defaultPipelineDefinitionPath is the committed file `validate` reads by
+// default, matching the setup PR's `.ankra/pipeline.yaml` alongside
+// `.ankra/ankra.yaml`.
+const defaultPipelineDefinitionPath = ".ankra/pipeline.yaml"
+
+func newPipelineValidateCommand() *cobra.Command {
+	validateCommand := &cobra.Command{
+		Use:   "validate [file]",
+		Short: "Dry-run a pipeline definition without writing anything",
+		Long: fmt.Sprintf(`Dry-run a pipeline definition: parse it, validate it, and plan it for a
+synthetic push and a synthetic pull request, without writing anything.
+
+Defaults to %s when no file is given; with neither that file nor a
+--application/--repository definition already stored, there is nothing to
+validate. Passing a file validates its content directly, which is what a
+'is my pipeline.yaml correct before I commit it' check wants.`, defaultPipelineDefinitionPath),
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			selector, selectorError := resolvePipelineSelector(command)
+			if selectorError != nil {
+				return selectorError
+			}
+			filePath := defaultPipelineDefinitionPath
+			if len(arguments) == 1 {
+				filePath = arguments[0]
+			}
+			return runPipelineValidate(command, selector, filePath)
+		},
+	}
+	registerPipelineSelectorFlags(validateCommand)
+	registerStructuredOutputFlags(validateCommand)
+	return validateCommand
+}
+
+func runPipelineValidate(command *cobra.Command, selector client.PipelineSelector, filePath string) error {
+	format, formatError := structuredFormatFromFlags(command)
+	if formatError != nil {
+		return formatError
+	}
+	var specYAML string
+	contents, readError := readApplicationFile(filePath)
+	switch {
+	case readError == nil:
+		specYAML = string(contents)
+	case filePath == defaultPipelineDefinitionPath:
+		// The default file is optional: falling back validates whatever is
+		// already stored server-side, which is the honest answer for a
+		// repository that generated its pipeline rather than committing one.
+	default:
+		return readError
+	}
+
+	validation, validateError := apiClient.ValidatePipelineDefinition(command.Context(), selector, specYAML)
+	if validateError != nil {
+		return validateError
+	}
+	if format != outputDefault {
+		return encodeStructured(command.OutOrStdout(), format, validation)
+	}
+	printPipelineValidation(command, validation)
+	if validation.Severity == "fatal" {
+		return withExitCode(exitError, fmt.Errorf("the pipeline definition has fatal violations"))
+	}
+	return nil
+}
+
+func printPipelineValidation(command *cobra.Command, validation *client.PipelineValidation) {
+	out := command.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "Severity: %s\n", validation.Severity)
+	if len(validation.Violations) > 0 {
+		_, _ = fmt.Fprintln(out, "Violations:")
+		for _, violation := range validation.Violations {
+			_, _ = fmt.Fprintf(out, "  - %s\n", violation)
+		}
+	}
+	for _, event := range validation.Events {
+		_, _ = fmt.Fprintf(out, "\n%s:\n", event.Event)
+		if !event.Run {
+			_, _ = fmt.Fprintf(out, "  Would not run: %s\n", pipelineOptionalString(event.Reason))
+			continue
+		}
+		_, _ = fmt.Fprintf(out, "  Would run %d step(s)", len(event.Steps))
+		if event.MatchedTrigger != nil && *event.MatchedTrigger != "" {
+			_, _ = fmt.Fprintf(out, " (matched trigger %q)", *event.MatchedTrigger)
+		}
+		_, _ = fmt.Fprintln(out)
+		for _, step := range event.Steps {
+			_, _ = fmt.Fprintf(out, "    %s (%s, %s)\n", step.StepKey, step.Stage, step.Kind)
+		}
+		for _, skipped := range event.Skipped {
+			_, _ = fmt.Fprintf(out, "    %s skipped: %s\n", skipped.StepKey, skipped.Message)
+		}
+		for _, diagnostic := range event.Diagnostics {
+			_, _ = fmt.Fprintf(out, "    diagnostic: %s\n", diagnostic)
+		}
+	}
+}
+
+func newPipelineDefinitionCommand() *cobra.Command {
+	definitionCommand := &cobra.Command{
+		Use:   "definition",
+		Short: "Manage the pipeline definition of record",
+	}
+	definitionCommand.AddCommand(newPipelineDefinitionGetCommand(), newPipelineDefinitionPutCommand())
+	return definitionCommand
+}
+
+func newPipelineDefinitionGetCommand() *cobra.Command {
+	getCommand := &cobra.Command{
+		Use:   "get",
+		Short: "Show the pipeline definition of record",
+		Args:  cobra.NoArgs,
+		RunE: func(command *cobra.Command, arguments []string) error {
+			selector, selectorError := resolvePipelineSelector(command)
+			if selectorError != nil {
+				return selectorError
+			}
+			return runPipelineDefinitionGet(command, selector)
+		},
+	}
+	registerPipelineSelectorFlags(getCommand)
+	registerStructuredOutputFlags(getCommand)
+	return getCommand
+}
+
+func runPipelineDefinitionGet(command *cobra.Command, selector client.PipelineSelector) error {
+	format, formatError := structuredFormatFromFlags(command)
+	if formatError != nil {
+		return formatError
+	}
+	definition, getError := apiClient.GetPipelineDefinition(command.Context(), selector)
+	if getError != nil {
+		return getError
+	}
+	if format != outputDefault {
+		return encodeStructured(command.OutOrStdout(), format, definition)
+	}
+	printPipelineDefinition(command.OutOrStdout(), definition)
+	return nil
+}
+
+func printPipelineDefinition(out io.Writer, definition *client.PipelineDefinition) {
+	_, _ = fmt.Fprintf(out, "Repository:  %s/%s\n", definition.Repository.Owner, definition.Repository.Name)
+	_, _ = fmt.Fprintf(out, "Source:      %s\n", definition.Source)
+	_, _ = fmt.Fprintf(out, "Spec hash:   %s\n", definition.SpecHash)
+	if len(definition.Violations) > 0 {
+		_, _ = fmt.Fprintln(out, "Violations:")
+		for _, violation := range definition.Violations {
+			_, _ = fmt.Fprintf(out, "  - %s\n", violation)
+		}
+	}
+	_, _ = fmt.Fprintln(out)
+	writer := table.NewWriter()
+	writer.SetOutputMirror(out)
+	writer.SetStyle(table.StyleRounded)
+	writer.AppendHeader(table.Row{"STAGE", "KIND", "SECTION", "NEEDS"})
+	for _, stage := range definition.Stages {
+		writer.AppendRow(table.Row{stage.Name, stage.Kind, stage.Section, strings.Join(stage.Needs, ", ")})
+	}
+	writer.Render()
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintln(out, definition.SpecYAML)
+}
+
+func newPipelineDefinitionPutCommand() *cobra.Command {
+	putCommand := &cobra.Command{
+		Use:   "put <file>",
+		Short: "Store a pipeline definition as the definition of record",
+		Long: `Store a generated pipeline definition server-side, replacing the
+repository's definition of record. Requires the pipelines.manage permission.
+
+This does not touch the repository's committed .ankra/pipeline.yaml: a
+committed file still wins for logic per the DescriptorOfRecord contract,
+so 'put' is for a repository whose pipeline Ankra generates and stores rather
+than one you author and commit yourself.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			selector, selectorError := resolvePipelineSelector(command)
+			if selectorError != nil {
+				return selectorError
+			}
+			return runPipelineDefinitionPut(command, selector, arguments[0])
+		},
+	}
+	registerPipelineSelectorFlags(putCommand)
+	registerStructuredOutputFlags(putCommand)
+	return putCommand
+}
+
+func runPipelineDefinitionPut(command *cobra.Command, selector client.PipelineSelector, filePath string) error {
+	format, formatError := structuredFormatFromFlags(command)
+	if formatError != nil {
+		return formatError
+	}
+	contents, readError := readApplicationFile(filePath)
+	if readError != nil {
+		return readError
+	}
+	definition, putError := apiClient.PutPipelineDefinition(command.Context(), selector, string(contents))
+	if putError != nil {
+		return putError
+	}
+	if format != outputDefault {
+		return encodeStructured(command.OutOrStdout(), format, definition)
+	}
+	_, _ = fmt.Fprintf(command.OutOrStdout(), "Stored definition %s (source: %s)\n", definition.SpecHash, definition.Source)
+	if len(definition.Violations) > 0 {
+		_, _ = fmt.Fprintln(command.OutOrStdout(), "Violations:")
+		for _, violation := range definition.Violations {
+			_, _ = fmt.Fprintf(command.OutOrStdout(), "  - %s\n", violation)
+		}
+	}
+	return nil
+}

--- a/cmd/pipeline_definition.go
+++ b/cmd/pipeline_definition.go
@@ -4,8 +4,10 @@ package cmd
 // (go/internal/pipelineapi/definition.go).
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"strings"
 
 	"ankra/internal/client"
@@ -58,10 +60,15 @@ func runPipelineValidate(command *cobra.Command, selector client.PipelineSelecto
 	switch {
 	case readError == nil:
 		specYAML = string(contents)
-	case filePath == defaultPipelineDefinitionPath:
-		// The default file is optional: falling back validates whatever is
-		// already stored server-side, which is the honest answer for a
-		// repository that generated its pipeline rather than committing one.
+	case filePath == defaultPipelineDefinitionPath && errors.Is(readError, fs.ErrNotExist):
+		// The default file is optional, and only its absence is optional:
+		// falling back validates whatever is already stored server-side,
+		// which is the honest answer for a repository that generated its
+		// pipeline rather than committing one. Any other read failure - a
+		// permission denial, an unreadable directory, a transient fault -
+		// is reported, because validating the stored definition and printing
+		// "ok" would answer a question the caller did not ask about a file
+		// this command could not read.
 	default:
 		return readError
 	}

--- a/cmd/pipeline_logs.go
+++ b/cmd/pipeline_logs.go
@@ -78,22 +78,26 @@ func runPipelineLogs(command *cobra.Command, selector client.PipelineSelector, r
 		if streamError != nil {
 			var unavailable *client.PipelineLogStreamUnavailableError
 			if errors.As(streamError, &unavailable) && follow {
+				// A 503 that carries no Retry-After, or a zero one, must not
+				// turn --follow into a tight reconnect loop against the relay.
+				retryAfter := time.Duration(unavailable.RetryAfterSeconds) * time.Second
+				if retryAfter < pipelineLogStreamReconnectDelay {
+					retryAfter = pipelineLogStreamReconnectDelay
+				}
 				_, _ = fmt.Fprintf(progress, "Log stream unavailable (%s); retrying in %ds.\n",
-					unavailable.Detail, unavailable.RetryAfterSeconds)
-				time.Sleep(time.Duration(unavailable.RetryAfterSeconds) * time.Second)
+					unavailable.Detail, int(retryAfter.Seconds()))
+				time.Sleep(retryAfter)
 				continue
 			}
 			return streamError
 		}
 
-		streamFaulted := false
 		for event := range events {
 			switch event.Type {
 			case "line":
 				_, _ = fmt.Fprintf(out, "[%s] %s\n", event.Stream, event.Line)
 				lastSeq = event.Seq
 			case "error":
-				streamFaulted = true
 				_, _ = fmt.Fprintf(progress, "Log stream fault: %s\n", event.Error)
 			}
 		}
@@ -110,9 +114,10 @@ func runPipelineLogs(command *cobra.Command, selector client.PipelineSelector, r
 			_, _ = fmt.Fprintln(progress, "Log stream ended.")
 			return nil
 		}
-		if streamFaulted {
-			time.Sleep(pipelineLogStreamReconnectDelay)
-		}
+		// Every reconnect waits, not only a faulted one: a proxy that closes
+		// each connection promptly would otherwise be reconnected to as fast
+		// as it hangs up.
+		time.Sleep(pipelineLogStreamReconnectDelay)
 	}
 }
 

--- a/cmd/pipeline_logs.go
+++ b/cmd/pipeline_logs.go
@@ -1,0 +1,166 @@
+package cmd
+
+// The step log relay: go/internal/pipelineapi/streams.go over the shared
+// execution_output JetStream stream. See internal/client/pipeline_logs.go for
+// the wire contract and its one real limitation: a fresh connection has no
+// history to replay, so this command only ever shows output produced from the
+// moment it connects.
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// pipelineLogStreamReconnectDelay is how long `logs --follow` waits before
+// reconnecting after the relay's own error frame or a stream fault, so a
+// transient disconnect does not spin the CLI in a tight retry loop.
+const pipelineLogStreamReconnectDelay = 2 * time.Second
+
+func newPipelineLogsCommand() *cobra.Command {
+	logsCommand := &cobra.Command{
+		Use:   "logs <run>",
+		Short: "Show a pipeline step's live output",
+		Long: `Show a pipeline step's live output over the log relay.
+
+The relay has no history yet: a fresh connection only sees lines produced
+from the moment it connects, not what the step already printed before then
+(the durable per-step log artifact this will read from instead has not
+shipped). Without --follow, the command tails the step until it concludes and
+then stops; with --follow it does the same, so the difference is mainly
+diagnostic - a bare 'logs' exits with the step's outcome, 'logs --follow'
+keeps reconnecting through a dropped stream instead of giving up.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			selector, selectorError := resolvePipelineSelector(command)
+			if selectorError != nil {
+				return selectorError
+			}
+			return runPipelineLogs(command, selector, arguments[0])
+		},
+	}
+	registerPipelineSelectorFlags(logsCommand)
+	registerPipelineLogsFlags(logsCommand)
+	return logsCommand
+}
+
+// registerPipelineLogsFlags is shared by `pipeline logs` and
+// `application pipeline logs`.
+func registerPipelineLogsFlags(command *cobra.Command) {
+	command.Flags().String("step", "", "Step key to follow (required when the run has more than one step)")
+	command.Flags().Bool("follow", false, "Keep streaming, reconnecting through transient stream faults, until the step concludes")
+}
+
+func runPipelineLogs(command *cobra.Command, selector client.PipelineSelector, runID string) error {
+	stepReference, _ := command.Flags().GetString("step")
+	follow, _ := command.Flags().GetBool("follow")
+	runID = strings.TrimSpace(runID)
+
+	step, resolveError := resolvePipelineStep(command, selector, runID, strings.TrimSpace(stepReference))
+	if resolveError != nil {
+		return resolveError
+	}
+	if step.ExecutionID == nil || step.ExecutionStepID == nil {
+		return fmt.Errorf("step %q has not started, so it has no log stream yet - "+
+			"check 'ankra pipeline get %s' for its status", step.StepKey, runID)
+	}
+
+	out := command.OutOrStdout()
+	progress := command.ErrOrStderr()
+	var lastSeq int64
+	for {
+		events, streamError := apiClient.StreamPipelineStepLogs(command.Context(), selector, runID, step.ID, lastSeq)
+		if streamError != nil {
+			var unavailable *client.PipelineLogStreamUnavailableError
+			if errors.As(streamError, &unavailable) && follow {
+				_, _ = fmt.Fprintf(progress, "Log stream unavailable (%s); retrying in %ds.\n",
+					unavailable.Detail, unavailable.RetryAfterSeconds)
+				time.Sleep(time.Duration(unavailable.RetryAfterSeconds) * time.Second)
+				continue
+			}
+			return streamError
+		}
+
+		streamFaulted := false
+		for event := range events {
+			switch event.Type {
+			case "line":
+				_, _ = fmt.Fprintf(out, "[%s] %s\n", event.Stream, event.Line)
+				lastSeq = event.Seq
+			case "error":
+				streamFaulted = true
+				_, _ = fmt.Fprintf(progress, "Log stream fault: %s\n", event.Error)
+			}
+		}
+
+		concluded, statusError := pipelineStepConcluded(command, selector, runID, step.ID)
+		if statusError != nil {
+			return statusError
+		}
+		if concluded {
+			_, _ = fmt.Fprintln(progress, "Log stream ended: the step has concluded.")
+			return nil
+		}
+		if !follow {
+			_, _ = fmt.Fprintln(progress, "Log stream ended.")
+			return nil
+		}
+		if streamFaulted {
+			time.Sleep(pipelineLogStreamReconnectDelay)
+		}
+	}
+}
+
+// resolvePipelineStep finds the step a logs invocation names: the exact step
+// key when --step was given, or the run's only step when it has just one.
+// More than one step with no --step is a usage error - guessing which one the
+// user meant would show them the wrong build's output.
+func resolvePipelineStep(command *cobra.Command, selector client.PipelineSelector, runID string,
+	stepReference string) (client.PipelineStep, error) {
+	detail, getError := apiClient.GetPipelineRun(command.Context(), selector, runID)
+	if getError != nil {
+		return client.PipelineStep{}, getError
+	}
+	if stepReference != "" {
+		for _, step := range detail.Steps {
+			if step.StepKey == stepReference || step.ID == stepReference {
+				return step, nil
+			}
+		}
+		return client.PipelineStep{}, withExitCode(exitNotFound,
+			fmt.Errorf("no step %q on run %s - run 'ankra pipeline get %s' to see the planned steps",
+				stepReference, runID, runID))
+	}
+	switch len(detail.Steps) {
+	case 0:
+		return client.PipelineStep{}, fmt.Errorf("run %s has no planned steps yet", runID)
+	case 1:
+		return detail.Steps[0], nil
+	default:
+		return client.PipelineStep{}, withExitCode(exitUsage,
+			fmt.Errorf("run %s has %d steps - pass --step to name the one to follow", runID, len(detail.Steps)))
+	}
+}
+
+// pipelineStepConcluded re-reads one step's status. It is a full run fetch
+// because the API has no single-step read on this surface; the run detail is
+// small enough that polling it once per disconnect is not a cost worth a
+// dedicated route for.
+func pipelineStepConcluded(command *cobra.Command, selector client.PipelineSelector, runID string,
+	stepID string) (bool, error) {
+	detail, getError := apiClient.GetPipelineRun(command.Context(), selector, runID)
+	if getError != nil {
+		return false, getError
+	}
+	for _, step := range detail.Steps {
+		if step.ID == stepID {
+			return step.Status == "concluded", nil
+		}
+	}
+	return false, withExitCode(exitNotFound, fmt.Errorf("step %s is no longer on run %s", stepID, runID))
+}

--- a/cmd/pipeline_logs.go
+++ b/cmd/pipeline_logs.go
@@ -86,7 +86,9 @@ func runPipelineLogs(command *cobra.Command, selector client.PipelineSelector, r
 				}
 				_, _ = fmt.Fprintf(progress, "Log stream unavailable (%s); retrying in %ds.\n",
 					unavailable.Detail, int(retryAfter.Seconds()))
-				time.Sleep(retryAfter)
+				if sleepError := sleepInterrupted(command.Context(), retryAfter); sleepError != nil {
+					return sleepError
+				}
 				continue
 			}
 			return streamError
@@ -116,8 +118,11 @@ func runPipelineLogs(command *cobra.Command, selector client.PipelineSelector, r
 		}
 		// Every reconnect waits, not only a faulted one: a proxy that closes
 		// each connection promptly would otherwise be reconnected to as fast
-		// as it hangs up.
-		time.Sleep(pipelineLogStreamReconnectDelay)
+		// as it hangs up. The wait is interruptible so Ctrl+C stops --follow
+		// at once rather than at the next network call.
+		if sleepError := sleepInterrupted(command.Context(), pipelineLogStreamReconnectDelay); sleepError != nil {
+			return sleepError
+		}
 	}
 }
 

--- a/cmd/pipeline_run.go
+++ b/cmd/pipeline_run.go
@@ -1,0 +1,406 @@
+package cmd
+
+// The run lifecycle: dispatch, list, get, cancel, rerun. Each RunE here
+// resolves its own selector from --application/--repository and then calls
+// the shared runPipeline* function; cmd/application_pipeline.go calls the
+// same functions with a selector forced from a leading <application-id>
+// argument, so the two surfaces cannot drift.
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+// pipelineRunWaitPollInterval is how often `run --wait` and `rerun --wait`
+// re-read the run while it is in flight.
+const pipelineRunWaitPollInterval = 3 * time.Second
+
+func newPipelineRunCommand() *cobra.Command {
+	runCommand := &cobra.Command{
+		Use:   "run",
+		Short: "Dispatch a manual pipeline run",
+		Long: `Dispatch a manual run of a pipeline's stored definition.
+
+--sha is mandatory: resolving a ref to a commit belongs to the trigger lane
+(push/PR/tag webhooks), so a dispatch that names no commit is refused rather
+than run against whatever commit the platform happens to have stored last.`,
+		Args: cobra.NoArgs,
+		RunE: func(command *cobra.Command, arguments []string) error {
+			selector, selectorError := resolvePipelineSelector(command)
+			if selectorError != nil {
+				return selectorError
+			}
+			return runPipelineDispatch(command, selector)
+		},
+	}
+	registerPipelineSelectorFlags(runCommand)
+	registerPipelineRunDispatchFlags(runCommand)
+	registerStructuredOutputFlags(runCommand)
+	return runCommand
+}
+
+// registerPipelineRunDispatchFlags is shared by `pipeline run` and
+// `application pipeline run`.
+func registerPipelineRunDispatchFlags(command *cobra.Command) {
+	command.Flags().String("ref", "", "Git reference to run at (defaults to the repository's default branch)")
+	command.Flags().String("sha", "", "Full commit sha to run (required)")
+	command.Flags().StringArray("input", nil, "Dispatch input as key=value (repeatable)")
+	command.Flags().String("reason", "", "Human note recorded on the run")
+	command.Flags().String("spec-file", "", "Run this pipeline definition instead of the stored one (requires pipelines.manage)")
+	command.Flags().Bool("wait", false, "Wait for the run to conclude before returning")
+}
+
+// runPipelineDispatch reads the dispatch flags and drives the shared
+// CreatePipelineRun call; used by both `pipeline run` and
+// `application pipeline run`.
+func runPipelineDispatch(command *cobra.Command, selector client.PipelineSelector) error {
+	format, formatError := structuredFormatFromFlags(command)
+	if formatError != nil {
+		return formatError
+	}
+	ref, _ := command.Flags().GetString("ref")
+	sha, _ := command.Flags().GetString("sha")
+	reason, _ := command.Flags().GetString("reason")
+	specFile, _ := command.Flags().GetString("spec-file")
+	rawInputs, _ := command.Flags().GetStringArray("input")
+	wait, _ := command.Flags().GetBool("wait")
+
+	sha = strings.TrimSpace(sha)
+	if sha == "" {
+		return withExitCode(exitUsage, fmt.Errorf("--sha is required: a pipeline run needs the full commit sha to run at"))
+	}
+	inputs, inputsError := parsePipelineInputFlags(rawInputs)
+	if inputsError != nil {
+		return inputsError
+	}
+	var specYAML string
+	if strings.TrimSpace(specFile) != "" {
+		contents, readError := readApplicationFile(specFile)
+		if readError != nil {
+			return readError
+		}
+		specYAML = string(contents)
+	}
+
+	result, createError := apiClient.CreatePipelineRun(command.Context(), selector, client.CreatePipelineRunRequest{
+		Ref:      strings.TrimSpace(ref),
+		HeadSHA:  sha,
+		Inputs:   inputs,
+		Reason:   strings.TrimSpace(reason),
+		SpecYAML: specYAML,
+	})
+	if createError != nil {
+		return createError
+	}
+
+	if !wait {
+		if rendered, renderError := renderStructured(command, result); rendered || renderError != nil {
+			return renderError
+		}
+		_, _ = fmt.Fprintf(command.OutOrStdout(), "Run #%d queued: %s\nFollow it with 'ankra pipeline get %s' or 'ankra pipeline logs %s --follow'.\n",
+			result.RunNumber, result.PipelineRunID, result.PipelineRunID, result.PipelineRunID)
+		return nil
+	}
+
+	detail, waitError := waitForPipelineRunConclusion(command, selector, result.PipelineRunID)
+	if waitError != nil {
+		return waitError
+	}
+	if format != outputDefault {
+		return encodeStructured(command.OutOrStdout(), format, detail)
+	}
+	printPipelineRunDetail(command.OutOrStdout(), *detail)
+	return pipelineRunConclusionError(detail.PipelineRun)
+}
+
+// waitForPipelineRunConclusion polls GetPipelineRun until the run's status is
+// "concluded". There is no --timeout: a person who wants to give up presses
+// Ctrl+C, the same contract 'cluster operations list --watch' already gives.
+func waitForPipelineRunConclusion(command *cobra.Command, selector client.PipelineSelector,
+	runID string) (*client.PipelineRunDetail, error) {
+	progress := command.ErrOrStderr()
+	announced := ""
+	for {
+		detail, getError := apiClient.GetPipelineRun(command.Context(), selector, runID)
+		if getError != nil {
+			return nil, getError
+		}
+		if detail.Status != announced {
+			_, _ = fmt.Fprintf(progress, "Run #%d is %s.\n", detail.RunNumber, detail.Status)
+			announced = detail.Status
+		}
+		if detail.Status == "concluded" {
+			return detail, nil
+		}
+		time.Sleep(pipelineRunWaitPollInterval)
+	}
+}
+
+// pipelineRunConclusionError reports a non-success conclusion as an error so
+// `--wait` exits non-zero on a failed run, the way a CI step should.
+func pipelineRunConclusionError(run client.PipelineRun) error {
+	outcome := pipelineOptionalString(run.Outcome)
+	if outcome == "success" {
+		return nil
+	}
+	message := fmt.Sprintf("run #%d concluded %s", run.RunNumber, outcome)
+	if run.ErrorMessage != nil && *run.ErrorMessage != "" {
+		message += ": " + *run.ErrorMessage
+	}
+	return fmt.Errorf("%s", message)
+}
+
+func newPipelineListCommand() *cobra.Command {
+	listCommand := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List a pipeline's runs",
+		Args:    cobra.NoArgs,
+		RunE: func(command *cobra.Command, arguments []string) error {
+			selector, selectorError := resolvePipelineSelector(command)
+			if selectorError != nil {
+				return selectorError
+			}
+			return runPipelineList(command, selector)
+		},
+	}
+	registerPipelineSelectorFlags(listCommand)
+	registerPipelineListFlags(listCommand)
+	registerStructuredOutputFlags(listCommand)
+	return listCommand
+}
+
+// registerPipelineListFlags is shared by `pipeline list` and
+// `application pipeline list`.
+func registerPipelineListFlags(command *cobra.Command) {
+	command.Flags().String("status", "", "Filter by run status: queued, running, or concluded")
+	command.Flags().String("trigger", "", "Filter by trigger: push, pull_request, tag, schedule, manual, api, agent, or rerun")
+	command.Flags().String("branch", "", "Filter by trigger branch")
+	command.Flags().String("head-sha", "", "Filter by the exact full commit sha")
+	command.Flags().String("cursor", "", "Page cursor from a previous listing's next_cursor")
+	command.Flags().Int("limit", 0, "Maximum number of runs to return (server default 50, max 100)")
+}
+
+func runPipelineList(command *cobra.Command, selector client.PipelineSelector) error {
+	format, formatError := structuredFormatFromFlags(command)
+	if formatError != nil {
+		return formatError
+	}
+	status, _ := command.Flags().GetString("status")
+	trigger, _ := command.Flags().GetString("trigger")
+	branch, _ := command.Flags().GetString("branch")
+	headSHA, _ := command.Flags().GetString("head-sha")
+	cursor, _ := command.Flags().GetString("cursor")
+	limit, _ := command.Flags().GetInt("limit")
+
+	page, listError := apiClient.ListPipelineRuns(command.Context(), selector, client.ListPipelineRunsOptions{
+		Status:  strings.TrimSpace(status),
+		Trigger: strings.TrimSpace(trigger),
+		Branch:  strings.TrimSpace(branch),
+		HeadSHA: strings.TrimSpace(headSHA),
+		Cursor:  strings.TrimSpace(cursor),
+		Limit:   limit,
+	})
+	if listError != nil {
+		return listError
+	}
+	if format != outputDefault {
+		return encodeStructured(command.OutOrStdout(), format, page)
+	}
+	if len(page.Runs) == 0 {
+		_, _ = fmt.Fprintln(command.OutOrStdout(), "No pipeline runs found.")
+		return nil
+	}
+	renderPipelineRunTable(command.OutOrStdout(), page.Runs)
+	if page.NextCursor != nil {
+		_, _ = fmt.Fprintf(command.ErrOrStderr(), "\nMore runs available: pass --cursor %s to see the next page.\n", *page.NextCursor)
+	}
+	return nil
+}
+
+func renderPipelineRunTable(out io.Writer, runs []client.PipelineRun) {
+	writer := table.NewWriter()
+	writer.SetOutputMirror(out)
+	writer.SetStyle(table.StyleRounded)
+	writer.AppendHeader(table.Row{"ID", "RUN #", "STATUS", "TRIGGER", "REF", "SHA", "QUEUED"})
+	for _, run := range runs {
+		writer.AppendRow(table.Row{
+			run.ID,
+			run.RunNumber,
+			renderColouredStatus(pipelineOutcomeLabel(run.Status, run.Outcome)),
+			run.Trigger,
+			run.TriggerRef,
+			pipelineShortSHA(run.HeadSHA),
+			formatTimeAgo(run.QueuedAt),
+		})
+	}
+	writer.Render()
+}
+
+func newPipelineGetCommand() *cobra.Command {
+	getCommand := &cobra.Command{
+		Use:   "get <run>",
+		Short: "Show a pipeline run's detail",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			selector, selectorError := resolvePipelineSelector(command)
+			if selectorError != nil {
+				return selectorError
+			}
+			return runPipelineGet(command, selector, arguments[0])
+		},
+	}
+	registerPipelineSelectorFlags(getCommand)
+	registerStructuredOutputFlags(getCommand)
+	return getCommand
+}
+
+func runPipelineGet(command *cobra.Command, selector client.PipelineSelector, runID string) error {
+	format, formatError := structuredFormatFromFlags(command)
+	if formatError != nil {
+		return formatError
+	}
+	detail, getError := apiClient.GetPipelineRun(command.Context(), selector, strings.TrimSpace(runID))
+	if getError != nil {
+		return getError
+	}
+	if format != outputDefault {
+		return encodeStructured(command.OutOrStdout(), format, detail)
+	}
+	printPipelineRunDetail(command.OutOrStdout(), *detail)
+	return nil
+}
+
+func printPipelineRunDetail(out io.Writer, detail client.PipelineRunDetail) {
+	_, _ = fmt.Fprintf(out, "Run #%d (%s)\n", detail.RunNumber, detail.ID)
+	_, _ = fmt.Fprintf(out, "  Status:    %s\n", renderColouredStatus(pipelineOutcomeLabel(detail.Status, detail.Outcome)))
+	_, _ = fmt.Fprintf(out, "  Trigger:   %s (%s)\n", detail.Trigger, detail.TriggerRef)
+	_, _ = fmt.Fprintf(out, "  Commit:    %s\n", detail.HeadSHA)
+	if detail.ErrorMessage != nil && *detail.ErrorMessage != "" {
+		_, _ = fmt.Fprintf(out, "  Error:     %s\n", *detail.ErrorMessage)
+	}
+	_, _ = fmt.Fprintf(out, "  Queued:    %s\n", formatTimeAgo(detail.QueuedAt))
+	if detail.StartedAt != nil {
+		_, _ = fmt.Fprintf(out, "  Started:   %s\n", formatTimeAgo(*detail.StartedAt))
+	}
+	if detail.FinishedAt != nil {
+		_, _ = fmt.Fprintf(out, "  Finished:  %s\n", formatTimeAgo(*detail.FinishedAt))
+	}
+	_, _ = fmt.Fprintln(out)
+	if len(detail.Steps) == 0 {
+		_, _ = fmt.Fprintln(out, "No steps planned yet.")
+		return
+	}
+	writer := table.NewWriter()
+	writer.SetOutputMirror(out)
+	writer.SetStyle(table.StyleRounded)
+	writer.AppendHeader(table.Row{"STEP", "STAGE", "KIND", "STATUS", "EXIT"})
+	for _, step := range detail.Steps {
+		exitCode := "-"
+		if step.ExitCode != nil {
+			exitCode = fmt.Sprintf("%d", *step.ExitCode)
+		}
+		writer.AppendRow(table.Row{
+			step.StepKey,
+			step.Stage,
+			step.Kind,
+			renderColouredStatus(pipelineOutcomeLabel(step.Status, step.Outcome)),
+			exitCode,
+		})
+	}
+	writer.Render()
+}
+
+func newPipelineCancelCommand() *cobra.Command {
+	cancelCommand := &cobra.Command{
+		Use:     "cancel <run>",
+		Aliases: []string{"stop"},
+		Short:   "Cancel a pipeline run that has not concluded",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			selector, selectorError := resolvePipelineSelector(command)
+			if selectorError != nil {
+				return selectorError
+			}
+			return runPipelineCancel(command, selector, arguments[0])
+		},
+	}
+	registerPipelineSelectorFlags(cancelCommand)
+	registerStructuredOutputFlags(cancelCommand)
+	return cancelCommand
+}
+
+func runPipelineCancel(command *cobra.Command, selector client.PipelineSelector, runID string) error {
+	run, cancelError := apiClient.CancelPipelineRun(command.Context(), selector, strings.TrimSpace(runID))
+	if cancelError != nil {
+		return cancelError
+	}
+	if rendered, renderError := renderStructured(command, run); rendered || renderError != nil {
+		return renderError
+	}
+	_, _ = fmt.Fprintf(command.OutOrStdout(), "Run #%d cancelled (status: %s)\n", run.RunNumber, run.Status)
+	return nil
+}
+
+func newPipelineRerunCommand() *cobra.Command {
+	rerunCommand := &cobra.Command{
+		Use:   "rerun <run>",
+		Short: "Re-run a concluded pipeline run",
+		Long: `Open a new run from a run that already happened.
+
+The new run is a fresh run, not a retry of the old one: the old run's outcome
+stays the record of what happened, and 'rerun_of_run_id' ties the two together.
+--failed-only restricts the new run to the steps that did not succeed and
+whatever depended on them.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			selector, selectorError := resolvePipelineSelector(command)
+			if selectorError != nil {
+				return selectorError
+			}
+			return runPipelineRerun(command, selector, arguments[0])
+		},
+	}
+	registerPipelineSelectorFlags(rerunCommand)
+	rerunCommand.Flags().Bool("failed-only", false, "Re-run only the steps that did not succeed, and whatever depends on them")
+	rerunCommand.Flags().Bool("wait", false, "Wait for the new run to conclude before returning")
+	registerStructuredOutputFlags(rerunCommand)
+	return rerunCommand
+}
+
+func runPipelineRerun(command *cobra.Command, selector client.PipelineSelector, runID string) error {
+	format, formatError := structuredFormatFromFlags(command)
+	if formatError != nil {
+		return formatError
+	}
+	failedOnly, _ := command.Flags().GetBool("failed-only")
+	wait, _ := command.Flags().GetBool("wait")
+
+	result, rerunError := apiClient.RerunPipelineRun(command.Context(), selector, strings.TrimSpace(runID), failedOnly)
+	if rerunError != nil {
+		return rerunError
+	}
+	if !wait {
+		if rendered, renderError := renderStructured(command, result); rendered || renderError != nil {
+			return renderError
+		}
+		_, _ = fmt.Fprintf(command.OutOrStdout(), "Run #%d queued: %s\n", result.RunNumber, result.PipelineRunID)
+		return nil
+	}
+	detail, waitError := waitForPipelineRunConclusion(command, selector, result.PipelineRunID)
+	if waitError != nil {
+		return waitError
+	}
+	if format != outputDefault {
+		return encodeStructured(command.OutOrStdout(), format, detail)
+	}
+	printPipelineRunDetail(command.OutOrStdout(), *detail)
+	return pipelineRunConclusionError(detail.PipelineRun)
+}

--- a/cmd/pipeline_run.go
+++ b/cmd/pipeline_run.go
@@ -7,6 +7,7 @@ package cmd
 // argument, so the two surfaces cannot drift.
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -139,16 +140,41 @@ func waitForPipelineRunConclusion(command *cobra.Command, selector client.Pipeli
 		if detail.Status == "concluded" {
 			return detail, nil
 		}
-		time.Sleep(pipelineRunWaitPollInterval)
+		if sleepError := sleepInterrupted(command.Context(), pipelineRunWaitPollInterval); sleepError != nil {
+			return nil, sleepError
+		}
+	}
+}
+
+// sleepInterrupted waits, or stops early when the command is interrupted. A
+// bare time.Sleep would hold a Ctrl+C until the next network call noticed the
+// cancelled context, which for a poll interval means the user waits for a
+// command they already stopped.
+func sleepInterrupted(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
 	}
 }
 
 // pipelineRunConclusionError reports a non-success conclusion as an error so
 // `--wait` exits non-zero on a failed run, the way a CI step should.
+//
+// A run that concluded with no outcome recorded at all is reported as that
+// rather than as a named failure: it is the same distinction the rest of this
+// lane keeps, and telling someone their run "concluded -" sends them looking
+// for an outcome nothing wrote.
 func pipelineRunConclusionError(run client.PipelineRun) error {
 	outcome := pipelineOptionalString(run.Outcome)
 	if outcome == "success" {
 		return nil
+	}
+	if run.Outcome == nil || strings.TrimSpace(*run.Outcome) == "" {
+		return fmt.Errorf("run #%d concluded without recording an outcome", run.RunNumber)
 	}
 	message := fmt.Sprintf("run #%d concluded %s", run.RunNumber, outcome)
 	if run.ErrorMessage != nil && *run.ErrorMessage != "" {

--- a/cmd/pipeline_schedules.go
+++ b/cmd/pipeline_schedules.go
@@ -208,11 +208,21 @@ func runPipelineSchedulesUpdate(command *cobra.Command, selector client.Pipeline
 	}
 	switch {
 	case enabledChanged:
-		enabled := true
+		// The flag's value, not its presence: `--enabled=false` asks for a
+		// disabled schedule, and reading only Changed() would enable the very
+		// schedule the caller was turning off.
+		enabled, enabledError := command.Flags().GetBool("enabled")
+		if enabledError != nil {
+			return enabledError
+		}
 		request.Enabled = &enabled
 	case disabledChanged:
-		disabled := false
-		request.Enabled = &disabled
+		disabled, disabledError := command.Flags().GetBool("disabled")
+		if disabledError != nil {
+			return disabledError
+		}
+		wanted := !disabled
+		request.Enabled = &wanted
 	}
 	if request.Cron == nil && request.Timezone == nil && request.Ref == nil &&
 		request.Inputs == nil && request.Enabled == nil {

--- a/cmd/pipeline_schedules.go
+++ b/cmd/pipeline_schedules.go
@@ -1,0 +1,267 @@
+package cmd
+
+// Cron schedules (go/internal/pipelineapi/schedules.go). The loop that fires
+// them is a later WS-I item; these commands only guarantee that nothing it
+// will ever read was stored without proving it can fire (the server validates
+// the cron expression and timezone synchronously on create/update).
+
+import (
+	"fmt"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+func newPipelineSchedulesCommand() *cobra.Command {
+	schedulesCommand := &cobra.Command{
+		Use:   "schedules",
+		Short: "Manage a pipeline's cron schedules",
+	}
+	schedulesCommand.AddCommand(
+		newPipelineSchedulesListCommand(),
+		newPipelineSchedulesCreateCommand(),
+		newPipelineSchedulesUpdateCommand(),
+		newPipelineSchedulesDeleteCommand(),
+	)
+	return schedulesCommand
+}
+
+func newPipelineSchedulesListCommand() *cobra.Command {
+	listCommand := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List a pipeline's cron schedules",
+		Args:    cobra.NoArgs,
+		RunE: func(command *cobra.Command, arguments []string) error {
+			selector, selectorError := resolvePipelineSelector(command)
+			if selectorError != nil {
+				return selectorError
+			}
+			return runPipelineSchedulesList(command, selector)
+		},
+	}
+	registerPipelineSelectorFlags(listCommand)
+	registerStructuredOutputFlags(listCommand)
+	return listCommand
+}
+
+func runPipelineSchedulesList(command *cobra.Command, selector client.PipelineSelector) error {
+	format, formatError := structuredFormatFromFlags(command)
+	if formatError != nil {
+		return formatError
+	}
+	list, listError := apiClient.ListPipelineSchedules(command.Context(), selector)
+	if listError != nil {
+		return listError
+	}
+	if format != outputDefault {
+		return encodeStructured(command.OutOrStdout(), format, list)
+	}
+	if len(list.Schedules) == 0 {
+		_, _ = fmt.Fprintln(command.OutOrStdout(), "No schedules configured for this pipeline.")
+		return nil
+	}
+	writer := table.NewWriter()
+	writer.SetOutputMirror(command.OutOrStdout())
+	writer.SetStyle(table.StyleRounded)
+	writer.AppendHeader(table.Row{"ID", "CRON", "TIMEZONE", "REF", "ENABLED", "NEXT FIRE", "LAST FIRED"})
+	for _, schedule := range list.Schedules {
+		writer.AppendRow(table.Row{
+			schedule.ID,
+			schedule.Cron,
+			schedule.Timezone,
+			schedule.Ref,
+			schedule.Enabled,
+			pipelineOptionalTimeAgo(schedule.NextFireAt),
+			pipelineOptionalTimeAgo(schedule.LastFiredAt),
+		})
+	}
+	writer.Render()
+	return nil
+}
+
+func pipelineOptionalTimeAgo(value *string) string {
+	if value == nil || *value == "" {
+		return "-"
+	}
+	return formatTimeAgo(*value)
+}
+
+func newPipelineSchedulesCreateCommand() *cobra.Command {
+	createCommand := &cobra.Command{
+		Use:   "create",
+		Short: "Add a cron schedule",
+		Args:  cobra.NoArgs,
+		RunE: func(command *cobra.Command, arguments []string) error {
+			selector, selectorError := resolvePipelineSelector(command)
+			if selectorError != nil {
+				return selectorError
+			}
+			return runPipelineSchedulesCreate(command, selector)
+		},
+	}
+	registerPipelineSelectorFlags(createCommand)
+	createCommand.Flags().String("cron", "", "Cron expression (required)")
+	createCommand.Flags().String("timezone", "", "IANA timezone the cron is evaluated in (default UTC)")
+	createCommand.Flags().String("ref", "", "Git reference the schedule runs at (default the repository's default branch)")
+	createCommand.Flags().StringArray("input", nil, "Dispatch input as key=value (repeatable)")
+	createCommand.Flags().Bool("enabled", true, "Whether the schedule fires")
+	registerStructuredOutputFlags(createCommand)
+	return createCommand
+}
+
+func runPipelineSchedulesCreate(command *cobra.Command, selector client.PipelineSelector) error {
+	cron, _ := command.Flags().GetString("cron")
+	timezone, _ := command.Flags().GetString("timezone")
+	ref, _ := command.Flags().GetString("ref")
+	rawInputs, _ := command.Flags().GetStringArray("input")
+	enabled, _ := command.Flags().GetBool("enabled")
+
+	cron = strings.TrimSpace(cron)
+	if cron == "" {
+		return withExitCode(exitUsage, fmt.Errorf("--cron is required"))
+	}
+	inputs, inputsError := parsePipelineInputFlags(rawInputs)
+	if inputsError != nil {
+		return inputsError
+	}
+
+	schedule, createError := apiClient.CreatePipelineSchedule(command.Context(), selector, client.CreatePipelineScheduleRequest{
+		Cron:     cron,
+		Timezone: strings.TrimSpace(timezone),
+		Ref:      strings.TrimSpace(ref),
+		Inputs:   inputs,
+		Enabled:  &enabled,
+	})
+	if createError != nil {
+		return createError
+	}
+	if rendered, renderError := renderStructured(command, schedule); rendered || renderError != nil {
+		return renderError
+	}
+	_, _ = fmt.Fprintf(command.OutOrStdout(), "Schedule created: %s (%s %s)\n", schedule.ID, schedule.Cron, schedule.Timezone)
+	return nil
+}
+
+func newPipelineSchedulesUpdateCommand() *cobra.Command {
+	updateCommand := &cobra.Command{
+		Use:   "update <schedule-id>",
+		Short: "Change a cron schedule",
+		Long: `Change a cron schedule. Every flag is optional and only what is given
+changes - an update that names only --enabled leaves the cron, timezone, ref,
+and inputs exactly as they were.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			selector, selectorError := resolvePipelineSelector(command)
+			if selectorError != nil {
+				return selectorError
+			}
+			return runPipelineSchedulesUpdate(command, selector, arguments[0])
+		},
+	}
+	registerPipelineSelectorFlags(updateCommand)
+	updateCommand.Flags().String("cron", "", "New cron expression")
+	updateCommand.Flags().String("timezone", "", "New IANA timezone")
+	updateCommand.Flags().String("ref", "", "New git reference")
+	updateCommand.Flags().StringArray("input", nil, "Replace the dispatch inputs entirely, as key=value (repeatable)")
+	updateCommand.Flags().Bool("enabled", false, "Enable the schedule")
+	updateCommand.Flags().Bool("disabled", false, "Disable the schedule")
+	registerStructuredOutputFlags(updateCommand)
+	return updateCommand
+}
+
+func runPipelineSchedulesUpdate(command *cobra.Command, selector client.PipelineSelector, scheduleID string) error {
+	request := client.UpdatePipelineScheduleRequest{}
+	if command.Flags().Changed("cron") {
+		cron, _ := command.Flags().GetString("cron")
+		cron = strings.TrimSpace(cron)
+		request.Cron = &cron
+	}
+	if command.Flags().Changed("timezone") {
+		timezone, _ := command.Flags().GetString("timezone")
+		timezone = strings.TrimSpace(timezone)
+		request.Timezone = &timezone
+	}
+	if command.Flags().Changed("ref") {
+		ref, _ := command.Flags().GetString("ref")
+		ref = strings.TrimSpace(ref)
+		request.Ref = &ref
+	}
+	if command.Flags().Changed("input") {
+		rawInputs, _ := command.Flags().GetStringArray("input")
+		inputs, inputsError := parsePipelineInputFlags(rawInputs)
+		if inputsError != nil {
+			return inputsError
+		}
+		if inputs == nil {
+			inputs = map[string]string{}
+		}
+		request.Inputs = &inputs
+	}
+	enabledChanged := command.Flags().Changed("enabled")
+	disabledChanged := command.Flags().Changed("disabled")
+	if enabledChanged && disabledChanged {
+		return withExitCode(exitUsage, fmt.Errorf("--enabled and --disabled are mutually exclusive"))
+	}
+	switch {
+	case enabledChanged:
+		enabled := true
+		request.Enabled = &enabled
+	case disabledChanged:
+		disabled := false
+		request.Enabled = &disabled
+	}
+	if request.Cron == nil && request.Timezone == nil && request.Ref == nil &&
+		request.Inputs == nil && request.Enabled == nil {
+		return withExitCode(exitUsage, fmt.Errorf("nothing to update - pass at least one of "+
+			"--cron, --timezone, --ref, --input, --enabled, or --disabled"))
+	}
+
+	schedule, updateError := apiClient.UpdatePipelineSchedule(command.Context(), selector,
+		strings.TrimSpace(scheduleID), request)
+	if updateError != nil {
+		return updateError
+	}
+	if rendered, renderError := renderStructured(command, schedule); rendered || renderError != nil {
+		return renderError
+	}
+	_, _ = fmt.Fprintf(command.OutOrStdout(), "Schedule updated: %s (%s %s, enabled: %t)\n",
+		schedule.ID, schedule.Cron, schedule.Timezone, schedule.Enabled)
+	return nil
+}
+
+func newPipelineSchedulesDeleteCommand() *cobra.Command {
+	deleteCommand := &cobra.Command{
+		Use:     "delete <schedule-id>",
+		Aliases: []string{"rm"},
+		Short:   "Remove a cron schedule",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			selector, selectorError := resolvePipelineSelector(command)
+			if selectorError != nil {
+				return selectorError
+			}
+			return runPipelineSchedulesDelete(command, selector, arguments[0])
+		},
+	}
+	registerPipelineSelectorFlags(deleteCommand)
+	deleteCommand.Flags().Bool("yes", false, "Skip the confirmation prompt")
+	return deleteCommand
+}
+
+func runPipelineSchedulesDelete(command *cobra.Command, selector client.PipelineSelector, scheduleID string) error {
+	scheduleID = strings.TrimSpace(scheduleID)
+	skipConfirmation, _ := command.Flags().GetBool("yes")
+	confirmMessage := fmt.Sprintf("Delete pipeline schedule %s? [y/N] ", scheduleID)
+	if confirmError := confirmPrompt(command.InOrStdin(), command.OutOrStdout(), confirmMessage, skipConfirmation); confirmError != nil {
+		return confirmError
+	}
+	if deleteError := apiClient.DeletePipelineSchedule(command.Context(), selector, scheduleID); deleteError != nil {
+		return deleteError
+	}
+	_, _ = fmt.Fprintf(command.OutOrStdout(), "Schedule %s deleted.\n", scheduleID)
+	return nil
+}

--- a/cmd/pipeline_test.go
+++ b/cmd/pipeline_test.go
@@ -1,0 +1,573 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// pipelineLaneMock stubs the pipeline surface of APIClient with call
+// tracking, so a test can assert both what was returned and what the CLI
+// asked for.
+type pipelineLaneMock struct {
+	baseMock
+
+	lastSelector client.PipelineSelector
+
+	listOptions client.ListPipelineRunsOptions
+	listResult  *client.PipelineRunList
+	listError   error
+
+	createRequest client.CreatePipelineRunRequest
+	createResult  *client.CreatePipelineRunResult
+	createError   error
+	createCalls   int
+
+	getRunID  string
+	getResult *client.PipelineRunDetail
+	getError  error
+
+	cancelRunID  string
+	cancelResult *client.PipelineRun
+	cancelError  error
+
+	rerunRunID      string
+	rerunFailedOnly bool
+	rerunResult     *client.CreatePipelineRunResult
+	rerunError      error
+
+	artifactsRunID  string
+	artifactsResult *client.PipelineArtifactList
+	artifactsError  error
+
+	downloadArtifactID string
+	downloadError      error
+	downloadPayload    string
+
+	definitionResult *client.PipelineDefinition
+	definitionError  error
+	putSpecYAML      string
+
+	validateSpecYAML string
+	validateResult   *client.PipelineValidation
+	validateError    error
+
+	schedulesResult *client.PipelineScheduleList
+	schedulesError  error
+
+	createScheduleRequest client.CreatePipelineScheduleRequest
+	createScheduleResult  *client.PipelineSchedule
+	createScheduleError   error
+
+	updateScheduleID      string
+	updateScheduleRequest client.UpdatePipelineScheduleRequest
+	updateScheduleResult  *client.PipelineSchedule
+	updateScheduleError   error
+
+	deleteScheduleID    string
+	deleteScheduleError error
+}
+
+func (mock *pipelineLaneMock) ListPipelineRuns(ctx context.Context, selector client.PipelineSelector, options client.ListPipelineRunsOptions) (*client.PipelineRunList, error) {
+	mock.lastSelector = selector
+	mock.listOptions = options
+	if mock.listError != nil {
+		return nil, mock.listError
+	}
+	return mock.listResult, nil
+}
+
+func (mock *pipelineLaneMock) CreatePipelineRun(ctx context.Context, selector client.PipelineSelector, request client.CreatePipelineRunRequest) (*client.CreatePipelineRunResult, error) {
+	mock.lastSelector = selector
+	mock.createRequest = request
+	mock.createCalls++
+	if mock.createError != nil {
+		return nil, mock.createError
+	}
+	return mock.createResult, nil
+}
+
+func (mock *pipelineLaneMock) GetPipelineRun(ctx context.Context, selector client.PipelineSelector, runID string) (*client.PipelineRunDetail, error) {
+	mock.lastSelector = selector
+	mock.getRunID = runID
+	if mock.getError != nil {
+		return nil, mock.getError
+	}
+	return mock.getResult, nil
+}
+
+func (mock *pipelineLaneMock) RerunPipelineRun(ctx context.Context, selector client.PipelineSelector, runID string, failedOnly bool) (*client.CreatePipelineRunResult, error) {
+	mock.lastSelector = selector
+	mock.rerunRunID = runID
+	mock.rerunFailedOnly = failedOnly
+	if mock.rerunError != nil {
+		return nil, mock.rerunError
+	}
+	return mock.rerunResult, nil
+}
+
+func (mock *pipelineLaneMock) CancelPipelineRun(ctx context.Context, selector client.PipelineSelector, runID string) (*client.PipelineRun, error) {
+	mock.lastSelector = selector
+	mock.cancelRunID = runID
+	if mock.cancelError != nil {
+		return nil, mock.cancelError
+	}
+	return mock.cancelResult, nil
+}
+
+func (mock *pipelineLaneMock) StreamPipelineStepLogs(ctx context.Context, selector client.PipelineSelector, runID string, stepID string, fromSequence int64) (<-chan client.PipelineLogEvent, error) {
+	events := make(chan client.PipelineLogEvent)
+	close(events)
+	return events, nil
+}
+
+func (mock *pipelineLaneMock) ListPipelineArtifacts(ctx context.Context, selector client.PipelineSelector, runID string) (*client.PipelineArtifactList, error) {
+	mock.lastSelector = selector
+	mock.artifactsRunID = runID
+	if mock.artifactsError != nil {
+		return nil, mock.artifactsError
+	}
+	return mock.artifactsResult, nil
+}
+
+func (mock *pipelineLaneMock) DownloadPipelineArtifact(ctx context.Context, selector client.PipelineSelector, artifactID string, destination io.Writer) error {
+	mock.lastSelector = selector
+	mock.downloadArtifactID = artifactID
+	if mock.downloadError != nil {
+		return mock.downloadError
+	}
+	_, writeError := destination.Write([]byte(mock.downloadPayload))
+	return writeError
+}
+
+func (mock *pipelineLaneMock) GetPipelineDefinition(ctx context.Context, selector client.PipelineSelector) (*client.PipelineDefinition, error) {
+	mock.lastSelector = selector
+	if mock.definitionError != nil {
+		return nil, mock.definitionError
+	}
+	return mock.definitionResult, nil
+}
+
+func (mock *pipelineLaneMock) PutPipelineDefinition(ctx context.Context, selector client.PipelineSelector, specYAML string) (*client.PipelineDefinition, error) {
+	mock.lastSelector = selector
+	mock.putSpecYAML = specYAML
+	if mock.definitionError != nil {
+		return nil, mock.definitionError
+	}
+	return mock.definitionResult, nil
+}
+
+func (mock *pipelineLaneMock) ValidatePipelineDefinition(ctx context.Context, selector client.PipelineSelector, specYAML string) (*client.PipelineValidation, error) {
+	mock.lastSelector = selector
+	mock.validateSpecYAML = specYAML
+	if mock.validateError != nil {
+		return nil, mock.validateError
+	}
+	return mock.validateResult, nil
+}
+
+func (mock *pipelineLaneMock) ListPipelineSchedules(ctx context.Context, selector client.PipelineSelector) (*client.PipelineScheduleList, error) {
+	mock.lastSelector = selector
+	if mock.schedulesError != nil {
+		return nil, mock.schedulesError
+	}
+	return mock.schedulesResult, nil
+}
+
+func (mock *pipelineLaneMock) CreatePipelineSchedule(ctx context.Context, selector client.PipelineSelector, request client.CreatePipelineScheduleRequest) (*client.PipelineSchedule, error) {
+	mock.lastSelector = selector
+	mock.createScheduleRequest = request
+	if mock.createScheduleError != nil {
+		return nil, mock.createScheduleError
+	}
+	return mock.createScheduleResult, nil
+}
+
+func (mock *pipelineLaneMock) UpdatePipelineSchedule(ctx context.Context, selector client.PipelineSelector, scheduleID string, request client.UpdatePipelineScheduleRequest) (*client.PipelineSchedule, error) {
+	mock.lastSelector = selector
+	mock.updateScheduleID = scheduleID
+	mock.updateScheduleRequest = request
+	if mock.updateScheduleError != nil {
+		return nil, mock.updateScheduleError
+	}
+	return mock.updateScheduleResult, nil
+}
+
+func (mock *pipelineLaneMock) DeletePipelineSchedule(ctx context.Context, selector client.PipelineSelector, scheduleID string) error {
+	mock.lastSelector = selector
+	mock.deleteScheduleID = scheduleID
+	return mock.deleteScheduleError
+}
+
+func runPipelineCommand(t *testing.T, mockClient APIClient, arguments ...string) (string, error) {
+	t.Helper()
+	previousClient := apiClient
+	apiClient = mockClient
+	t.Cleanup(func() { apiClient = previousClient })
+
+	pipelineCommand := newPipelineCommand()
+	var output bytes.Buffer
+	pipelineCommand.SetOut(&output)
+	pipelineCommand.SetErr(&output)
+	pipelineCommand.SetArgs(arguments)
+	executeError := pipelineCommand.Execute()
+	return output.String(), executeError
+}
+
+func TestPipelineCommandsRegistered(t *testing.T) {
+	pipelineCommand := newPipelineCommand()
+	registered := map[string]bool{}
+	for _, subcommand := range pipelineCommand.Commands() {
+		registered[subcommand.Name()] = true
+	}
+	for _, expected := range []string{
+		"run", "list", "get", "cancel", "rerun", "logs", "artifacts", "validate", "definition", "schedules",
+	} {
+		if !registered[expected] {
+			t.Errorf("pipeline subcommand %q is not registered", expected)
+		}
+	}
+
+	artifactsCommand := findSubcommand(t, pipelineCommand, "artifacts")
+	if findSubcommandOrNil(artifactsCommand, "download") == nil {
+		t.Error("pipeline artifacts subcommand \"download\" is not registered")
+	}
+	definitionCommand := findSubcommand(t, pipelineCommand, "definition")
+	for _, expected := range []string{"get", "put"} {
+		if findSubcommandOrNil(definitionCommand, expected) == nil {
+			t.Errorf("pipeline definition subcommand %q is not registered", expected)
+		}
+	}
+	schedulesCommand := findSubcommand(t, pipelineCommand, "schedules")
+	for _, expected := range []string{"list", "create", "update", "delete"} {
+		if findSubcommandOrNil(schedulesCommand, expected) == nil {
+			t.Errorf("pipeline schedules subcommand %q is not registered", expected)
+		}
+	}
+}
+
+func TestApplicationPipelineCommandsRegistered(t *testing.T) {
+	applicationPipelineCommand := findSubcommand(t, newApplicationCommand(), "pipeline")
+	for _, expected := range []string{
+		"run", "list", "get", "cancel", "rerun", "logs", "artifacts", "validate", "definition", "schedules",
+	} {
+		if findSubcommandOrNil(applicationPipelineCommand, expected) == nil {
+			t.Errorf("application pipeline subcommand %q is not registered", expected)
+		}
+	}
+}
+
+func findSubcommand(t *testing.T, parent *cobra.Command, name string) *cobra.Command {
+	t.Helper()
+	found := findSubcommandOrNil(parent, name)
+	if found == nil {
+		t.Fatalf("subcommand %q is not registered under %q", name, parent.Use)
+	}
+	return found
+}
+
+func findSubcommandOrNil(parent *cobra.Command, name string) *cobra.Command {
+	if parent == nil {
+		return nil
+	}
+	for _, subcommand := range parent.Commands() {
+		if subcommand.Name() == name {
+			return subcommand
+		}
+	}
+	return nil
+}
+
+func TestPipelineSelectorRequiresExactlyOne(t *testing.T) {
+	mockClient := &pipelineLaneMock{}
+	_, executeError := runPipelineCommand(t, mockClient, "list")
+	if executeError == nil {
+		t.Fatal("expected an error when neither --application nor --repository is given")
+	}
+	if exitCodeFor(executeError) != exitUsage {
+		t.Errorf("exit code = %d, want %d", exitCodeFor(executeError), exitUsage)
+	}
+
+	_, executeError = runPipelineCommand(t, mockClient, "list", "--application", testApplicationID, "--repository", "repo-1")
+	if executeError == nil {
+		t.Fatal("expected an error when both --application and --repository are given")
+	}
+	if exitCodeFor(executeError) != exitUsage {
+		t.Errorf("exit code = %d, want %d", exitCodeFor(executeError), exitUsage)
+	}
+}
+
+func TestPipelineSelectorRepositoryMustBeAnID(t *testing.T) {
+	mockClient := &pipelineLaneMock{}
+	_, executeError := runPipelineCommand(t, mockClient, "list", "--repository", "acme/webapp")
+	if executeError == nil {
+		t.Fatal("expected --repository owner/name to be refused")
+	}
+	if exitCodeFor(executeError) != exitUsage {
+		t.Errorf("exit code = %d, want %d", exitCodeFor(executeError), exitUsage)
+	}
+	if !strings.Contains(executeError.Error(), "there is no lookup by owner/name") {
+		t.Errorf("error = %q, want it to explain the gap", executeError.Error())
+	}
+}
+
+func TestPipelineListEmpty(t *testing.T) {
+	mockClient := &pipelineLaneMock{listResult: &client.PipelineRunList{Runs: []client.PipelineRun{}}}
+	output, executeError := runPipelineCommand(t, mockClient, "list", "--application", testApplicationID)
+	if executeError != nil {
+		t.Fatalf("list error = %v", executeError)
+	}
+	if !strings.Contains(output, "No pipeline runs found") {
+		t.Errorf("output = %q", output)
+	}
+	if mockClient.lastSelector.ApplicationID != testApplicationID {
+		t.Errorf("selector = %+v", mockClient.lastSelector)
+	}
+}
+
+func TestPipelineListHappyPathRendersTable(t *testing.T) {
+	mockClient := &pipelineLaneMock{listResult: &client.PipelineRunList{Runs: []client.PipelineRun{
+		{ID: "run-1", RunNumber: 12, Status: "concluded", Outcome: strPipelinePtr("success"),
+			Trigger: "push", TriggerRef: "refs/heads/main", HeadSHA: strings.Repeat("a", 40),
+			QueuedAt: "2026-09-01T00:00:00Z"},
+	}}}
+	output, executeError := runPipelineCommand(t, mockClient, "list", "--application", testApplicationID, "--status", "concluded", "--limit", "5")
+	if executeError != nil {
+		t.Fatalf("list error = %v", executeError)
+	}
+	if !strings.Contains(output, "run-1") || !strings.Contains(output, "12") {
+		t.Errorf("output = %q", output)
+	}
+	if mockClient.listOptions.Status != "concluded" || mockClient.listOptions.Limit != 5 {
+		t.Errorf("list options = %+v", mockClient.listOptions)
+	}
+}
+
+func TestPipelineGetNotFound(t *testing.T) {
+	mockClient := &pipelineLaneMock{getError: errors.New("Pipeline run not found")}
+	_, executeError := runPipelineCommand(t, mockClient, "get", "missing-run", "--application", testApplicationID)
+	if executeError == nil || executeError.Error() != "Pipeline run not found" {
+		t.Fatalf("error = %v, want the sentinel text verbatim", executeError)
+	}
+}
+
+func TestPipelineRunRequiresSHA(t *testing.T) {
+	mockClient := &pipelineLaneMock{}
+	_, executeError := runPipelineCommand(t, mockClient, "run", "--application", testApplicationID, "--ref", "main")
+	if executeError == nil {
+		t.Fatal("expected --sha to be required")
+	}
+	if exitCodeFor(executeError) != exitUsage {
+		t.Errorf("exit code = %d, want %d", exitCodeFor(executeError), exitUsage)
+	}
+	if mockClient.createCalls != 0 {
+		t.Errorf("CreatePipelineRun calls = %d, want 0", mockClient.createCalls)
+	}
+}
+
+func TestPipelineRunPassesInputsAndSelector(t *testing.T) {
+	mockClient := &pipelineLaneMock{createResult: &client.CreatePipelineRunResult{
+		RunID: "umbrella-1", PipelineRunID: "run-1", RunNumber: 7,
+	}}
+	sha := strings.Repeat("b", 40)
+	output, executeError := runPipelineCommand(t, mockClient, "run",
+		"--application", testApplicationID, "--sha", sha, "--input", "env=staging", "--input", "replicas=3")
+	if executeError != nil {
+		t.Fatalf("run error = %v", executeError)
+	}
+	if mockClient.createRequest.HeadSHA != sha {
+		t.Errorf("head sha = %q", mockClient.createRequest.HeadSHA)
+	}
+	if mockClient.createRequest.Inputs["env"] != "staging" || mockClient.createRequest.Inputs["replicas"] != "3" {
+		t.Errorf("inputs = %+v", mockClient.createRequest.Inputs)
+	}
+	if !strings.Contains(output, "Run #7 queued") {
+		t.Errorf("output = %q", output)
+	}
+}
+
+func TestPipelineRunPlanRefusalCarriesDiagnostics(t *testing.T) {
+	mockClient := &pipelineLaneMock{createError: &client.PipelineValidationError{
+		Reason:      "This pipeline definition has at least one fatal violation",
+		Diagnostics: []string{"pipeline_stages: stage \"build\" has no kind"},
+	}}
+	sha := strings.Repeat("c", 40)
+	_, executeError := runPipelineCommand(t, mockClient, "run", "--application", testApplicationID, "--sha", sha)
+	if executeError == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(executeError.Error(), "fatal violation") || !strings.Contains(executeError.Error(), "has no kind") {
+		t.Errorf("error = %q, want the reason and the diagnostic both rendered", executeError.Error())
+	}
+}
+
+func TestPipelineCancelRendersOutcome(t *testing.T) {
+	mockClient := &pipelineLaneMock{cancelResult: &client.PipelineRun{ID: "run-1", RunNumber: 4, Status: "concluded"}}
+	output, executeError := runPipelineCommand(t, mockClient, "cancel", "run-1", "--application", testApplicationID)
+	if executeError != nil {
+		t.Fatalf("cancel error = %v", executeError)
+	}
+	if mockClient.cancelRunID != "run-1" {
+		t.Errorf("cancel run id = %q", mockClient.cancelRunID)
+	}
+	if !strings.Contains(output, "Run #4 cancelled") {
+		t.Errorf("output = %q", output)
+	}
+}
+
+func TestPipelineCancelAlreadyConcluded(t *testing.T) {
+	mockClient := &pipelineLaneMock{cancelError: errors.New("This pipeline run has already concluded")}
+	_, executeError := runPipelineCommand(t, mockClient, "cancel", "run-1", "--application", testApplicationID)
+	if executeError == nil || executeError.Error() != "This pipeline run has already concluded" {
+		t.Fatalf("error = %v", executeError)
+	}
+}
+
+func TestPipelineRerunPassesFailedOnly(t *testing.T) {
+	mockClient := &pipelineLaneMock{rerunResult: &client.CreatePipelineRunResult{PipelineRunID: "run-2", RunNumber: 8}}
+	_, executeError := runPipelineCommand(t, mockClient, "rerun", "run-1", "--application", testApplicationID, "--failed-only")
+	if executeError != nil {
+		t.Fatalf("rerun error = %v", executeError)
+	}
+	if !mockClient.rerunFailedOnly {
+		t.Error("failed-only was not passed through")
+	}
+	if mockClient.rerunRunID != "run-1" {
+		t.Errorf("rerun run id = %q", mockClient.rerunRunID)
+	}
+}
+
+func TestPipelineArtifactsListEmpty(t *testing.T) {
+	mockClient := &pipelineLaneMock{artifactsResult: &client.PipelineArtifactList{Artifacts: []client.PipelineArtifact{}}}
+	output, executeError := runPipelineCommand(t, mockClient, "artifacts", "run-1", "--application", testApplicationID)
+	if executeError != nil {
+		t.Fatalf("artifacts error = %v", executeError)
+	}
+	if !strings.Contains(output, "No artifacts stored") {
+		t.Errorf("output = %q", output)
+	}
+}
+
+func TestPipelineArtifactsDownloadWritesFile(t *testing.T) {
+	mockClient := &pipelineLaneMock{downloadPayload: "binary-content"}
+	outputPath := t.TempDir() + "/artifact.bin"
+	_, executeError := runPipelineCommand(t, mockClient, "artifacts", "download", "artifact-1",
+		"--application", testApplicationID, "--out", outputPath)
+	if executeError != nil {
+		t.Fatalf("download error = %v", executeError)
+	}
+	if mockClient.downloadArtifactID != "artifact-1" {
+		t.Errorf("artifact id = %q", mockClient.downloadArtifactID)
+	}
+}
+
+func TestPipelineValidateFatalExitsNonZero(t *testing.T) {
+	mockClient := &pipelineLaneMock{validateResult: &client.PipelineValidation{
+		Severity:   "fatal",
+		Violations: []string{"pipeline_stages: at least one stage is required"},
+		Events:     []client.PipelineEventPlan{},
+	}}
+	_, executeError := runPipelineCommand(t, mockClient, "validate", "--application", testApplicationID)
+	if executeError == nil {
+		t.Fatal("expected a fatal validation to exit non-zero")
+	}
+}
+
+func TestPipelineValidateOKPassesThroughFileContent(t *testing.T) {
+	mockClient := &pipelineLaneMock{validateResult: &client.PipelineValidation{Severity: "ok", Events: []client.PipelineEventPlan{}}}
+	fixturePath := t.TempDir() + "/pipeline.yaml"
+	if writeError := os.WriteFile(fixturePath, []byte("apiVersion: ankra.io/v1\nkind: Pipeline\n"), 0o600); writeError != nil {
+		t.Fatalf("writing fixture: %v", writeError)
+	}
+	_, executeError := runPipelineCommand(t, mockClient, "validate", fixturePath, "--application", testApplicationID)
+	if executeError != nil {
+		t.Fatalf("validate error = %v", executeError)
+	}
+	if mockClient.validateSpecYAML != "apiVersion: ankra.io/v1\nkind: Pipeline\n" {
+		t.Errorf("spec yaml = %q", mockClient.validateSpecYAML)
+	}
+}
+
+func TestPipelineSchedulesUpdateRequiresAChange(t *testing.T) {
+	mockClient := &pipelineLaneMock{}
+	_, executeError := runPipelineCommand(t, mockClient, "schedules", "update", "sched-1", "--application", testApplicationID)
+	if executeError == nil {
+		t.Fatal("expected a bare update with no flags to fail")
+	}
+	if exitCodeFor(executeError) != exitUsage {
+		t.Errorf("exit code = %d, want %d", exitCodeFor(executeError), exitUsage)
+	}
+}
+
+func TestPipelineSchedulesUpdateEnabledDisabledMutuallyExclusive(t *testing.T) {
+	mockClient := &pipelineLaneMock{}
+	_, executeError := runPipelineCommand(t, mockClient, "schedules", "update", "sched-1",
+		"--application", testApplicationID, "--enabled", "--disabled")
+	if executeError == nil {
+		t.Fatal("expected --enabled and --disabled together to fail")
+	}
+	if exitCodeFor(executeError) != exitUsage {
+		t.Errorf("exit code = %d, want %d", exitCodeFor(executeError), exitUsage)
+	}
+}
+
+func TestPipelineSchedulesUpdateOnlyChangedField(t *testing.T) {
+	mockClient := &pipelineLaneMock{updateScheduleResult: &client.PipelineSchedule{ID: "sched-1", Enabled: false}}
+	_, executeError := runPipelineCommand(t, mockClient, "schedules", "update", "sched-1",
+		"--application", testApplicationID, "--disabled")
+	if executeError != nil {
+		t.Fatalf("update error = %v", executeError)
+	}
+	if mockClient.updateScheduleRequest.Cron != nil || mockClient.updateScheduleRequest.Ref != nil {
+		t.Errorf("request = %+v, only Enabled should be set", mockClient.updateScheduleRequest)
+	}
+	if mockClient.updateScheduleRequest.Enabled == nil || *mockClient.updateScheduleRequest.Enabled {
+		t.Errorf("enabled = %v, want a pointer to false", mockClient.updateScheduleRequest.Enabled)
+	}
+}
+
+func TestPipelineSchedulesDeleteConfirms(t *testing.T) {
+	mockClient := &pipelineLaneMock{}
+	previousClient := apiClient
+	apiClient = mockClient
+	t.Cleanup(func() { apiClient = previousClient })
+
+	pipelineCommand := newPipelineCommand()
+	var output bytes.Buffer
+	pipelineCommand.SetOut(&output)
+	pipelineCommand.SetErr(&output)
+	pipelineCommand.SetIn(strings.NewReader("n\n"))
+	pipelineCommand.SetArgs([]string{"schedules", "delete", "sched-1", "--application", testApplicationID})
+	executeError := pipelineCommand.Execute()
+	if executeError == nil || exitCodeFor(executeError) != exitCancelled {
+		t.Fatalf("declined delete error = %v", executeError)
+	}
+	if mockClient.deleteScheduleID != "" {
+		t.Errorf("DeletePipelineSchedule was called despite the decline")
+	}
+}
+
+// TestApplicationPipelineAliasesForceTheApplicationSelector pins that
+// `application pipeline <verb> <application-id> ...` calls the exact same
+// runPipeline* function as `pipeline <verb> --application <application-id>`,
+// by asserting the selector the mock observed.
+func TestApplicationPipelineAliasesForceTheApplicationSelector(t *testing.T) {
+	mockClient := &pipelineLaneMock{listResult: &client.PipelineRunList{Runs: []client.PipelineRun{}}}
+	_, executeError := runApplicationCommand(t, mockClient, "pipeline", "list", testApplicationID)
+	if executeError != nil {
+		t.Fatalf("application pipeline list error = %v", executeError)
+	}
+	if mockClient.lastSelector.ApplicationID != testApplicationID || mockClient.lastSelector.RepositoryID != "" {
+		t.Errorf("selector = %+v", mockClient.lastSelector)
+	}
+}
+
+func strPipelinePtr(value string) *string { return &value }

--- a/cmd/pipeline_test.go
+++ b/cmd/pipeline_test.go
@@ -534,6 +534,30 @@ func TestPipelineSchedulesUpdateOnlyChangedField(t *testing.T) {
 	}
 }
 
+func TestPipelineSchedulesUpdateReadsTheFlagValueNotItsPresence(t *testing.T) {
+	for _, testCase := range []struct {
+		argument string
+		wanted   bool
+	}{
+		{"--enabled=false", false},
+		{"--enabled=true", true},
+		{"--disabled=false", true},
+		{"--disabled=true", false},
+	} {
+		mockClient := &pipelineLaneMock{updateScheduleResult: &client.PipelineSchedule{ID: "sched-1"}}
+		_, executeError := runPipelineCommand(t, mockClient, "schedules", "update", "sched-1",
+			"--application", testApplicationID, testCase.argument)
+		if executeError != nil {
+			t.Fatalf("%s: update error = %v", testCase.argument, executeError)
+		}
+		if mockClient.updateScheduleRequest.Enabled == nil ||
+			*mockClient.updateScheduleRequest.Enabled != testCase.wanted {
+			t.Errorf("%s: enabled = %v, want a pointer to %v", testCase.argument,
+				mockClient.updateScheduleRequest.Enabled, testCase.wanted)
+		}
+	}
+}
+
 func TestPipelineSchedulesDeleteConfirms(t *testing.T) {
 	mockClient := &pipelineLaneMock{}
 	previousClient := apiClient

--- a/cmd/pipeline_test.go
+++ b/cmd/pipeline_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -566,6 +567,23 @@ func TestPipelineArtifactsDownloadRefusesAPathOutsideTheDirectory(t *testing.T) 
 		if executeError == nil {
 			t.Fatalf("--out %q was accepted; a download must not write outside the directory", outside)
 		}
+	}
+}
+
+func TestPipelineArtifactsDownloadUsesOnlyTheBaseNameOfAServerChosenID(t *testing.T) {
+	for _, hostile := range []string{"sub/dir", "/etc/passwd", "../escaped"} {
+		mockClient := &pipelineLaneMock{}
+		_, executeError := runPipelineCommand(t, mockClient, "artifacts", "download", hostile,
+			"--application", testApplicationID)
+		if executeError != nil {
+			// A refusal is fine; what must never happen is a write outside
+			// the working directory, which the base-name reduction prevents.
+			continue
+		}
+		if _, statError := os.Stat(filepath.Base(filepath.Clean(hostile))); statError != nil {
+			t.Fatalf("%q: expected the download to land on its base name, got %v", hostile, statError)
+		}
+		_ = os.Remove(filepath.Base(filepath.Clean(hostile)))
 	}
 }
 

--- a/cmd/pipeline_test.go
+++ b/cmd/pipeline_test.go
@@ -558,6 +558,33 @@ func TestPipelineSchedulesUpdateReadsTheFlagValueNotItsPresence(t *testing.T) {
 	}
 }
 
+func TestPipelineArtifactsDownloadRefusesAPathOutsideTheDirectory(t *testing.T) {
+	for _, outside := range []string{"../escaped", "../../etc/passwd"} {
+		mockClient := &pipelineLaneMock{}
+		_, executeError := runPipelineCommand(t, mockClient, "artifacts", "download", "artifact-1",
+			"--application", testApplicationID, "--out", outside)
+		if executeError == nil {
+			t.Fatalf("--out %q was accepted; a download must not write outside the directory", outside)
+		}
+	}
+}
+
+func TestPipelineRunConclusionErrorNamesAnAbsentOutcomeAsAbsent(t *testing.T) {
+	absent := pipelineRunConclusionError(client.PipelineRun{RunNumber: 7})
+	if absent == nil || !strings.Contains(absent.Error(), "without recording an outcome") {
+		t.Fatalf("a run that concluded with no outcome must say so, got %v", absent)
+	}
+	failed := "failure"
+	named := pipelineRunConclusionError(client.PipelineRun{RunNumber: 8, Outcome: &failed})
+	if named == nil || !strings.Contains(named.Error(), "concluded failure") {
+		t.Fatalf("a named outcome is reported verbatim, got %v", named)
+	}
+	succeeded := "success"
+	if ok := pipelineRunConclusionError(client.PipelineRun{RunNumber: 9, Outcome: &succeeded}); ok != nil {
+		t.Fatalf("a successful run is not an error, got %v", ok)
+	}
+}
+
 func TestPipelineSchedulesDeleteConfirms(t *testing.T) {
 	mockClient := &pipelineLaneMock{}
 	previousClient := apiClient

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -692,4 +692,20 @@ type APIClient interface {
 	TestNotificationRoute(routeID string) (*client.NotificationRouteTestResult, error)
 	PreviewNotificationRoutes(request client.PreviewNotificationRoutesRequest) (*client.NotificationRoutePreview, error)
 	DisableClusterDNSZone(clusterID string) (*client.ClusterDNSZoneResponse, error)
+
+	ListPipelineRuns(ctx context.Context, selector client.PipelineSelector, options client.ListPipelineRunsOptions) (*client.PipelineRunList, error)
+	CreatePipelineRun(ctx context.Context, selector client.PipelineSelector, request client.CreatePipelineRunRequest) (*client.CreatePipelineRunResult, error)
+	GetPipelineRun(ctx context.Context, selector client.PipelineSelector, runID string) (*client.PipelineRunDetail, error)
+	RerunPipelineRun(ctx context.Context, selector client.PipelineSelector, runID string, failedOnly bool) (*client.CreatePipelineRunResult, error)
+	CancelPipelineRun(ctx context.Context, selector client.PipelineSelector, runID string) (*client.PipelineRun, error)
+	StreamPipelineStepLogs(ctx context.Context, selector client.PipelineSelector, runID string, stepID string, fromSequence int64) (<-chan client.PipelineLogEvent, error)
+	ListPipelineArtifacts(ctx context.Context, selector client.PipelineSelector, runID string) (*client.PipelineArtifactList, error)
+	DownloadPipelineArtifact(ctx context.Context, selector client.PipelineSelector, artifactID string, destination io.Writer) error
+	GetPipelineDefinition(ctx context.Context, selector client.PipelineSelector) (*client.PipelineDefinition, error)
+	PutPipelineDefinition(ctx context.Context, selector client.PipelineSelector, specYAML string) (*client.PipelineDefinition, error)
+	ValidatePipelineDefinition(ctx context.Context, selector client.PipelineSelector, specYAML string) (*client.PipelineValidation, error)
+	ListPipelineSchedules(ctx context.Context, selector client.PipelineSelector) (*client.PipelineScheduleList, error)
+	CreatePipelineSchedule(ctx context.Context, selector client.PipelineSelector, request client.CreatePipelineScheduleRequest) (*client.PipelineSchedule, error)
+	UpdatePipelineSchedule(ctx context.Context, selector client.PipelineSelector, scheduleID string, request client.UpdatePipelineScheduleRequest) (*client.PipelineSchedule, error)
+	DeletePipelineSchedule(ctx context.Context, selector client.PipelineSelector, scheduleID string) error
 }

--- a/internal/client/pipeline_logs.go
+++ b/internal/client/pipeline_logs.go
@@ -1,0 +1,129 @@
+package client
+
+// The step log relay client: go/internal/pipelineapi/streams.go relays one
+// step's output as SSE frames over the shared execution_output JetStream
+// stream (the dedicated pipeline_output stream is WS-B item B3; when it lands
+// nothing here changes - the frames, the seq resume cursor and the status
+// codes are the shared sserelay's either way).
+//
+// The relay has no history to replay: a fresh connection (from_seq unset)
+// only sees output published from the moment it connects, because the
+// durable per-step log artifact is WS-C item C1 and does not exist yet. That
+// is a real, current limitation - not a client bug - and PipelineLogEvent
+// carries every frame decoded rather than pretending otherwise.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	neturl "net/url"
+	"strings"
+)
+
+// PipelineLogEvent is one decoded frame from the step log relay.
+//
+// Type is "line" for a step output line, "error" for a stream fault the relay
+// reported before closing (its own ErrorFrame, or a local read failure), and
+// "" is never sent - callers switch on Type.
+type PipelineLogEvent struct {
+	Type string
+	// Stream is "stdout" or "stderr", set when Type == "line".
+	Stream string
+	// Line is the step's output text, set when Type == "line".
+	Line string
+	// Seq is the relay's stream sequence for this frame, the value a
+	// reconnect echoes back as from_seq. Zero when Type == "error".
+	Seq int64
+	// Error is the fault message, set when Type == "error".
+	Error string
+}
+
+// StreamPipelineStepLogs opens the step log SSE relay and returns a channel
+// of decoded frames. The channel closes when the response ends (server
+// disconnect, or the context is cancelled) or after one Type=="error" event -
+// a stream fault is terminal, since the relay's own protocol answers it as a
+// single frame before it stops (sserelay.ErrorFrame).
+//
+// fromSequence resumes a previous read after that stream sequence; zero
+// starts from whatever the relay publishes next.
+func (c *Client) StreamPipelineStepLogs(ctx context.Context, selector PipelineSelector,
+	runID string, stepID string, fromSequence int64) (<-chan PipelineLogEvent, error) {
+	base, selectorError := selector.basePath()
+	if selectorError != nil {
+		return nil, selectorError
+	}
+	endpoint := fmt.Sprintf("%s%s/pipeline-runs/%s/steps/%s/logs",
+		c.BaseURL, base, neturl.PathEscape(runID), neturl.PathEscape(stepID))
+	if fromSequence > 0 {
+		endpoint = fmt.Sprintf("%s?from_seq=%d", endpoint, fromSequence)
+	}
+
+	request, requestError := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if requestError != nil {
+		return nil, fmt.Errorf("create request: %w", requestError)
+	}
+	request.Header.Set("Authorization", "Bearer "+c.Token)
+	request.Header.Set("Accept", "text/event-stream")
+
+	response, doError := c.StreamingHTTP.Do(request)
+	if doError != nil {
+		return nil, fmt.Errorf("request failed: %w", doError)
+	}
+	if response.StatusCode != http.StatusOK {
+		body, readError := readResponseBody(response)
+		closeBody(response)
+		if readError != nil {
+			return nil, fmt.Errorf("read response: %w", readError)
+		}
+		return nil, pipelineErrorFromResponse(response.StatusCode, body, response.Header.Get("Retry-After"))
+	}
+
+	events := make(chan PipelineLogEvent, 100)
+	go func() {
+		defer closeBody(response)
+		defer close(events)
+		reader := bufio.NewReader(response.Body)
+		for {
+			line, readError := reader.ReadString('\n')
+			if readError != nil {
+				if readError != io.EOF && ctx.Err() == nil {
+					events <- PipelineLogEvent{Type: "error", Error: readError.Error()}
+				}
+				return
+			}
+			line = strings.TrimSpace(line)
+			if !strings.HasPrefix(line, "data:") {
+				// Comment keepalives and the blank frame separators; the
+				// relay's own contract is "data:" frames only.
+				continue
+			}
+			data := sseData(line)
+			var frame struct {
+				// The relay's own error frame (sserelay.ErrorFrame).
+				Type    string `json:"type"`
+				Message string `json:"message"`
+				// The agent's output-line event
+				// (agent/go/internal/scheduler/progress.go OnTaskOutput).
+				EventType string `json:"event_type"`
+				Stream    string `json:"stream"`
+				Line      string `json:"line"`
+				Seq       int64  `json:"seq"`
+			}
+			if unmarshalError := json.Unmarshal([]byte(data), &frame); unmarshalError != nil {
+				continue
+			}
+			if frame.Type == "error" {
+				events <- PipelineLogEvent{Type: "error", Error: frame.Message}
+				return
+			}
+			if frame.EventType != "task_output" {
+				continue
+			}
+			events <- PipelineLogEvent{Type: "line", Stream: frame.Stream, Line: frame.Line, Seq: frame.Seq}
+		}
+	}()
+	return events, nil
+}

--- a/internal/client/pipeline_logs_test.go
+++ b/internal/client/pipeline_logs_test.go
@@ -1,0 +1,125 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// TestStreamPipelineStepLogsDecodesOutputLines pins the frame decode: only
+// "task_output" events become Type=="line" events, everything else on the
+// wire (a differently-shaped agent event, in particular) is dropped rather
+// than surfaced as a log line.
+func TestStreamPipelineStepLogsDecodesOutputLines(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/org/applications/app-1/pipeline-runs/run-1/steps/step-1/logs" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		_, _ = fmt.Fprint(w, "data: {\"event_type\":\"task_output\",\"stream\":\"stdout\",\"line\":\"building\",\"seq\":1}\n\n")
+		_, _ = fmt.Fprint(w, "data: {\"event_type\":\"plan_set\",\"seq\":2}\n\n")
+		_, _ = fmt.Fprint(w, "data: {\"event_type\":\"task_output\",\"stream\":\"stderr\",\"line\":\"warning\",\"seq\":3}\n\n")
+		flusher.Flush()
+	})
+
+	events, streamError := testClient.StreamPipelineStepLogs(context.Background(),
+		PipelineSelector{ApplicationID: "app-1"}, "run-1", "step-1", 0)
+	if streamError != nil {
+		t.Fatalf("StreamPipelineStepLogs error = %v", streamError)
+	}
+
+	var lines []PipelineLogEvent
+	for event := range events {
+		lines = append(lines, event)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("events = %+v, want exactly the two task_output frames", lines)
+	}
+	if lines[0].Line != "building" || lines[0].Stream != "stdout" || lines[0].Seq != 1 {
+		t.Errorf("first event = %+v", lines[0])
+	}
+	if lines[1].Line != "warning" || lines[1].Stream != "stderr" || lines[1].Seq != 3 {
+		t.Errorf("second event = %+v", lines[1])
+	}
+}
+
+// TestStreamPipelineStepLogsSurfacesTheRelaysErrorFrame pins the relay's own
+// terminal answer (sserelay.ErrorFrame): one Type=="error" event, and the
+// channel closes without a further read hanging.
+func TestStreamPipelineStepLogsSurfacesTheRelaysErrorFrame(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		_, _ = fmt.Fprint(w, "data: {\"type\":\"error\",\"message\":\"stream closed\"}\n\n")
+		flusher.Flush()
+	})
+
+	events, streamError := testClient.StreamPipelineStepLogs(context.Background(),
+		PipelineSelector{ApplicationID: "app-1"}, "run-1", "step-1", 0)
+	if streamError != nil {
+		t.Fatalf("StreamPipelineStepLogs error = %v", streamError)
+	}
+	event, ok := <-events
+	if !ok || event.Type != "error" || event.Error != "stream closed" {
+		t.Fatalf("event = %+v, ok = %v", event, ok)
+	}
+	if _, stillOpen := <-events; stillOpen {
+		t.Fatal("channel stayed open after the relay's error frame")
+	}
+}
+
+// TestStreamPipelineStepLogsReconnectsFromSequence pins the resume contract:
+// a caller that reconnects with fromSequence gets from_seq on the wire, and
+// only the frames after it.
+func TestStreamPipelineStepLogsReconnectsFromSequence(t *testing.T) {
+	var capturedQuery string
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		_, _ = fmt.Fprint(w, "data: {\"event_type\":\"task_output\",\"stream\":\"stdout\",\"line\":\"resumed\",\"seq\":6}\n\n")
+		flusher.Flush()
+	})
+
+	events, streamError := testClient.StreamPipelineStepLogs(context.Background(),
+		PipelineSelector{ApplicationID: "app-1"}, "run-1", "step-1", 5)
+	if streamError != nil {
+		t.Fatalf("StreamPipelineStepLogs error = %v", streamError)
+	}
+	event := <-events
+	if event.Line != "resumed" || event.Seq != 6 {
+		t.Fatalf("event = %+v", event)
+	}
+	if capturedQuery != "from_seq=5" {
+		t.Errorf("query = %q, want from_seq=5", capturedQuery)
+	}
+}
+
+// TestStreamPipelineStepLogsUnavailableCarriesRetryAfter pins the log
+// relay's degraded-state 503: the client answers a typed error carrying the
+// server's Retry-After rather than a generic failure.
+func TestStreamPipelineStepLogsUnavailableCarriesRetryAfter(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "7")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = fmt.Fprint(w, `{"detail":"The pipeline log stream is not available right now"}`)
+	})
+	_, streamError := testClient.StreamPipelineStepLogs(context.Background(),
+		PipelineSelector{ApplicationID: "app-1"}, "run-1", "step-1", 0)
+	if streamError == nil {
+		t.Fatal("expected an error")
+	}
+	var unavailable *PipelineLogStreamUnavailableError
+	if !errors.As(streamError, &unavailable) {
+		t.Fatalf("error = %v (%T), want *PipelineLogStreamUnavailableError", streamError, streamError)
+	}
+	if unavailable.RetryAfterSeconds != 7 {
+		t.Errorf("retry after = %d, want 7", unavailable.RetryAfterSeconds)
+	}
+}

--- a/internal/client/pipelines.go
+++ b/internal/client/pipelines.go
@@ -1,0 +1,741 @@
+package client
+
+// Ankra Pipelines (ankra-vn0bd.2.8, WS-B item B8): the typed client for
+// go/internal/pipelineapi on the cluster-api - runs, the definition of
+// record, and cron schedules.
+//
+// The server mounts every route four times (session/token twin x
+// by-application/by-repository twin); this client only ever speaks the
+// bearer-PAT twin, and PipelineSelector picks which of the two addresses a
+// call uses. There is no route yet that lists or looks up a pipeline
+// repository by owner/name - only by-id and by-application addressing exist
+// (go/internal/pipelineapi/pipelineapi.go, ankra-vn0bd.2.7) - so
+// PipelineSelector.RepositoryID takes the repository's id, not "owner/name".
+// A future item that adds a repository listing route can widen this to
+// resolve a name the way resolveApplicationID already does for applications.
+//
+// Findings have no route yet either (WS-C item C5): there is no
+// ListPipelineFindings here, deliberately, until the server has one.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	neturl "net/url"
+	"strconv"
+	"strings"
+)
+
+// PipelineSelector addresses one pipeline: either the repository directly, or
+// the application it is linked to. Exactly one of the two must be set; the
+// CLI's flag parsing enforces that before a selector ever reaches the client.
+type PipelineSelector struct {
+	ApplicationID string
+	RepositoryID  string
+}
+
+// ErrPipelineSelectorRequired refuses a call whose selector names neither a
+// repository nor an application.
+var ErrPipelineSelectorRequired = errors.New("a pipeline repository id or an application is required")
+
+func (selector PipelineSelector) basePath() (string, error) {
+	switch {
+	case selector.RepositoryID != "":
+		return "/api/v1/org/pipeline-repositories/" + neturl.PathEscape(selector.RepositoryID), nil
+	case selector.ApplicationID != "":
+		return "/api/v1/org/applications/" + neturl.PathEscape(selector.ApplicationID), nil
+	default:
+		return "", ErrPipelineSelectorRequired
+	}
+}
+
+// PipelineRun is the wire shape of a `pipeline_runs` row
+// (go/internal/pipelineapi/runs.go pipelineRunResponse).
+type PipelineRun struct {
+	ID                string  `json:"id"`
+	RunID             string  `json:"run_id"`
+	OrganisationID    string  `json:"organisation_id"`
+	RepositoryID      string  `json:"repository_id"`
+	ApplicationID     *string `json:"application_id"`
+	ClusterID         *string `json:"cluster_id"`
+	DefinitionID      string  `json:"definition_id"`
+	RunNumber         int64   `json:"run_number"`
+	Trigger           string  `json:"trigger"`
+	TriggerRef        string  `json:"trigger_ref"`
+	HeadSHA           string  `json:"head_sha"`
+	BaseSHA           string  `json:"base_sha"`
+	PullRequestNumber *int64  `json:"pull_request_number"`
+	IsFork            bool    `json:"is_fork"`
+	ConcurrencyGroup  string  `json:"concurrency_group"`
+	Status            string  `json:"status"`
+	Outcome           *string `json:"outcome"`
+	ErrorClass        *string `json:"error_class"`
+	ErrorMessage      *string `json:"error_message"`
+	RequestedBy       string  `json:"requested_by"`
+	RerunOfRunID      *string `json:"rerun_of_run_id"`
+	QueuedAt          string  `json:"queued_at"`
+	StartedAt         *string `json:"started_at"`
+	FinishedAt        *string `json:"finished_at"`
+	CreatedAt         string  `json:"created_at"`
+	UpdatedAt         string  `json:"updated_at"`
+}
+
+// PipelineStep is the wire shape of a `pipeline_run_steps` row.
+type PipelineStep struct {
+	ID              string          `json:"id"`
+	RunID           string          `json:"run_id"`
+	Stage           string          `json:"stage"`
+	StepKey         string          `json:"step_key"`
+	DisplayName     string          `json:"display_name"`
+	Kind            string          `json:"kind"`
+	Matrix          json.RawMessage `json:"matrix"`
+	DependsOn       []string        `json:"depends_on"`
+	Status          string          `json:"status"`
+	Outcome         *string         `json:"outcome"`
+	ContinueOnError bool            `json:"continue_on_error"`
+	ExitCode        *int32          `json:"exit_code"`
+	Attempt         int16           `json:"attempt"`
+	TimeoutSeconds  int32           `json:"timeout_seconds"`
+	Executor        string          `json:"executor"`
+	ExecutionID     *string         `json:"execution_id"`
+	ExecutionStepID *string         `json:"execution_step_id"`
+	NodeName        string          `json:"node_name"`
+	CacheResult     string          `json:"cache_result"`
+	Outputs         json.RawMessage `json:"outputs"`
+	ErrorClass      *string         `json:"error_class"`
+	ErrorMessage    *string         `json:"error_message"`
+	StartedAt       *string         `json:"started_at"`
+	FinishedAt      *string         `json:"finished_at"`
+	CreatedAt       string          `json:"created_at"`
+	UpdatedAt       string          `json:"updated_at"`
+}
+
+// PipelineRunList is the GET …/pipeline-runs body.
+type PipelineRunList struct {
+	Runs       []PipelineRun `json:"runs"`
+	NextCursor *string       `json:"next_cursor"`
+}
+
+// PipelineRunDetail is the GET …/pipeline-runs/{run_id} body: the run plus
+// its planned steps.
+type PipelineRunDetail struct {
+	PipelineRun
+	Steps []PipelineStep `json:"steps"`
+}
+
+// ListPipelineRunsOptions is the GET …/pipeline-runs query.
+type ListPipelineRunsOptions struct {
+	Status  string
+	Trigger string
+	Branch  string
+	HeadSHA string
+	Cursor  string
+	Limit   int
+}
+
+// CreatePipelineRunRequest is the POST …/pipeline-runs body: a manual
+// dispatch. HeadSHA is mandatory - the server refuses ErrHeadSHARequired
+// without it, because resolving a ref to a commit is the trigger lane's job,
+// not the dispatch route's.
+type CreatePipelineRunRequest struct {
+	Ref      string            `json:"ref,omitempty"`
+	HeadSHA  string            `json:"head_sha"`
+	Inputs   map[string]string `json:"inputs,omitempty"`
+	Reason   string            `json:"reason,omitempty"`
+	SpecYAML string            `json:"spec_yaml,omitempty"`
+}
+
+// CreatePipelineRunResult is the 202 body a dispatch or a re-run answers.
+type CreatePipelineRunResult struct {
+	RunID         string `json:"run_id"`
+	PipelineRunID string `json:"pipeline_run_id"`
+	RunNumber     int64  `json:"run_number"`
+}
+
+// PipelineArtifact is the wire shape one stored run artifact will carry
+// (go/internal/pipelineapi/artifacts.go). The store behind this route is WS-C
+// item C1; until it lands the listing always answers empty and the download
+// always answers 404.
+type PipelineArtifact struct {
+	ID          string `json:"id"`
+	RunID       string `json:"run_id"`
+	StepID      string `json:"step_id"`
+	Name        string `json:"name"`
+	ContentType string `json:"content_type"`
+	SizeBytes   int64  `json:"size_bytes"`
+	CreatedAt   string `json:"created_at"`
+}
+
+// PipelineArtifactList is the GET …/pipeline-runs/{run_id}/artifacts body.
+type PipelineArtifactList struct {
+	Artifacts []PipelineArtifact `json:"artifacts"`
+}
+
+// PipelineRepositoryReference names the repository a definition belongs to,
+// carried on the definition response so a caller who addressed by
+// application learns which repository answered.
+type PipelineRepositoryReference struct {
+	ID            string  `json:"id"`
+	Provider      string  `json:"provider"`
+	Owner         string  `json:"owner"`
+	Name          string  `json:"name"`
+	DefaultBranch string  `json:"default_branch"`
+	ApplicationID *string `json:"application_id"`
+}
+
+// PipelineStage is one stage of a resolved definition, flattened across its
+// three declaration blocks (Section is "stages", "on_failure" or "finally").
+type PipelineStage struct {
+	Name    string   `json:"name"`
+	Kind    string   `json:"kind"`
+	Section string   `json:"section"`
+	Needs   []string `json:"needs"`
+}
+
+// PipelineDefinition is the GET/PUT …/pipeline body: the definition of
+// record. ProtectedHash is nil until the fork-policy lane (WS-D) computes it.
+type PipelineDefinition struct {
+	Source        string                      `json:"source"`
+	SpecYAML      string                      `json:"spec_yaml"`
+	SpecHash      string                      `json:"spec_hash"`
+	ProtectedHash *string                     `json:"protected_hash"`
+	Stages        []PipelineStage             `json:"stages"`
+	Violations    []string                    `json:"violations"`
+	Repository    PipelineRepositoryReference `json:"repository"`
+}
+
+// PipelinePlannedStep is one node of a dry-run DAG.
+type PipelinePlannedStep struct {
+	StepKey        string   `json:"step_key"`
+	Stage          string   `json:"stage"`
+	Kind           string   `json:"kind"`
+	DependsOn      []string `json:"depends_on"`
+	RunCondition   string   `json:"run_condition"`
+	TimeoutSeconds int      `json:"timeout_seconds"`
+}
+
+// PipelineSkippedStage is one stage a dry run would not execute.
+type PipelineSkippedStage struct {
+	Stage   string `json:"stage"`
+	StepKey string `json:"step_key"`
+	Reason  string `json:"reason"`
+	Message string `json:"message"`
+}
+
+// PipelineEventPlan is the planner's answer for one synthetic event
+// (`validate` probes a push and a pull request against the default branch).
+type PipelineEventPlan struct {
+	Event          string                 `json:"event"`
+	Run            bool                   `json:"run"`
+	Reason         *string                `json:"reason"`
+	MatchedTrigger *string                `json:"matched_trigger"`
+	Steps          []PipelinePlannedStep  `json:"steps"`
+	Skipped        []PipelineSkippedStage `json:"skipped"`
+	Diagnostics    []string               `json:"diagnostics"`
+}
+
+// PipelineValidation is the POST …/pipeline/validate body: a dry run that
+// writes nothing.
+type PipelineValidation struct {
+	Severity   string              `json:"severity"`
+	Violations []string            `json:"violations"`
+	Events     []PipelineEventPlan `json:"events"`
+}
+
+// PipelineSchedule is the wire shape of a `pipeline_schedules` row.
+// NextFireAt is null until the (not yet built) dispatch loop computes one,
+// which is not the same as "never fires".
+type PipelineSchedule struct {
+	ID           string          `json:"id"`
+	RepositoryID string          `json:"repository_id"`
+	Cron         string          `json:"cron"`
+	Timezone     string          `json:"timezone"`
+	Ref          string          `json:"ref"`
+	Inputs       json.RawMessage `json:"inputs"`
+	Enabled      bool            `json:"enabled"`
+	NextFireAt   *string         `json:"next_fire_at"`
+	LastFiredAt  *string         `json:"last_fired_at"`
+	LastRunID    *string         `json:"last_run_id"`
+	CreatedAt    string          `json:"created_at"`
+	UpdatedAt    string          `json:"updated_at"`
+}
+
+// PipelineScheduleList is the GET …/pipeline/schedules body.
+type PipelineScheduleList struct {
+	Schedules []PipelineSchedule `json:"schedules"`
+}
+
+// CreatePipelineScheduleRequest is the POST …/pipeline/schedules body.
+type CreatePipelineScheduleRequest struct {
+	Cron     string            `json:"cron"`
+	Timezone string            `json:"timezone,omitempty"`
+	Ref      string            `json:"ref,omitempty"`
+	Inputs   map[string]string `json:"inputs,omitempty"`
+	Enabled  *bool             `json:"enabled,omitempty"`
+}
+
+// UpdatePipelineScheduleRequest is the PUT …/pipeline/schedules/{id} body.
+// Every member is a pointer so an omitted field leaves the stored value
+// alone - the server contract, mirrored here.
+type UpdatePipelineScheduleRequest struct {
+	Cron     *string            `json:"cron,omitempty"`
+	Timezone *string            `json:"timezone,omitempty"`
+	Ref      *string            `json:"ref,omitempty"`
+	Inputs   *map[string]string `json:"inputs,omitempty"`
+	Enabled  *bool              `json:"enabled,omitempty"`
+}
+
+// PipelineValidationError is the platform's structured 422 for a dispatch or
+// a definition write the planner refused
+// (go/internal/pipelineapi/pipelineapi.go writePipelineError,
+// pipelines.PlanRefusedError): the frozen reason, plus every diagnostic the
+// planner recorded on the way there.
+type PipelineValidationError struct {
+	StatusCode  int
+	Reason      string
+	Diagnostics []string
+}
+
+func (validationError *PipelineValidationError) Error() string {
+	if validationError == nil {
+		return ""
+	}
+	if len(validationError.Diagnostics) == 0 {
+		return validationError.Reason
+	}
+	return validationError.Reason + "\n  - " + strings.Join(validationError.Diagnostics, "\n  - ")
+}
+
+// PipelineLogStreamUnavailableError marks the step log relay's degraded-state
+// 503 (go/internal/pipelineapi/streams.go logStreamUnavailableCode): the
+// stream cannot be reached right now, distinct from a step whose log is
+// simply empty. RetryAfterSeconds is the server's Retry-After, defaulting to
+// 10 when the header is absent or does not parse.
+type PipelineLogStreamUnavailableError struct {
+	Detail            string
+	RetryAfterSeconds int
+}
+
+func (unavailableError *PipelineLogStreamUnavailableError) Error() string {
+	if unavailableError == nil {
+		return ""
+	}
+	return unavailableError.Detail
+}
+
+// pipelineErrorFromResponse maps one non-2xx pipeline API response onto a
+// typed or detail-carrying error. It is shared by every pipeline request path
+// (JSON and SSE alike) so the mapping cannot drift between them.
+func pipelineErrorFromResponse(statusCode int, body []byte, retryAfterHeader string) error {
+	if statusCode == http.StatusUnauthorized {
+		return ErrUnauthorized
+	}
+	if denied := PermissionDeniedFromResponse(statusCode, body); denied != nil {
+		return denied
+	}
+
+	// The planner-refusal shape: {"detail": "...", "diagnostics": [...]}.
+	// json.Unmarshal fails outright when "detail" is the pydantic array shape
+	// instead, so this branch is skipped for that case rather than silently
+	// matching it.
+	var refusal struct {
+		Detail      string   `json:"detail"`
+		Diagnostics []string `json:"diagnostics"`
+	}
+	if unmarshalError := json.Unmarshal(body, &refusal); unmarshalError == nil && refusal.Detail != "" {
+		switch {
+		case len(refusal.Diagnostics) > 0:
+			return &PipelineValidationError{StatusCode: statusCode, Reason: refusal.Detail, Diagnostics: refusal.Diagnostics}
+		case statusCode == http.StatusServiceUnavailable:
+			return &PipelineLogStreamUnavailableError{
+				Detail:            refusal.Detail,
+				RetryAfterSeconds: parseRetryAfterSeconds(retryAfterHeader),
+			}
+		default:
+			return errors.New(refusal.Detail)
+		}
+	}
+
+	// The pydantic v2 422 shape: {"detail": [{"loc": [...], "msg": "..."}]}.
+	if message := pipelineValidationDetailFromBody(body); message != "" {
+		return errors.New(message)
+	}
+
+	return newUnexpectedResponseError("pipeline request failed", statusCode, redactedBodyForError(body, 500))
+}
+
+// parseRetryAfterSeconds reads the Retry-After header as seconds, defaulting
+// to 10 (the server's own logStreamRetryAfterSeconds) when it is absent or
+// not a plain integer.
+func parseRetryAfterSeconds(header string) int {
+	seconds, parseError := strconv.Atoi(strings.TrimSpace(header))
+	if parseError != nil || seconds <= 0 {
+		return 10
+	}
+	return seconds
+}
+
+// pipelineValidationDetailFromBody flattens the pydantic v2 422 body
+// ({"detail": [{"loc": [...], "msg": "..."}]}) into "field: message" lines,
+// mirroring mcpDetailFromBody.
+func pipelineValidationDetailFromBody(body []byte) string {
+	var validationEnvelope struct {
+		Detail []struct {
+			Loc []any  `json:"loc"`
+			Msg string `json:"msg"`
+		} `json:"detail"`
+	}
+	if unmarshalError := json.Unmarshal(body, &validationEnvelope); unmarshalError != nil || len(validationEnvelope.Detail) == 0 {
+		return ""
+	}
+	messages := make([]string, 0, len(validationEnvelope.Detail))
+	for _, item := range validationEnvelope.Detail {
+		var path string
+		for _, member := range item.Loc {
+			if member == "body" || member == "query" || member == "path" {
+				continue
+			}
+			if path != "" {
+				path += "."
+			}
+			path += fmt.Sprintf("%v", member)
+		}
+		if path != "" {
+			messages = append(messages, path+": "+item.Msg)
+		} else {
+			messages = append(messages, item.Msg)
+		}
+	}
+	return strings.Join(messages, "; ")
+}
+
+// doPipelineRequest issues an authenticated JSON request against the pipeline
+// API and decodes a 2xx response into target (nil target discards the body,
+// which is every DELETE and any GET/POST whose caller only needs the error).
+func (c *Client) doPipelineRequest(ctx context.Context, method string, endpoint string,
+	payload any, target any) error {
+	var bodyReader *bytes.Reader
+	if payload != nil {
+		encoded, marshalError := json.Marshal(payload)
+		if marshalError != nil {
+			return fmt.Errorf("marshal request: %w", marshalError)
+		}
+		bodyReader = bytes.NewReader(encoded)
+	} else {
+		bodyReader = bytes.NewReader(nil)
+	}
+
+	request, requestError := http.NewRequestWithContext(ctx, method, endpoint, bodyReader)
+	if requestError != nil {
+		return fmt.Errorf("create request: %w", requestError)
+	}
+	if payload != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	request.Header.Set("Authorization", "Bearer "+c.Token)
+
+	response, doError := c.HTTP.Do(request)
+	if doError != nil {
+		return fmt.Errorf("request failed: %w", doError)
+	}
+	defer closeBody(response)
+
+	body, readError := readResponseBody(response)
+	if readError != nil {
+		return fmt.Errorf("read response: %w", readError)
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return pipelineErrorFromResponse(response.StatusCode, body, response.Header.Get("Retry-After"))
+	}
+	if target == nil || len(bytes.TrimSpace(body)) == 0 {
+		return nil
+	}
+	if unmarshalError := json.Unmarshal(body, target); unmarshalError != nil {
+		return fmt.Errorf("parse response: %w", unmarshalError)
+	}
+	return nil
+}
+
+func pipelineRunsEndpoint(base string, options ListPipelineRunsOptions) string {
+	query := neturl.Values{}
+	if options.Status != "" {
+		query.Set("status", options.Status)
+	}
+	if options.Trigger != "" {
+		query.Set("trigger", options.Trigger)
+	}
+	if options.Branch != "" {
+		query.Set("branch", options.Branch)
+	}
+	if options.HeadSHA != "" {
+		query.Set("head_sha", options.HeadSHA)
+	}
+	if options.Cursor != "" {
+		query.Set("cursor", options.Cursor)
+	}
+	if options.Limit > 0 {
+		query.Set("limit", strconv.Itoa(options.Limit))
+	}
+	endpoint := base + "/pipeline-runs"
+	if len(query) > 0 {
+		endpoint += "?" + query.Encode()
+	}
+	return endpoint
+}
+
+// ListPipelineRuns reads one page of the selected repository's runs, newest
+// first (GET …/pipeline-runs).
+func (c *Client) ListPipelineRuns(ctx context.Context, selector PipelineSelector,
+	options ListPipelineRunsOptions) (*PipelineRunList, error) {
+	base, selectorError := selector.basePath()
+	if selectorError != nil {
+		return nil, selectorError
+	}
+	var result PipelineRunList
+	if requestError := c.doPipelineRequest(ctx, http.MethodGet,
+		c.BaseURL+pipelineRunsEndpoint(base, options), nil, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// CreatePipelineRun dispatches a manual run (POST …/pipeline-runs).
+func (c *Client) CreatePipelineRun(ctx context.Context, selector PipelineSelector,
+	request CreatePipelineRunRequest) (*CreatePipelineRunResult, error) {
+	base, selectorError := selector.basePath()
+	if selectorError != nil {
+		return nil, selectorError
+	}
+	var result CreatePipelineRunResult
+	if requestError := c.doPipelineRequest(ctx, http.MethodPost,
+		c.BaseURL+base+"/pipeline-runs", request, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// GetPipelineRun reads one run with its steps (GET …/pipeline-runs/{run_id}).
+func (c *Client) GetPipelineRun(ctx context.Context, selector PipelineSelector,
+	runID string) (*PipelineRunDetail, error) {
+	base, selectorError := selector.basePath()
+	if selectorError != nil {
+		return nil, selectorError
+	}
+	var result PipelineRunDetail
+	if requestError := c.doPipelineRequest(ctx, http.MethodGet,
+		fmt.Sprintf("%s%s/pipeline-runs/%s", c.BaseURL, base, neturl.PathEscape(runID)),
+		nil, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// RerunPipelineRun opens a new run from a run that already happened (POST
+// …/pipeline-runs/{run_id}/rerun). failedOnly restricts the new run to the
+// steps that did not succeed and whatever depends on them.
+func (c *Client) RerunPipelineRun(ctx context.Context, selector PipelineSelector,
+	runID string, failedOnly bool) (*CreatePipelineRunResult, error) {
+	base, selectorError := selector.basePath()
+	if selectorError != nil {
+		return nil, selectorError
+	}
+	endpoint := fmt.Sprintf("%s%s/pipeline-runs/%s/rerun", c.BaseURL, base, neturl.PathEscape(runID))
+	if failedOnly {
+		endpoint += "?failed_only=true"
+	}
+	var result CreatePipelineRunResult
+	if requestError := c.doPipelineRequest(ctx, http.MethodPost, endpoint, nil, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// CancelPipelineRun stops a run that has not concluded (POST
+// …/pipeline-runs/{run_id}/cancel) and returns the settled run.
+func (c *Client) CancelPipelineRun(ctx context.Context, selector PipelineSelector,
+	runID string) (*PipelineRun, error) {
+	base, selectorError := selector.basePath()
+	if selectorError != nil {
+		return nil, selectorError
+	}
+	var result PipelineRun
+	if requestError := c.doPipelineRequest(ctx, http.MethodPost,
+		fmt.Sprintf("%s%s/pipeline-runs/%s/cancel", c.BaseURL, base, neturl.PathEscape(runID)),
+		nil, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// ListPipelineArtifacts lists a run's stored artifacts (GET
+// …/pipeline-runs/{run_id}/artifacts). The store is WS-C item C1; until it
+// lands this always answers an empty list for a run the caller can see.
+func (c *Client) ListPipelineArtifacts(ctx context.Context, selector PipelineSelector,
+	runID string) (*PipelineArtifactList, error) {
+	base, selectorError := selector.basePath()
+	if selectorError != nil {
+		return nil, selectorError
+	}
+	var result PipelineArtifactList
+	if requestError := c.doPipelineRequest(ctx, http.MethodGet,
+		fmt.Sprintf("%s%s/pipeline-runs/%s/artifacts", c.BaseURL, base, neturl.PathEscape(runID)),
+		nil, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// DownloadPipelineArtifact follows the 302 the download route answers
+// (GET …/artifacts/{artifact_id}/download) and streams the artifact into
+// destination. Until WS-C item C1 lands, the route always answers 404 with
+// pipelines.ErrArtifactsUnavailable.
+func (c *Client) DownloadPipelineArtifact(ctx context.Context, selector PipelineSelector,
+	artifactID string, destination io.Writer) error {
+	base, selectorError := selector.basePath()
+	if selectorError != nil {
+		return selectorError
+	}
+	endpoint := fmt.Sprintf("%s%s/artifacts/%s/download", c.BaseURL, base, neturl.PathEscape(artifactID))
+	request, requestError := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if requestError != nil {
+		return fmt.Errorf("create request: %w", requestError)
+	}
+	request.Header.Set("Authorization", "Bearer "+c.Token)
+
+	// The default client's redirect policy strips Authorization when a
+	// redirect crosses hosts, which is exactly right here: the 302 target is
+	// a presigned vault URL on a different host, and the cluster-api bearer
+	// token must never reach it.
+	response, doError := c.StreamingHTTP.Do(request)
+	if doError != nil {
+		return fmt.Errorf("request failed: %w", doError)
+	}
+	defer closeBody(response)
+
+	if response.StatusCode != http.StatusOK {
+		body, readError := readResponseBody(response)
+		if readError != nil {
+			return fmt.Errorf("read response: %w", readError)
+		}
+		return pipelineErrorFromResponse(response.StatusCode, body, "")
+	}
+	if _, copyError := io.Copy(destination, response.Body); copyError != nil {
+		return fmt.Errorf("download artifact: %w", copyError)
+	}
+	return nil
+}
+
+// GetPipelineDefinition reads the definition of record (GET …/pipeline).
+func (c *Client) GetPipelineDefinition(ctx context.Context, selector PipelineSelector) (*PipelineDefinition, error) {
+	base, selectorError := selector.basePath()
+	if selectorError != nil {
+		return nil, selectorError
+	}
+	var result PipelineDefinition
+	if requestError := c.doPipelineRequest(ctx, http.MethodGet, c.BaseURL+base+"/pipeline",
+		nil, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// PutPipelineDefinition stores a generated-spec override as the repository's
+// definition of record (PUT …/pipeline).
+func (c *Client) PutPipelineDefinition(ctx context.Context, selector PipelineSelector,
+	specYAML string) (*PipelineDefinition, error) {
+	base, selectorError := selector.basePath()
+	if selectorError != nil {
+		return nil, selectorError
+	}
+	var result PipelineDefinition
+	if requestError := c.doPipelineRequest(ctx, http.MethodPut, c.BaseURL+base+"/pipeline",
+		struct {
+			SpecYAML string `json:"spec_yaml"`
+		}{SpecYAML: specYAML}, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// ValidatePipelineDefinition dry-runs a definition without writing anything
+// (POST …/pipeline/validate). An empty specYAML validates the stored
+// definition instead of one the caller supplies.
+func (c *Client) ValidatePipelineDefinition(ctx context.Context, selector PipelineSelector,
+	specYAML string) (*PipelineValidation, error) {
+	base, selectorError := selector.basePath()
+	if selectorError != nil {
+		return nil, selectorError
+	}
+	var result PipelineValidation
+	if requestError := c.doPipelineRequest(ctx, http.MethodPost, c.BaseURL+base+"/pipeline/validate",
+		struct {
+			SpecYAML string `json:"spec_yaml"`
+		}{SpecYAML: specYAML}, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// ListPipelineSchedules lists the repository's cron entries (GET
+// …/pipeline/schedules).
+func (c *Client) ListPipelineSchedules(ctx context.Context, selector PipelineSelector) (*PipelineScheduleList, error) {
+	base, selectorError := selector.basePath()
+	if selectorError != nil {
+		return nil, selectorError
+	}
+	var result PipelineScheduleList
+	if requestError := c.doPipelineRequest(ctx, http.MethodGet, c.BaseURL+base+"/pipeline/schedules",
+		nil, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// CreatePipelineSchedule adds a cron entry (POST …/pipeline/schedules).
+func (c *Client) CreatePipelineSchedule(ctx context.Context, selector PipelineSelector,
+	request CreatePipelineScheduleRequest) (*PipelineSchedule, error) {
+	base, selectorError := selector.basePath()
+	if selectorError != nil {
+		return nil, selectorError
+	}
+	var result PipelineSchedule
+	if requestError := c.doPipelineRequest(ctx, http.MethodPost, c.BaseURL+base+"/pipeline/schedules",
+		request, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// UpdatePipelineSchedule changes a cron entry (PUT
+// …/pipeline/schedules/{schedule_id}).
+func (c *Client) UpdatePipelineSchedule(ctx context.Context, selector PipelineSelector,
+	scheduleID string, request UpdatePipelineScheduleRequest) (*PipelineSchedule, error) {
+	base, selectorError := selector.basePath()
+	if selectorError != nil {
+		return nil, selectorError
+	}
+	var result PipelineSchedule
+	if requestError := c.doPipelineRequest(ctx, http.MethodPut,
+		fmt.Sprintf("%s%s/pipeline/schedules/%s", c.BaseURL, base, neturl.PathEscape(scheduleID)),
+		request, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
+}
+
+// DeletePipelineSchedule removes a cron entry (DELETE
+// …/pipeline/schedules/{schedule_id}). A schedule that was not there answers
+// 404 rather than a silent success.
+func (c *Client) DeletePipelineSchedule(ctx context.Context, selector PipelineSelector, scheduleID string) error {
+	base, selectorError := selector.basePath()
+	if selectorError != nil {
+		return selectorError
+	}
+	return c.doPipelineRequest(ctx, http.MethodDelete,
+		fmt.Sprintf("%s%s/pipeline/schedules/%s", c.BaseURL, base, neturl.PathEscape(scheduleID)),
+		nil, nil)
+}

--- a/internal/client/pipelines_test.go
+++ b/internal/client/pipelines_test.go
@@ -1,0 +1,251 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestListPipelineRunsHappyPath(t *testing.T) {
+	var capturedPath, capturedQuery string
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedQuery = r.URL.RawQuery
+		_, _ = fmt.Fprint(w, `{"runs":[{"id":"run-1","run_id":"umbrella-1","organisation_id":"org-1",
+			"repository_id":"repo-1","application_id":"app-1","definition_id":"def-1","run_number":3,
+			"trigger":"push","trigger_ref":"refs/heads/main","head_sha":"`+strings.Repeat("a", 40)+`",
+			"base_sha":"","is_fork":false,"concurrency_group":"repo-1:main","status":"concluded",
+			"outcome":"success","requested_by":"user:1","queued_at":"2026-09-01T00:00:00Z",
+			"created_at":"2026-09-01T00:00:00Z","updated_at":"2026-09-01T00:00:00Z"}],"next_cursor":null}`)
+	})
+
+	list, err := testClient.ListPipelineRuns(context.Background(),
+		PipelineSelector{ApplicationID: "app-1"}, ListPipelineRunsOptions{Status: "concluded", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListPipelineRuns error = %v", err)
+	}
+	if capturedPath != "/api/v1/org/applications/app-1/pipeline-runs" {
+		t.Errorf("path = %q", capturedPath)
+	}
+	if !strings.Contains(capturedQuery, "status=concluded") || !strings.Contains(capturedQuery, "limit=10") {
+		t.Errorf("query = %q", capturedQuery)
+	}
+	if len(list.Runs) != 1 || list.Runs[0].ID != "run-1" || list.Runs[0].RunNumber != 3 {
+		t.Fatalf("runs = %+v", list.Runs)
+	}
+	if list.NextCursor != nil {
+		t.Errorf("next cursor = %v, want nil", list.NextCursor)
+	}
+}
+
+func TestListPipelineRunsEmpty(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, `{"runs":[],"next_cursor":null}`)
+	})
+	list, err := testClient.ListPipelineRuns(context.Background(), PipelineSelector{RepositoryID: "repo-1"}, ListPipelineRunsOptions{})
+	if err != nil {
+		t.Fatalf("ListPipelineRuns error = %v", err)
+	}
+	if len(list.Runs) != 0 {
+		t.Fatalf("runs = %+v, want empty", list.Runs)
+	}
+}
+
+func TestListPipelineRunsByRepositoryPath(t *testing.T) {
+	var capturedPath string
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		_, _ = fmt.Fprint(w, `{"runs":[],"next_cursor":null}`)
+	})
+	if _, err := testClient.ListPipelineRuns(context.Background(), PipelineSelector{RepositoryID: "repo-9"}, ListPipelineRunsOptions{}); err != nil {
+		t.Fatalf("ListPipelineRuns error = %v", err)
+	}
+	if capturedPath != "/api/v1/org/pipeline-repositories/repo-9/pipeline-runs" {
+		t.Errorf("path = %q", capturedPath)
+	}
+}
+
+func TestGetPipelineRunNotFound(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, `{"detail":"Pipeline run not found"}`)
+	})
+	_, err := testClient.GetPipelineRun(context.Background(), PipelineSelector{ApplicationID: "app-1"}, "missing-run")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	// The server's sentinel text is rendered verbatim, so a caller cannot
+	// tell "absent" from "belongs to another organisation" - matching the
+	// route's own contract.
+	if err.Error() != "Pipeline run not found" {
+		t.Errorf("error = %q, want the server's sentinel text verbatim", err.Error())
+	}
+}
+
+func TestCreatePipelineRunRequiresHeadSHA(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = fmt.Fprint(w, `{"detail":"A pipeline run needs the full commit sha to run at"}`)
+	})
+	_, err := testClient.CreatePipelineRun(context.Background(), PipelineSelector{ApplicationID: "app-1"},
+		CreatePipelineRunRequest{Ref: "main"})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if err.Error() != "A pipeline run needs the full commit sha to run at" {
+		t.Errorf("error = %q", err.Error())
+	}
+}
+
+// TestCreatePipelineRunPlanRefusalCarriesDiagnostics pins the
+// PipelineValidationError shape the planner-refusal 422
+// ({"detail": "...", "diagnostics": [...]}) decodes into, so a caller can
+// show every diagnostic the planner recorded, not just the headline reason.
+func TestCreatePipelineRunPlanRefusalCarriesDiagnostics(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = fmt.Fprint(w, `{"detail":"This pipeline definition has at least one fatal violation",
+			"diagnostics":["pipeline_stages: stage \"build\" has no kind","pipeline_matrix: matrix leg 2 is empty"]}`)
+	})
+	_, err := testClient.CreatePipelineRun(context.Background(), PipelineSelector{ApplicationID: "app-1"},
+		CreatePipelineRunRequest{HeadSHA: strings.Repeat("a", 40)})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	var validationError *PipelineValidationError
+	if !errors.As(err, &validationError) {
+		t.Fatalf("error = %v (%T), want *PipelineValidationError", err, err)
+	}
+	if validationError.Reason != "This pipeline definition has at least one fatal violation" {
+		t.Errorf("reason = %q", validationError.Reason)
+	}
+	if len(validationError.Diagnostics) != 2 {
+		t.Fatalf("diagnostics = %v", validationError.Diagnostics)
+	}
+}
+
+// TestPipelineScheduleValidationErrorFlattensPydanticShape pins the other
+// 422 shape a schedule write can answer: pydantic's
+// {"detail": [{"loc": [...], "msg": "..."}]}, which carries no diagnostics
+// array and so must not be mistaken for a plan refusal.
+func TestPipelineScheduleValidationErrorFlattensPydanticShape(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = fmt.Fprint(w, `{"detail":[{"loc":["body","cron"],"msg":"invalid cron expression"}]}`)
+	})
+	_, err := testClient.CreatePipelineSchedule(context.Background(), PipelineSelector{ApplicationID: "app-1"},
+		CreatePipelineScheduleRequest{Cron: "not a cron"})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "cron") || !strings.Contains(err.Error(), "invalid cron expression") {
+		t.Errorf("error = %q, want it to name the field and the message", err.Error())
+	}
+	var validationError *PipelineValidationError
+	if errors.As(err, &validationError) {
+		t.Errorf("a pydantic validation error must not decode as *PipelineValidationError: %+v", validationError)
+	}
+}
+
+func TestCancelPipelineRunAlreadyConcluded(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = fmt.Fprint(w, `{"detail":"This pipeline run has already concluded"}`)
+	})
+	_, err := testClient.CancelPipelineRun(context.Background(), PipelineSelector{ApplicationID: "app-1"}, "run-1")
+	if err == nil || err.Error() != "This pipeline run has already concluded" {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestSelectorRequiresExactlyOneAddress(t *testing.T) {
+	if _, err := (PipelineSelector{}).basePath(); !errors.Is(err, ErrPipelineSelectorRequired) {
+		t.Errorf("empty selector error = %v, want ErrPipelineSelectorRequired", err)
+	}
+}
+
+func TestListPipelineArtifactsEmptyUntilTheStoreLands(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, `{"artifacts":[]}`)
+	})
+	list, err := testClient.ListPipelineArtifacts(context.Background(), PipelineSelector{ApplicationID: "app-1"}, "run-1")
+	if err != nil {
+		t.Fatalf("ListPipelineArtifacts error = %v", err)
+	}
+	if len(list.Artifacts) != 0 {
+		t.Fatalf("artifacts = %+v, want empty", list.Artifacts)
+	}
+}
+
+func TestDownloadPipelineArtifactUnavailablePlaceholder(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, `{"detail":"Artifacts are not available for this run"}`)
+	})
+	var buf strings.Builder
+	err := testClient.DownloadPipelineArtifact(context.Background(), PipelineSelector{ApplicationID: "app-1"}, "artifact-1", &buf)
+	if err == nil || err.Error() != "Artifacts are not available for this run" {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestValidatePipelineDefinitionEmptySpecValidatesStored(t *testing.T) {
+	var capturedBody string
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		_, _ = fmt.Fprint(w, `{"severity":"ok","violations":[],"events":[]}`)
+	})
+	validation, err := testClient.ValidatePipelineDefinition(context.Background(), PipelineSelector{ApplicationID: "app-1"}, "")
+	if err != nil {
+		t.Fatalf("ValidatePipelineDefinition error = %v", err)
+	}
+	if validation.Severity != "ok" {
+		t.Errorf("severity = %q", validation.Severity)
+	}
+	if !strings.Contains(capturedBody, `"spec_yaml":""`) {
+		t.Errorf("body = %q, want an explicit empty spec_yaml", capturedBody)
+	}
+}
+
+func TestUpdatePipelineScheduleOnlyChangedFieldsCross(t *testing.T) {
+	var capturedBody string
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		_, _ = fmt.Fprint(w, `{"id":"sched-1","repository_id":"repo-1","cron":"0 0 * * *","timezone":"UTC","ref":"main",
+			"inputs":{},"enabled":false,"created_at":"2026-09-01T00:00:00Z","updated_at":"2026-09-01T00:00:00Z"}`)
+	})
+	enabled := false
+	schedule, err := testClient.UpdatePipelineSchedule(context.Background(), PipelineSelector{ApplicationID: "app-1"},
+		"sched-1", UpdatePipelineScheduleRequest{Enabled: &enabled})
+	if err != nil {
+		t.Fatalf("UpdatePipelineSchedule error = %v", err)
+	}
+	if schedule.Enabled {
+		t.Errorf("enabled = %v, want false", schedule.Enabled)
+	}
+	// Only "enabled" was set on the request, so the body must not carry
+	// cron/timezone/ref/inputs at all - the server contract is "an omitted
+	// field leaves the stored value alone".
+	for _, field := range []string{"cron", "timezone", "ref", "inputs"} {
+		if strings.Contains(capturedBody, `"`+field+`"`) {
+			t.Errorf("body = %q, must not carry unset field %q", capturedBody, field)
+		}
+	}
+}
+
+func TestDeletePipelineScheduleNotFound(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, `{"detail":"Pipeline schedule not found"}`)
+	})
+	err := testClient.DeletePipelineSchedule(context.Background(), PipelineSelector{ApplicationID: "app-1"}, "sched-missing")
+	if err == nil || err.Error() != "Pipeline schedule not found" {
+		t.Fatalf("error = %v", err)
+	}
+}


### PR DESCRIPTION
`ankra pipeline` over the pipeline runs API that landed in cluster#2450: `run` (with `--wait`), `list`, `get`, `logs [--step] [--follow]` over the SSE relay with resume-on-drop, `cancel`, `rerun`, `artifacts list|download`, `validate` (defaulting to `.ankra/pipeline.yaml`, rendering the server's diagnostics with file:line), `definition get|put`, and `schedules list|create|update|delete`, plus `ankra application pipeline …` aliases for the by-application surface. Human-readable tables by default, `-o json` verbatim; the server's sentinel texts are rendered unchanged, and an id in another organisation reads exactly like an absent one.

Plan: WS-B item B8 of epic ankra-vn0bd.

Verification: `make build`, `make test` (whole module, including the new `cmd` and `internal/client` suites against an httptest server with recorded fixtures: happy path, empty list, 404, 422 diagnostics, and an SSE stream that drops and resumes), `make lint` (0 issues), `make verify-skills`.

Not included: `ankra pipeline findings` — the findings API is WS-C item C5 (bead ankra-vn0bd.3.5) and does not exist yet. The ankra-docs CLI reference is generated, so it is not hand-edited here; it regenerates with the next release.

Bead: ankra-vn0bd.2.8
