### PR TITLE
feat(stack-profiles): contents command decodes a version's manifests and add-on values

### DIFF
--- a/cmd/stack_profile_contents.go
+++ b/cmd/stack_profile_contents.go
@@ -1,0 +1,325 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"ankra/internal/client"
+)
+
+// profileVersionPayload is the slice of GET
+// /stack-profiles/{id}/versions/{n} this command needs. The endpoint returns
+// the whole version record; only the stack spec carries resource content.
+type profileVersionPayload struct {
+	Version int    `json:"version"`
+	Channel string `json:"channel"`
+	Spec    struct {
+		Stacks []client.StackSpec `json:"stacks"`
+	} `json:"spec"`
+}
+
+// profileResource is one addressable piece of a profile version: a manifest's
+// YAML or an add-on's values.yaml. Both are stored base64-encoded in the
+// spec, which is why reading a published profile previously meant decoding it
+// by hand outside the CLI.
+type profileResource struct {
+	Name    string
+	Kind    string
+	Content string
+}
+
+const profileResourceKindManifest = "manifest"
+const profileResourceKindAddon = "addon"
+
+func decodeProfileSpecField(encoded string, label string) (string, error) {
+	if strings.TrimSpace(encoded) == "" {
+		return "", nil
+	}
+	decoded, decodeError := base64.StdEncoding.DecodeString(encoded)
+	if decodeError != nil {
+		return "", fmt.Errorf("base64-decode %s: %w", label, decodeError)
+	}
+	return string(decoded), nil
+}
+
+// profileVersionResources flattens a version's manifests and add-on values
+// into one addressable list, decoded and in spec order.
+func profileVersionResources(payload *profileVersionPayload) ([]profileResource, error) {
+	resources := []profileResource{}
+	for _, stack := range payload.Spec.Stacks {
+		for _, manifest := range stack.Manifests {
+			content, decodeError := decodeProfileSpecField(manifest.ManifestBase64, "manifest "+manifest.Name)
+			if decodeError != nil {
+				return nil, decodeError
+			}
+			resources = append(resources, profileResource{
+				Name:    manifest.Name,
+				Kind:    profileResourceKindManifest,
+				Content: content,
+			})
+		}
+		for _, addon := range stack.Addons {
+			encoded := ""
+			if addon.Configuration != nil {
+				encoded = addon.Configuration.ValuesBase64
+			}
+			content, decodeError := decodeProfileSpecField(encoded, "add-on "+addon.Name+" values")
+			if decodeError != nil {
+				return nil, decodeError
+			}
+			resources = append(resources, profileResource{
+				Name:    addon.Name,
+				Kind:    profileResourceKindAddon,
+				Content: content,
+			})
+		}
+	}
+	return resources, nil
+}
+
+// manifestKindAndNamespace reads the kind and namespace out of a decoded
+// manifest so the inventory can say what each resource actually is. A
+// manifest holding several YAML documents reports the first kind plus a count
+// of the rest, and the first namespace found across the documents (a leading
+// Namespace object usually carries none of its own). Anything unparseable
+// degrades to "-" rather than failing the whole listing.
+func manifestKindAndNamespace(content string) (string, string) {
+	if strings.TrimSpace(content) == "" {
+		return "-", "-"
+	}
+	type manifestHead struct {
+		Kind     string `yaml:"kind"`
+		Metadata struct {
+			Namespace string `yaml:"namespace"`
+		} `yaml:"metadata"`
+	}
+	decoder := yaml.NewDecoder(strings.NewReader(content))
+	kinds := []string{}
+	namespace := ""
+	for {
+		var head manifestHead
+		if decodeError := decoder.Decode(&head); decodeError != nil {
+			break
+		}
+		if head.Kind != "" {
+			kinds = append(kinds, head.Kind)
+		}
+		if namespace == "" {
+			namespace = head.Metadata.Namespace
+		}
+	}
+	if len(kinds) == 0 {
+		return "-", "-"
+	}
+	kind := kinds[0]
+	if len(kinds) > 1 {
+		kind = fmt.Sprintf("%s (+%d)", kind, len(kinds)-1)
+	}
+	if namespace == "" {
+		namespace = "-"
+	}
+	return kind, namespace
+}
+
+func findProfileResource(resources []profileResource, name string) (profileResource, error) {
+	matches := []profileResource{}
+	for _, resource := range resources {
+		if resource.Name == name {
+			matches = append(matches, resource)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	if len(matches) > 1 {
+		return profileResource{}, fmt.Errorf(
+			"resource %q is ambiguous in this version (matched %d resources)", name, len(matches))
+	}
+	available := make([]string, 0, len(resources))
+	for _, resource := range resources {
+		available = append(available, resource.Name)
+	}
+	sort.Strings(available)
+	return profileResource{}, fmt.Errorf(
+		"no resource named %q in this profile version (available: %s)", name, strings.Join(available, ", "))
+}
+
+// writeAllProfileResources emits every resource as one multi-document YAML
+// stream, each preceded by a comment naming it. This is the form you can pipe
+// into grep to audit a published profile in one pass.
+func writeAllProfileResources(out io.Writer, resources []profileResource) error {
+	for index, resource := range resources {
+		if index > 0 {
+			if _, writeError := io.WriteString(out, "---\n"); writeError != nil {
+				return writeError
+			}
+		}
+		header := fmt.Sprintf("# %s: %s\n", resource.Kind, resource.Name)
+		if _, writeError := io.WriteString(out, header); writeError != nil {
+			return writeError
+		}
+		text := resource.Content
+		if text != "" && !strings.HasSuffix(text, "\n") {
+			text += "\n"
+		}
+		if _, writeError := io.WriteString(out, text); writeError != nil {
+			return writeError
+		}
+	}
+	return nil
+}
+
+func renderProfileContentsInventory(out io.Writer, payload *profileVersionPayload, resources []profileResource) {
+	_, _ = fmt.Fprintf(out, "Profile version v%d", payload.Version)
+	if payload.Channel != "" {
+		_, _ = fmt.Fprintf(out, " (%s)", payload.Channel)
+	}
+	_, _ = fmt.Fprintln(out)
+
+	addons := []profileResource{}
+	manifests := []profileResource{}
+	for _, resource := range resources {
+		if resource.Kind == profileResourceKindAddon {
+			addons = append(addons, resource)
+			continue
+		}
+		manifests = append(manifests, resource)
+	}
+
+	addonSpecByName := map[string]client.AddonSpec{}
+	for _, stack := range payload.Spec.Stacks {
+		for _, addon := range stack.Addons {
+			addonSpecByName[addon.Name] = addon
+		}
+	}
+
+	if len(addons) > 0 {
+		_, _ = fmt.Fprintln(out, "\nAdd-ons:")
+		addonsTable := table.NewWriter()
+		addonsTable.SetOutputMirror(out)
+		addonsTable.SetStyle(table.StyleRounded)
+		addonsTable.AppendHeader(table.Row{"Name", "Chart", "Version", "Namespace"})
+		for _, resource := range addons {
+			spec := addonSpecByName[resource.Name]
+			namespace := spec.Namespace
+			if namespace == "" {
+				namespace = "-"
+			}
+			chartVersion := spec.ChartVersion
+			if chartVersion == "" {
+				chartVersion = "-"
+			}
+			addonsTable.AppendRow(table.Row{resource.Name, spec.ChartName, chartVersion, namespace})
+		}
+		addonsTable.Render()
+	}
+
+	if len(manifests) > 0 {
+		_, _ = fmt.Fprintln(out, "\nManifests:")
+		manifestsTable := table.NewWriter()
+		manifestsTable.SetOutputMirror(out)
+		manifestsTable.SetStyle(table.StyleRounded)
+		manifestsTable.AppendHeader(table.Row{"Name", "Kind", "Namespace"})
+		for _, resource := range manifests {
+			kind, namespace := manifestKindAndNamespace(resource.Content)
+			manifestsTable.AppendRow(table.Row{resource.Name, kind, namespace})
+		}
+		manifestsTable.Render()
+	}
+
+	if len(addons) == 0 && len(manifests) == 0 {
+		_, _ = fmt.Fprintln(out, "  (no resources)")
+		return
+	}
+	_, _ = fmt.Fprintln(out, "\nPrint one resource with --resource <name>, or every resource with --all.")
+}
+
+var stackProfilesContentsCmd = &cobra.Command{
+	Use:   "contents [profile-id|profile-name] <version>",
+	Short: "List or print the decoded manifests and add-on values in a profile version",
+	Long: `Show what a published profile version actually contains.
+
+Manifests and add-on values are stored base64-encoded, so ` + "`export-iac`" + ` and
+` + "`version`" + ` cannot be read or grepped directly. This command decodes them.
+
+With no --resource, it lists the add-ons and manifests, reading each
+manifest's kind and namespace out of the decoded YAML:
+
+  ankra stack-profiles contents opensearch 2
+
+--resource prints one resource's decoded content, the same way
+` + "`ankra cluster manifests get`" + ` prints a live manifest:
+
+  ankra stack-profiles contents opensearch 2 --resource opensearch-cluster
+  ankra stack-profiles contents opensearch 2 --resource fluent-bit -o raw
+
+--all prints every resource as one multi-document YAML stream, which is the
+form to audit a whole profile in one pass:
+
+  ankra stack-profiles contents opensearch 1 --all | grep -A2 secretKeyRef`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		resourceName, _ := cmd.Flags().GetString("resource")
+		allResources, _ := cmd.Flags().GetBool("all")
+		outputFormat, _ := cmd.Flags().GetString("output")
+
+		if resourceName != "" && allResources {
+			return fmt.Errorf("--resource and --all are mutually exclusive")
+		}
+		if outputFormat != "" && resourceName == "" {
+			return fmt.Errorf("-o applies only to --resource; the inventory is always human-readable and --all is always decoded YAML")
+		}
+
+		profileID, resolveError := resolveStackProfileID(apiClient, args[0])
+		if resolveError != nil {
+			return resolveError
+		}
+		version, versionError := parseRequiredProfileVersionArgument(args[1])
+		if versionError != nil {
+			return versionError
+		}
+
+		raw, getError := apiClient.GetStackProfileVersion(cmd.Context(), profileID, version)
+		if getError != nil {
+			return fmt.Errorf("getting stack profile version: %w", getError)
+		}
+		var payload profileVersionPayload
+		if unmarshalError := json.Unmarshal(raw, &payload); unmarshalError != nil {
+			return fmt.Errorf("parsing stack profile version: %w", unmarshalError)
+		}
+
+		resources, decodeError := profileVersionResources(&payload)
+		if decodeError != nil {
+			return decodeError
+		}
+
+		output := cmd.OutOrStdout()
+		if allResources {
+			return writeAllProfileResources(output, resources)
+		}
+		if resourceName != "" {
+			resource, findError := findProfileResource(resources, resourceName)
+			if findError != nil {
+				return findError
+			}
+			return writeDecodedDoc(output, resource.Content, outputFormat)
+		}
+		renderProfileContentsInventory(output, &payload, resources)
+		return nil
+	},
+}
+
+func init() {
+	stackProfilesContentsCmd.Flags().String("resource", "", "Print one resource's decoded content by name (manifest or add-on)")
+	stackProfilesContentsCmd.Flags().Bool("all", false, "Print every resource as one multi-document YAML stream")
+	stackProfilesContentsCmd.Flags().StringP("output", "o", "", "Content format for --resource: yaml (decoded, default) or raw (base64)")
+	stackProfilesCmd.AddCommand(stackProfilesContentsCmd)
+}

--- a/cmd/stack_profile_contents_test.go
+++ b/cmd/stack_profile_contents_test.go
@@ -1,0 +1,221 @@
+package cmd
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type stackProfileContentsMock struct {
+	baseMock
+	payload json.RawMessage
+	err     error
+}
+
+func (m *stackProfileContentsMock) GetStackProfileVersion(ctx context.Context, profileID string, version int) (json.RawMessage, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.payload, nil
+}
+
+func encodeForProfile(content string) string {
+	return base64.StdEncoding.EncodeToString([]byte(content))
+}
+
+const clusterManifestYAML = `apiVersion: opensearch.org/v1
+kind: OpenSearchCluster
+metadata:
+  name: logs
+  namespace: opensearch
+spec:
+  general:
+    serviceName: logs
+`
+
+const namespaceManifestYAML = `apiVersion: v1
+kind: Namespace
+metadata:
+  name: opensearch
+`
+
+const fluentBitValuesYAML = `config:
+  pipeline:
+    outputs:
+      - name: opensearch
+        http_user: fluentbit
+`
+
+func profileVersionFixture() json.RawMessage {
+	return json.RawMessage(fmt.Sprintf(`{
+  "version": 2,
+  "channel": "stable",
+  "spec": {
+    "stacks": [
+      {
+        "name": "opensearch",
+        "manifests": [
+          {"name": "opensearch-namespace", "manifest_base64": %q},
+          {"name": "opensearch-cluster", "manifest_base64": %q}
+        ],
+        "addons": [
+          {
+            "name": "fluent-bit",
+            "chart_name": "fluent-bit-collector",
+            "chart_version": "1.1.1",
+            "namespace": "opensearch",
+            "configuration": {"values_base64": %q}
+          }
+        ]
+      }
+    ]
+  }
+}`,
+		encodeForProfile(namespaceManifestYAML),
+		encodeForProfile(clusterManifestYAML),
+		encodeForProfile(fluentBitValuesYAML)))
+}
+
+func resetStackProfileContentsFlags(t *testing.T) {
+	t.Helper()
+	flags := stackProfilesContentsCmd.Flags()
+	_ = flags.Set("resource", "")
+	_ = flags.Set("all", "false")
+	_ = flags.Set("output", "")
+}
+
+func TestStackProfileContentsListsResources(t *testing.T) {
+	resetStackProfileContentsFlags(t)
+	setMockClient(t, &stackProfileContentsMock{payload: profileVersionFixture()})
+
+	stdout, err := executeCommand("stack-profiles", "contents", "profile-1", "2")
+	if err != nil {
+		t.Fatalf("contents failed: %v", err)
+	}
+
+	for _, expected := range []string{
+		"fluent-bit",
+		"fluent-bit-collector",
+		"1.1.1",
+		"opensearch-cluster",
+		// The kind is read out of the decoded manifest, which is the whole
+		// point: the encoded spec cannot tell you what a resource is.
+		"OpenSearchCluster",
+		"Namespace",
+	} {
+		if !strings.Contains(stdout, expected) {
+			t.Errorf("expected %q in inventory output, got:\n%s", expected, stdout)
+		}
+	}
+}
+
+func TestStackProfileContentsPrintsOneResourceDecoded(t *testing.T) {
+	resetStackProfileContentsFlags(t)
+	setMockClient(t, &stackProfileContentsMock{payload: profileVersionFixture()})
+
+	stdout, err := executeCommand("stack-profiles", "contents", "profile-1", "2", "--resource", "opensearch-cluster")
+	if err != nil {
+		t.Fatalf("contents failed: %v", err)
+	}
+
+	if !strings.Contains(stdout, "kind: OpenSearchCluster") {
+		t.Errorf("expected decoded manifest YAML, got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "manifest_base64") {
+		t.Errorf("expected decoded content, not the encoded envelope, got:\n%s", stdout)
+	}
+}
+
+func TestStackProfileContentsPrintsAddonValues(t *testing.T) {
+	resetStackProfileContentsFlags(t)
+	setMockClient(t, &stackProfileContentsMock{payload: profileVersionFixture()})
+
+	stdout, err := executeCommand("stack-profiles", "contents", "profile-1", "2", "--resource", "fluent-bit")
+	if err != nil {
+		t.Fatalf("contents failed: %v", err)
+	}
+
+	if !strings.Contains(stdout, "http_user: fluentbit") {
+		t.Errorf("expected decoded add-on values, got:\n%s", stdout)
+	}
+}
+
+func TestStackProfileContentsRawKeepsBase64(t *testing.T) {
+	resetStackProfileContentsFlags(t)
+	setMockClient(t, &stackProfileContentsMock{payload: profileVersionFixture()})
+
+	stdout, err := executeCommand("stack-profiles", "contents", "profile-1", "2", "--resource", "opensearch-cluster", "-o", "raw")
+	if err != nil {
+		t.Fatalf("contents failed: %v", err)
+	}
+
+	if !strings.Contains(stdout, encodeForProfile(clusterManifestYAML)) {
+		t.Errorf("expected base64 content for -o raw, got:\n%s", stdout)
+	}
+}
+
+func TestStackProfileContentsAllStreamsEveryResource(t *testing.T) {
+	resetStackProfileContentsFlags(t)
+	setMockClient(t, &stackProfileContentsMock{payload: profileVersionFixture()})
+
+	stdout, err := executeCommand("stack-profiles", "contents", "profile-1", "2", "--all")
+	if err != nil {
+		t.Fatalf("contents failed: %v", err)
+	}
+
+	for _, expected := range []string{
+		"# manifest: opensearch-namespace",
+		"# manifest: opensearch-cluster",
+		"# addon: fluent-bit",
+		"kind: OpenSearchCluster",
+		"http_user: fluentbit",
+	} {
+		if !strings.Contains(stdout, expected) {
+			t.Errorf("expected %q in --all output, got:\n%s", expected, stdout)
+		}
+	}
+}
+
+func TestStackProfileContentsUnknownResourceListsAvailable(t *testing.T) {
+	resetStackProfileContentsFlags(t)
+	setMockClient(t, &stackProfileContentsMock{payload: profileVersionFixture()})
+
+	_, err := executeCommand("stack-profiles", "contents", "profile-1", "2", "--resource", "nope")
+	if err == nil {
+		t.Fatal("expected an error for an unknown resource")
+	}
+	if !strings.Contains(err.Error(), "opensearch-cluster") {
+		t.Errorf("expected the error to list available resources, got: %v", err)
+	}
+}
+
+func TestStackProfileContentsRejectsResourceWithAll(t *testing.T) {
+	resetStackProfileContentsFlags(t)
+	setMockClient(t, &stackProfileContentsMock{payload: profileVersionFixture()})
+
+	_, err := executeCommand("stack-profiles", "contents", "profile-1", "2", "--resource", "fluent-bit", "--all")
+	if err == nil {
+		t.Fatal("expected an error when --resource and --all are combined")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("expected a mutual-exclusion error, got: %v", err)
+	}
+}
+
+func TestManifestKindAndNamespaceHandlesMultiDocAndJunk(t *testing.T) {
+	kind, namespace := manifestKindAndNamespace(namespaceManifestYAML + "---\n" + clusterManifestYAML)
+	if !strings.HasPrefix(kind, "Namespace") || !strings.Contains(kind, "+1") {
+		t.Errorf("expected the first kind plus a count for a multi-doc manifest, got %q", kind)
+	}
+	if namespace != "opensearch" {
+		t.Errorf("expected the first namespace found across the documents, got %q", namespace)
+	}
+
+	// An unparseable manifest must degrade rather than break the listing.
+	if kind, namespace := manifestKindAndNamespace("\t not: [valid"); kind != "-" || namespace != "-" {
+		t.Errorf("expected placeholders for unparseable content, got %q/%q", kind, namespace)
+	}
+}

--- a/cmd/stack_profile_manage.go
+++ b/cmd/stack_profile_manage.go
@@ -232,8 +232,15 @@ Rolling back is setting the pointer to an earlier version.`,
 
 var stackProfilesVersionCmd = &cobra.Command{
 	Use:   "version [profile-id|profile-name] <version>",
-	Short: "Show one published version's contents and parameters",
-	Args:  cobra.ExactArgs(2),
+	Short: "Show one published version's record and parameters",
+	Long: `Print the stored record of one published version: its spec, parameters and
+channel, as JSON (default) or YAML.
+
+Manifests and add-on values inside the record are base64-encoded. To read
+them decoded, list them, or grep across them, use:
+
+  ankra stack-profiles contents <profile> <version>`,
+	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if _, formatError := structuredFormatFromFlags(cmd); formatError != nil {
 			return formatError


### PR DESCRIPTION
Adds `ankra stack-profiles contents <profile> <version>`, so a published profile's manifests and add-on values can be read from the CLI.

### Why

A stack profile version stores every manifest as `manifest_base64` and every add-on's values as `values_base64`. `ankra stack-profiles version` prints that record verbatim, and `export-iac` writes the same encoding (correctly, since `import` consumes it). So there was no way to see, list, or grep what a profile actually contains without decoding it by hand outside the CLI.

This surfaced on camera while making the stack-profiles guide film: auditing v1 of the `opensearch` profile, the step that exposed Fluent Bit reading `infra-admin-password` and the `'*'` ISM pattern had to be `python3 decode.py v1.yaml | grep -A2 secretKeyRef`. The cluster side already has the right convention (`ankra cluster manifests get` and `cluster addons values` decode by default, `-o raw` for base64); profiles never got it.

### What it does

With no flags, a decoded inventory. The kind and namespace come out of each manifest's YAML, which the encoded record cannot tell you:

```
$ ankra stack-profiles contents opensearch 2
Profile version v2 (stable)

Add-ons:
│ NAME                │ CHART                │ VERSION │ NAMESPACE           │
│ opensearch-operator │ opensearch-operator  │ 3.0.2   │ opensearch-operator │
│ fluent-bit          │ fluent-bit-collector │ 1.1.1   │ opensearch          │

Manifests:
│ NAME                              │ KIND                      │ NAMESPACE  │
│ opensearch-cluster                │ OpenSearchCluster         │ opensearch │
│ opensearch-fluentbit-role         │ OpensearchRole            │ opensearch │
│ opensearch-retention-policy       │ OpenSearchISMPolicy       │ opensearch │
...
```

`--resource <name>` prints one resource decoded (`-o raw` for the base64), mirroring `cluster manifests get`. `--all` streams every resource as one multi-document YAML with a `# manifest: <name>` / `# addon: <name>` comment on each, which is the greppable form. The on-camera audit is now:

```
$ ankra stack-profiles contents opensearch 1 --all | grep -A2 secretKeyRef
      secretKeyRef:
        name: infra-admin-password
        key: username
```

Verified against the live `opensearch` profile in Ankra AB: both commands above reproduce the earlier Python output exactly.

`version` is unchanged in behaviour; its help now says it prints the stored record and points at `contents` for decoded reading, since its old "contents" wording described something it never did.

### Checks

- `make lint`: 0 issues
- `make test` (`go test -race`): all packages pass
- New tests cover the inventory (kind decoded from YAML), `--resource` for a manifest and an add-on, `-o raw`, `--all`, an unknown resource listing what is available, the `--resource`/`--all` exclusion, and multi-document / unparseable manifests degrading instead of failing.

No docs change: `ankra-docs/reference/cli` is generated from the cobra help on stable tags.

Bead: the tracker refused the write with a Dolt merge conflict (the unhealed fork from this morning's `bd-health` warning), so no bead id yet; I will add the `Bead:` line once the tracker is repaired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jpdceC53qBgdoHfzxjYCm
