### PR TITLE
feat(security): sbom findings lists the CVEs on one image (ankra-0ugaj)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Ankra CLI Changelog
 
+## Unreleased
+
+### Added
+
+- **`ankra security sbom findings <image>` lists the CVEs on one image.** The
+  image detail counted findings per component and stopped there; this is the
+  list behind the count: one row per CVE and installed package version,
+  aggregated across the containers running the image, with the fixed version
+  when one exists, the CISA KEV listing and EPSS probability, the worst
+  disposition across its occurrences, and how many workloads and clusters run
+  it. It answers for an image without a bill of materials too - the CVEs come
+  from the vulnerability reports - and says ABSENT in the header so the gap
+  stays visible. `--severity` (repeatable), `--search`, `--sort` and paging
+  narrow it; `-o json` for scripts. Pairs with `ankra security finding <id>`
+  for one CVE in full.
+- **`ankra security namespaces` rows carry `sbom_images`**: the distinct
+  images running in the namespace that have a bill of materials, against the
+  images the scanner reported on, so a namespace's SBOM gap is visible in the
+  breakdown without opening it. The SBOM coverage block on `ankra security
+  sbom`, `sbom images` and `sbom containers` now follows `--namespace`,
+  `--workload-kind` and `--workload-name`, so the headline above a narrowed
+  list is that scope's, not the fleet's.
+
 ## v0.15.0-rc1 — 2026-09-03
 
 ### Added

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1006,6 +1006,10 @@ func (m baseMock) ListSecuritySBOMContainers(client.SecuritySBOMContainersOption
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) ListSecuritySBOMImageFindings(client.SecuritySBOMImageFindingsOptions) (*client.SecuritySBOMImageFindingList, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) ExportSecuritySBOMImage(client.SecuritySBOMExportOptions) (*client.SecuritySBOMExport, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/security_sbom.go
+++ b/cmd/security_sbom.go
@@ -716,15 +716,18 @@ func renderSecuritySbomImageFindings(cmd *cobra.Command, list *client.SecuritySB
 	if image.ImageDigest != nil {
 		_, _ = fmt.Fprintf(out, "Digest:      %s\n", *image.ImageDigest)
 	}
-	sbomStatus := "present"
-	if image.SBOMStatus != "present" {
-		sbomStatus = text.FgYellow.Sprint("ABSENT") + " - the CVEs below come from the vulnerability reports; no package inventory is stored"
-	}
-	_, _ = fmt.Fprintf(out, "SBOM:        %s\n", sbomStatus)
+	_, _ = fmt.Fprintf(out, "SBOM:        %s\n", sbomStatusLabel(image.SBOMStatus))
 	summary := list.Summary
+	knownExploited := redIfPositive(summary.KnownExploited)
+	if list.Intelligence.KevSyncedAt == nil {
+		knownExploited = "unknown"
+	}
 	_, _ = fmt.Fprintf(out, "Findings:    %d CVE(s) across %d occurrences · %d actionable (%d critical, %d high) · %d with a fix · %s known exploited · %d accepted risk\n",
 		summary.Findings, summary.Observed, summary.ActionableTotal, summary.Actionable.Critical, summary.Actionable.High,
-		summary.Fixable, redIfPositive(summary.KnownExploited), summary.AcceptedRisk)
+		summary.Fixable, knownExploited, summary.AcceptedRisk)
+	for _, caveat := range intelligenceCaveats(list.Intelligence) {
+		_, _ = fmt.Fprintln(out, caveat)
+	}
 	_, _ = fmt.Fprintln(out)
 	if len(list.Result) == 0 {
 		if list.Pagination.TotalCount == 0 && summary.Observed == 0 {
@@ -756,9 +759,35 @@ func renderSecuritySbomImageFindings(cmd *cobra.Command, list *client.SecuritySB
 	}
 	writer.Render()
 	_, _ = fmt.Fprintf(out, "Page %d of %d · %d vulnerabilities\n", list.Pagination.Page, list.Pagination.TotalPages, list.Pagination.TotalCount)
-	if list.Intelligence.KevSyncedAt == nil {
-		_, _ = fmt.Fprintln(out, "The CISA KEV catalog has not been synced yet, so known-exploited status is unknown for these findings.")
+}
+
+// sbomStatusLabel keeps an unknown status apart from a confirmed absence:
+// a platform that predates the field says nothing about the bill of
+// materials, which is not the same observation as "none is stored".
+func sbomStatusLabel(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "present":
+		return "present"
+	case "absent":
+		return text.FgYellow.Sprint("ABSENT") + " - the CVEs below come from the vulnerability reports; no package inventory is stored"
+	default:
+		return "unknown - this platform version does not report whether a bill of materials is stored"
 	}
+}
+
+// intelligenceCaveats names the public feeds the platform has never
+// applied, so a blank known-exploited column or a missing EPSS probability
+// reads as unknown rather than as clear. They print above the table and on
+// an empty page alike: an empty list is where the caveat matters most.
+func intelligenceCaveats(intelligence client.SecurityIntelligenceStatus) []string {
+	var caveats []string
+	if intelligence.KevSyncedAt == nil {
+		caveats = append(caveats, "The CISA KEV catalog has not been synced yet, so known-exploited status is unknown for these findings.")
+	}
+	if intelligence.EPSSSyncedAt == nil {
+		caveats = append(caveats, "EPSS has not been synced yet, so a missing exploitation probability is unknown, not low.")
+	}
+	return caveats
 }
 
 func init() {

--- a/cmd/security_sbom.go
+++ b/cmd/security_sbom.go
@@ -198,6 +198,49 @@ var securitySbomImageCmd = &cobra.Command{
 	},
 }
 
+var securitySbomFindingsCmd = &cobra.Command{
+	Use:   "findings <digest or reference>",
+	Short: "The vulnerabilities (CVEs) on one image, worst first, with or without a bill of materials",
+	Long: `List every CVE the scanner names on one image: one row per CVE and
+installed package version, aggregated across the containers running the
+image, with the fixed version when one exists, the CISA KEV listing and EPSS
+probability, and the worst disposition across its occurrences.
+
+The image is identified the way the inventories list it: a sha256 digest, or
+the repository:tag reference when the scanner knew no digest. An image
+without a bill of materials still answers - the CVEs come from the
+vulnerability reports - and the header says ABSENT so the gap is visible.
+
+The summary line totals the image before --search and --severity narrow the
+rows. Read one CVE in full with ankra security finding <finding id>.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		page, _ := cmd.Flags().GetInt("page")
+		pageSize, _ := cmd.Flags().GetInt("page-size")
+		search, _ := cmd.Flags().GetString("search")
+		severities, _ := cmd.Flags().GetStringSlice("severity")
+		sort, _ := cmd.Flags().GetString("sort")
+		order, _ := cmd.Flags().GetString("order")
+		list, err := apiClient.ListSecuritySBOMImageFindings(client.SecuritySBOMImageFindingsOptions{
+			ImageIdentity: strings.TrimSpace(args[0]),
+			Page:          page,
+			PageSize:      pageSize,
+			Search:        search,
+			Severities:    severities,
+			Sort:          sort,
+			Order:         order,
+		})
+		if err != nil {
+			return fmt.Errorf("reading the image's vulnerabilities: %w", err)
+		}
+		if rendered, err := renderStructured(cmd, list); rendered || err != nil {
+			return err
+		}
+		renderSecuritySbomImageFindings(cmd, list)
+		return nil
+	},
+}
+
 var securitySbomContainersCmd = &cobra.Command{
 	Use:   "containers",
 	Short: "Every running container with or without a bill of materials, absent first",
@@ -666,11 +709,71 @@ func renderSecuritySbomImageDetail(cmd *cobra.Command, detail *client.SecuritySB
 	_, _ = fmt.Fprintf(out, "Page %d of %d · %d components\n", detail.Pagination.Page, detail.Pagination.TotalPages, detail.Pagination.TotalCount)
 }
 
+func renderSecuritySbomImageFindings(cmd *cobra.Command, list *client.SecuritySBOMImageFindingList) {
+	out := cmd.OutOrStdout()
+	image := list.Image
+	_, _ = fmt.Fprintln(out, text.Bold.Sprint(image.ImageRef))
+	if image.ImageDigest != nil {
+		_, _ = fmt.Fprintf(out, "Digest:      %s\n", *image.ImageDigest)
+	}
+	sbomStatus := "present"
+	if image.SBOMStatus != "present" {
+		sbomStatus = text.FgYellow.Sprint("ABSENT") + " - the CVEs below come from the vulnerability reports; no package inventory is stored"
+	}
+	_, _ = fmt.Fprintf(out, "SBOM:        %s\n", sbomStatus)
+	summary := list.Summary
+	_, _ = fmt.Fprintf(out, "Findings:    %d CVE(s) across %d occurrences · %d actionable (%d critical, %d high) · %d with a fix · %s known exploited · %d accepted risk\n",
+		summary.Findings, summary.Observed, summary.ActionableTotal, summary.Actionable.Critical, summary.Actionable.High,
+		summary.Fixable, redIfPositive(summary.KnownExploited), summary.AcceptedRisk)
+	_, _ = fmt.Fprintln(out)
+	if len(list.Result) == 0 {
+		if list.Pagination.TotalCount == 0 && summary.Observed == 0 {
+			_, _ = fmt.Fprintln(out, "No vulnerability names this image.")
+		} else {
+			_, _ = fmt.Fprintln(out, "No vulnerabilities match these filters.")
+		}
+		return
+	}
+	writer := newSecurityTable(out)
+	writer.AppendHeader(table.Row{"CVE", "Severity", "Exploitation", "Package", "Installed", "Fixed in", "Status", "Workloads", "Last seen", "Finding ID"})
+	for _, finding := range list.Result {
+		fixed := "-"
+		if finding.FixedVersion != nil {
+			fixed = *finding.FixedVersion
+		}
+		writer.AppendRow(table.Row{
+			finding.CVEID,
+			severityCell(finding.Severity),
+			exploitationCell(finding.SecurityExploitIntelligence),
+			finding.PackageName + " (" + finding.PackageType + ")",
+			finding.InstalledVersion,
+			fixed,
+			finding.Disposition,
+			fmt.Sprintf("%d on %d cluster(s)", finding.Workloads, finding.Clusters),
+			formatTimeAgo(finding.LastSeenAt),
+			finding.FindingID,
+		})
+	}
+	writer.Render()
+	_, _ = fmt.Fprintf(out, "Page %d of %d · %d vulnerabilities\n", list.Pagination.Page, list.Pagination.TotalPages, list.Pagination.TotalCount)
+	if list.Intelligence.KevSyncedAt == nil {
+		_, _ = fmt.Fprintln(out, "The CISA KEV catalog has not been synced yet, so known-exploited status is unknown for these findings.")
+	}
+}
+
 func init() {
 	securityCmd.AddCommand(securityNamespacesCmd, securityPodsCmd, securitySbomCmd)
-	securitySbomCmd.AddCommand(securitySbomImagesCmd, securitySbomImageCmd, securitySbomContainersCmd, securitySbomExportCmd)
+	securitySbomCmd.AddCommand(securitySbomImagesCmd, securitySbomImageCmd, securitySbomFindingsCmd,
+		securitySbomContainersCmd, securitySbomExportCmd)
 	registerStructuredOutputFlags(securityNamespacesCmd, securityPodsCmd, securitySbomCmd,
-		securitySbomImagesCmd, securitySbomImageCmd, securitySbomContainersCmd)
+		securitySbomImagesCmd, securitySbomImageCmd, securitySbomFindingsCmd, securitySbomContainersCmd)
+
+	securitySbomFindingsCmd.Flags().String("search", "", "Match CVE id, package name or title")
+	securitySbomFindingsCmd.Flags().StringSlice("severity", nil, "Severity filter, repeatable: critical, high, medium, low, unknown")
+	securitySbomFindingsCmd.Flags().String("sort", "exploitability", "Sort key: exploitability, severity, epss, cve_id, package_name, last_seen_at, occurrences")
+	securitySbomFindingsCmd.Flags().String("order", "desc", "Sort order: asc or desc")
+	securitySbomFindingsCmd.Flags().Int("page", 1, "Page number")
+	securitySbomFindingsCmd.Flags().Int("page-size", 50, "Vulnerabilities per page (max 100)")
 
 	securityNamespacesCmd.Flags().String("search", "", "Match namespace or cluster name")
 	securityNamespacesCmd.Flags().String("cluster", "", "Only namespaces on one cluster (name or id)")

--- a/cmd/security_sbom_test.go
+++ b/cmd/security_sbom_test.go
@@ -384,10 +384,25 @@ func TestSecuritySbomFindingsListsTheCVEsOnOneImageAndNamesAnAbsentBillOfMateria
 			t.Fatalf("output lacks %q:\n%s", expected, output)
 		}
 	}
-	if !strings.Contains(output, "CISA KEV catalog has not been synced") {
-		t.Fatalf("an unsynced catalog is said, not implied:\n%s", output)
+	if !strings.Contains(output, "CISA KEV catalog has not been synced") || !strings.Contains(output, "EPSS has not been synced") ||
+		!strings.Contains(output, "unknown known exploited") {
+		t.Fatalf("unsynced feeds are said, not implied:\n%s", output)
 	}
 	if _, executeError := runSecurityCommand(t, mock, "security", "sbom", "findings"); executeError == nil {
 		t.Fatalf("the image identity is required")
+	}
+
+	mock.imageFindings.Result = nil
+	mock.imageFindings.Pagination.TotalCount = 0
+	mock.imageFindings.Image.SBOMStatus = ""
+	output, executeError = runSecurityCommand(t, mock, "security", "sbom", "findings", "sha256:abc")
+	if executeError != nil {
+		t.Fatalf("an empty page still renders: %v", executeError)
+	}
+	if !strings.Contains(output, "CISA KEV catalog has not been synced") || !strings.Contains(output, "No vulnerabilities match these filters.") {
+		t.Fatalf("the caveat survives an empty page:\n%s", output)
+	}
+	if strings.Contains(output, "ABSENT") || !strings.Contains(output, "SBOM:        unknown") {
+		t.Fatalf("a missing status is unknown, not absent:\n%s", output)
 	}
 }

--- a/cmd/security_sbom_test.go
+++ b/cmd/security_sbom_test.go
@@ -21,6 +21,8 @@ type securitySbomMock struct {
 	imagesOptions     *client.SecuritySBOMImagesOptions
 	containers        *client.SecuritySBOMContainerList
 	containersOptions *client.SecuritySBOMContainersOptions
+	imageFindings     *client.SecuritySBOMImageFindingList
+	findingsOptions   *client.SecuritySBOMImageFindingsOptions
 	export            *client.SecuritySBOMExport
 	exportOptions     *client.SecuritySBOMExportOptions
 }
@@ -47,6 +49,11 @@ func (m *securitySbomMock) ListSecuritySBOMImages(options client.SecuritySBOMIma
 func (m *securitySbomMock) ListSecuritySBOMContainers(options client.SecuritySBOMContainersOptions) (*client.SecuritySBOMContainerList, error) {
 	m.containersOptions = &options
 	return m.containers, nil
+}
+
+func (m *securitySbomMock) ListSecuritySBOMImageFindings(options client.SecuritySBOMImageFindingsOptions) (*client.SecuritySBOMImageFindingList, error) {
+	m.findingsOptions = &options
+	return m.imageFindings, nil
 }
 
 func (m *securitySbomMock) ExportSecuritySBOMImage(options client.SecuritySBOMExportOptions) (*client.SecuritySBOMExport, error) {
@@ -344,5 +351,43 @@ func TestSecuritySbomExportNeverTreatsTheServerFileNameAsAPath(t *testing.T) {
 	}
 	if _, statError := os.Stat(workDirectory + "/escaped.json"); statError != nil {
 		t.Fatalf("file not written where announced: %v", statError)
+	}
+}
+
+func TestSecuritySbomFindingsListsTheCVEsOnOneImageAndNamesAnAbsentBillOfMaterials(t *testing.T) {
+	fixed, title := "3.0.1", "OpenSSL issue"
+	mock := &securitySbomMock{imageFindings: &client.SecuritySBOMImageFindingList{
+		Image: client.SecuritySBOMImageFindingImage{ImageIdentity: "sha256:abc", ImageRef: "registry.test/grafana:1.0.0", SBOMStatus: "absent"},
+		Result: []client.SecuritySBOMImageFinding{{
+			FindingID: "f-1", CVEID: "CVE-2026-9001", Severity: "CRITICAL", Title: &title, PackageType: "deb", PackageName: "openssl",
+			InstalledVersion: "3.0.0", FixedVersion: &fixed, Fixable: true, Disposition: "open",
+			Dispositions: client.SecurityDispositionCounts{Open: 2}, Occurrences: 2, Workloads: 1, Clusters: 1,
+			LastSeenAt:                  "2026-09-04T09:00:00Z",
+			SecurityExploitIntelligence: client.SecurityExploitIntelligence{KnownExploited: true},
+		}},
+		Pagination: client.SecurityPagination{Page: 1, PageSize: 50, TotalPages: 1, TotalCount: 1},
+		Summary: client.SecuritySBOMImageFindingSummary{Observed: 2, Actionable: client.SecuritySeverityCounts{Critical: 2},
+			ActionableTotal: 2, Fixable: 2, KnownExploited: 2, Findings: 1},
+	}}
+	output, executeError := runSecurityCommand(t, mock, "security", "sbom", "findings", " sha256:abc ",
+		"--severity", "critical", "--severity", "high", "--search", "openssl", "--sort", "severity", "--order", "asc", "--page-size", "10")
+	if executeError != nil {
+		t.Fatalf("security sbom findings failed: %v", executeError)
+	}
+	options := mock.findingsOptions
+	if options == nil || options.ImageIdentity != "sha256:abc" || len(options.Severities) != 2 || options.Search != "openssl" ||
+		options.Sort != "severity" || options.Order != "asc" || options.PageSize != 10 {
+		t.Fatalf("findings options = %+v", options)
+	}
+	for _, expected := range []string{"registry.test/grafana:1.0.0", "ABSENT", "1 CVE(s) across 2 occurrences", "CVE-2026-9001", "openssl (deb)", "3.0.1", "open", "1 on 1 cluster(s)", "Page 1 of 1 · 1 vulnerabilities"} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("output lacks %q:\n%s", expected, output)
+		}
+	}
+	if !strings.Contains(output, "CISA KEV catalog has not been synced") {
+		t.Fatalf("an unsynced catalog is said, not implied:\n%s", output)
+	}
+	if _, executeError := runSecurityCommand(t, mock, "security", "sbom", "findings"); executeError == nil {
+		t.Fatalf("the image identity is required")
 	}
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -49,6 +49,7 @@ type APIClient interface {
 	ListSecuritySBOMImages(options client.SecuritySBOMImagesOptions) (*client.SecuritySBOMImageList, error)
 	GetSecuritySBOMImage(options client.SecuritySBOMImageOptions) (*client.SecuritySBOMImageDetail, error)
 	ListSecuritySBOMContainers(options client.SecuritySBOMContainersOptions) (*client.SecuritySBOMContainerList, error)
+	ListSecuritySBOMImageFindings(options client.SecuritySBOMImageFindingsOptions) (*client.SecuritySBOMImageFindingList, error)
 	ExportSecuritySBOMImage(options client.SecuritySBOMExportOptions) (*client.SecuritySBOMExport, error)
 
 	ListPowerSchedules(clusterID string) (*client.PowerScheduleListResult, error)

--- a/internal/client/security_sbom.go
+++ b/internal/client/security_sbom.go
@@ -184,6 +184,72 @@ type SecuritySBOMImageDetail struct {
 	Workloads  []SecuritySBOMWorkload      `json:"workloads" yaml:"workloads"`
 }
 
+// SecuritySBOMImageFindingsOptions narrows the vulnerabilities on one image.
+type SecuritySBOMImageFindingsOptions struct {
+	ImageIdentity string
+	Page          int
+	PageSize      int
+	Search        string
+	Severities    []string
+	Sort          string
+	Order         string
+}
+
+// SecuritySBOMImageFindingImage is the image a vulnerability list was read
+// for. SBOMStatus is "present" when the platform holds a bill of materials
+// for it and "absent" when only the vulnerability scanner named it.
+type SecuritySBOMImageFindingImage struct {
+	ImageIdentity string  `json:"image_identity" yaml:"image_identity"`
+	ImageRef      string  `json:"image_ref" yaml:"image_ref"`
+	ImageDigest   *string `json:"image_digest" yaml:"image_digest"`
+	SBOMStatus    string  `json:"sbom_status" yaml:"sbom_status"`
+}
+
+// SecuritySBOMImageFinding is one CVE on one installed package version of
+// the image, aggregated across every container running it. Disposition is
+// the worst across those occurrences: open before acknowledged before
+// accepted_risk.
+type SecuritySBOMImageFinding struct {
+	FindingID                   string                    `json:"finding_id" yaml:"finding_id"`
+	CVEID                       string                    `json:"cve_id" yaml:"cve_id"`
+	Severity                    string                    `json:"severity" yaml:"severity"`
+	Title                       *string                   `json:"title" yaml:"title"`
+	PackageType                 string                    `json:"package_type" yaml:"package_type"`
+	PackageName                 string                    `json:"package_name" yaml:"package_name"`
+	InstalledVersion            string                    `json:"installed_version" yaml:"installed_version"`
+	FixedVersion                *string                   `json:"fixed_version" yaml:"fixed_version"`
+	Fixable                     bool                      `json:"fixable" yaml:"fixable"`
+	Disposition                 string                    `json:"disposition" yaml:"disposition"`
+	Dispositions                SecurityDispositionCounts `json:"dispositions" yaml:"dispositions"`
+	Occurrences                 int                       `json:"occurrences" yaml:"occurrences"`
+	Workloads                   int                       `json:"workloads" yaml:"workloads"`
+	Clusters                    int                       `json:"clusters" yaml:"clusters"`
+	LastSeenAt                  string                    `json:"last_seen_at" yaml:"last_seen_at"`
+	SecurityExploitIntelligence `yaml:",inline"`
+}
+
+// SecuritySBOMImageFindingSummary totals the image's active occurrences
+// before search and severity narrow the rows.
+type SecuritySBOMImageFindingSummary struct {
+	Observed        int                    `json:"observed" yaml:"observed"`
+	Actionable      SecuritySeverityCounts `json:"actionable" yaml:"actionable"`
+	ActionableTotal int                    `json:"actionable_total" yaml:"actionable_total"`
+	AcceptedRisk    int                    `json:"accepted_risk" yaml:"accepted_risk"`
+	Fixable         int                    `json:"fixable" yaml:"fixable"`
+	KnownExploited  int                    `json:"known_exploited" yaml:"known_exploited"`
+	Findings        int                    `json:"findings" yaml:"findings"`
+}
+
+// SecuritySBOMImageFindingList is the paginated vulnerability list of one
+// image.
+type SecuritySBOMImageFindingList struct {
+	Image        SecuritySBOMImageFindingImage   `json:"image" yaml:"image"`
+	Result       []SecuritySBOMImageFinding      `json:"result" yaml:"result"`
+	Pagination   SecurityPagination              `json:"pagination" yaml:"pagination"`
+	Summary      SecuritySBOMImageFindingSummary `json:"summary" yaml:"summary"`
+	Intelligence SecurityIntelligenceStatus      `json:"intelligence" yaml:"intelligence"`
+}
+
 // SecurityNamespacesOptions mirrors the namespace breakdown controls.
 type SecurityNamespacesOptions struct {
 	Page      int
@@ -531,4 +597,25 @@ func (c *Client) ExportSecuritySBOMImage(options SecuritySBOMExportOptions) (*Se
 		ContentType: response.Header.Get("Content-Type"),
 		Body:        body,
 	}, nil
+}
+
+// ListSecuritySBOMImageFindings lists the vulnerabilities named on one image.
+func (c *Client) ListSecuritySBOMImageFindings(options SecuritySBOMImageFindingsOptions) (*SecuritySBOMImageFindingList, error) {
+	query := neturl.Values{}
+	setPaging(query, options.Page, options.PageSize)
+	setListControls(query, options.Search, options.Sort, options.Order)
+	query.Set("image", options.ImageIdentity)
+	for _, severity := range options.Severities {
+		if trimmed := strings.TrimSpace(severity); trimmed != "" {
+			query.Add("severity", trimmed)
+		}
+	}
+	var list SecuritySBOMImageFindingList
+	if err := c.getJSON(securityURL(c.BaseURL, "/sbom/image/findings", query), &list); err != nil {
+		return nil, fmt.Errorf("security sbom image findings request failed: %w", err)
+	}
+	if list.Result == nil {
+		list.Result = []SecuritySBOMImageFinding{}
+	}
+	return &list, nil
 }

--- a/internal/client/security_sbom_test.go
+++ b/internal/client/security_sbom_test.go
@@ -139,6 +139,42 @@ func TestSecuritySBOMContainersAndExportEncodeTheirControls(t *testing.T) {
 	}
 }
 
+func TestListSecuritySBOMImageFindingsEncodesItsControlsAndDecodesTheRows(t *testing.T) {
+	var captured http.Request
+	_, apiClient := newSecurityTestServer(t, `{"image": {"image_identity": "sha256:abc", "image_ref": "registry.test/grafana:1.0.0", "image_digest": "sha256:abc", "sbom_status": "present"},
+        "result": [{"finding_id": "f-1", "cve_id": "CVE-2026-9001", "severity": "CRITICAL", "title": null, "package_type": "deb", "package_name": "openssl",
+        "installed_version": "3.0.0", "fixed_version": "3.0.1", "fixable": true, "disposition": "open",
+        "dispositions": {"open": 2, "acknowledged": 0, "accepted_risk": 0, "resolved": 0}, "occurrences": 2, "workloads": 1, "clusters": 1,
+        "last_seen_at": "2026-09-04T09:00:00Z", "known_exploited": true, "epss_score": 0.42}],
+        "pagination": {"page": 1, "page_size": 50, "total_pages": 1, "total_count": 1},
+        "summary": {"observed": 2, "actionable": {"critical": 2, "high": 0, "medium": 0, "low": 0, "unknown": 0}, "actionable_total": 2, "accepted_risk": 0, "fixable": 2, "known_exploited": 2, "findings": 1},
+        "intelligence": {"kev_synced_at": "2026-09-01T00:00:00Z", "epss_synced_at": null, "kev_listed": 1}}`, &captured)
+	list, listError := apiClient.ListSecuritySBOMImageFindings(SecuritySBOMImageFindingsOptions{
+		ImageIdentity: "sha256:abc", Severities: []string{"critical", " high ", ""}, Search: "ssl", Sort: "severity", Order: "asc", Page: 2, PageSize: 10,
+	})
+	if listError != nil {
+		t.Fatalf("ListSecuritySBOMImageFindings returned an error: %v", listError)
+	}
+	expectedQuery := url.Values{"page": {"2"}, "page_size": {"10"}, "search": {"ssl"}, "sort": {"severity"}, "order": {"asc"},
+		"image": {"sha256:abc"}, "severity": {"critical", "high"}}
+	if captured.URL.Path != "/api/v1/org/security/sbom/image/findings" || !reflect.DeepEqual(captured.URL.Query(), expectedQuery) {
+		t.Fatalf("request = %s?%s", captured.URL.Path, captured.URL.RawQuery)
+	}
+	if list.Image.SBOMStatus != "present" || len(list.Result) != 1 || list.Result[0].CVEID != "CVE-2026-9001" ||
+		!list.Result[0].KnownExploited || *list.Result[0].FixedVersion != "3.0.1" || list.Result[0].Dispositions.Open != 2 ||
+		list.Summary.Findings != 1 || list.Intelligence.KevSyncedAt == nil {
+		t.Fatalf("image findings not decoded: %+v", list)
+	}
+	_, apiClient = newSecurityTestServer(t, `{"image": {"image_identity": "sha256:abc", "image_ref": "x", "image_digest": null, "sbom_status": "absent"}, "result": null,
+        "pagination": {"page": 1, "page_size": 50, "total_pages": 0, "total_count": 0},
+        "summary": {"observed": 0, "actionable": {"critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0}, "actionable_total": 0, "accepted_risk": 0, "fixable": 0, "known_exploited": 0, "findings": 0},
+        "intelligence": {"kev_synced_at": null, "epss_synced_at": null, "kev_listed": 0}}`, &captured)
+	empty, emptyError := apiClient.ListSecuritySBOMImageFindings(SecuritySBOMImageFindingsOptions{ImageIdentity: "sha256:abc"})
+	if emptyError != nil || empty.Result == nil {
+		t.Fatalf("a null result decodes to an empty slice: %+v %v", empty, emptyError)
+	}
+}
+
 func TestExportSecuritySBOMImageDownloadsTheDocumentWithItsFileName(t *testing.T) {
 	var captured http.Request
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {


### PR DESCRIPTION
Stacked on #232 (base `feat/security-sbom-complete`); retarget to `master` once that lands. Pairs with cluster #2537.

The image detail counted findings per component and stopped there; the list behind that count did not exist.

## What changes

- **`ankra security sbom findings <image>`** lists every CVE the scanner names on one image: one row per CVE and installed package version, aggregated across the containers running it, with the fixed version, the CISA KEV listing and EPSS probability, the worst disposition across its occurrences, and how many workloads and clusters run it. It answers for an image without a bill of materials too and prints **ABSENT** in the header so the gap stays visible. `--severity` (repeatable), `--search`, `--sort`, `--order`, paging, `-o json|yaml`.
- **`ankra security namespaces`** rows carry `sbom_images`; the SBOM coverage block on the inventories follows `--namespace` / `--workload-*` (backend change, no CLI code).
- Client read `ListSecuritySBOMImageFindings` on `/sbom/image/findings`; `APIClient` interface + `baseMock` extended; changelog under Unreleased.

## Verification

`go build`, `go test ./cmd/ ./internal/client/`, golangci-lint clean (pre-commit hook).

Bead: ankra-0ugaj

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013j2ViDDygzZG3cQB4v1ErN
