### PR TITLE
chore: gitignore local worktree directories (ankra-htxvm.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ release/
 
 # Claude Code agent worktrees (ephemeral, never commit)
 .claude/worktrees/
+# Local MR-review worktrees (git worktree checkouts of other branches).
+.mr-worktrees/


### PR DESCRIPTION
Bead: ankra-htxvm.1 (step 0 of the cross-repo contract census plan, epic ankra-htxvm)

Work happens in git worktrees checked out under `.mr-worktrees/` and `.claude/worktrees/` inside the repo. Neither was ignored here, so every tool that walks the tree (indexers, code search, review scripts) saw N stale copies of the codebase, and `git status` listed the worktree roots as untracked. On 2026-09-05 the portal checkout held 51 such worktrees. cluster already ignores both directories; this mirrors its entries.

No code change. Review: `CROSS_REPO_CONTRACTS_REVIEW_2026-09-05.md` in the workspace, seam 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
