### PR TITLE
feat(security): sbom containers, export, workload scope and -o on every sbom read

### DIFF
--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1002,6 +1002,14 @@ func (m baseMock) GetSecuritySBOMImage(client.SecuritySBOMImageOptions) (*client
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) ListSecuritySBOMContainers(client.SecuritySBOMContainersOptions) (*client.SecuritySBOMContainerList, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) ExportSecuritySBOMImage(client.SecuritySBOMExportOptions) (*client.SecuritySBOMExport, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) CreateAPIToken(name string, expiresAt *string, scopes []string) (*client.CreateAPITokenResponse, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/security_sbom.go
+++ b/cmd/security_sbom.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"ankra/internal/client"
@@ -138,10 +139,13 @@ var securitySbomImagesCmd = &cobra.Command{
 		search, _ := cmd.Flags().GetString("search")
 		clusterFlag, _ := cmd.Flags().GetString("cluster")
 		namespace, _ := cmd.Flags().GetString("namespace")
+		workloadKind, _ := cmd.Flags().GetString("workload-kind")
+		workloadName, _ := cmd.Flags().GetString("workload-name")
 		sort, _ := cmd.Flags().GetString("sort")
 		order, _ := cmd.Flags().GetString("order")
 		options := client.SecuritySBOMImagesOptions{
-			Page: page, PageSize: pageSize, Search: search, Namespace: namespace, Sort: sort, Order: order,
+			Page: page, PageSize: pageSize, Search: search, Namespace: namespace,
+			WorkloadKind: workloadKind, WorkloadName: workloadName, Sort: sort, Order: order,
 		}
 		if clusterFlag != "" {
 			clusterID, err := resolveClusterID(clusterFlag)
@@ -193,6 +197,116 @@ var securitySbomImageCmd = &cobra.Command{
 	},
 }
 
+var securitySbomContainersCmd = &cobra.Command{
+	Use:   "containers",
+	Short: "Every running container with or without a bill of materials, absent first",
+	Long: `List every container the resource cache says is running on the scoped
+clusters, init containers included, each joined to the bill of materials of
+the image it runs - or marked ABSENT when the scanner has none for it.
+
+An absent bill of materials is a state to act on, not an empty image: the
+cluster may have SBOM generation switched off, the scanner may not be able
+to pull from the image's registry, or the tag rolled since the last scan.
+Absent rows sort first by default; --status absent lists only them.
+
+The inventory line counts the scope (cluster, namespace, workload) before
+--status and --search narrow the rows, so it holds while you drill.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		page, _ := cmd.Flags().GetInt("page")
+		pageSize, _ := cmd.Flags().GetInt("page-size")
+		search, _ := cmd.Flags().GetString("search")
+		clusterFlag, _ := cmd.Flags().GetString("cluster")
+		namespace, _ := cmd.Flags().GetString("namespace")
+		workloadKind, _ := cmd.Flags().GetString("workload-kind")
+		workloadName, _ := cmd.Flags().GetString("workload-name")
+		status, _ := cmd.Flags().GetString("status")
+		sort, _ := cmd.Flags().GetString("sort")
+		order, _ := cmd.Flags().GetString("order")
+		switch strings.ToLower(strings.TrimSpace(status)) {
+		case "", "any", "present", "absent":
+		default:
+			return withExitCode(exitUsage, fmt.Errorf("--status must be present, absent or any, got %q", status))
+		}
+		options := client.SecuritySBOMContainersOptions{
+			Page: page, PageSize: pageSize, Search: search, Namespace: namespace,
+			WorkloadKind: workloadKind, WorkloadName: workloadName, Status: status, Sort: sort, Order: order,
+		}
+		if strings.EqualFold(strings.TrimSpace(status), "any") {
+			options.Status = ""
+		}
+		if clusterFlag != "" {
+			clusterID, err := resolveClusterID(clusterFlag)
+			if err != nil {
+				return err
+			}
+			options.ClusterID = clusterID
+		}
+		list, err := apiClient.ListSecuritySBOMContainers(options)
+		if err != nil {
+			return fmt.Errorf("listing running containers and their bills of materials: %w", err)
+		}
+		if rendered, err := renderStructured(cmd, list); rendered || err != nil {
+			return err
+		}
+		renderSecuritySbomContainers(cmd, list)
+		return nil
+	},
+}
+
+var securitySbomExportCmd = &cobra.Command{
+	Use:   "export <digest or reference>",
+	Short: "Download one image's bill of materials as CycloneDX JSON or CSV",
+	Long: `Download one image's bill of materials, rebuilt from the components the
+platform stores: a CycloneDX 1.5 JSON document by default (what
+Dependency-Track, Grype and licence scanners ingest) or a flat CSV with
+--format csv. Every component is included, unpaged.
+
+The document goes to the file the platform names (repository_tag.cdx.json)
+in the current directory, to --output-file, or to standard output with
+--output-file -.
+
+Example:
+  ankra security sbom export sha256:18ed3a...  --format csv --output-file backend.csv`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		format, _ := cmd.Flags().GetString("format")
+		outputFile, _ := cmd.Flags().GetString("output-file")
+		export, err := apiClient.ExportSecuritySBOMImage(client.SecuritySBOMExportOptions{
+			ImageIdentity: strings.TrimSpace(args[0]),
+			Format:        format,
+		})
+		if err != nil {
+			return fmt.Errorf("downloading the image's bill of materials: %w", err)
+		}
+		if outputFile == "-" {
+			_, writeError := cmd.OutOrStdout().Write(export.Body)
+			return writeError
+		}
+		target := strings.TrimSpace(outputFile)
+		if target == "" {
+			target = export.FileName
+		}
+		if target == "" {
+			target = "sbom." + sbomExportExtension(format)
+		}
+		if writeError := os.WriteFile(target, export.Body, 0o600); writeError != nil {
+			return fmt.Errorf("writing %s: %w", target, writeError)
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Wrote %s (%d bytes, %s)\n", target, len(export.Body), export.ContentType)
+		return nil
+	},
+}
+
+// sbomExportExtension names the file for a format when the platform sent no
+// file name of its own.
+func sbomExportExtension(format string) string {
+	if strings.EqualFold(strings.TrimSpace(format), "csv") {
+		return "csv"
+	}
+	return "cdx.json"
+}
+
 // securitySbomComponentsOptionsFromFlags maps the component flags. --vulnerable
 // accepts true, false or any so the inventory can be narrowed to packages a
 // finding names, or to the ones nothing names.
@@ -203,6 +317,8 @@ func securitySbomComponentsOptionsFromFlags(cmd *cobra.Command) (client.Security
 	packageTypes, _ := cmd.Flags().GetStringSlice("type")
 	clusterFlag, _ := cmd.Flags().GetString("cluster")
 	namespace, _ := cmd.Flags().GetString("namespace")
+	workloadKind, _ := cmd.Flags().GetString("workload-kind")
+	workloadName, _ := cmd.Flags().GetString("workload-name")
 	image, _ := cmd.Flags().GetString("image")
 	vulnerableRaw, _ := cmd.Flags().GetString("vulnerable")
 	sort, _ := cmd.Flags().GetString("sort")
@@ -213,6 +329,8 @@ func securitySbomComponentsOptionsFromFlags(cmd *cobra.Command) (client.Security
 		Search:        search,
 		PackageTypes:  packageTypes,
 		Namespace:     namespace,
+		WorkloadKind:  workloadKind,
+		WorkloadName:  workloadName,
 		ImageIdentity: image,
 		Sort:          sort,
 		Order:         order,
@@ -411,6 +529,57 @@ func renderSecuritySbomImages(cmd *cobra.Command, list *client.SecuritySBOMImage
 	_, _ = fmt.Fprintf(out, "Page %d of %d · %d images\n", list.Pagination.Page, list.Pagination.TotalPages, list.Pagination.TotalCount)
 }
 
+func renderSecuritySbomContainers(cmd *cobra.Command, list *client.SecuritySBOMContainerList) {
+	out := cmd.OutOrStdout()
+	renderSbomCoverage(cmd, list.Coverage)
+	inventory := list.Inventory
+	if inventory.Containers > 0 {
+		without := fmt.Sprintf("%d", inventory.WithoutSBOM)
+		if inventory.WithoutSBOM > 0 {
+			without = text.FgRed.Sprint(without)
+		}
+		_, _ = fmt.Fprintf(out, "Inventory: %d containers in %d pods, %d with a bill of materials, %s without\n",
+			inventory.Containers, inventory.Pods, inventory.WithSBOM, without)
+	}
+	if len(list.Result) == 0 {
+		_, _ = fmt.Fprintln(out, "No running containers match these filters.")
+		return
+	}
+	writer := newSecurityTable(out)
+	writer.AppendHeader(table.Row{"Cluster", "Namespace", "Workload", "Pod", "Container", "Image", "Bill of materials", "Components", "OS", "Generated"})
+	for _, container := range list.Result {
+		workload := "(bare pod)"
+		if container.WorkloadName != nil {
+			workload = strings.TrimSpace(stringOrEmpty(container.WorkloadKind) + " " + *container.WorkloadName)
+		}
+		containerLabel := container.ContainerName
+		if container.ContainerKind == "init" {
+			containerLabel += " (init)"
+		}
+		status := text.FgGreen.Sprint("present")
+		components := "-"
+		if container.SBOMStatus != "present" {
+			status = text.FgRed.Sprint("ABSENT")
+		} else if container.ComponentCount != nil {
+			components = fmt.Sprintf("%d", *container.ComponentCount)
+		}
+		writer.AppendRow(table.Row{
+			container.ClusterName,
+			container.Namespace,
+			workload,
+			container.PodName,
+			containerLabel,
+			container.Image,
+			status,
+			components,
+			stringOrEmpty(container.OSName),
+			optionalTimeAgo(container.GeneratedAt),
+		})
+	}
+	writer.Render()
+	_, _ = fmt.Fprintf(out, "Page %d of %d · %d containers\n", list.Pagination.Page, list.Pagination.TotalPages, list.Pagination.TotalCount)
+}
+
 func renderSecuritySbomImageDetail(cmd *cobra.Command, detail *client.SecuritySBOMImageDetail) {
 	out := cmd.OutOrStdout()
 	image := detail.Image
@@ -472,7 +641,9 @@ func renderSecuritySbomImageDetail(cmd *cobra.Command, detail *client.SecuritySB
 
 func init() {
 	securityCmd.AddCommand(securityNamespacesCmd, securityPodsCmd, securitySbomCmd)
-	securitySbomCmd.AddCommand(securitySbomImagesCmd, securitySbomImageCmd)
+	securitySbomCmd.AddCommand(securitySbomImagesCmd, securitySbomImageCmd, securitySbomContainersCmd, securitySbomExportCmd)
+	registerStructuredOutputFlags(securityNamespacesCmd, securityPodsCmd, securitySbomCmd,
+		securitySbomImagesCmd, securitySbomImageCmd, securitySbomContainersCmd)
 
 	securityNamespacesCmd.Flags().String("search", "", "Match namespace or cluster name")
 	securityNamespacesCmd.Flags().String("cluster", "", "Only namespaces on one cluster (name or id)")
@@ -493,6 +664,8 @@ func init() {
 	securitySbomCmd.Flags().StringSlice("type", nil, "Ecosystem filter, repeatable: deb, apk, rpm, npm, pypi, golang, maven, ...")
 	securitySbomCmd.Flags().String("cluster", "", "Only packages in images running on one cluster (name or id)")
 	securitySbomCmd.Flags().String("namespace", "", "Only packages in images running in one namespace")
+	securitySbomCmd.Flags().String("workload-kind", "", "Only packages in images run by workloads of this kind (Deployment, StatefulSet, DaemonSet, CronJob, ...)")
+	securitySbomCmd.Flags().String("workload-name", "", "Only packages in images run by the workload with this name; combine with --workload-kind to pin one workload")
 	securitySbomCmd.Flags().String("image", "", "Only packages in one image (digest or reference)")
 	securitySbomCmd.Flags().String("vulnerable", "any", "Findings filter: true (a finding names the package), false or any")
 	securitySbomCmd.Flags().String("sort", "images", "Sort key: images, workloads, clusters, vulnerable, actionable, name, version, package_type")
@@ -503,6 +676,8 @@ func init() {
 	securitySbomImagesCmd.Flags().String("search", "", "Match image reference, digest or OS")
 	securitySbomImagesCmd.Flags().String("cluster", "", "Only images running on one cluster (name or id)")
 	securitySbomImagesCmd.Flags().String("namespace", "", "Only images running in one namespace")
+	securitySbomImagesCmd.Flags().String("workload-kind", "", "Only images run by workloads of this kind (Deployment, StatefulSet, DaemonSet, CronJob, ...)")
+	securitySbomImagesCmd.Flags().String("workload-name", "", "Only images run by the workload with this name; combine with --workload-kind to pin one workload")
 	securitySbomImagesCmd.Flags().String("sort", "actionable", "Sort key: actionable, known_exploited, workloads, clusters, components, image_ref, generated_at, last_seen_at")
 	securitySbomImagesCmd.Flags().String("order", "desc", "Sort order: asc or desc")
 	securitySbomImagesCmd.Flags().Int("page", 1, "Page number")
@@ -514,4 +689,18 @@ func init() {
 	securitySbomImageCmd.Flags().String("order", "desc", "Sort order: asc or desc")
 	securitySbomImageCmd.Flags().Int("page", 1, "Page number")
 	securitySbomImageCmd.Flags().Int("page-size", 100, "Components per page (max 100)")
+
+	securitySbomContainersCmd.Flags().String("search", "", "Match image, container, pod, workload or namespace")
+	securitySbomContainersCmd.Flags().String("cluster", "", "One cluster (name or id); omit for every live cluster")
+	securitySbomContainersCmd.Flags().String("namespace", "", "Only containers in one namespace")
+	securitySbomContainersCmd.Flags().String("workload-kind", "", "Match the resolved workload, its direct owner, or 'pod' for bare pods")
+	securitySbomContainersCmd.Flags().String("workload-name", "", "Match the resolved workload, its direct owner, or the pod name")
+	securitySbomContainersCmd.Flags().String("status", "any", "Bill of materials filter: present, absent or any")
+	securitySbomContainersCmd.Flags().String("sort", "status", "Sort key: status (absent first), image, container, pod, namespace, workload, cluster_name, components, last_seen_at")
+	securitySbomContainersCmd.Flags().String("order", "desc", "Sort order: asc or desc")
+	securitySbomContainersCmd.Flags().Int("page", 1, "Page number")
+	securitySbomContainersCmd.Flags().Int("page-size", 50, "Containers per page (max 100)")
+
+	securitySbomExportCmd.Flags().String("format", "cyclonedx", "Document format: cyclonedx or csv")
+	securitySbomExportCmd.Flags().String("output-file", "", "Where to write the document; the platform's file name by default, - for standard output")
 }

--- a/cmd/security_sbom.go
+++ b/cmd/security_sbom.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"ankra/internal/client"
@@ -272,9 +273,14 @@ Example:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		format, _ := cmd.Flags().GetString("format")
 		outputFile, _ := cmd.Flags().GetString("output-file")
+		force, _ := cmd.Flags().GetBool("force")
+		normalizedFormat, formatError := normalizeSbomExportFormat(format)
+		if formatError != nil {
+			return formatError
+		}
 		export, err := apiClient.ExportSecuritySBOMImage(client.SecuritySBOMExportOptions{
 			ImageIdentity: strings.TrimSpace(args[0]),
-			Format:        format,
+			Format:        normalizedFormat,
 		})
 		if err != nil {
 			return fmt.Errorf("downloading the image's bill of materials: %w", err)
@@ -285,10 +291,12 @@ Example:
 		}
 		target := strings.TrimSpace(outputFile)
 		if target == "" {
-			target = export.FileName
+			target = sbomExportLocalFileName(export.FileName, normalizedFormat)
 		}
-		if target == "" {
-			target = "sbom." + sbomExportExtension(format)
+		if !force {
+			if _, statError := os.Stat(target); statError == nil {
+				return withExitCode(exitUsage, fmt.Errorf("%s already exists; pass --force to overwrite it or --output-file to write elsewhere", target))
+			}
 		}
 		if writeError := os.WriteFile(target, export.Body, 0o600); writeError != nil {
 			return fmt.Errorf("writing %s: %w", target, writeError)
@@ -298,13 +306,32 @@ Example:
 	},
 }
 
-// sbomExportExtension names the file for a format when the platform sent no
-// file name of its own.
-func sbomExportExtension(format string) string {
-	if strings.EqualFold(strings.TrimSpace(format), "csv") {
-		return "csv"
+// normalizeSbomExportFormat maps the accepted spellings to the two formats
+// the platform serves, so a typo is a usage error here rather than a
+// server error or a silently defaulted document.
+func normalizeSbomExportFormat(requested string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "", "cyclonedx", "cdx", "json":
+		return "cyclonedx", nil
+	case "csv":
+		return "csv", nil
 	}
-	return "cdx.json"
+	return "", withExitCode(exitUsage, fmt.Errorf("--format must be cyclonedx or csv, got %q", requested))
+}
+
+// sbomExportLocalFileName is the file the download lands in when the caller
+// named none: the platform's suggested name reduced to its last path element
+// (a Content-Disposition is server input, never a path), or a name derived
+// from the format when the platform sent none.
+func sbomExportLocalFileName(suggested string, format string) string {
+	base := filepath.Base(strings.TrimSpace(suggested))
+	if base == "" || base == "." || base == string(filepath.Separator) || strings.HasPrefix(base, ".") {
+		if format == "csv" {
+			return "sbom.csv"
+		}
+		return "sbom.cdx.json"
+	}
+	return base
 }
 
 // securitySbomComponentsOptionsFromFlags maps the component flags. --vulnerable
@@ -702,5 +729,6 @@ func init() {
 	securitySbomContainersCmd.Flags().Int("page-size", 50, "Containers per page (max 100)")
 
 	securitySbomExportCmd.Flags().String("format", "cyclonedx", "Document format: cyclonedx or csv")
-	securitySbomExportCmd.Flags().String("output-file", "", "Where to write the document; the platform's file name by default, - for standard output")
+	securitySbomExportCmd.Flags().String("output-file", "", "Where to write the document; the platform's file name in the current directory by default, - for standard output")
+	securitySbomExportCmd.Flags().Bool("force", false, "Overwrite the target file if it already exists")
 }

--- a/cmd/security_sbom.go
+++ b/cmd/security_sbom.go
@@ -224,17 +224,17 @@ The inventory line counts the scope (cluster, namespace, workload) before
 		status, _ := cmd.Flags().GetString("status")
 		sort, _ := cmd.Flags().GetString("sort")
 		order, _ := cmd.Flags().GetString("order")
-		switch strings.ToLower(strings.TrimSpace(status)) {
-		case "", "any", "present", "absent":
+		normalizedStatus := strings.ToLower(strings.TrimSpace(status))
+		switch normalizedStatus {
+		case "", "any":
+			normalizedStatus = ""
+		case "present", "absent":
 		default:
 			return withExitCode(exitUsage, fmt.Errorf("--status must be present, absent or any, got %q", status))
 		}
 		options := client.SecuritySBOMContainersOptions{
 			Page: page, PageSize: pageSize, Search: search, Namespace: namespace,
-			WorkloadKind: workloadKind, WorkloadName: workloadName, Status: status, Sort: sort, Order: order,
-		}
-		if strings.EqualFold(strings.TrimSpace(status), "any") {
-			options.Status = ""
+			WorkloadKind: workloadKind, WorkloadName: workloadName, Status: normalizedStatus, Sort: sort, Order: order,
 		}
 		if clusterFlag != "" {
 			clusterID, err := resolveClusterID(clusterFlag)
@@ -325,7 +325,7 @@ func normalizeSbomExportFormat(requested string) (string, error) {
 // from the format when the platform sent none.
 func sbomExportLocalFileName(suggested string, format string) string {
 	base := filepath.Base(strings.TrimSpace(suggested))
-	if base == "" || base == "." || base == string(filepath.Separator) || strings.HasPrefix(base, ".") {
+	if base == "" || strings.HasPrefix(base, ".") {
 		if format == "csv" {
 			return "sbom.csv"
 		}

--- a/cmd/security_sbom_test.go
+++ b/cmd/security_sbom_test.go
@@ -264,6 +264,12 @@ func TestSecuritySbomContainersListsAbsentRowsFirstAndTalliesTheScope(t *testing
 	if _, executeError := runSecurityCommand(t, mock, "security", "sbom", "containers", "--status", "nope"); executeError == nil {
 		t.Fatalf("an unknown status must be refused")
 	}
+	if _, executeError := runSecurityCommand(t, mock, "security", "sbom", "containers", "--status", " ABSENT "); executeError != nil {
+		t.Fatalf("any casing of a known status is accepted: %v", executeError)
+	}
+	if mock.containersOptions.Status != "absent" {
+		t.Fatalf("the status reaches the platform in its canonical form, got %q", mock.containersOptions.Status)
+	}
 }
 
 func TestSecuritySbomExportWritesTheDocumentToStdoutOrAFile(t *testing.T) {

--- a/cmd/security_sbom_test.go
+++ b/cmd/security_sbom_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -17,6 +18,11 @@ type securitySbomMock struct {
 	images            *client.SecuritySBOMImageList
 	detail            *client.SecuritySBOMImageDetail
 	detailOptions     *client.SecuritySBOMImageOptions
+	imagesOptions     *client.SecuritySBOMImagesOptions
+	containers        *client.SecuritySBOMContainerList
+	containersOptions *client.SecuritySBOMContainersOptions
+	export            *client.SecuritySBOMExport
+	exportOptions     *client.SecuritySBOMExportOptions
 }
 
 func (m *securitySbomMock) ListSecurityNamespaces(client.SecurityNamespacesOptions) (*client.SecurityNamespaceList, error) {
@@ -33,8 +39,19 @@ func (m *securitySbomMock) ListSecuritySBOMComponents(options client.SecuritySBO
 	return m.components, nil
 }
 
-func (m *securitySbomMock) ListSecuritySBOMImages(client.SecuritySBOMImagesOptions) (*client.SecuritySBOMImageList, error) {
+func (m *securitySbomMock) ListSecuritySBOMImages(options client.SecuritySBOMImagesOptions) (*client.SecuritySBOMImageList, error) {
+	m.imagesOptions = &options
 	return m.images, nil
+}
+
+func (m *securitySbomMock) ListSecuritySBOMContainers(options client.SecuritySBOMContainersOptions) (*client.SecuritySBOMContainerList, error) {
+	m.containersOptions = &options
+	return m.containers, nil
+}
+
+func (m *securitySbomMock) ExportSecuritySBOMImage(options client.SecuritySBOMExportOptions) (*client.SecuritySBOMExport, error) {
+	m.exportOptions = &options
+	return m.export, nil
 }
 
 func (m *securitySbomMock) GetSecuritySBOMImage(options client.SecuritySBOMImageOptions) (*client.SecuritySBOMImageDetail, error) {
@@ -178,5 +195,103 @@ func TestSecuritySbomImagesAndImageDetail(t *testing.T) {
 		if !strings.Contains(output, expected) {
 			t.Fatalf("detail output lacks %q:\n%s", expected, output)
 		}
+	}
+}
+
+func TestSecuritySbomInventoriesAcceptTheWorkloadSelectorAndStructuredOutput(t *testing.T) {
+	mock := &securitySbomMock{
+		components: &client.SecuritySBOMComponentList{Result: []client.SecuritySBOMComponent{sbomComponent()},
+			Pagination: client.SecurityPagination{Page: 1, PageSize: 50, TotalPages: 1, TotalCount: 1}, Coverage: sbomCoverage()},
+		images: &client.SecuritySBOMImageList{Result: []client.SecuritySBOMImage{},
+			Pagination: client.SecurityPagination{Page: 1, PageSize: 50}, Coverage: sbomCoverage()},
+	}
+	output, executeError := runSecurityCommand(t, mock, "security", "sbom",
+		"--workload-kind", "Deployment", "--workload-name", "grafana", "-o", "json")
+	if executeError != nil {
+		t.Fatalf("sbom -o json returned an error: %v", executeError)
+	}
+	if mock.componentsOptions.WorkloadKind != "Deployment" || mock.componentsOptions.WorkloadName != "grafana" {
+		t.Fatalf("workload selector not passed: %+v", mock.componentsOptions)
+	}
+	if !strings.Contains(output, "\"coverage\"") || !strings.Contains(output, "\"openssl\"") {
+		t.Fatalf("-o json must render the full API document, got %s", output)
+	}
+	if _, executeError := runSecurityCommand(t, mock, "security", "sbom", "images",
+		"--workload-name", "redis", "-o", "yaml"); executeError != nil {
+		t.Fatalf("sbom images -o yaml returned an error: %v", executeError)
+	}
+	if mock.imagesOptions.WorkloadName != "redis" {
+		t.Fatalf("image workload selector not passed: %+v", mock.imagesOptions)
+	}
+}
+
+func TestSecuritySbomContainersListsAbsentRowsFirstAndTalliesTheScope(t *testing.T) {
+	deployment, grafana, components := "Deployment", "grafana", 212
+	os := "debian 12.7"
+	identity := "sha256:abc"
+	generated := "2026-09-03T21:39:44Z"
+	mock := &securitySbomMock{containers: &client.SecuritySBOMContainerList{
+		Result: []client.SecuritySBOMContainer{
+			{ClusterName: "prod", Namespace: "smart-collector", PodName: "backend-6bbcfbf97f-x1", ContainerName: "backend",
+				ContainerKind: "app", Image: "registry.test/backend:sha-8a7cd7d", SBOMStatus: "absent", LastSeenAt: generated},
+			{ClusterName: "prod", Namespace: "security", PodName: "grafana-7d9f8-abcde", ContainerName: "migrate",
+				ContainerKind: "init", Image: "registry.test/redis:1.0.0", SBOMStatus: "present", WorkloadKind: &deployment,
+				WorkloadName: &grafana, ImageIdentity: &identity, ComponentCount: &components, OSName: &os,
+				GeneratedAt: &generated, LastSeenAt: generated},
+		},
+		Pagination: client.SecurityPagination{Page: 1, PageSize: 50, TotalPages: 1, TotalCount: 2},
+		Inventory:  client.SecuritySBOMContainerInventory{Containers: 113, WithSBOM: 84, WithoutSBOM: 29, Pods: 98},
+		Coverage:   sbomCoverage(),
+	}}
+	output, executeError := runSecurityCommand(t, mock, "security", "sbom", "containers",
+		"--namespace", "smart-collector", "--status", "any", "--workload-kind", "deployment")
+	if executeError != nil {
+		t.Fatalf("sbom containers returned an error: %v", executeError)
+	}
+	if mock.containersOptions.Namespace != "smart-collector" || mock.containersOptions.Status != "" ||
+		mock.containersOptions.WorkloadKind != "deployment" {
+		t.Fatalf("filters not passed (any must clear the status): %+v", mock.containersOptions)
+	}
+	for _, expected := range []string{
+		"113 containers in 98 pods, 84 with a bill of materials", "29",
+		"ABSENT", "(bare pod)", "migrate (init)", "Deployment grafana", "present", "212", "debian 12.7",
+		"Page 1 of 1 · 2 containers",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("output missing %q:\n%s", expected, output)
+		}
+	}
+	if _, executeError := runSecurityCommand(t, mock, "security", "sbom", "containers", "--status", "nope"); executeError == nil {
+		t.Fatalf("an unknown status must be refused")
+	}
+}
+
+func TestSecuritySbomExportWritesTheDocumentToStdoutOrAFile(t *testing.T) {
+	mock := &securitySbomMock{export: &client.SecuritySBOMExport{
+		FileName: "registry.test-grafana_1.0.0.cdx.json", ContentType: "application/vnd.cyclonedx+json; version=1.5",
+		Body: []byte("{\"bomFormat\":\"CycloneDX\"}\n"),
+	}}
+	output, executeError := runSecurityCommand(t, mock, "security", "sbom", "export", "sha256:abc", "--output-file", "-")
+	if executeError != nil {
+		t.Fatalf("sbom export returned an error: %v", executeError)
+	}
+	if mock.exportOptions.ImageIdentity != "sha256:abc" || mock.exportOptions.Format != "cyclonedx" {
+		t.Fatalf("export options = %+v", mock.exportOptions)
+	}
+	if strings.TrimSpace(output) != "{\"bomFormat\":\"CycloneDX\"}" {
+		t.Fatalf("stdout must carry the document verbatim, got %q", output)
+	}
+	target := t.TempDir() + "/bom.csv"
+	mock.export = &client.SecuritySBOMExport{FileName: "x.csv", ContentType: "text/csv", Body: []byte("name,version\n")}
+	output, executeError = runSecurityCommand(t, mock, "security", "sbom", "export", "sha256:abc", "--format", "csv", "--output-file", target)
+	if executeError != nil {
+		t.Fatalf("sbom export --format csv returned an error: %v", executeError)
+	}
+	if mock.exportOptions.Format != "csv" || !strings.Contains(output, "Wrote "+target) {
+		t.Fatalf("csv export = %+v %q", mock.exportOptions, output)
+	}
+	written, readError := os.ReadFile(target)
+	if readError != nil || string(written) != "name,version\n" {
+		t.Fatalf("file not written: %v %q", readError, written)
 	}
 }

--- a/cmd/security_sbom_test.go
+++ b/cmd/security_sbom_test.go
@@ -294,4 +294,49 @@ func TestSecuritySbomExportWritesTheDocumentToStdoutOrAFile(t *testing.T) {
 	if readError != nil || string(written) != "name,version\n" {
 		t.Fatalf("file not written: %v %q", readError, written)
 	}
+	if _, executeError := runSecurityCommand(t, mock, "security", "sbom", "export", "sha256:abc", "--format", "csv", "--output-file", target); executeError == nil {
+		t.Fatalf("an existing target must be refused without --force")
+	}
+	if _, executeError := runSecurityCommand(t, mock, "security", "sbom", "export", "sha256:abc", "--format", "csv", "--output-file", target, "--force"); executeError != nil {
+		t.Fatalf("--force must overwrite: %v", executeError)
+	}
+	if _, executeError := runSecurityCommand(t, mock, "security", "sbom", "export", "sha256:abc", "--format", "yaml", "--output-file", "-"); executeError == nil {
+		t.Fatalf("an unknown format must be a usage error before any request is made")
+	}
+}
+
+func TestSecuritySbomExportNeverTreatsTheServerFileNameAsAPath(t *testing.T) {
+	for suggested, expected := range map[string]string{
+		"registry.test-grafana_1.0.0.cdx.json": "registry.test-grafana_1.0.0.cdx.json",
+		"../../etc/passwd":                     "passwd",
+		"/tmp/evil.json":                       "evil.json",
+		"":                                     "sbom.cdx.json",
+		".":                                    "sbom.cdx.json",
+		"..":                                   "sbom.cdx.json",
+		".hidden":                              "sbom.cdx.json",
+	} {
+		if got := sbomExportLocalFileName(suggested, "cyclonedx"); got != expected {
+			t.Fatalf("sbomExportLocalFileName(%q) = %q, want %q", suggested, got, expected)
+		}
+	}
+	if got := sbomExportLocalFileName("", "csv"); got != "sbom.csv" {
+		t.Fatalf("csv fallback = %q", got)
+	}
+	workDirectory := t.TempDir()
+	previous, _ := os.Getwd()
+	if changeError := os.Chdir(workDirectory); changeError != nil {
+		t.Fatal(changeError)
+	}
+	t.Cleanup(func() { _ = os.Chdir(previous) })
+	mock := &securitySbomMock{export: &client.SecuritySBOMExport{FileName: "../../escaped.json", ContentType: "application/json", Body: []byte("{}")}}
+	output, executeError := runSecurityCommand(t, mock, "security", "sbom", "export", "sha256:abc", "--format", "cyclonedx", "--output-file", "")
+	if executeError != nil {
+		t.Fatalf("export returned an error: %v", executeError)
+	}
+	if !strings.Contains(output, "Wrote escaped.json") {
+		t.Fatalf("the download must land in the current directory under the base name, got %q", output)
+	}
+	if _, statError := os.Stat(workDirectory + "/escaped.json"); statError != nil {
+		t.Fatalf("file not written where announced: %v", statError)
+	}
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -48,6 +48,8 @@ type APIClient interface {
 	ListSecuritySBOMComponents(options client.SecuritySBOMComponentsOptions) (*client.SecuritySBOMComponentList, error)
 	ListSecuritySBOMImages(options client.SecuritySBOMImagesOptions) (*client.SecuritySBOMImageList, error)
 	GetSecuritySBOMImage(options client.SecuritySBOMImageOptions) (*client.SecuritySBOMImageDetail, error)
+	ListSecuritySBOMContainers(options client.SecuritySBOMContainersOptions) (*client.SecuritySBOMContainerList, error)
+	ExportSecuritySBOMImage(options client.SecuritySBOMExportOptions) (*client.SecuritySBOMExport, error)
 
 	ListPowerSchedules(clusterID string) (*client.PowerScheduleListResult, error)
 	CreatePowerSchedule(clusterID string, request client.PowerScheduleRequest) (*client.PowerScheduleListResult, error)

--- a/internal/client/security_sbom.go
+++ b/internal/client/security_sbom.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"fmt"
+	"mime"
+	"net/http"
 	neturl "net/url"
 	"strconv"
 	"strings"
@@ -213,6 +215,8 @@ type SecuritySBOMComponentsOptions struct {
 	PackageTypes  []string
 	ClusterID     string
 	Namespace     string
+	WorkloadKind  string
+	WorkloadName  string
 	ImageIdentity string
 	Vulnerable    *bool
 	Sort          string
@@ -221,13 +225,37 @@ type SecuritySBOMComponentsOptions struct {
 
 // SecuritySBOMImagesOptions mirrors the image inventory filters.
 type SecuritySBOMImagesOptions struct {
-	Page      int
-	PageSize  int
-	Search    string
-	ClusterID string
-	Namespace string
-	Sort      string
-	Order     string
+	Page         int
+	PageSize     int
+	Search       string
+	ClusterID    string
+	Namespace    string
+	WorkloadKind string
+	WorkloadName string
+	Sort         string
+	Order        string
+}
+
+// SecuritySBOMContainersOptions filters the running-container inventory.
+// Status is present, absent or empty for any.
+type SecuritySBOMContainersOptions struct {
+	Page         int
+	PageSize     int
+	Search       string
+	ClusterID    string
+	Namespace    string
+	WorkloadKind string
+	WorkloadName string
+	Status       string
+	Sort         string
+	Order        string
+}
+
+// SecuritySBOMExportOptions names the image to download and the document
+// format: cyclonedx (the default) or csv.
+type SecuritySBOMExportOptions struct {
+	ImageIdentity string
+	Format        string
 }
 
 // SecuritySBOMImageOptions pages the components of one image.
@@ -313,6 +341,7 @@ func (c *Client) ListSecuritySBOMComponents(options SecuritySBOMComponentsOption
 	if options.Namespace != "" {
 		query.Set("namespace", options.Namespace)
 	}
+	setWorkloadSelector(query, options.WorkloadKind, options.WorkloadName)
 	if options.ImageIdentity != "" {
 		query.Set("image", options.ImageIdentity)
 	}
@@ -340,6 +369,7 @@ func (c *Client) ListSecuritySBOMImages(options SecuritySBOMImagesOptions) (*Sec
 	if options.Namespace != "" {
 		query.Set("namespace", options.Namespace)
 	}
+	setWorkloadSelector(query, options.WorkloadKind, options.WorkloadName)
 	var list SecuritySBOMImageList
 	if err := c.getJSON(securityURL(c.BaseURL, "/sbom/images", query), &list); err != nil {
 		return nil, fmt.Errorf("security sbom images request failed: %w", err)
@@ -372,4 +402,133 @@ func (c *Client) GetSecuritySBOMImage(options SecuritySBOMImageOptions) (*Securi
 		detail.Workloads = []SecuritySBOMWorkload{}
 	}
 	return &detail, nil
+}
+
+func setWorkloadSelector(query neturl.Values, workloadKind string, workloadName string) {
+	if trimmed := strings.TrimSpace(workloadKind); trimmed != "" {
+		query.Set("workload_kind", trimmed)
+	}
+	if trimmed := strings.TrimSpace(workloadName); trimmed != "" {
+		query.Set("workload_name", trimmed)
+	}
+}
+
+// SecuritySBOMContainer is one running container joined to the bill of
+// materials of its image. SBOMStatus absent leaves ImageIdentity,
+// ComponentCount, OSName and GeneratedAt nil: the scanner has no bill of
+// materials for that image, which is a state to act on, not an empty image.
+type SecuritySBOMContainer struct {
+	ClusterID      string  `json:"cluster_id" yaml:"cluster_id"`
+	ClusterName    string  `json:"cluster_name" yaml:"cluster_name"`
+	Namespace      string  `json:"namespace" yaml:"namespace"`
+	PodName        string  `json:"pod_name" yaml:"pod_name"`
+	PodUID         *string `json:"pod_uid" yaml:"pod_uid"`
+	OwnerKind      *string `json:"owner_kind" yaml:"owner_kind"`
+	OwnerName      *string `json:"owner_name" yaml:"owner_name"`
+	WorkloadKind   *string `json:"workload_kind" yaml:"workload_kind"`
+	WorkloadName   *string `json:"workload_name" yaml:"workload_name"`
+	ContainerName  string  `json:"container_name" yaml:"container_name"`
+	ContainerKind  string  `json:"container_kind" yaml:"container_kind"`
+	Image          string  `json:"image" yaml:"image"`
+	ImageDigest    *string `json:"image_digest" yaml:"image_digest"`
+	SBOMStatus     string  `json:"sbom_status" yaml:"sbom_status"`
+	ImageIdentity  *string `json:"image_identity" yaml:"image_identity"`
+	ComponentCount *int    `json:"component_count" yaml:"component_count"`
+	OSName         *string `json:"os_name" yaml:"os_name"`
+	GeneratedAt    *string `json:"generated_at" yaml:"generated_at"`
+	LastSeenAt     string  `json:"last_seen_at" yaml:"last_seen_at"`
+}
+
+// SecuritySBOMContainerInventory tallies the scoped containers before the
+// status and search filters, so the headline holds while the list is
+// narrowed.
+type SecuritySBOMContainerInventory struct {
+	Containers  int `json:"containers" yaml:"containers"`
+	WithSBOM    int `json:"with_sbom" yaml:"with_sbom"`
+	WithoutSBOM int `json:"without_sbom" yaml:"without_sbom"`
+	Pods        int `json:"pods" yaml:"pods"`
+}
+
+// SecuritySBOMContainerList is the paginated running-container inventory.
+type SecuritySBOMContainerList struct {
+	Result     []SecuritySBOMContainer        `json:"result" yaml:"result"`
+	Pagination SecurityPagination             `json:"pagination" yaml:"pagination"`
+	Inventory  SecuritySBOMContainerInventory `json:"inventory" yaml:"inventory"`
+	Coverage   SecuritySBOMCoverage           `json:"coverage" yaml:"coverage"`
+}
+
+// ListSecuritySBOMContainers pages through every running container of the
+// scoped clusters with or without a bill of materials.
+func (c *Client) ListSecuritySBOMContainers(options SecuritySBOMContainersOptions) (*SecuritySBOMContainerList, error) {
+	query := neturl.Values{}
+	setPaging(query, options.Page, options.PageSize)
+	setListControls(query, options.Search, options.Sort, options.Order)
+	if options.ClusterID != "" {
+		query.Set("cluster_id", options.ClusterID)
+	}
+	if options.Namespace != "" {
+		query.Set("namespace", options.Namespace)
+	}
+	setWorkloadSelector(query, options.WorkloadKind, options.WorkloadName)
+	if trimmed := strings.TrimSpace(options.Status); trimmed != "" {
+		query.Set("status", trimmed)
+	}
+	var list SecuritySBOMContainerList
+	if err := c.getJSON(securityURL(c.BaseURL, "/sbom/containers", query), &list); err != nil {
+		return nil, fmt.Errorf("security sbom containers request failed: %w", err)
+	}
+	if list.Result == nil {
+		list.Result = []SecuritySBOMContainer{}
+	}
+	return &list, nil
+}
+
+// SecuritySBOMExport is a downloaded bill of materials: the bytes, the
+// media type the platform served, and the file name it suggested.
+type SecuritySBOMExport struct {
+	FileName    string
+	ContentType string
+	Body        []byte
+}
+
+// ExportSecuritySBOMImage downloads one image's bill of materials.
+func (c *Client) ExportSecuritySBOMImage(options SecuritySBOMExportOptions) (*SecuritySBOMExport, error) {
+	query := neturl.Values{}
+	query.Set("image", strings.TrimSpace(options.ImageIdentity))
+	if trimmed := strings.TrimSpace(options.Format); trimmed != "" {
+		query.Set("format", trimmed)
+	}
+	request, requestError := http.NewRequest(http.MethodGet, securityURL(c.BaseURL, "/sbom/image/export", query), nil)
+	if requestError != nil {
+		return nil, requestError
+	}
+	request.Header.Set("Authorization", "Bearer "+c.Token)
+	response, doError := c.HTTP.Do(request)
+	if doError != nil {
+		return nil, fmt.Errorf("security sbom export request failed: %w", doError)
+	}
+	defer closeBody(response)
+	if response.StatusCode == http.StatusUnauthorized {
+		return nil, ErrUnauthorized
+	}
+	body, readError := readResponseBody(response)
+	if readError != nil {
+		return nil, fmt.Errorf("security sbom export read failed: %w", readError)
+	}
+	if response.StatusCode != http.StatusOK {
+		if denied := PermissionDeniedFromResponse(response.StatusCode, body); denied != nil {
+			return nil, denied
+		}
+		return nil, newUnexpectedResponseErrorWithMessage(response.StatusCode,
+			fmt.Sprintf("security sbom export failed: %s", redactedBodyForError(body, 300)))
+	}
+	fileName := ""
+	if _, parameters, parseError := mime.ParseMediaType(response.Header.Get("Content-Disposition")); parseError == nil {
+		fileName = parameters["filename"]
+	}
+	return &SecuritySBOMExport{
+		FileName:    fileName,
+		ContentType: response.Header.Get("Content-Type"),
+		Body:        body,
+	}, nil
 }

--- a/internal/client/security_sbom_test.go
+++ b/internal/client/security_sbom_test.go
@@ -2,8 +2,10 @@ package client
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -97,5 +99,67 @@ func TestSecuritySBOMReadsEncodeFiltersAndDecodeCoverage(t *testing.T) {
 	}
 	if detail.Components == nil || detail.Workloads == nil {
 		t.Fatalf("null lists must decode to empty slices: %+v", detail)
+	}
+}
+
+func TestSecuritySBOMContainersAndExportEncodeTheirControls(t *testing.T) {
+	var captured http.Request
+	_, apiClient := newSecurityTestServer(t, `{"result": [{"cluster_id": "c1", "cluster_name": "prod", "namespace": "security",
+        "pod_name": "grafana-1", "pod_uid": "u1", "owner_kind": "ReplicaSet", "owner_name": "grafana-7d9f8",
+        "workload_kind": "Deployment", "workload_name": "grafana", "container_name": "app", "container_kind": "app",
+        "image": "registry.test/grafana:1.0.0", "image_digest": "sha256:abc", "sbom_status": "present",
+        "image_identity": "sha256:abc", "component_count": 2, "os_name": "debian 12.7",
+        "generated_at": "2026-09-03T21:39:44Z", "last_seen_at": "2026-09-03T21:39:44Z"}],
+        "pagination": {"page": 1, "page_size": 50, "total_pages": 1, "total_count": 1},
+        "inventory": {"containers": 3, "with_sbom": 2, "without_sbom": 1, "pods": 2},
+        "coverage": {"scanned_clusters": 1, "clusters_with_sbom": 1, "images": 2, "components": 3, "workloads": 2, "latest_generated_at": null}}`, &captured)
+	list, listError := apiClient.ListSecuritySBOMContainers(SecuritySBOMContainersOptions{
+		ClusterID: "c1", Namespace: "security", WorkloadKind: " Deployment ", WorkloadName: "grafana", Status: "present",
+		Search: "graf", Sort: "status", Order: "desc", Page: 2, PageSize: 10,
+	})
+	if listError != nil {
+		t.Fatalf("ListSecuritySBOMContainers returned an error: %v", listError)
+	}
+	expectedQuery := url.Values{"page": {"2"}, "page_size": {"10"}, "search": {"graf"}, "sort": {"status"}, "order": {"desc"},
+		"cluster_id": {"c1"}, "namespace": {"security"}, "workload_kind": {"Deployment"}, "workload_name": {"grafana"}, "status": {"present"}}
+	if captured.URL.Path != "/api/v1/org/security/sbom/containers" || !reflect.DeepEqual(captured.URL.Query(), expectedQuery) {
+		t.Fatalf("request = %s?%s", captured.URL.Path, captured.URL.RawQuery)
+	}
+	if len(list.Result) != 1 || list.Result[0].SBOMStatus != "present" || *list.Result[0].ComponentCount != 2 ||
+		list.Inventory.WithoutSBOM != 1 || list.Coverage.Images != 2 {
+		t.Fatalf("containers not decoded: %+v", list)
+	}
+
+	_, apiClient = newSecurityTestServer(t, `{"result": [], "pagination": {"page": 1, "page_size": 50, "total_pages": 0, "total_count": 0}, "coverage": {"scanned_clusters": 0, "clusters_with_sbom": 0, "images": 0, "components": 0, "workloads": 0, "latest_generated_at": null}}`, &captured)
+	if _, imagesError := apiClient.ListSecuritySBOMImages(SecuritySBOMImagesOptions{WorkloadKind: "DaemonSet"}); imagesError != nil {
+		t.Fatalf("ListSecuritySBOMImages returned an error: %v", imagesError)
+	}
+	if captured.URL.Query().Get("workload_kind") != "DaemonSet" || captured.URL.Query().Has("workload_name") {
+		t.Fatalf("image workload selector = %s", captured.URL.RawQuery)
+	}
+}
+
+func TestExportSecuritySBOMImageDownloadsTheDocumentWithItsFileName(t *testing.T) {
+	var captured http.Request
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		captured = *request
+		writer.Header().Set("Content-Type", "application/vnd.cyclonedx+json; version=1.5")
+		writer.Header().Set("Content-Disposition", `attachment; filename="registry.test-grafana_1.0.0.cdx.json"`)
+		_, _ = writer.Write([]byte(`{"bomFormat":"CycloneDX"}`))
+	}))
+	defer server.Close()
+	apiClient := &Client{BaseURL: server.URL, Token: "token", HTTP: server.Client()}
+	export, exportError := apiClient.ExportSecuritySBOMImage(SecuritySBOMExportOptions{ImageIdentity: " sha256:abc ", Format: "cyclonedx"})
+	if exportError != nil {
+		t.Fatalf("ExportSecuritySBOMImage returned an error: %v", exportError)
+	}
+	if captured.URL.Path != "/api/v1/org/security/sbom/image/export" ||
+		captured.URL.Query().Get("image") != "sha256:abc" || captured.URL.Query().Get("format") != "cyclonedx" ||
+		captured.Header.Get("Authorization") != "Bearer token" {
+		t.Fatalf("request = %s?%s %v", captured.URL.Path, captured.URL.RawQuery, captured.Header)
+	}
+	if export.FileName != "registry.test-grafana_1.0.0.cdx.json" || string(export.Body) != `{"bomFormat":"CycloneDX"}` ||
+		!strings.HasPrefix(export.ContentType, "application/vnd.cyclonedx+json") {
+		t.Fatalf("export = %+v", export)
 	}
 }


### PR DESCRIPTION
## What

Completes `ankra security sbom` against the platform's new bill-of-materials reads (cluster [#2528](https://github.com/ankraio/cluster/pull/2528)), and fixes a shipped bug in the family.

**Fix — `-o json|yaml` never worked on the sbom family.** `security.go` registers the shared structured-output flag through `registerStructuredOutputFlags(...)`, but `security_sbom.go`'s `init` never called it, so every one of `namespaces`, `pods`, `sbom`, `sbom images` and `sbom image` promised `-o json` in its help and answered `unknown shorthand flag: 'o'`. Registered for all of them and the new command.

**`ankra security sbom containers`** — every container the scoped clusters run right now, init containers included, with or without a bill of materials. `ABSENT` rows first, an inventory line that counts the scope before `--status`/`--search` narrow it, `--status present|absent|any`, `--cluster`, `--namespace`, `--workload-kind`, `--workload-name`.

**`ankra security sbom export <digest or reference>`** — CycloneDX 1.5 JSON (default) or `--format csv`, written to the platform's file name in the current directory, to `--output-file`, or to stdout with `--output-file -`.

**`--workload-kind` / `--workload-name`** on `sbom` and `sbom images`.

Client: `ListSecuritySBOMContainers`, `ExportSecuritySBOMImage` (a raw authenticated download that keeps the `Content-Disposition` file name and maps 401/403 like the reads), and the workload selector on the component and image options.

## Testing

Command tests cover the flag pass-through and structured output, the containers rendering (absent-first, init marker, bare pod, inventory line, `--status` validation) and both export paths (stdout verbatim, file write). Client tests pin the query encoding for containers and the workload selector, and the export download with its file name. `go vet ./... && go test ./...` green; the pre-commit hook ran the linter at 0 issues.

Depends on the cluster PR for the endpoints; against an older API the two new commands answer the platform's 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013j2ViDDygzZG3cQB4v1ErN

Bead: ankra-0ugaj
