### PR TITLE
fix(pipeline): logs replay a concluded step's log artifact, artifacts verbs are real, and findings is a verb (ankra-vn0bd)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,13 +41,17 @@
   `pipeline run --wait`, or when checking an older run - showed nothing.
   `logs` now reads a concluded step's complete, durably archived log
   instead; `--follow` is unchanged for a step that is still running, which
-  is the only case it ever did anything.
+  is the only case it ever did anything. It follows the artifact listing's
+  pages to find that log, so a run with more artifacts than one page no
+  longer reads as if the step had never recorded one.
 - **`ankra pipeline artifacts` and `artifacts download` talk to the real
   artifact store.** Both were wired against the wire contract before the
   store existed, and said so in their help text; the store has since
   shipped, so listing and downloading a run's step logs and declared
   artifacts now works end to end, and the help text no longer claims
-  otherwise.
+  otherwise. The listing is paged like `pipeline list`: `--cursor` and
+  `--limit` choose the page, and a run with another page says so instead of
+  presenting its oldest artifacts as the whole record.
 
 ## v0.15.0-rc1 — 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,10 @@
   artifacts now works end to end, and the help text no longer claims
   otherwise. The listing is paged like `pipeline list`: `--cursor` and
   `--limit` choose the page, and a run with another page says so instead of
-  presenting its oldest artifacts as the whole record.
+  presenting its oldest artifacts as the whole record. A negative `--limit`
+  is now refused on both listings rather than dropped on the way to the
+  query, which used to hand back the server's default page as though the
+  flag had been honoured.
 
 ## v0.15.0-rc1 — 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,9 @@
   instead; `--follow` is unchanged for a step that is still running, which
   is the only case it ever did anything. It follows the artifact listing's
   pages to find that log, so a run with more artifacts than one page no
-  longer reads as if the step had never recorded one.
+  longer reads as if the step had never recorded one, and it reads the
+  step's current log rather than an upload a re-dispatch of the same step
+  had already superseded.
 - **`ankra pipeline artifacts` and `artifacts download` talk to the real
   artifact store.** Both were wired against the wire contract before the
   store existed, and said so in their help text; the store has since

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Ankra CLI Changelog
 
