### PR TITLE
release: cut v0.15.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,22 @@
 # Ankra CLI Changelog
 
-## Unreleased
+## v0.15.0-rc1 — 2026-09-03
 
 ### Added
 
+- **`ankra stack-profiles contents` shows what a published profile actually
+  contains.** A profile version stores every manifest and every add-on's
+  values base64-encoded, and both `stack-profiles version` and `export-iac`
+  hand that encoding back verbatim, so reading a profile meant decoding it by
+  hand outside the CLI. `contents <profile> <version>` prints a decoded
+  inventory - each add-on with its chart, pinned version and namespace, and
+  each manifest with the kind and namespace read out of its YAML, which the
+  encoded record cannot tell you. `--resource <name>` prints one resource
+  decoded (`-o raw` for the base64), the way `cluster manifests get` prints a
+  live manifest, and `--all` streams every resource as one multi-document
+  YAML with a comment naming each - the form to grep across a whole profile
+  in one pass. `stack-profiles version` is unchanged; its help now says it
+  prints the stored record and points here.
 - **`ankra pipeline` drives Ankra Pipelines from the terminal.** `ankra pipeline
   run` dispatches a run of a repository's `.ankra/pipeline.yaml` (with
   `--input k=v` for declared inputs and `--wait` to follow it to a conclusion
@@ -110,6 +123,20 @@
   conversation id with a hint, instead of surfacing the backend's 422.
 - The org-switch test no longer writes `~/.ankra/organisation.json` into the
   developer's real home directory.
+- **`ankra backup vaults provision --wait` no longer reports a failure for an
+  UpCloud provision that is still succeeding.** The shared `--timeout` default
+  sat below the bound the platform itself works to - UpCloud's object storage
+  service alone is allowed fifteen minutes to reach running, and the bucket,
+  the access key and the verification all come after it - so a normal
+  provision printed `context deadline exceeded` at ten minutes and then
+  reached `ready` anyway. The wait now outlasts the platform's own bound.
+- **`ankra backup vaults` no longer tells you to fix access keys that are
+  fine.** A vault Ankra provisioned that had verified before and then came
+  back as an error row - a failed teardown leaves the keys working and a
+  provider resource behind - was answered with "fix the access keys, then
+  verify", a wrong cause and a command that cannot help. That branch now
+  quotes the error the row carries and offers both real ways out: re-verify,
+  or delete with `--destroy-provider-resources`.
 
 ## v0.15.0-rc0 — 2026-09-01
 


### PR DESCRIPTION
Cuts `v0.15.0-rc1`: everything on `master` above the `v0.15.0-rc0` tag (2026-09-01). CHANGELOG.md only, per the release process.

Above the tag, in merge order:

- #227 `ankra stack-profiles contents` — decodes a profile version's manifests and add-on values (entry written at cut time; the PR shipped none)
- #226 `ankra pipeline run|list|get|logs|cancel|rerun|artifacts|validate|schedules`
- #224 `ankra cluster delete|restart|cordon|uncordon|drain` and `cluster helm get|history|rollback|upgrade`
- #225 backup vaults `provision --wait` no longer fails a still-succeeding UpCloud provision (entry written at cut time)
- #222 backup vaults no longer blames working access keys (entry written at cut time)
- #223 `ankra security sbom`, `security namespaces`, `security pods`
- #221 CI runner labels behind org variables (no user-facing entry)
- #220, #219, #218 `ankra chat` on the durable sessions API, named conversations, no narrative status line

Checks done before opening this: the `## v0.15.0-rc1 — 2026-09-03` heading matches the release workflow's `^## v?VERSION([[:space:]]|$)` extractor (a miss silently falls back to `--generate-notes`); the extracted section carries nine bold lead-in entries across Added / Changed / Fixed; no post-rc0 entry sat under the rc0 heading; master has both #227 files intact after the CodeStaple merge; master's toolchain is `go1.26.6` (Go 1.26.8 exists — if govulncheck reds this PR, the fix is a toolchain bump, not a release change).

After merge: `git tag -a v0.15.0-rc1 <merge-sha>` and push, which publishes the pre-release and builds the binaries; then verify the shipped darwin-arm64 artifact (sha256 match, `--version` stamps rc1, `stack-profiles contents opensearch 2 --org ankra-ab` against production) before it's called good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jpdceC53qBgdoHfzxjYCm
