### PR TITLE
fix(cli): say what Hetzner 'deprovision --force' actually deletes (ankra-eg2v5, PLA-822)

### DIFF
--- a/cmd/cloud_deprovision_force_help_parity_test.go
+++ b/cmd/cloud_deprovision_force_help_parity_test.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// Every cloud provider's `deprovision --force` deletes the cluster's storage
+// volumes and load balancers. The help text has to say so, because the flag is
+// destructive in a direction the operator cannot undo: the volumes hold their
+// data.
+//
+// Hetzner's said the opposite until ankra-eg2v5 ("cloud resources may leak"),
+// which was the pre-ankra-phep meaning of the flag — it survived three sibling
+// rewrites because nothing pinned the wording. This test is that pin.
+func TestDeprovisionForceHelpNamesWhatItDeletes(t *testing.T) {
+	tests := []struct {
+		name    string
+		command *cobra.Command
+	}{
+		{name: "hetzner", command: hetznerDeprovisionCmd},
+		{name: "upcloud", command: upcloudDeprovisionCmd},
+		{name: "digitalocean", command: digitaloceanDeprovisionCmd},
+		{name: "ovh", command: ovhDeprovisionCmd},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flag := tt.command.Flags().Lookup("force")
+			if flag == nil {
+				t.Fatal("no --force flag registered")
+			}
+			usage := strings.ToLower(flag.Usage)
+
+			if !strings.Contains(usage, "volumes") {
+				t.Errorf("--force help does not mention volumes: %q", flag.Usage)
+			}
+			if !strings.Contains(usage, "load balancers") {
+				t.Errorf("--force help does not mention load balancers: %q", flag.Usage)
+			}
+			// The stale wording claimed the opposite of what the flag does:
+			// --force is the mode in which resources do NOT leak.
+			if strings.Contains(usage, "may leak") {
+				t.Errorf("--force help still carries the stale leak wording: %q", flag.Usage)
+			}
+		})
+	}
+}

--- a/cmd/hetzner_cluster.go
+++ b/cmd/hetzner_cluster.go
@@ -626,7 +626,7 @@ func init() {
 	_ = hetznerCreateCmd.MarkFlagRequired("credential-id")
 	_ = hetznerCreateCmd.MarkFlagRequired("location")
 
-	hetznerDeprovisionCmd.Flags().Bool("force", false, "Force deprovision without waiting for the cluster agent (use only when the cluster agent is permanently offline; cloud resources may leak)")
+	hetznerDeprovisionCmd.Flags().Bool("force", false, "Force teardown: also delete the cluster's CSI storage volumes and load balancers (destroys persisted data), and tolerate unreachable infrastructure")
 	hetznerDeprovisionCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 	nodeGroupDeleteCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 


### PR DESCRIPTION
<!-- ankra-tech-agent:pr -->
Linear: https://linear.app/ankra/issue/PLA-822/1144-from-board-t-137-deregister-deleted-cluster-depict-foundation
Bead: ankra-eg2v5

## The problem

`ankra cluster hetzner deprovision --force` described itself like this:

> Force deprovision without waiting for the cluster agent (use only when the cluster agent is permanently offline; cloud resources may leak)

That is the flag's pre-`ankra-phep` meaning, and it is now wrong **in the dangerous
direction**. `--force` is the mode in which cloud resources do *not* leak — it is the mode
that deletes them:

- `scheduler/go/internal/hetznerjobs/network.go` passes `payload.ForceDelete` as
  `sweepNetworkOrphans`' `includeVolumes`, so the volume half of the sweep
  (`label_selector=ankra-cluster-id=<cluster>`) runs only under `--force`;
- `enginekit/clusterengine/cloudforcecleanup.go` additionally reclaims the CSI volume ids
  captured from the cluster's own Kubernetes PV inventory.

So the single thing an operator most needs to know before typing it — that it **deletes the
cluster's CSI volumes and destroys the data on them** — was the one thing the help text did
not say. It said the opposite.

## Why only Hetzner

Every sibling is already correct, which is how this survived:

| command | says what it deletes |
|---|---|
| `upcloud deprovision --force` | yes |
| `digitalocean deprovision --force` | yes |
| `ovh deprovision --force` | yes |
| `hetzner stop --force` | yes |
| `hetzner deprovision --force` | **no** |

Nothing pinned the wording, so three sibling rewrites went past it.

## The change

Adopt the sibling phrasing, and keep the data-destruction note that Hetzner's own
`stop --force` already carries:

> Force teardown: also delete the cluster's CSI storage volumes and load balancers (destroys persisted data), and tolerate unreachable infrastructure

Then pin it: `cmd/cloud_deprovision_force_help_parity_test.go` asserts that all four
provider `deprovision --force` flags name the volumes and the load balancers, and that none
of them carries the stale "may leak" claim. Verified failing on the old text (all three
assertions) and passing on the new.

## Scope

Help text and one new test. No behaviour change — `--force` did all of this already; only
its description was wrong.

## Validation

- `go test ./cmd/ -run TestDeprovisionForceHelpNamesWhatItDeletes` — fails before, passes after
- `go vet ./cmd/` — clean
- `go build -buildvcs=false ./...` — clean

## Provenance

Found while answering Depict's deprovision blast-radius question on PLA-822 — they read the
docs and the CLI help before deciding whether to run a deprovision, and both were wrong in
the same direction. The docs half is ankra-docs#288 (`ankra-m0xug`).