-## v0.15.0-rc1 — 2026-09-03
+## Unreleased
+
+### Added
+
+- **`ankra pipeline findings <run>`** lists a run's persisted scan findings -
+  the deduplicated Semgrep, Checkov and Trivy results (and the informational
+  SBOM summary) recorded for the run's own commit, the same rows the
+  application's Security tab reads. The table sorts worst severity first and
+  groups by tool; `-o json`/`yaml` prints every field, including each
+  finding's tool-specific detail. `ankra pipeline artifacts` now also shows
+  each row's `KIND` (`step_log` or `artifact`) and `STATUS` (`pending`,
+  `uploaded`, `failed` or `expired`), so a caller can tell a still-archiving
+  or failed row from one `artifacts download` can actually fetch.
+
+### Fixed
+
+- **`ankra pipeline logs` on a concluded step now shows its output.** The
+  live log relay only ever streamed what a step printed from the moment a
+  client connected, so running `logs` (with or without `--follow`) against a
+  step that had already finished - the ordinary case right after
+  `pipeline run --wait`, or when checking an older run - showed nothing.
+  `logs` now reads a concluded step's complete, durably archived log
+  instead; `--follow` is unchanged for a step that is still running, which
+  is the only case it ever did anything.
+- **`ankra pipeline artifacts` and `artifacts download` talk to the real
+  artifact store.** Both were wired against the wire contract before the
+  store existed, and said so in their help text; the store has since
+  shipped, so listing and downloading a run's step logs and declared
+  artifacts now works end to end, and the help text no longer claims
+  otherwise.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ per command family:
 | [ankra logout](https://docs.ankra.ai/reference/cli/logout) | Revoke the login token and remove saved credentials |
 | [ankra openclaw](https://docs.ankra.ai/reference/cli/openclaw) | Integrate Ankra with the OpenClaw assistant |
 | [ankra org](https://docs.ankra.ai/reference/cli/org) | Manage organisations, members, roles, org variables, DNS, and MCP tool servers |
-| [ankra pipeline](https://docs.ankra.ai/reference/cli/pipeline) | Run, watch and manage Ankra Pipelines: dispatch a run, list and inspect runs, follow step logs, cancel or re-run, download artifacts, validate `.ankra/pipeline.yaml`, and manage the definition and its schedules |
+| [ankra pipeline](https://docs.ankra.ai/reference/cli/pipeline) | Run, watch and manage Ankra Pipelines: dispatch a run, list and inspect runs, follow a running step's logs live or replay a concluded step's archived log, cancel or re-run, list and download stored artifacts, read a run's persisted scan findings, validate `.ankra/pipeline.yaml`, and manage the definition and its schedules |
 | [ankra profile](https://docs.ankra.ai/reference/cli/profile) | Open profile authentication settings (MFA, passkeys) in the browser |
 | [ankra skills](https://docs.ankra.ai/reference/cli/skills) | Install Ankra Agent Skills into Cursor or Claude Code |
 | [ankra migrate](https://docs.ankra.ai/reference/cli/migrate) | Convert a docker-compose file, Dockerfile, or running containers into Ankra cluster and stack definitions, and export their databases for a restore into the cluster; extensible with `ankra-module-<name>` executables |

--- a/cmd/application_pipeline.go
+++ b/cmd/application_pipeline.go
@@ -158,6 +158,7 @@ func newApplicationPipelineArtifactsCommand() *cobra.Command {
 		},
 	}
 	registerStructuredOutputFlags(artifactsCommand)
+	registerPipelineArtifactsListFlags(artifactsCommand)
 	artifactsCommand.AddCommand(newApplicationPipelineArtifactsDownloadCommand())
 	return artifactsCommand
 }

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -2454,6 +2454,10 @@ func (m baseMock) DownloadPipelineArtifact(ctx context.Context, selector client.
 	return errors.New("not implemented")
 }
 
+func (m baseMock) ListPipelineFindings(ctx context.Context, selector client.PipelineSelector, runID string) (*client.PipelineFindingList, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) GetPipelineDefinition(ctx context.Context, selector client.PipelineSelector) (*client.PipelineDefinition, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -2458,7 +2458,7 @@ func (m baseMock) StreamPipelineStepLogs(ctx context.Context, selector client.Pi
 	return nil, errors.New("not implemented")
 }
 
-func (m baseMock) ListPipelineArtifacts(ctx context.Context, selector client.PipelineSelector, runID string) (*client.PipelineArtifactList, error) {
+func (m baseMock) ListPipelineArtifacts(ctx context.Context, selector client.PipelineSelector, runID string, options client.ListPipelineArtifactsOptions) (*client.PipelineArtifactList, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -51,6 +51,7 @@ umbrella run this pipeline run belongs to, useful for correlating with
 		newPipelineRerunCommand(),
 		newPipelineLogsCommand(),
 		newPipelineArtifactsCommand(),
+		newPipelineFindingsCommand(),
 		newPipelineValidateCommand(),
 		newPipelineDefinitionCommand(),
 		newPipelineSchedulesCommand(),

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -143,6 +143,21 @@ func pipelineOptionalString(value *string) string {
 	return *value
 }
 
+// pipelinePageLimitFromFlags reads a listing's --limit. Zero means "let the
+// server choose its own page" and is passed through unsent; a negative one
+// is refused rather than dropped, because silently answering a smaller
+// listing than the caller asked for is the same lie as presenting one page
+// as a whole record. A limit above the route's ceiling is left to the
+// server, which names its own maximum in the refusal.
+func pipelinePageLimitFromFlags(command *cobra.Command) (int, error) {
+	limit, _ := command.Flags().GetInt("limit")
+	if limit < 0 {
+		return 0, withExitCode(exitUsage,
+			fmt.Errorf("--limit must be a positive number of rows, got %d", limit))
+	}
+	return limit, nil
+}
+
 // pipelineShortSHA renders a commit for a table cell: short enough to scan,
 // long enough that two commits on the same branch stay distinguishable.
 func pipelineShortSHA(sha string) string {

--- a/cmd/pipeline_artifacts.go
+++ b/cmd/pipeline_artifacts.go
@@ -72,7 +72,10 @@ func runPipelineArtifactsList(command *cobra.Command, selector client.PipelineSe
 		return formatError
 	}
 	cursor, _ := command.Flags().GetString("cursor")
-	limit, _ := command.Flags().GetInt("limit")
+	limit, limitError := pipelinePageLimitFromFlags(command)
+	if limitError != nil {
+		return limitError
+	}
 	list, listError := apiClient.ListPipelineArtifacts(command.Context(), selector, strings.TrimSpace(runID),
 		client.ListPipelineArtifactsOptions{Cursor: strings.TrimSpace(cursor), Limit: limit})
 	if listError != nil {

--- a/cmd/pipeline_artifacts.go
+++ b/cmd/pipeline_artifacts.go
@@ -32,11 +32,16 @@ first.
 Every step's complete output is archived as a "step_log" artifact once the
 step concludes ('ankra pipeline logs' reads that one automatically for a
 concluded step); anything a stage's own "artifacts:" block declared shows up
-as "artifact". An empty list means the run genuinely has nothing stored yet
-- no step has concluded, or the organisation has no ready backup vault to
-store into. STATUS is "pending" until the upload is confirmed, "uploaded"
-once "artifacts download" can fetch it, "failed" if it never arrived (see
-the row's error), or "expired" once retention removed it.`,
+as "artifact". An empty first page means the run genuinely has nothing
+stored yet - no step has concluded, or the organisation has no ready backup
+vault to store into. STATUS is "pending" until the upload is confirmed,
+"uploaded" once "artifacts download" can fetch it, "failed" if it never
+arrived (see the row's error), or "expired" once retention removed it.
+
+The listing is paged: it prints one server page (50 rows by default) and
+says when there is another, which --cursor reads. So a run with more
+artifacts than one page shows its oldest first, and the list is complete
+only once no further page is offered.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(command *cobra.Command, arguments []string) error {
 			selector, selectorError := resolvePipelineSelector(command)
@@ -48,6 +53,8 @@ the row's error), or "expired" once retention removed it.`,
 	}
 	registerPipelineSelectorFlags(artifactsCommand)
 	registerStructuredOutputFlags(artifactsCommand)
+	artifactsCommand.Flags().String("cursor", "", "Page cursor from a previous listing's next_cursor")
+	artifactsCommand.Flags().Int("limit", 0, "Maximum number of artifacts to return (server default 50, max 100)")
 	artifactsCommand.AddCommand(newPipelineArtifactsDownloadCommand())
 	return artifactsCommand
 }
@@ -57,7 +64,10 @@ func runPipelineArtifactsList(command *cobra.Command, selector client.PipelineSe
 	if formatError != nil {
 		return formatError
 	}
-	list, listError := apiClient.ListPipelineArtifacts(command.Context(), selector, strings.TrimSpace(runID))
+	cursor, _ := command.Flags().GetString("cursor")
+	limit, _ := command.Flags().GetInt("limit")
+	list, listError := apiClient.ListPipelineArtifacts(command.Context(), selector, strings.TrimSpace(runID),
+		client.ListPipelineArtifactsOptions{Cursor: strings.TrimSpace(cursor), Limit: limit})
 	if listError != nil {
 		return listError
 	}
@@ -65,6 +75,11 @@ func runPipelineArtifactsList(command *cobra.Command, selector client.PipelineSe
 		return encodeStructured(command.OutOrStdout(), format, list)
 	}
 	if len(list.Artifacts) == 0 {
+		if list.NextCursor != nil {
+			_, _ = fmt.Fprintf(command.OutOrStdout(),
+				"No artifacts on this page; pass --cursor %s to read the next one.\n", *list.NextCursor)
+			return nil
+		}
 		_, _ = fmt.Fprintln(command.OutOrStdout(), "No artifacts stored for this run.")
 		return nil
 	}
@@ -85,6 +100,10 @@ func runPipelineArtifactsList(command *cobra.Command, selector client.PipelineSe
 		})
 	}
 	writer.Render()
+	if list.NextCursor != nil {
+		_, _ = fmt.Fprintf(command.ErrOrStderr(),
+			"\nMore artifacts available: pass --cursor %s to see the next page.\n", *list.NextCursor)
+	}
 	return nil
 }
 

--- a/cmd/pipeline_artifacts.go
+++ b/cmd/pipeline_artifacts.go
@@ -75,12 +75,14 @@ func runPipelineArtifactsList(command *cobra.Command, selector client.PipelineSe
 		return encodeStructured(command.OutOrStdout(), format, list)
 	}
 	if len(list.Artifacts) == 0 {
-		if list.NextCursor != nil {
-			_, _ = fmt.Fprintf(command.OutOrStdout(),
-				"No artifacts on this page; pass --cursor %s to read the next one.\n", *list.NextCursor)
+		if list.NextCursor == nil {
+			_, _ = fmt.Fprintln(command.OutOrStdout(), "No artifacts stored for this run.")
 			return nil
 		}
-		_, _ = fmt.Fprintln(command.OutOrStdout(), "No artifacts stored for this run.")
+		// An empty page the server still offers a cursor past is "more to
+		// read", not "this run stored nothing".
+		_, _ = fmt.Fprintln(command.OutOrStdout(), "No artifacts on this page.")
+		renderPipelineArtifactsNextPageHint(command, list.NextCursor)
 		return nil
 	}
 	writer := table.NewWriter()
@@ -100,11 +102,20 @@ func runPipelineArtifactsList(command *cobra.Command, selector client.PipelineSe
 		})
 	}
 	writer.Render()
-	if list.NextCursor != nil {
-		_, _ = fmt.Fprintf(command.ErrOrStderr(),
-			"\nMore artifacts available: pass --cursor %s to see the next page.\n", *list.NextCursor)
-	}
+	renderPipelineArtifactsNextPageHint(command, list.NextCursor)
 	return nil
+}
+
+// renderPipelineArtifactsNextPageHint says on stderr that the listing was a
+// page, not the whole record. Both table branches route it here so the hint
+// lands on the same stream either way and a piped listing keeps stdout to
+// itself; `-o json` needs no hint at all, since next_cursor is in the body.
+func renderPipelineArtifactsNextPageHint(command *cobra.Command, nextCursor *string) {
+	if nextCursor == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(command.ErrOrStderr(),
+		"\nMore artifacts available: pass --cursor %s to see the next page.\n", *nextCursor)
 }
 
 func newPipelineArtifactsDownloadCommand() *cobra.Command {

--- a/cmd/pipeline_artifacts.go
+++ b/cmd/pipeline_artifacts.go
@@ -53,10 +53,17 @@ only once no further page is offered.`,
 	}
 	registerPipelineSelectorFlags(artifactsCommand)
 	registerStructuredOutputFlags(artifactsCommand)
-	artifactsCommand.Flags().String("cursor", "", "Page cursor from a previous listing's next_cursor")
-	artifactsCommand.Flags().Int("limit", 0, "Maximum number of artifacts to return (server default 50, max 100)")
+	registerPipelineArtifactsListFlags(artifactsCommand)
 	artifactsCommand.AddCommand(newPipelineArtifactsDownloadCommand())
 	return artifactsCommand
+}
+
+// registerPipelineArtifactsListFlags is shared by `pipeline artifacts` and
+// `application pipeline artifacts`, so both surfaces can walk a run with
+// more artifacts than one page rather than only one of them.
+func registerPipelineArtifactsListFlags(command *cobra.Command) {
+	command.Flags().String("cursor", "", "Page cursor from a previous listing's next_cursor")
+	command.Flags().Int("limit", 0, "Maximum number of artifacts to return (server default 50, max 100)")
 }
 
 func runPipelineArtifactsList(command *cobra.Command, selector client.PipelineSelector, runID string) error {

--- a/cmd/pipeline_artifacts.go
+++ b/cmd/pipeline_artifacts.go
@@ -1,10 +1,14 @@
 package cmd
 
-// Artifacts: the store behind these routes is WS-C item C1 and does not
-// exist yet, so the list always answers empty and the download always
-// answers 404 today (go/internal/pipelineapi/artifacts.go). Both commands are
-// wired to the real contract now so nothing about them changes once the
-// store lands.
+// Artifacts: a run's step logs and declared artifacts, stored as objects in
+// the organisation's backup vault (go/internal/pipelineapi/artifacts.go,
+// enginekit/pipelineartifacts). list reads a keyset page of the run's rows;
+// download follows the route's 302 to a five-minute presigned GET on the
+// vault - the bytes never pass through the platform. An artifact that
+// cannot be downloaded says which fact it hit (its own Status, surfaced in
+// the list) rather than a bare 404: 409 while its step has not settled, its
+// upload failed, or its vault is gone; 410 once the retention sweep removed
+// it.
 
 import (
 	"fmt"
@@ -22,10 +26,17 @@ func newPipelineArtifactsCommand() *cobra.Command {
 	artifactsCommand := &cobra.Command{
 		Use:   "artifacts <run>",
 		Short: "List a pipeline run's stored artifacts",
-		Long: `List a pipeline run's stored artifacts.
+		Long: `List a pipeline run's stored step logs and declared artifacts, oldest
+first.
 
-The artifact store has not shipped yet, so every run answers an empty list
-until it does - this is not a sign that a run produced nothing.`,
+Every step's complete output is archived as a "step_log" artifact once the
+step concludes ('ankra pipeline logs' reads that one automatically for a
+concluded step); anything a stage's own "artifacts:" block declared shows up
+as "artifact". An empty list means the run genuinely has nothing stored yet
+- no step has concluded, or the organisation has no ready backup vault to
+store into. STATUS is "pending" until the upload is confirmed, "uploaded"
+once "artifacts download" can fetch it, "failed" if it never arrived (see
+the row's error), or "expired" once retention removed it.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(command *cobra.Command, arguments []string) error {
 			selector, selectorError := resolvePipelineSelector(command)
@@ -60,12 +71,14 @@ func runPipelineArtifactsList(command *cobra.Command, selector client.PipelineSe
 	writer := table.NewWriter()
 	writer.SetOutputMirror(command.OutOrStdout())
 	writer.SetStyle(table.StyleRounded)
-	writer.AppendHeader(table.Row{"ID", "NAME", "STEP", "CONTENT TYPE", "SIZE", "CREATED"})
+	writer.AppendHeader(table.Row{"ID", "KIND", "NAME", "STEP", "STATUS", "CONTENT TYPE", "SIZE", "CREATED"})
 	for _, artifact := range list.Artifacts {
 		writer.AppendRow(table.Row{
 			artifact.ID,
+			artifact.Kind,
 			artifact.Name,
-			artifact.StepID,
+			pipelineOptionalString(artifact.StepID),
+			artifact.Status,
 			artifact.ContentType,
 			artifact.SizeBytes,
 			formatTimeAgo(artifact.CreatedAt),

--- a/cmd/pipeline_findings.go
+++ b/cmd/pipeline_findings.go
@@ -1,0 +1,138 @@
+package cmd
+
+// The findings verb: a run's persisted scan findings
+// (go/internal/pipelineapi/findings.go, enginekit/pipelinefindings) - the
+// deduplicated Semgrep, Checkov and Trivy results (and the informational
+// SBOM summary) recorded for the run's own commit, the same rows the
+// application's Security tab reads once a pipeline run exists for it.
+// Read-only: nothing here decides or reruns a gate verdict, which is a
+// separate concern (the run's own "gate" step, see 'ankra pipeline get').
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+func newPipelineFindingsCommand() *cobra.Command {
+	findingsCommand := &cobra.Command{
+		Use:   "findings <run>",
+		Short: "List a pipeline run's persisted scan findings",
+		Long: `List a pipeline run's persisted scan findings.
+
+Findings are recorded once a "scan" step has concluded for the run's own
+commit; a run with no scan step, or one still running, answers an empty
+list rather than an error. The default table sorts worst severity first and
+groups by tool, so the findings most likely to block a "gate" step are
+always at the top; -o json/yaml prints every field the server carries,
+including each finding's tool-specific detail.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, arguments []string) error {
+			selector, selectorError := resolvePipelineSelector(command)
+			if selectorError != nil {
+				return selectorError
+			}
+			return runPipelineFindingsList(command, selector, arguments[0])
+		},
+	}
+	registerPipelineSelectorFlags(findingsCommand)
+	registerStructuredOutputFlags(findingsCommand)
+	return findingsCommand
+}
+
+// pipelineFindingSeverityRank orders the platform's shared severity
+// vocabulary from most to least severe, mirroring
+// enginekit/pipelinegate's own severityRank so the table's default sort
+// reads worst-first regardless of what order the server answered in. A
+// severity this map does not recognise sorts as UNKNOWN (0), never assumed
+// worse than something the platform did classify.
+var pipelineFindingSeverityRank = map[string]int{
+	client.PipelineFindingSeverityCritical: 4,
+	client.PipelineFindingSeverityHigh:     3,
+	client.PipelineFindingSeverityMedium:   2,
+	client.PipelineFindingSeverityLow:      1,
+	client.PipelineFindingSeverityUnknown:  0,
+}
+
+func runPipelineFindingsList(command *cobra.Command, selector client.PipelineSelector, runID string) error {
+	format, formatError := structuredFormatFromFlags(command)
+	if formatError != nil {
+		return formatError
+	}
+	list, listError := apiClient.ListPipelineFindings(command.Context(), selector, strings.TrimSpace(runID))
+	if listError != nil {
+		return listError
+	}
+	if format != outputDefault {
+		return encodeStructured(command.OutOrStdout(), format, list)
+	}
+	if len(list.Findings) == 0 {
+		_, _ = fmt.Fprintln(command.OutOrStdout(), "No findings recorded for this run.")
+		return nil
+	}
+
+	findings := append([]client.PipelineFinding(nil), list.Findings...)
+	sort.SliceStable(findings, func(i, j int) bool {
+		rankI, rankJ := pipelineFindingSeverityRank[findings[i].Severity], pipelineFindingSeverityRank[findings[j].Severity]
+		if rankI != rankJ {
+			return rankI > rankJ
+		}
+		if findings[i].Tool != findings[j].Tool {
+			return findings[i].Tool < findings[j].Tool
+		}
+		return findings[i].Title < findings[j].Title
+	})
+
+	writer := table.NewWriter()
+	writer.SetOutputMirror(command.OutOrStdout())
+	writer.SetStyle(table.StyleRounded)
+	writer.AppendHeader(table.Row{"TOOL", "SEVERITY", "RULE / CVE", "TITLE", "PACKAGE", "PATH", "FIXED IN"})
+	for _, finding := range findings {
+		writer.AppendRow(table.Row{
+			finding.Tool,
+			finding.Severity,
+			pipelineFindingRuleOrCVE(finding),
+			pipelineStringOrDash(finding.Title),
+			pipelineFindingPackage(finding),
+			pipelineStringOrDash(finding.Path),
+			pipelineStringOrDash(finding.FixedVersion),
+		})
+	}
+	writer.Render()
+	return nil
+}
+
+// pipelineFindingRuleOrCVE is the finding's own identity for the table: the
+// CVE when the tool named one (Trivy), otherwise the scanner's own rule id
+// (Semgrep, Checkov).
+func pipelineFindingRuleOrCVE(finding client.PipelineFinding) string {
+	if finding.CVEID != nil && *finding.CVEID != "" {
+		return *finding.CVEID
+	}
+	return pipelineStringOrDash(finding.RuleID)
+}
+
+// pipelineFindingPackage renders a Trivy finding's affected dependency as
+// "name@version"; a finding with no package name (Semgrep, Checkov, most
+// SBOM rows) has nothing to show here.
+func pipelineFindingPackage(finding client.PipelineFinding) string {
+	if finding.PackageName == "" {
+		return "-"
+	}
+	if finding.PackageVersion == "" {
+		return finding.PackageName
+	}
+	return finding.PackageName + "@" + finding.PackageVersion
+}
+
+func pipelineStringOrDash(value string) string {
+	if value == "" {
+		return "-"
+	}
+	return value
+}

--- a/cmd/pipeline_findings_test.go
+++ b/cmd/pipeline_findings_test.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+// pipelineFindingsMock adds ListPipelineFindings to pipelineLaneMock without
+// touching its shared definition in pipeline_test.go: Go resolves the
+// method on the outer type before the embedded one, so this is the whole
+// override.
+type pipelineFindingsMock struct {
+	pipelineLaneMock
+
+	findingsRunID  string
+	findingsResult *client.PipelineFindingList
+	findingsError  error
+}
+
+func (mock *pipelineFindingsMock) ListPipelineFindings(ctx context.Context, selector client.PipelineSelector,
+	runID string) (*client.PipelineFindingList, error) {
+	mock.lastSelector = selector
+	mock.findingsRunID = runID
+	if mock.findingsError != nil {
+		return nil, mock.findingsError
+	}
+	return mock.findingsResult, nil
+}
+
+func cveID(value string) *string { return &value }
+
+func TestPipelineFindingsRegistered(t *testing.T) {
+	pipelineCommand := newPipelineCommand()
+	if findSubcommandOrNil(pipelineCommand, "findings") == nil {
+		t.Fatal("pipeline subcommand \"findings\" is not registered")
+	}
+}
+
+func TestPipelineFindingsEmpty(t *testing.T) {
+	mockClient := &pipelineFindingsMock{findingsResult: &client.PipelineFindingList{Findings: []client.PipelineFinding{}}}
+	output, executeError := runPipelineCommand(t, mockClient, "findings", "run-1", "--application", testApplicationID)
+	if executeError != nil {
+		t.Fatalf("findings error = %v", executeError)
+	}
+	if !strings.Contains(output, "No findings recorded") {
+		t.Errorf("output = %q", output)
+	}
+	if mockClient.findingsRunID != "run-1" {
+		t.Errorf("findings run id = %q", mockClient.findingsRunID)
+	}
+}
+
+func TestPipelineFindingsTableSortsWorstSeverityFirst(t *testing.T) {
+	mockClient := &pipelineFindingsMock{findingsResult: &client.PipelineFindingList{Findings: []client.PipelineFinding{
+		{Tool: "checkov", Severity: "LOW", RuleID: "CKV_LOW_1", Title: "minor misconfiguration"},
+		{Tool: "trivy", Severity: "CRITICAL", CVEID: cveID("CVE-2026-9999"), PackageName: "openssl",
+			PackageVersion: "1.0.0", FixedVersion: "1.0.1", Title: "critical CVE"},
+		{Tool: "semgrep", Severity: "HIGH", RuleID: "python.lang.security.audit", Title: "hardcoded secret"},
+	}}}
+	output, executeError := runPipelineCommand(t, mockClient, "findings", "run-1", "--application", testApplicationID)
+	if executeError != nil {
+		t.Fatalf("findings error = %v", executeError)
+	}
+	criticalIndex := strings.Index(output, "critical CVE")
+	highIndex := strings.Index(output, "hardcoded secret")
+	lowIndex := strings.Index(output, "minor misconfiguration")
+	if criticalIndex == -1 || highIndex == -1 || lowIndex == -1 {
+		t.Fatalf("output missing a row: %q", output)
+	}
+	if criticalIndex >= highIndex || highIndex >= lowIndex {
+		t.Errorf("rows are not worst-severity-first: critical=%d high=%d low=%d", criticalIndex, highIndex, lowIndex)
+	}
+	if !strings.Contains(output, "CVE-2026-9999") || !strings.Contains(output, "openssl@1.0.0") {
+		t.Errorf("output missing the CVE / package columns: %q", output)
+	}
+}
+
+func TestPipelineFindingsStructuredOutputSkipsTheTable(t *testing.T) {
+	mockClient := &pipelineFindingsMock{findingsResult: &client.PipelineFindingList{Findings: []client.PipelineFinding{
+		{Tool: "trivy", Severity: "HIGH", Title: "a finding"},
+	}}}
+	output, executeError := runPipelineCommand(t, mockClient, "findings", "run-1", "--application", testApplicationID, "-o", "json")
+	if executeError != nil {
+		t.Fatalf("findings -o json error = %v", executeError)
+	}
+	if !strings.Contains(output, `"tool": "trivy"`) || strings.Contains(output, "SEVERITY") {
+		t.Errorf("output = %q, want the raw JSON shape rather than the table", output)
+	}
+}
+
+func TestPipelineFindingsRunNotFound(t *testing.T) {
+	mockClient := &pipelineFindingsMock{findingsError: errors.New("Pipeline run not found")}
+	_, executeError := runPipelineCommand(t, mockClient, "findings", "missing-run", "--application", testApplicationID)
+	if executeError == nil || executeError.Error() != "Pipeline run not found" {
+		t.Fatalf("error = %v, want the sentinel text verbatim", executeError)
+	}
+}

--- a/cmd/pipeline_logs.go
+++ b/cmd/pipeline_logs.go
@@ -10,9 +10,11 @@ package cmd
 // (enginekit/pipelineartifacts.KindStepLog, uploaded when the step
 // concluded) through the same artifacts list and presigned download
 // cmd/pipeline_artifacts.go uses, and prints it whole - mirroring the
-// portal's usePipelineStepArtifactLog. --follow only ever applies to the
-// live relay: a concluded step's log is a fixed, complete record, so there
-// is nothing left to follow.
+// portal's usePipelineStepArtifactLog. That listing is keyset-paged, so the
+// search follows its cursor rather than read the first page as the run's
+// whole record. --follow only ever applies to the live relay: a concluded
+// step's log is a fixed, complete record, so there is nothing left to
+// follow.
 
 import (
 	"bytes"
@@ -35,6 +37,20 @@ const pipelineStepStatusConcluded = "concluded"
 // reconnecting after the relay's own error frame or a stream fault, so a
 // transient disconnect does not spin the CLI in a tight retry loop.
 const pipelineLogStreamReconnectDelay = 2 * time.Second
+
+// pipelineArtifactPageSize is the page findPipelineStepLogArtifact asks for:
+// the route's own ceiling (enginekit/pipelineartifacts.MaxListLimit), so the
+// walk makes as few round trips as the server allows.
+const pipelineArtifactPageSize = 100
+
+// pipelineArtifactPageBudget bounds that walk. A run's step logs are written
+// oldest-first alongside its declared artifacts, so the one this command
+// wants is usually on the first page; the budget exists so a pathological
+// run (or a server that keeps handing back a cursor) cannot turn one 'logs'
+// call into an unbounded walk. At the page size above that is 5000 artifacts
+// before the search gives up, and giving up is reported as a capped read
+// rather than as an absent log.
+const pipelineArtifactPageBudget = 50
 
 func newPipelineLogsCommand() *cobra.Command {
 	logsCommand := &cobra.Command{
@@ -205,20 +221,21 @@ func runPipelineLogsFromArchive(command *cobra.Command, selector client.Pipeline
 	out := command.OutOrStdout()
 	progress := command.ErrOrStderr()
 
-	list, listError := apiClient.ListPipelineArtifacts(command.Context(), selector, runID)
-	if listError != nil {
-		return listError
-	}
-	var logArtifact *client.PipelineArtifact
-	for index := range list.Artifacts {
-		candidate := list.Artifacts[index]
-		if candidate.Kind == client.PipelineArtifactKindStepLog &&
-			candidate.StepID != nil && *candidate.StepID == step.ID {
-			logArtifact = &list.Artifacts[index]
-			break
-		}
+	logArtifact, wasFullyRead, findError := findPipelineStepLogArtifact(command, selector, runID, step.ID)
+	if findError != nil {
+		return findError
 	}
 	if logArtifact == nil {
+		if !wasFullyRead {
+			// The search stopped at its own page cap, so absence was never
+			// observed: say the read was capped rather than report a log
+			// that may well exist on a page this command declined to fetch.
+			_, _ = fmt.Fprintf(progress,
+				"Stopped after %d pages of run %s's artifacts without finding a log for step %q;"+
+					" list them with 'ankra pipeline artifacts %s'.\n",
+				pipelineArtifactPageBudget, runID, step.StepKey, runID)
+			return nil
+		}
 		_, _ = fmt.Fprintf(progress, "No archived log was recorded for step %q.\n", step.StepKey)
 		return nil
 	}
@@ -249,4 +266,32 @@ func runPipelineLogsFromArchive(command *cobra.Command, selector client.Pipeline
 			step.StepKey, logArtifact.Status)
 		return nil
 	}
+}
+
+// findPipelineStepLogArtifact walks the run's artifact pages for the given
+// step's step_log row. It returns the artifact when it finds one, and
+// otherwise reports through wasFullyRead whether the run's artifacts were
+// read to the end (a genuine absence) or the page budget ran out first (an
+// answer the caller must not state as absence).
+func findPipelineStepLogArtifact(command *cobra.Command, selector client.PipelineSelector, runID string,
+	stepID string) (artifact *client.PipelineArtifact, wasFullyRead bool, findError error) {
+	options := client.ListPipelineArtifactsOptions{Limit: pipelineArtifactPageSize}
+	for page := 0; page < pipelineArtifactPageBudget; page++ {
+		list, listError := apiClient.ListPipelineArtifacts(command.Context(), selector, runID, options)
+		if listError != nil {
+			return nil, false, listError
+		}
+		for index := range list.Artifacts {
+			candidate := list.Artifacts[index]
+			if candidate.Kind == client.PipelineArtifactKindStepLog &&
+				candidate.StepID != nil && *candidate.StepID == stepID {
+				return &list.Artifacts[index], true, nil
+			}
+		}
+		if list.NextCursor == nil || *list.NextCursor == "" {
+			return nil, true, nil
+		}
+		options.Cursor = *list.NextCursor
+	}
+	return nil, false, nil
 }

--- a/cmd/pipeline_logs.go
+++ b/cmd/pipeline_logs.go
@@ -17,7 +17,6 @@ package cmd
 // follow.
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"strings"
@@ -242,12 +241,10 @@ func runPipelineLogsFromArchive(command *cobra.Command, selector client.Pipeline
 
 	switch logArtifact.Status {
 	case client.PipelineArtifactStatusUploaded:
-		var downloaded bytes.Buffer
-		if downloadError := apiClient.DownloadPipelineArtifact(command.Context(), selector, logArtifact.ID, &downloaded); downloadError != nil {
-			return downloadError
-		}
-		_, writeError := out.Write(downloaded.Bytes())
-		return writeError
+		// Streamed straight through rather than buffered: a step log is
+		// whatever the build printed, which for a verbose one is tens of
+		// megabytes, and holding all of it to write it once buys nothing.
+		return apiClient.DownloadPipelineArtifact(command.Context(), selector, logArtifact.ID, out)
 	case client.PipelineArtifactStatusPending:
 		_, _ = fmt.Fprintf(progress,
 			"Step %q has concluded; its log is still being archived - try again shortly.\n", step.StepKey)

--- a/cmd/pipeline_logs.go
+++ b/cmd/pipeline_logs.go
@@ -1,12 +1,21 @@
 package cmd
 
-// The step log relay: go/internal/pipelineapi/streams.go over the shared
-// execution_output JetStream stream. See internal/client/pipeline_logs.go for
-// the wire contract and its one real limitation: a fresh connection has no
-// history to replay, so this command only ever shows output produced from the
-// moment it connects.
+// A pipeline step's output, two ways. A running step is followed live over
+// the step log relay (go/internal/pipelineapi/streams.go, over the shared
+// execution_output JetStream stream) - see internal/client/pipeline_logs.go
+// for that wire contract and its one real limitation: a fresh connection has
+// no history to replay, so a live connection only ever shows output produced
+// from the moment it connects. A step that has already concluded reads
+// differently: this command instead fetches its durable step_log artifact
+// (enginekit/pipelineartifacts.KindStepLog, uploaded when the step
+// concluded) through the same artifacts list and presigned download
+// cmd/pipeline_artifacts.go uses, and prints it whole - mirroring the
+// portal's usePipelineStepArtifactLog. --follow only ever applies to the
+// live relay: a concluded step's log is a fixed, complete record, so there
+// is nothing left to follow.
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"strings"
@@ -17,6 +26,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// pipelineStepStatusConcluded is the PipelineStep.Status value a settled
+// step carries, shared by the archive-log branch below and
+// pipelineStepConcluded's own poll.
+const pipelineStepStatusConcluded = "concluded"
+
 // pipelineLogStreamReconnectDelay is how long `logs --follow` waits before
 // reconnecting after the relay's own error frame or a stream fault, so a
 // transient disconnect does not spin the CLI in a tight retry loop.
@@ -25,16 +39,17 @@ const pipelineLogStreamReconnectDelay = 2 * time.Second
 func newPipelineLogsCommand() *cobra.Command {
 	logsCommand := &cobra.Command{
 		Use:   "logs <run>",
-		Short: "Show a pipeline step's live output",
-		Long: `Show a pipeline step's live output over the log relay.
+		Short: "Show a pipeline step's output",
+		Long: `Show a pipeline step's output.
 
-The relay has no history yet: a fresh connection only sees lines produced
-from the moment it connects, not what the step already printed before then
-(the durable per-step log artifact this will read from instead has not
-shipped). Without --follow, the command tails the step until it concludes and
-then stops; with --follow it does the same, so the difference is mainly
-diagnostic - a bare 'logs' exits with the step's outcome, 'logs --follow'
-keeps reconnecting through a dropped stream instead of giving up.`,
+A step that has already concluded prints its complete, archived log in one
+shot - --follow does nothing extra for it, since there is nothing left to
+produce. A step that is still running is followed over the live log relay
+instead: without --follow, the command tails the step until it concludes and
+then stops; with --follow it keeps reconnecting through a dropped stream
+instead of giving up. The relay itself has no history - a fresh connection
+only sees lines produced from the moment it connects - which is exactly why
+a concluded step reads its archived log instead.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(command *cobra.Command, arguments []string) error {
 			selector, selectorError := resolvePipelineSelector(command)
@@ -64,6 +79,9 @@ func runPipelineLogs(command *cobra.Command, selector client.PipelineSelector, r
 	step, resolveError := resolvePipelineStep(command, selector, runID, strings.TrimSpace(stepReference))
 	if resolveError != nil {
 		return resolveError
+	}
+	if step.Status == pipelineStepStatusConcluded {
+		return runPipelineLogsFromArchive(command, selector, runID, step)
 	}
 	if step.ExecutionID == nil || step.ExecutionStepID == nil {
 		return fmt.Errorf("step %q has not started, so it has no log stream yet - "+
@@ -169,8 +187,66 @@ func pipelineStepConcluded(command *cobra.Command, selector client.PipelineSelec
 	}
 	for _, step := range detail.Steps {
 		if step.ID == stepID {
-			return step.Status == "concluded", nil
+			return step.Status == pipelineStepStatusConcluded, nil
 		}
 	}
 	return false, withExitCode(exitNotFound, fmt.Errorf("step %s is no longer on run %s", stepID, runID))
+}
+
+// runPipelineLogsFromArchive prints a concluded step's complete log from its
+// durable step_log artifact instead of opening the live relay, which would
+// see nothing for a step that already finished (DeliverNewPolicy - see the
+// package doc above). Mirrors the portal's usePipelineStepArtifactLog: find
+// the run's step_log artifact for this step, then branch on its own Status,
+// since "no artifact" and each of the artifact's three non-terminal-success
+// states are different facts a caller must not collapse into "no log".
+func runPipelineLogsFromArchive(command *cobra.Command, selector client.PipelineSelector, runID string,
+	step client.PipelineStep) error {
+	out := command.OutOrStdout()
+	progress := command.ErrOrStderr()
+
+	list, listError := apiClient.ListPipelineArtifacts(command.Context(), selector, runID)
+	if listError != nil {
+		return listError
+	}
+	var logArtifact *client.PipelineArtifact
+	for index := range list.Artifacts {
+		candidate := list.Artifacts[index]
+		if candidate.Kind == client.PipelineArtifactKindStepLog &&
+			candidate.StepID != nil && *candidate.StepID == step.ID {
+			logArtifact = &list.Artifacts[index]
+			break
+		}
+	}
+	if logArtifact == nil {
+		_, _ = fmt.Fprintf(progress, "No archived log was recorded for step %q.\n", step.StepKey)
+		return nil
+	}
+
+	switch logArtifact.Status {
+	case client.PipelineArtifactStatusUploaded:
+		var downloaded bytes.Buffer
+		if downloadError := apiClient.DownloadPipelineArtifact(command.Context(), selector, logArtifact.ID, &downloaded); downloadError != nil {
+			return downloadError
+		}
+		_, writeError := out.Write(downloaded.Bytes())
+		return writeError
+	case client.PipelineArtifactStatusPending:
+		_, _ = fmt.Fprintf(progress,
+			"Step %q has concluded; its log is still being archived - try again shortly.\n", step.StepKey)
+		return nil
+	case client.PipelineArtifactStatusFailed:
+		detail := logArtifact.ErrorMessage
+		if detail == "" {
+			detail = "Ankra could not archive this log."
+		}
+		return fmt.Errorf("step %q's log was not archived: %s", step.StepKey, detail)
+	case client.PipelineArtifactStatusExpired:
+		return withExitCode(exitNotFound,
+			fmt.Errorf("step %q's log has expired and was removed from storage", step.StepKey))
+	default:
+		_, _ = fmt.Fprintf(progress, "Step %q's log artifact is in an unrecognised state (%s).\n",
+			step.StepKey, logArtifact.Status)
+		return nil
+	}
 }

--- a/cmd/pipeline_logs.go
+++ b/cmd/pipeline_logs.go
@@ -270,9 +270,20 @@ func runPipelineLogsFromArchive(command *cobra.Command, selector client.Pipeline
 // otherwise reports through wasFullyRead whether the run's artifacts were
 // read to the end (a genuine absence) or the page budget ran out first (an
 // answer the caller must not state as absence).
+//
+// A step row carries at most one live step_log, but not necessarily only
+// one row: re-dispatching the same step supersedes whatever it had already
+// minted, marking that row failed with a superseding reason and writing a
+// fresh one. The listing is oldest-first, so the step's real log is the
+// last matching row, not the first - taking the first would report a
+// superseded upload's failure as the step's log. The walk therefore keeps
+// the newest match it has seen, and returns early only on a match that
+// cannot have been superseded, since supersession always leaves the row
+// failed.
 func findPipelineStepLogArtifact(command *cobra.Command, selector client.PipelineSelector, runID string,
 	stepID string) (artifact *client.PipelineArtifact, wasFullyRead bool, findError error) {
 	options := client.ListPipelineArtifactsOptions{Limit: pipelineArtifactPageSize}
+	var newest *client.PipelineArtifact
 	for page := 0; page < pipelineArtifactPageBudget; page++ {
 		list, listError := apiClient.ListPipelineArtifacts(command.Context(), selector, runID, options)
 		if listError != nil {
@@ -280,15 +291,19 @@ func findPipelineStepLogArtifact(command *cobra.Command, selector client.Pipelin
 		}
 		for index := range list.Artifacts {
 			candidate := list.Artifacts[index]
-			if candidate.Kind == client.PipelineArtifactKindStepLog &&
-				candidate.StepID != nil && *candidate.StepID == stepID {
-				return &list.Artifacts[index], true, nil
+			if candidate.Kind != client.PipelineArtifactKindStepLog ||
+				candidate.StepID == nil || *candidate.StepID != stepID {
+				continue
+			}
+			newest = &list.Artifacts[index]
+			if candidate.Status != client.PipelineArtifactStatusFailed {
+				return newest, true, nil
 			}
 		}
 		if list.NextCursor == nil || *list.NextCursor == "" {
-			return nil, true, nil
+			return newest, true, nil
 		}
 		options.Cursor = *list.NextCursor
 	}
-	return nil, false, nil
+	return newest, false, nil
 }

--- a/cmd/pipeline_logs_test.go
+++ b/cmd/pipeline_logs_test.go
@@ -145,6 +145,71 @@ func TestPipelineLogsConcludedStepStopsPagingOnceFound(t *testing.T) {
 	}
 }
 
+func TestPipelineLogsConcludedStepPrefersTheLiveLogOverASupersededOne(t *testing.T) {
+	// Re-dispatching a step supersedes the step_log it had already minted -
+	// that row is marked failed and a fresh one written under the same step
+	// id - and the listing is oldest-first, so the first match is the
+	// superseded row. Reporting its failure would state that the step's log
+	// was not archived when the live one is sitting further down the run.
+	stepID := "step-1"
+	secondCursor := "cursor-2"
+	mockClient := &pipelineLaneMock{
+		getResult: &client.PipelineRunDetail{Steps: []client.PipelineStep{concludedStep()}},
+		artifactsPages: []client.PipelineArtifactList{
+			{Artifacts: []client.PipelineArtifact{
+				{ID: "artifact-superseded", StepID: &stepID, Kind: client.PipelineArtifactKindStepLog,
+					Status:       client.PipelineArtifactStatusFailed,
+					ErrorMessage: "a new attempt of the step was dispatched before this upload was settled"},
+			}, NextCursor: &secondCursor},
+			{Artifacts: []client.PipelineArtifact{
+				{ID: "artifact-live", StepID: &stepID, Kind: client.PipelineArtifactKindStepLog,
+					Status: client.PipelineArtifactStatusUploaded},
+			}},
+		},
+		downloadPayload: "the log the step actually wrote\n",
+	}
+	output, executeError := runPipelineCommand(t, mockClient, "logs", "run-1",
+		"--application", testApplicationID, "--step", "checkout")
+	if executeError != nil {
+		t.Fatalf("logs error = %v", executeError)
+	}
+	if output != "the log the step actually wrote\n" {
+		t.Errorf("output = %q, want the live log rather than the superseded row's failure", output)
+	}
+	if mockClient.downloadArtifactID != "artifact-live" {
+		t.Errorf("downloaded artifact id = %q, want the newest step_log for the step", mockClient.downloadArtifactID)
+	}
+	if len(mockClient.artifactsOptions) != 2 {
+		t.Errorf("artifact list calls = %d, want the walk to keep looking past a superseded row",
+			len(mockClient.artifactsOptions))
+	}
+}
+
+func TestPipelineLogsConcludedStepReportsTheNewestFailureWhenEveryLogFailed(t *testing.T) {
+	// When every step_log for the step failed, the one worth reporting is
+	// the newest - the superseded row's reason describes the dispatch that
+	// replaced it, not why this step has no log.
+	stepID := "step-1"
+	mockClient := &pipelineLaneMock{
+		getResult: &client.PipelineRunDetail{Steps: []client.PipelineStep{concludedStep()}},
+		artifactsResult: &client.PipelineArtifactList{Artifacts: []client.PipelineArtifact{
+			{ID: "artifact-superseded", StepID: &stepID, Kind: client.PipelineArtifactKindStepLog,
+				Status:       client.PipelineArtifactStatusFailed,
+				ErrorMessage: "a new attempt of the step was dispatched before this upload was settled"},
+			{ID: "artifact-live", StepID: &stepID, Kind: client.PipelineArtifactKindStepLog,
+				Status: client.PipelineArtifactStatusFailed, ErrorMessage: "the vault rejected the upload"},
+		}},
+	}
+	_, executeError := runPipelineCommand(t, mockClient, "logs", "run-1",
+		"--application", testApplicationID, "--step", "checkout")
+	if executeError == nil {
+		t.Fatalf("logs error = nil, want the archived log's own failure")
+	}
+	if !strings.Contains(executeError.Error(), "the vault rejected the upload") {
+		t.Errorf("error = %v, want the newest step_log row's reason", executeError)
+	}
+}
+
 func TestPipelineLogsConcludedStepCappedReadIsNotAbsence(t *testing.T) {
 	// A server that keeps handing back a cursor must not make the command
 	// walk forever, and giving up must not be reported as "no archived log

--- a/cmd/pipeline_logs_test.go
+++ b/cmd/pipeline_logs_test.go
@@ -72,6 +72,106 @@ func TestPipelineLogsConcludedStepNoArchivedLog(t *testing.T) {
 	}
 }
 
+func TestPipelineLogsConcludedStepFollowsArtifactPages(t *testing.T) {
+	// A run with more artifacts than one server page must not read as "no
+	// archived log": the search follows next_cursor until it finds the
+	// step's own step_log row.
+	stepID := "step-1"
+	otherStepID := "step-0"
+	secondCursor, thirdCursor := "cursor-2", "cursor-3"
+	mockClient := &pipelineLaneMock{
+		getResult: &client.PipelineRunDetail{Steps: []client.PipelineStep{concludedStep()}},
+		artifactsPages: []client.PipelineArtifactList{
+			{Artifacts: []client.PipelineArtifact{
+				{ID: "artifact-1", StepID: &otherStepID, Kind: client.PipelineArtifactKindStepLog,
+					Status: client.PipelineArtifactStatusUploaded},
+			}, NextCursor: &secondCursor},
+			{Artifacts: []client.PipelineArtifact{
+				{ID: "artifact-2", Kind: client.PipelineArtifactKindArtifact,
+					Status: client.PipelineArtifactStatusUploaded},
+			}, NextCursor: &thirdCursor},
+			{Artifacts: []client.PipelineArtifact{
+				{ID: "artifact-3", StepID: &stepID, Kind: client.PipelineArtifactKindStepLog,
+					Status: client.PipelineArtifactStatusUploaded},
+			}},
+		},
+		downloadPayload: "found on the third page\n",
+	}
+	output, executeError := runPipelineCommand(t, mockClient, "logs", "run-1", "--application", testApplicationID, "--step", "checkout")
+	if executeError != nil {
+		t.Fatalf("logs error = %v", executeError)
+	}
+	if output != "found on the third page\n" {
+		t.Errorf("output = %q", output)
+	}
+	if mockClient.downloadArtifactID != "artifact-3" {
+		t.Errorf("downloaded artifact id = %q, want the step_log found on a later page", mockClient.downloadArtifactID)
+	}
+	if len(mockClient.artifactsOptions) != 3 {
+		t.Fatalf("artifact list calls = %d, want one per page until the step_log is found", len(mockClient.artifactsOptions))
+	}
+	if mockClient.artifactsOptions[0].Cursor != "" ||
+		mockClient.artifactsOptions[1].Cursor != secondCursor ||
+		mockClient.artifactsOptions[2].Cursor != thirdCursor {
+		t.Errorf("cursors asked for = %+v, want each page's own next_cursor", mockClient.artifactsOptions)
+	}
+}
+
+func TestPipelineLogsConcludedStepStopsPagingOnceFound(t *testing.T) {
+	// The walk must stop at the page carrying the step's log rather than
+	// read the run's remaining artifacts for nothing.
+	stepID := "step-1"
+	secondCursor := "cursor-2"
+	mockClient := &pipelineLaneMock{
+		getResult: &client.PipelineRunDetail{Steps: []client.PipelineStep{concludedStep()}},
+		artifactsPages: []client.PipelineArtifactList{
+			{Artifacts: []client.PipelineArtifact{
+				{ID: "artifact-1", StepID: &stepID, Kind: client.PipelineArtifactKindStepLog,
+					Status: client.PipelineArtifactStatusUploaded},
+			}, NextCursor: &secondCursor},
+			{Artifacts: []client.PipelineArtifact{
+				{ID: "artifact-2", StepID: &stepID, Kind: client.PipelineArtifactKindStepLog,
+					Status: client.PipelineArtifactStatusUploaded},
+			}},
+		},
+		downloadPayload: "the first match\n",
+	}
+	if _, executeError := runPipelineCommand(t, mockClient, "logs", "run-1",
+		"--application", testApplicationID, "--step", "checkout"); executeError != nil {
+		t.Fatalf("logs error = %v", executeError)
+	}
+	if len(mockClient.artifactsOptions) != 1 {
+		t.Errorf("artifact list calls = %d, want the walk to stop at the first match", len(mockClient.artifactsOptions))
+	}
+}
+
+func TestPipelineLogsConcludedStepCappedReadIsNotAbsence(t *testing.T) {
+	// A server that keeps handing back a cursor must not make the command
+	// walk forever, and giving up must not be reported as "no archived log
+	// was recorded" - the absence was never observed.
+	endlessCursor := "cursor-next"
+	mockClient := &pipelineLaneMock{
+		getResult: &client.PipelineRunDetail{Steps: []client.PipelineStep{concludedStep()}},
+		artifactsPages: []client.PipelineArtifactList{
+			{Artifacts: []client.PipelineArtifact{}, NextCursor: &endlessCursor},
+		},
+	}
+	output, executeError := runPipelineCommand(t, mockClient, "logs", "run-1", "--application", testApplicationID, "--step", "checkout")
+	if executeError != nil {
+		t.Fatalf("logs error = %v", executeError)
+	}
+	if strings.Contains(output, "No archived log was recorded") {
+		t.Errorf("a capped read must not read as an observed absence: %q", output)
+	}
+	if !strings.Contains(output, "Stopped after") {
+		t.Errorf("output = %q, want it to say the read was capped", output)
+	}
+	if len(mockClient.artifactsOptions) != pipelineArtifactPageBudget {
+		t.Errorf("artifact list calls = %d, want the walk bounded at %d pages",
+			len(mockClient.artifactsOptions), pipelineArtifactPageBudget)
+	}
+}
+
 func TestPipelineLogsConcludedStepStillArchiving(t *testing.T) {
 	stepID := "step-1"
 	mockClient := &pipelineLaneMock{

--- a/cmd/pipeline_logs_test.go
+++ b/cmd/pipeline_logs_test.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+// concludedStep is one planned, concluded step - the fixture every archive-
+// log test below resolves through GetPipelineRun.
+func concludedStep() client.PipelineStep {
+	return client.PipelineStep{ID: "step-1", StepKey: "checkout", Status: pipelineStepStatusConcluded}
+}
+
+func TestPipelineLogsConcludedStepReadsArchivedStepLog(t *testing.T) {
+	stepID := "step-1"
+	mockClient := &pipelineLaneMock{
+		getResult: &client.PipelineRunDetail{Steps: []client.PipelineStep{concludedStep()}},
+		artifactsResult: &client.PipelineArtifactList{Artifacts: []client.PipelineArtifact{
+			{ID: "artifact-1", StepID: &stepID, Kind: client.PipelineArtifactKindStepLog,
+				Status: client.PipelineArtifactStatusUploaded},
+		}},
+		downloadPayload: "cloning commit abc123\nchecked out\n",
+	}
+	output, executeError := runPipelineCommand(t, mockClient, "logs", "run-1", "--application", testApplicationID, "--step", "checkout")
+	if executeError != nil {
+		t.Fatalf("logs error = %v", executeError)
+	}
+	if output != "cloning commit abc123\nchecked out\n" {
+		t.Errorf("output = %q", output)
+	}
+	if mockClient.downloadArtifactID != "artifact-1" {
+		t.Errorf("downloaded artifact id = %q, want the step_log artifact's own id", mockClient.downloadArtifactID)
+	}
+}
+
+func TestPipelineLogsConcludedStepFollowIsANoOp(t *testing.T) {
+	// --follow on an already-concluded step must not hang or error: there is
+	// nothing left to follow, so it reads the same archived log as a bare
+	// 'logs' call.
+	stepID := "step-1"
+	mockClient := &pipelineLaneMock{
+		getResult: &client.PipelineRunDetail{Steps: []client.PipelineStep{concludedStep()}},
+		artifactsResult: &client.PipelineArtifactList{Artifacts: []client.PipelineArtifact{
+			{ID: "artifact-1", StepID: &stepID, Kind: client.PipelineArtifactKindStepLog,
+				Status: client.PipelineArtifactStatusUploaded},
+		}},
+		downloadPayload: "the whole log\n",
+	}
+	output, executeError := runPipelineCommand(t, mockClient, "logs", "run-1",
+		"--application", testApplicationID, "--step", "checkout", "--follow")
+	if executeError != nil {
+		t.Fatalf("logs --follow error = %v", executeError)
+	}
+	if output != "the whole log\n" {
+		t.Errorf("output = %q", output)
+	}
+}
+
+func TestPipelineLogsConcludedStepNoArchivedLog(t *testing.T) {
+	mockClient := &pipelineLaneMock{
+		getResult:       &client.PipelineRunDetail{Steps: []client.PipelineStep{concludedStep()}},
+		artifactsResult: &client.PipelineArtifactList{Artifacts: []client.PipelineArtifact{}},
+	}
+	output, executeError := runPipelineCommand(t, mockClient, "logs", "run-1", "--application", testApplicationID, "--step", "checkout")
+	if executeError != nil {
+		t.Fatalf("logs error = %v", executeError)
+	}
+	if !strings.Contains(output, "No archived log was recorded") {
+		t.Errorf("output = %q", output)
+	}
+}
+
+func TestPipelineLogsConcludedStepStillArchiving(t *testing.T) {
+	stepID := "step-1"
+	mockClient := &pipelineLaneMock{
+		getResult: &client.PipelineRunDetail{Steps: []client.PipelineStep{concludedStep()}},
+		artifactsResult: &client.PipelineArtifactList{Artifacts: []client.PipelineArtifact{
+			{ID: "artifact-1", StepID: &stepID, Kind: client.PipelineArtifactKindStepLog,
+				Status: client.PipelineArtifactStatusPending},
+		}},
+	}
+	output, executeError := runPipelineCommand(t, mockClient, "logs", "run-1", "--application", testApplicationID, "--step", "checkout")
+	if executeError != nil {
+		t.Fatalf("logs error = %v", executeError)
+	}
+	if !strings.Contains(output, "still being archived") {
+		t.Errorf("output = %q", output)
+	}
+}
+
+func TestPipelineLogsConcludedStepArchiveFailed(t *testing.T) {
+	stepID := "step-1"
+	mockClient := &pipelineLaneMock{
+		getResult: &client.PipelineRunDetail{Steps: []client.PipelineStep{concludedStep()}},
+		artifactsResult: &client.PipelineArtifactList{Artifacts: []client.PipelineArtifact{
+			{ID: "artifact-1", StepID: &stepID, Kind: client.PipelineArtifactKindStepLog,
+				Status: client.PipelineArtifactStatusFailed, ErrorMessage: "the vault rejected the upload"},
+		}},
+	}
+	_, executeError := runPipelineCommand(t, mockClient, "logs", "run-1", "--application", testApplicationID, "--step", "checkout")
+	if executeError == nil || !strings.Contains(executeError.Error(), "the vault rejected the upload") {
+		t.Fatalf("error = %v, want it to carry the artifact's own error message", executeError)
+	}
+}
+
+func TestPipelineLogsRunningStepStillStreamsLive(t *testing.T) {
+	// A step that has not concluded must not take the archive-log branch,
+	// even when the run also carries an (irrelevant) artifacts result -
+	// resolving to the live relay is what --follow documents.
+	executionID, executionStepID := "execution-1", "execution-step-1"
+	mockClient := &pipelineLaneMock{
+		getResult: &client.PipelineRunDetail{Steps: []client.PipelineStep{
+			{ID: "step-1", StepKey: "checkout", Status: "running",
+				ExecutionID: &executionID, ExecutionStepID: &executionStepID},
+		}},
+	}
+	_, executeError := runPipelineCommand(t, mockClient, "logs", "run-1", "--application", testApplicationID, "--step", "checkout")
+	if executeError != nil {
+		t.Fatalf("logs error = %v", executeError)
+	}
+	if mockClient.artifactsRunID != "" {
+		t.Errorf("a running step must not read artifacts at all, got artifactsRunID = %q", mockClient.artifactsRunID)
+	}
+}

--- a/cmd/pipeline_run.go
+++ b/cmd/pipeline_run.go
@@ -224,7 +224,10 @@ func runPipelineList(command *cobra.Command, selector client.PipelineSelector) e
 	branch, _ := command.Flags().GetString("branch")
 	headSHA, _ := command.Flags().GetString("head-sha")
 	cursor, _ := command.Flags().GetString("cursor")
-	limit, _ := command.Flags().GetInt("limit")
+	limit, limitError := pipelinePageLimitFromFlags(command)
+	if limitError != nil {
+		return limitError
+	}
 
 	page, listError := apiClient.ListPipelineRuns(command.Context(), selector, client.ListPipelineRunsOptions{
 		Status:  strings.TrimSpace(status),

--- a/cmd/pipeline_test.go
+++ b/cmd/pipeline_test.go
@@ -487,6 +487,25 @@ func TestPipelineArtifactsListEmpty(t *testing.T) {
 	}
 }
 
+func TestPipelineListingsRefuseANegativeLimit(t *testing.T) {
+	// A negative --limit used to be dropped on the way to the query, so the
+	// caller silently got the server's default page instead of being told
+	// the flag was ignored.
+	for name, arguments := range map[string][]string{
+		"artifacts": {"artifacts", "run-1", "--application", testApplicationID, "--limit", "-5"},
+		"list":      {"list", "--application", testApplicationID, "--limit", "-5"},
+	} {
+		mockClient := &pipelineLaneMock{}
+		_, executeError := runPipelineCommand(t, mockClient, arguments...)
+		if executeError == nil || !strings.Contains(executeError.Error(), "--limit must be a positive number") {
+			t.Errorf("%s error = %v, want a usage refusal", name, executeError)
+		}
+		if len(mockClient.artifactsOptions) != 0 || mockClient.listOptions.Limit != 0 {
+			t.Errorf("%s must refuse before asking the server anything", name)
+		}
+	}
+}
+
 func TestPipelineArtifactsListSaysWhenAnotherPageExists(t *testing.T) {
 	nextCursor := "cursor-2"
 	stepID := "step-1"

--- a/cmd/pipeline_test.go
+++ b/cmd/pipeline_test.go
@@ -48,6 +48,11 @@ type pipelineLaneMock struct {
 	artifactsRunID  string
 	artifactsResult *client.PipelineArtifactList
 	artifactsError  error
+	// artifactsPages, when set, is served one page per call in order and
+	// takes precedence over artifactsResult, so a test can exercise a
+	// listing the caller has to follow NextCursor through.
+	artifactsPages   []client.PipelineArtifactList
+	artifactsOptions []client.ListPipelineArtifactsOptions
 
 	downloadArtifactID string
 	downloadError      error
@@ -130,11 +135,20 @@ func (mock *pipelineLaneMock) StreamPipelineStepLogs(ctx context.Context, select
 	return events, nil
 }
 
-func (mock *pipelineLaneMock) ListPipelineArtifacts(ctx context.Context, selector client.PipelineSelector, runID string) (*client.PipelineArtifactList, error) {
+func (mock *pipelineLaneMock) ListPipelineArtifacts(ctx context.Context, selector client.PipelineSelector, runID string, options client.ListPipelineArtifactsOptions) (*client.PipelineArtifactList, error) {
 	mock.lastSelector = selector
 	mock.artifactsRunID = runID
+	mock.artifactsOptions = append(mock.artifactsOptions, options)
 	if mock.artifactsError != nil {
 		return nil, mock.artifactsError
+	}
+	if mock.artifactsPages != nil {
+		index := len(mock.artifactsOptions) - 1
+		if index >= len(mock.artifactsPages) {
+			index = len(mock.artifactsPages) - 1
+		}
+		page := mock.artifactsPages[index]
+		return &page, nil
 	}
 	return mock.artifactsResult, nil
 }
@@ -454,6 +468,49 @@ func TestPipelineArtifactsListEmpty(t *testing.T) {
 	}
 	if !strings.Contains(output, "No artifacts stored") {
 		t.Errorf("output = %q", output)
+	}
+}
+
+func TestPipelineArtifactsListSaysWhenAnotherPageExists(t *testing.T) {
+	nextCursor := "cursor-2"
+	stepID := "step-1"
+	mockClient := &pipelineLaneMock{artifactsResult: &client.PipelineArtifactList{
+		Artifacts: []client.PipelineArtifact{
+			{ID: "artifact-1", StepID: &stepID, Kind: client.PipelineArtifactKindStepLog,
+				Status: client.PipelineArtifactStatusUploaded},
+		},
+		NextCursor: &nextCursor,
+	}}
+	output, executeError := runPipelineCommand(t, mockClient, "artifacts", "run-1",
+		"--application", testApplicationID, "--cursor", "cursor-1", "--limit", "100")
+	if executeError != nil {
+		t.Fatalf("artifacts error = %v", executeError)
+	}
+	if len(mockClient.artifactsOptions) != 1 ||
+		mockClient.artifactsOptions[0].Cursor != "cursor-1" || mockClient.artifactsOptions[0].Limit != 100 {
+		t.Fatalf("paging asked for = %+v, want the flags passed through", mockClient.artifactsOptions)
+	}
+	if !strings.Contains(output, "--cursor cursor-2") {
+		t.Errorf("output = %q, want it to name the next page's cursor", output)
+	}
+}
+
+func TestPipelineArtifactsListEmptyPageWithMoreToRead(t *testing.T) {
+	// An empty page that still offers a cursor is "more to read", not "the
+	// run stored nothing".
+	nextCursor := "cursor-2"
+	mockClient := &pipelineLaneMock{artifactsResult: &client.PipelineArtifactList{
+		Artifacts: []client.PipelineArtifact{}, NextCursor: &nextCursor,
+	}}
+	output, executeError := runPipelineCommand(t, mockClient, "artifacts", "run-1", "--application", testApplicationID)
+	if executeError != nil {
+		t.Fatalf("artifacts error = %v", executeError)
+	}
+	if strings.Contains(output, "No artifacts stored") {
+		t.Errorf("output = %q, must not claim the run stored nothing", output)
+	}
+	if !strings.Contains(output, "--cursor cursor-2") {
+		t.Errorf("output = %q, want it to name the next page's cursor", output)
 	}
 }
 

--- a/cmd/pipeline_test.go
+++ b/cmd/pipeline_test.go
@@ -280,6 +280,22 @@ func TestApplicationPipelineCommandsRegistered(t *testing.T) {
 	}
 }
 
+func TestPipelineArtifactsPagingFlagsOnBothSurfaces(t *testing.T) {
+	// A run with more artifacts than one page must be walkable from either
+	// address, so both surfaces carry the same paging flags.
+	surfaces := map[string]*cobra.Command{
+		"pipeline artifacts":             findSubcommand(t, newPipelineCommand(), "artifacts"),
+		"application pipeline artifacts": findSubcommand(t, findSubcommand(t, newApplicationCommand(), "pipeline"), "artifacts"),
+	}
+	for name, command := range surfaces {
+		for _, flag := range []string{"cursor", "limit"} {
+			if command.Flags().Lookup(flag) == nil {
+				t.Errorf("%q does not register --%s", name, flag)
+			}
+		}
+	}
+}
+
 func findSubcommand(t *testing.T, parent *cobra.Command, name string) *cobra.Command {
 	t.Helper()
 	found := findSubcommandOrNil(parent, name)

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -708,7 +708,7 @@ type APIClient interface {
 	RerunPipelineRun(ctx context.Context, selector client.PipelineSelector, runID string, failedOnly bool) (*client.CreatePipelineRunResult, error)
 	CancelPipelineRun(ctx context.Context, selector client.PipelineSelector, runID string) (*client.PipelineRun, error)
 	StreamPipelineStepLogs(ctx context.Context, selector client.PipelineSelector, runID string, stepID string, fromSequence int64) (<-chan client.PipelineLogEvent, error)
-	ListPipelineArtifacts(ctx context.Context, selector client.PipelineSelector, runID string) (*client.PipelineArtifactList, error)
+	ListPipelineArtifacts(ctx context.Context, selector client.PipelineSelector, runID string, options client.ListPipelineArtifactsOptions) (*client.PipelineArtifactList, error)
 	DownloadPipelineArtifact(ctx context.Context, selector client.PipelineSelector, artifactID string, destination io.Writer) error
 	ListPipelineFindings(ctx context.Context, selector client.PipelineSelector, runID string) (*client.PipelineFindingList, error)
 	GetPipelineDefinition(ctx context.Context, selector client.PipelineSelector) (*client.PipelineDefinition, error)

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -707,6 +707,7 @@ type APIClient interface {
 	StreamPipelineStepLogs(ctx context.Context, selector client.PipelineSelector, runID string, stepID string, fromSequence int64) (<-chan client.PipelineLogEvent, error)
 	ListPipelineArtifacts(ctx context.Context, selector client.PipelineSelector, runID string) (*client.PipelineArtifactList, error)
 	DownloadPipelineArtifact(ctx context.Context, selector client.PipelineSelector, artifactID string, destination io.Writer) error
+	ListPipelineFindings(ctx context.Context, selector client.PipelineSelector, runID string) (*client.PipelineFindingList, error)
 	GetPipelineDefinition(ctx context.Context, selector client.PipelineSelector) (*client.PipelineDefinition, error)
 	PutPipelineDefinition(ctx context.Context, selector client.PipelineSelector, specYAML string) (*client.PipelineDefinition, error)
 	ValidatePipelineDefinition(ctx context.Context, selector client.PipelineSelector, specYAML string) (*client.PipelineValidation, error)

--- a/internal/client/pipeline_logs.go
+++ b/internal/client/pipeline_logs.go
@@ -6,11 +6,16 @@ package client
 // nothing here changes - the frames, the seq resume cursor and the status
 // codes are the shared sserelay's either way).
 //
-// The relay has no history to replay: a fresh connection (from_seq unset)
-// only sees output published from the moment it connects, because the
-// durable per-step log artifact is WS-C item C1 and does not exist yet. That
-// is a real, current limitation - not a client bug - and PipelineLogEvent
-// carries every frame decoded rather than pretending otherwise.
+// The relay itself has no history to replay: a fresh connection (from_seq
+// unset) only sees output published from the moment it connects. That is a
+// real, permanent property of the relay, not a client bug, and
+// PipelineLogEvent carries every frame decoded rather than pretending
+// otherwise. It is not the whole story for a step that has already
+// concluded, though: the step's complete output is also archived as a
+// step_log pipeline artifact (enginekit/pipelineartifacts.KindStepLog), and
+// cmd/pipeline_logs.go reads that instead of opening this relay once a
+// step's Status is "concluded" - see PipelineArtifact and
+// Client.ListPipelineArtifacts / DownloadPipelineArtifact in pipelines.go.
 
 import (
 	"bufio"

--- a/internal/client/pipelines.go
+++ b/internal/client/pipelines.go
@@ -1,8 +1,8 @@
 package client
 
 // Ankra Pipelines (ankra-vn0bd.2.8, WS-B item B8): the typed client for
-// go/internal/pipelineapi on the cluster-api - runs, the definition of
-// record, and cron schedules.
+// go/internal/pipelineapi on the cluster-api - runs, artifacts, findings,
+// the definition of record, and cron schedules.
 //
 // The server mounts every route four times (session/token twin x
 // by-application/by-repository twin); this client only ever speaks the
@@ -13,9 +13,6 @@ package client
 // PipelineSelector.RepositoryID takes the repository's id, not "owner/name".
 // A future item that adds a repository listing route can widen this to
 // resolve a name the way resolveApplicationID already does for applications.
-//
-// Findings have no route yet either (WS-C item C5): there is no
-// ListPipelineFindings here, deliberately, until the server has one.
 
 import (
 	"bytes"
@@ -156,23 +153,133 @@ type CreatePipelineRunResult struct {
 	RunNumber     int64  `json:"run_number"`
 }
 
-// PipelineArtifact is the wire shape one stored run artifact will carry
-// (go/internal/pipelineapi/artifacts.go). The store behind this route is WS-C
-// item C1; until it lands the listing always answers empty and the download
-// always answers 404.
+// The two kinds of object a PipelineArtifact.Kind carries, mirroring
+// enginekit/pipelineartifacts.KindStepLog / KindArtifact: exactly one
+// step_log per step attempt (the step's complete output, the durable record
+// the SSE relay itself has no history for), and one artifact per declared
+// artifacts: path.
+const (
+	PipelineArtifactKindStepLog  = "step_log"
+	PipelineArtifactKindArtifact = "artifact"
+)
+
+// The life of one PipelineArtifact.Status, mirroring
+// enginekit/pipelineartifacts.Status*: pending until the agent's upload is
+// confirmed, then uploaded, or failed if it never arrived (ErrorMessage says
+// why), or expired once the retention sweep removed the object.
+const (
+	PipelineArtifactStatusPending  = "pending"
+	PipelineArtifactStatusUploaded = "uploaded"
+	PipelineArtifactStatusFailed   = "failed"
+	PipelineArtifactStatusExpired  = "expired"
+)
+
+// PipelineArtifact is the wire shape of one stored run artifact
+// (go/internal/pipelineapi/artifacts.go artifactResponse): a step's complete
+// log or one of its declared artifacts, stored as an object in the
+// organisation's backup vault. StepID is nil for a run-level object;
+// UploadedAt is nil until the upload is confirmed. A download is only good
+// once Status is PipelineArtifactStatusUploaded - see DownloadPipelineArtifact.
 type PipelineArtifact struct {
-	ID          string `json:"id"`
-	RunID       string `json:"run_id"`
-	StepID      string `json:"step_id"`
-	Name        string `json:"name"`
-	ContentType string `json:"content_type"`
-	SizeBytes   int64  `json:"size_bytes"`
-	CreatedAt   string `json:"created_at"`
+	ID           string  `json:"id"`
+	RunID        string  `json:"run_id"`
+	StepID       *string `json:"step_id"`
+	Kind         string  `json:"kind"`
+	Name         string  `json:"name"`
+	ContentType  string  `json:"content_type"`
+	SizeBytes    int64   `json:"size_bytes"`
+	SHA256       string  `json:"sha256"`
+	Status       string  `json:"status"`
+	ErrorMessage string  `json:"error_message"`
+	ExpiresAt    string  `json:"expires_at"`
+	CreatedAt    string  `json:"created_at"`
+	UploadedAt   *string `json:"uploaded_at"`
 }
 
 // PipelineArtifactList is the GET …/pipeline-runs/{run_id}/artifacts body.
+// NextCursor is nil on the last page; ListPipelineArtifacts itself does not
+// page through a run's artifacts today, so a run with more than one server
+// page only shows the first (see the method's own doc comment).
 type PipelineArtifactList struct {
-	Artifacts []PipelineArtifact `json:"artifacts"`
+	Artifacts  []PipelineArtifact `json:"artifacts"`
+	NextCursor *string            `json:"next_cursor"`
+}
+
+// PipelineFinding is the wire shape of one persisted scan finding
+// (go/internal/pipelineapi/findings.go findingResponse): a Semgrep, Checkov
+// or Trivy result, or an SBOM summary row, deduplicated by IdentityHash and
+// carrying its most recent occurrence's run, step and commit. CVEID is nil
+// for a tool that names no CVE (Semgrep, Checkov, SBOM). Detail is the
+// tool-specific report shape verbatim - a CodeFinding, a Vulnerability or an
+// SBOMSummary, distinguished by Tool - passed through rather than re-shaped.
+type PipelineFinding struct {
+	ID             string          `json:"id"`
+	RunID          string          `json:"run_id"`
+	StepID         *string         `json:"step_id"`
+	HeadSHA        string          `json:"head_sha"`
+	Tool           string          `json:"tool"`
+	Severity       string          `json:"severity"`
+	IdentityHash   string          `json:"identity_hash"`
+	RuleID         string          `json:"rule_id"`
+	CVEID          *string         `json:"cve_id"`
+	PackageName    string          `json:"package_name"`
+	PackageVersion string          `json:"package_version"`
+	FixedVersion   string          `json:"fixed_version"`
+	Path           string          `json:"path"`
+	Line           *int64          `json:"line"`
+	Title          string          `json:"title"`
+	Detail         json.RawMessage `json:"detail"`
+	FirstSeenRunID string          `json:"first_seen_run_id"`
+	FirstSeenAt    string          `json:"first_seen_at"`
+	CreatedAt      string          `json:"created_at"`
+	UpdatedAt      string          `json:"updated_at"`
+}
+
+// PipelineFindingList is the GET …/pipeline-runs/{run_id}/findings body.
+type PipelineFindingList struct {
+	Findings []PipelineFinding `json:"findings"`
+}
+
+// The closed vocabulary of PipelineFinding.Tool, mirroring
+// enginekit/pipelinefindings.Tool*. ToolSBOM findings are informational: a
+// bill of materials, never a vulnerability, and never blocking whatever the
+// gate policy.
+const (
+	PipelineFindingToolSemgrep = "semgrep"
+	PipelineFindingToolCheckov = "checkov"
+	PipelineFindingToolTrivy   = "trivy"
+	PipelineFindingToolSBOM    = "sbom"
+)
+
+// The platform's shared severity vocabulary for PipelineFinding.Severity,
+// mirroring enginekit/pipelinefindings.Severity* - CRITICAL down to
+// UNKNOWN, an unrecognised or not-applicable severity (an SBOM row, for
+// example).
+const (
+	PipelineFindingSeverityCritical = "CRITICAL"
+	PipelineFindingSeverityHigh     = "HIGH"
+	PipelineFindingSeverityMedium   = "MEDIUM"
+	PipelineFindingSeverityLow      = "LOW"
+	PipelineFindingSeverityUnknown  = "UNKNOWN"
+)
+
+// ListPipelineFindings reads a run's persisted scan findings (GET
+// …/pipeline-runs/{run_id}/findings) - the same rows the application's
+// Security tab reads once a pipeline run exists for it. There is no paging:
+// the route answers every finding of the run's own head_sha in one body.
+func (c *Client) ListPipelineFindings(ctx context.Context, selector PipelineSelector,
+	runID string) (*PipelineFindingList, error) {
+	base, selectorError := selector.basePath()
+	if selectorError != nil {
+		return nil, selectorError
+	}
+	var result PipelineFindingList
+	if requestError := c.doPipelineRequest(ctx, http.MethodGet,
+		fmt.Sprintf("%s%s/pipeline-runs/%s/findings", c.BaseURL, base, neturl.PathEscape(runID)),
+		nil, &result); requestError != nil {
+		return nil, requestError
+	}
+	return &result, nil
 }
 
 // PipelineRepositoryReference names the repository a definition belongs to,
@@ -571,9 +678,13 @@ func (c *Client) CancelPipelineRun(ctx context.Context, selector PipelineSelecto
 	return &result, nil
 }
 
-// ListPipelineArtifacts lists a run's stored artifacts (GET
-// …/pipeline-runs/{run_id}/artifacts). The store is WS-C item C1; until it
-// lands this always answers an empty list for a run the caller can see.
+// ListPipelineArtifacts lists a run's stored step logs and artifacts (GET
+// …/pipeline-runs/{run_id}/artifacts), oldest first. The server pages this
+// listing by keyset cursor (up to pipelineartifacts.MaxListLimit rows a
+// page); this method always asks for the server's default page and does not
+// follow NextCursor, so a run with more artifacts than that default fits
+// shows only its oldest ones - callers that need every artifact of a very
+// large run must page by hand until this method grows a cursor parameter.
 func (c *Client) ListPipelineArtifacts(ctx context.Context, selector PipelineSelector,
 	runID string) (*PipelineArtifactList, error) {
 	base, selectorError := selector.basePath()
@@ -591,8 +702,12 @@ func (c *Client) ListPipelineArtifacts(ctx context.Context, selector PipelineSel
 
 // DownloadPipelineArtifact follows the 302 the download route answers
 // (GET …/artifacts/{artifact_id}/download) and streams the artifact into
-// destination. Until WS-C item C1 lands, the route always answers 404 with
-// pipelines.ErrArtifactsUnavailable.
+// destination. The route answers 404 for an artifact outside the caller's
+// organisation or one that never existed, 409 while its step has not
+// settled or its upload failed or its vault is gone, and 410 once the
+// retention sweep removed it - check the artifact's own Status first
+// (PipelineArtifactStatusUploaded is the only one a download can satisfy) to
+// tell those apart from a plain mistake in the id.
 func (c *Client) DownloadPipelineArtifact(ctx context.Context, selector PipelineSelector,
 	artifactID string, destination io.Writer) error {
 	base, selectorError := selector.basePath()

--- a/internal/client/pipelines.go
+++ b/internal/client/pipelines.go
@@ -197,12 +197,20 @@ type PipelineArtifact struct {
 }
 
 // PipelineArtifactList is the GET …/pipeline-runs/{run_id}/artifacts body.
-// NextCursor is nil on the last page; ListPipelineArtifacts itself does not
-// page through a run's artifacts today, so a run with more than one server
-// page only shows the first (see the method's own doc comment).
+// NextCursor is nil on the last page and carries the cursor of the next one
+// otherwise, so an empty page with a NextCursor means "more to read", never
+// "nothing stored".
 type PipelineArtifactList struct {
 	Artifacts  []PipelineArtifact `json:"artifacts"`
 	NextCursor *string            `json:"next_cursor"`
+}
+
+// ListPipelineArtifactsOptions is the GET …/pipeline-runs/{run_id}/artifacts
+// query. Cursor is a NextCursor handed back by an earlier page; Limit is the
+// page size (the server defaults to 50 and clamps at 100).
+type ListPipelineArtifactsOptions struct {
+	Cursor string
+	Limit  int
 }
 
 // PipelineFinding is the wire shape of one persisted scan finding
@@ -678,23 +686,31 @@ func (c *Client) CancelPipelineRun(ctx context.Context, selector PipelineSelecto
 	return &result, nil
 }
 
-// ListPipelineArtifacts lists a run's stored step logs and artifacts (GET
-// …/pipeline-runs/{run_id}/artifacts), oldest first. The server pages this
-// listing by keyset cursor (up to pipelineartifacts.MaxListLimit rows a
-// page); this method always asks for the server's default page and does not
-// follow NextCursor, so a run with more artifacts than that default fits
-// shows only its oldest ones - callers that need every artifact of a very
-// large run must page by hand until this method grows a cursor parameter.
+// ListPipelineArtifacts reads one keyset page of a run's stored step logs
+// and artifacts (GET …/pipeline-runs/{run_id}/artifacts), oldest first. The
+// server pages this listing (50 rows a page by default, 100 at most), so a
+// caller that needs every artifact of a run must follow the answer's
+// NextCursor until it comes back nil rather than read the first page as the
+// whole record.
 func (c *Client) ListPipelineArtifacts(ctx context.Context, selector PipelineSelector,
-	runID string) (*PipelineArtifactList, error) {
+	runID string, options ListPipelineArtifactsOptions) (*PipelineArtifactList, error) {
 	base, selectorError := selector.basePath()
 	if selectorError != nil {
 		return nil, selectorError
 	}
+	endpoint := fmt.Sprintf("%s%s/pipeline-runs/%s/artifacts", c.BaseURL, base, neturl.PathEscape(runID))
+	query := neturl.Values{}
+	if options.Cursor != "" {
+		query.Set("cursor", options.Cursor)
+	}
+	if options.Limit > 0 {
+		query.Set("limit", strconv.Itoa(options.Limit))
+	}
+	if len(query) > 0 {
+		endpoint += "?" + query.Encode()
+	}
 	var result PipelineArtifactList
-	if requestError := c.doPipelineRequest(ctx, http.MethodGet,
-		fmt.Sprintf("%s%s/pipeline-runs/%s/artifacts", c.BaseURL, base, neturl.PathEscape(runID)),
-		nil, &result); requestError != nil {
+	if requestError := c.doPipelineRequest(ctx, http.MethodGet, endpoint, nil, &result); requestError != nil {
 		return nil, requestError
 	}
 	return &result, nil

--- a/internal/client/pipelines_test.go
+++ b/internal/client/pipelines_test.go
@@ -172,7 +172,8 @@ func TestListPipelineArtifactsEmpty(t *testing.T) {
 	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprint(w, `{"artifacts":[],"next_cursor":null}`)
 	})
-	list, err := testClient.ListPipelineArtifacts(context.Background(), PipelineSelector{ApplicationID: "app-1"}, "run-1")
+	list, err := testClient.ListPipelineArtifacts(context.Background(), PipelineSelector{ApplicationID: "app-1"}, "run-1",
+		ListPipelineArtifactsOptions{})
 	if err != nil {
 		t.Fatalf("ListPipelineArtifacts error = %v", err)
 	}
@@ -196,7 +197,8 @@ func TestListPipelineArtifactsDecodesKindStatusAndNullableStepID(t *testing.T) {
 			 "uploaded_at":null}
 		],"next_cursor":null}`)
 	})
-	list, err := testClient.ListPipelineArtifacts(context.Background(), PipelineSelector{RepositoryID: "repo-1"}, "run-1")
+	list, err := testClient.ListPipelineArtifacts(context.Background(), PipelineSelector{RepositoryID: "repo-1"}, "run-1",
+		ListPipelineArtifactsOptions{})
 	if err != nil {
 		t.Fatalf("ListPipelineArtifacts error = %v", err)
 	}
@@ -219,6 +221,41 @@ func TestListPipelineArtifactsDecodesKindStatusAndNullableStepID(t *testing.T) {
 	}
 	if declared.StepID != nil {
 		t.Errorf("declared artifact step id = %v, want nil (a run-level object)", declared.StepID)
+	}
+}
+
+func TestListPipelineArtifactsSendsCursorAndLimit(t *testing.T) {
+	var capturedCursor, capturedLimit string
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedCursor = r.URL.Query().Get("cursor")
+		capturedLimit = r.URL.Query().Get("limit")
+		_, _ = fmt.Fprint(w, `{"artifacts":[],"next_cursor":"cursor-2"}`)
+	})
+	list, err := testClient.ListPipelineArtifacts(context.Background(), PipelineSelector{ApplicationID: "app-1"}, "run-1",
+		ListPipelineArtifactsOptions{Cursor: "cursor-1", Limit: 100})
+	if err != nil {
+		t.Fatalf("ListPipelineArtifacts error = %v", err)
+	}
+	if capturedCursor != "cursor-1" || capturedLimit != "100" {
+		t.Errorf("query cursor = %q, limit = %q, want \"cursor-1\" and \"100\"", capturedCursor, capturedLimit)
+	}
+	if list.NextCursor == nil || *list.NextCursor != "cursor-2" {
+		t.Errorf("next cursor = %v, want the server's own", list.NextCursor)
+	}
+}
+
+func TestListPipelineArtifactsOmitsUnsetPaging(t *testing.T) {
+	var capturedRawQuery string
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedRawQuery = r.URL.RawQuery
+		_, _ = fmt.Fprint(w, `{"artifacts":[],"next_cursor":null}`)
+	})
+	if _, err := testClient.ListPipelineArtifacts(context.Background(), PipelineSelector{ApplicationID: "app-1"}, "run-1",
+		ListPipelineArtifactsOptions{}); err != nil {
+		t.Fatalf("ListPipelineArtifacts error = %v", err)
+	}
+	if capturedRawQuery != "" {
+		t.Errorf("raw query = %q, want none so the server chooses its own page", capturedRawQuery)
 	}
 }
 

--- a/internal/client/pipelines_test.go
+++ b/internal/client/pipelines_test.go
@@ -168,9 +168,9 @@ func TestSelectorRequiresExactlyOneAddress(t *testing.T) {
 	}
 }
 
-func TestListPipelineArtifactsEmptyUntilTheStoreLands(t *testing.T) {
+func TestListPipelineArtifactsEmpty(t *testing.T) {
 	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		_, _ = fmt.Fprint(w, `{"artifacts":[]}`)
+		_, _ = fmt.Fprint(w, `{"artifacts":[],"next_cursor":null}`)
 	})
 	list, err := testClient.ListPipelineArtifacts(context.Background(), PipelineSelector{ApplicationID: "app-1"}, "run-1")
 	if err != nil {
@@ -181,15 +181,137 @@ func TestListPipelineArtifactsEmptyUntilTheStoreLands(t *testing.T) {
 	}
 }
 
-func TestDownloadPipelineArtifactUnavailablePlaceholder(t *testing.T) {
+func TestListPipelineArtifactsDecodesKindStatusAndNullableStepID(t *testing.T) {
+	var capturedPath string
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		_, _ = fmt.Fprint(w, `{"artifacts":[
+			{"id":"artifact-1","run_id":"run-1","step_id":"step-1","kind":"step_log","name":"step.log",
+			 "content_type":"text/plain; charset=utf-8","size_bytes":512,"sha256":"deadbeef",
+			 "status":"uploaded","error_message":"","expires_at":"2026-10-01T00:00:00Z",
+			 "created_at":"2026-09-01T00:00:00Z","uploaded_at":"2026-09-01T00:05:00Z"},
+			{"id":"artifact-2","run_id":"run-1","step_id":null,"kind":"artifact","name":"coverage.xml",
+			 "content_type":"application/octet-stream","size_bytes":0,"sha256":"","status":"pending",
+			 "error_message":"","expires_at":"2026-10-01T00:00:00Z","created_at":"2026-09-01T00:00:00Z",
+			 "uploaded_at":null}
+		],"next_cursor":null}`)
+	})
+	list, err := testClient.ListPipelineArtifacts(context.Background(), PipelineSelector{RepositoryID: "repo-1"}, "run-1")
+	if err != nil {
+		t.Fatalf("ListPipelineArtifacts error = %v", err)
+	}
+	if capturedPath != "/api/v1/org/pipeline-repositories/repo-1/pipeline-runs/run-1/artifacts" {
+		t.Errorf("path = %q", capturedPath)
+	}
+	if len(list.Artifacts) != 2 {
+		t.Fatalf("artifacts = %+v", list.Artifacts)
+	}
+	stepLog := list.Artifacts[0]
+	if stepLog.Kind != PipelineArtifactKindStepLog || stepLog.Status != PipelineArtifactStatusUploaded {
+		t.Errorf("step log artifact = %+v", stepLog)
+	}
+	if stepLog.StepID == nil || *stepLog.StepID != "step-1" {
+		t.Errorf("step log artifact step id = %v, want \"step-1\"", stepLog.StepID)
+	}
+	declared := list.Artifacts[1]
+	if declared.Kind != PipelineArtifactKindArtifact || declared.Status != PipelineArtifactStatusPending {
+		t.Errorf("declared artifact = %+v", declared)
+	}
+	if declared.StepID != nil {
+		t.Errorf("declared artifact step id = %v, want nil (a run-level object)", declared.StepID)
+	}
+}
+
+func TestDownloadPipelineArtifactNotFound(t *testing.T) {
 	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		_, _ = fmt.Fprint(w, `{"detail":"Artifacts are not available for this run"}`)
+		_, _ = fmt.Fprint(w, `{"detail":"Pipeline artifact not found"}`)
 	})
 	var buf strings.Builder
 	err := testClient.DownloadPipelineArtifact(context.Background(), PipelineSelector{ApplicationID: "app-1"}, "artifact-1", &buf)
-	if err == nil || err.Error() != "Artifacts are not available for this run" {
-		t.Fatalf("error = %v", err)
+	if err == nil || err.Error() != "Pipeline artifact not found" {
+		t.Fatalf("error = %v, want the server's sentinel text verbatim", err)
+	}
+}
+
+func TestDownloadPipelineArtifactNotYetUploaded(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = fmt.Fprint(w, `{"detail":"This artifact has not been uploaded yet"}`)
+	})
+	var buf strings.Builder
+	err := testClient.DownloadPipelineArtifact(context.Background(), PipelineSelector{ApplicationID: "app-1"}, "artifact-1", &buf)
+	if err == nil || err.Error() != "This artifact has not been uploaded yet" {
+		t.Fatalf("error = %v, want the server's 409 sentinel text verbatim", err)
+	}
+}
+
+func TestDownloadPipelineArtifactHappyPathStreamsTheBody(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/org/applications/app-1/artifacts/artifact-1/download" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_, _ = fmt.Fprint(w, "line one\nline two\n")
+	})
+	var buf strings.Builder
+	err := testClient.DownloadPipelineArtifact(context.Background(), PipelineSelector{ApplicationID: "app-1"}, "artifact-1", &buf)
+	if err != nil {
+		t.Fatalf("DownloadPipelineArtifact error = %v", err)
+	}
+	if buf.String() != "line one\nline two\n" {
+		t.Errorf("body = %q", buf.String())
+	}
+}
+
+func TestListPipelineFindingsHappyPath(t *testing.T) {
+	var capturedPath string
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		_, _ = fmt.Fprint(w, `{"findings":[{"id":"finding-1","run_id":"run-1","step_id":"step-1",
+			"head_sha":"`+strings.Repeat("a", 40)+`","tool":"trivy","severity":"CRITICAL",
+			"identity_hash":"hash-1","rule_id":"","cve_id":"CVE-2026-1234","package_name":"openssl",
+			"package_version":"1.0.0","fixed_version":"1.0.1","path":"","line":null,
+			"title":"OpenSSL vulnerability","detail":{},"first_seen_run_id":"run-1",
+			"first_seen_at":"2026-09-01T00:00:00Z","created_at":"2026-09-01T00:00:00Z",
+			"updated_at":"2026-09-01T00:00:00Z"}]}`)
+	})
+	list, err := testClient.ListPipelineFindings(context.Background(), PipelineSelector{ApplicationID: "app-1"}, "run-1")
+	if err != nil {
+		t.Fatalf("ListPipelineFindings error = %v", err)
+	}
+	if capturedPath != "/api/v1/org/applications/app-1/pipeline-runs/run-1/findings" {
+		t.Errorf("path = %q", capturedPath)
+	}
+	if len(list.Findings) != 1 || list.Findings[0].Tool != PipelineFindingToolTrivy ||
+		list.Findings[0].Severity != PipelineFindingSeverityCritical {
+		t.Fatalf("findings = %+v", list.Findings)
+	}
+	if list.Findings[0].CVEID == nil || *list.Findings[0].CVEID != "CVE-2026-1234" {
+		t.Errorf("cve id = %v", list.Findings[0].CVEID)
+	}
+}
+
+func TestListPipelineFindingsEmptyRunHasNoScanStep(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, `{"findings":[]}`)
+	})
+	list, err := testClient.ListPipelineFindings(context.Background(), PipelineSelector{RepositoryID: "repo-1"}, "run-1")
+	if err != nil {
+		t.Fatalf("ListPipelineFindings error = %v", err)
+	}
+	if len(list.Findings) != 0 {
+		t.Fatalf("findings = %+v, want empty", list.Findings)
+	}
+}
+
+func TestListPipelineFindingsRunNotFound(t *testing.T) {
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, `{"detail":"Pipeline run not found"}`)
+	})
+	_, err := testClient.ListPipelineFindings(context.Background(), PipelineSelector{ApplicationID: "app-1"}, "missing-run")
+	if err == nil || err.Error() != "Pipeline run not found" {
+		t.Fatalf("error = %v, want the server's sentinel text verbatim", err)
 	}
 }
 


### PR DESCRIPTION
## What & why

A gap review of the Ankra Pipelines lane (epic `ankra-vn0bd`, closing wave item W3.5-F) found the CLI contradicting the server it talks to: the artifact store (WS-C item C1) and the findings route (WS-C item C5) both shipped, but `ankra pipeline`'s own help text and behaviour never caught up.

1. **`ankra pipeline logs` on a concluded step showed nothing.** The step log relay (`go/internal/sserelay`) is genuinely live-only - a fresh connection uses `DeliverNewPolicy`, so it only ever sees output published after it connects - but the durable per-step log this command used to say "has not shipped" (`cmd/pipeline_logs.go:32-34`) has, in fact, shipped: every concluded step's complete output is archived as a `step_log` pipeline artifact. `logs` now reads that artifact through the same list + presigned download `artifacts` uses, mirroring the portal's `usePipelineStepArtifactLog` (`portal/src/implementations/applications/pipelines/pipelineStepArtifactLog.ts`). `--follow` is unchanged for a step that is still running - it never did anything for a concluded one anyway.
2. **`ankra pipeline artifacts` said "the artifact store has not shipped yet".** It has (`go/internal/pipelineapi/artifacts.go`, `enginekit/pipelineartifacts` - a full plan/settle/expire/vault lifecycle, not a stub). The help text and doc comments no longer say otherwise, `PipelineArtifact` now carries every field the server sends (`kind`, `status`, `sha256`, `error_message`, `expires_at`, nullable `step_id`/`uploaded_at`), and the list table gains `KIND` and `STATUS` columns so a caller can tell a still-archiving or failed row from a downloadable one before trying `artifacts download` and getting a 409.
3. **There was no way to read a run's scan findings from the CLI.** `ankra pipeline findings <run>` lists a run's persisted findings (`GET .../pipeline-runs/{run_id}/findings`, `go/internal/pipelineapi/findings.go:164`) - the same rows the application's Security tab reads - as a table sorted worst-severity-first and grouped by tool, or `-o json`/`yaml` for the raw shape including each finding's tool-specific `detail`.

Open, unmerged CLI PRs #229 (repositories verbs) and #231 (definitions verbs) were not duplicated; this PR's new/changed files are `cmd/pipeline_logs.go`, `cmd/pipeline_artifacts.go`, `cmd/pipeline_findings.go` (new) + its test, `cmd/pipeline_logs_test.go` (new), `internal/client/pipelines.go` (additions), `internal/client/pipeline_logs.go` (one stale doc-comment fix), plus the unavoidable three-way registration points every pipeline-verb PR touches (`cmd/pipeline.go`, `cmd/services.go`, `cmd/e2e_test.go`), `README.md` and `CHANGELOG.md`.

**Deliberately left out** (both out of this change's declared scope):
- An `ankra application pipeline findings` twin - would touch `application_pipeline.go`, not in this PR's file list.
- Cursor pagination on `ListPipelineArtifacts` - the CLI still reads only the server's first (keyset) page; a follow-up once a run's artifact count in practice needs more than one page.

## Test plan

- `make build test lint` from the worktree: `go build ./...` clean, `go test -race -count=1 ./...` green across every package, `golangci-lint run` (v2) 0 issues.
- `gofmt -l` clean against the module's pinned `go1.26.6` toolchain (this machine runs go1.27; verified with the cached `golang.org/toolchain@v0.0.1-go1.26.6` binary directly, since a newer local `go` does not auto-downgrade).
- New/updated tests: `internal/client/pipelines_test.go` (artifact decode of `kind`/`status`/nullable `step_id`, download's four real status-code branches, three `ListPipelineFindings` cases; the two tests that encoded the old "store hasn't shipped" assumption are renamed/rewritten to the real contract) and two new `cmd` test files (`pipeline_logs_test.go`: concluded-step archive replay across uploaded/pending/failed/expired/no-artifact/still-running; `pipeline_findings_test.go`: empty, severity-sort, `-o json`, not-found).

## Docs checklist

- [ ] No user-facing command/flag changes — no docs needed
- [x] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); `Short`/`Long` on `findings` and the updated `logs`/`artifacts` help were written for docs readers
- [x] Broader behaviour changes — docs updated in [ankra-docs](https://github.com/ankraio/ankra-docs) (link the PR): the companion docs PR from this same review corrects `guides/ankra-pipelines.mdx` and `guides/pipeline-reference.mdx` against current code (caches, artifacts, logs replay, `test_results`, `scan.fail_on`, and the "not in place yet" list) - link added once opened.

Bead: ankra-vn0bd
