### PR TITLE
feat(alerts): ingest-credentials list and rebind, so a credential's pin or scope moves without a new token (ankra-z5cq5.28)

### DIFF
--- a/cmd/alerts_ingest_credentials.go
+++ b/cmd/alerts_ingest_credentials.go
@@ -1,0 +1,167 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+
+	"ankra/internal/client"
+)
+
+var alertsIngestCredentialsCmd = &cobra.Command{
+	Use:   "ingest-credentials",
+	Short: "List and rebind the credentials external notifiers deliver alerts with",
+	Long: `Ingest credentials are the per-credential secrets an external Alertmanager
+or log monitor uses to deliver alerts into Ankra. A credential is pinned to
+one cluster (scope cluster), carries the platform's own alerts with no pin
+(scope platform), or does both from a self-hosting cluster (scope mixed).
+
+The token is minted once, in the portal, and never shown again. These
+commands never touch it: a rebind moves the pin or the scope on the
+existing credential, so the notifier keeps delivering.
+
+  ankra alerts ingest-credentials list
+  ankra alerts ingest-credentials rebind <credential-id> --cluster prod-hel1
+  ankra alerts ingest-credentials rebind <credential-id> --unpin --scope platform`,
+}
+
+var alertsIngestCredentialsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List alert ingest credentials",
+	Long: `List the organisation's alert ingest credentials with the cluster each one
+is pinned to. A pin whose cluster is deleted, archived, slated for deletion
+or gone shows as BROKEN: the notifier still delivers, but its alerts have no
+cluster to land on until the credential is rebound.
+
+  ankra alerts ingest-credentials list
+  ankra alerts ingest-credentials list -o json`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		list, listError := apiClient.ListAlertIngestCredentials()
+		if listError != nil {
+			return fmt.Errorf("listing alert ingest credentials: %w", listError)
+		}
+		if rendered, renderError := renderStructured(cmd, list); rendered || renderError != nil {
+			return renderError
+		}
+		out := cmd.OutOrStdout()
+		if len(list.Items) == 0 {
+			_, _ = fmt.Fprintln(out, "No alert ingest credentials found.")
+			return nil
+		}
+		writer := table.NewWriter()
+		writer.SetOutputMirror(out)
+		writer.SetStyle(table.StyleRounded)
+		writer.AppendHeader(table.Row{"Name", "ID", "Scope", "Cluster", "Pin", "Enabled", "Last used"})
+		for _, credential := range list.Items {
+			writer.AppendRow(table.Row{
+				credential.Name,
+				credential.ID,
+				credential.Scope,
+				alertIngestCredentialCluster(credential),
+				alertIngestCredentialPin(credential),
+				credential.Enabled,
+				alertIngestCredentialLastUsed(credential),
+			})
+		}
+		writer.Render()
+		return nil
+	},
+}
+
+var alertsIngestCredentialsRebindCmd = &cobra.Command{
+	Use:   "rebind <credential-id>",
+	Short: "Move an ingest credential's cluster pin or scope without minting a new token",
+	Long: `Rebind an ingest credential: pin it to another cluster, unpin it, or change
+its scope. The token is untouched, so the notifier keeps delivering through
+the same credential.
+
+Pass --cluster with a cluster name to pin, --unpin to clear the pin, and
+--scope with cluster, platform or mixed. A platform-scoped credential
+carries no pin; a mixed one must keep one.
+
+  ankra alerts ingest-credentials rebind <credential-id> --cluster prod-hel1
+  ankra alerts ingest-credentials rebind <credential-id> --cluster prod-hel1 --scope mixed
+  ankra alerts ingest-credentials rebind <credential-id> --unpin --scope platform`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		clusterName, _ := cmd.Flags().GetString("cluster")
+		unpin, _ := cmd.Flags().GetBool("unpin")
+		scope := changedStringFlag(cmd, "scope")
+		if clusterName != "" && unpin {
+			return withExitCode(exitUsage, errors.New("--cluster and --unpin are exclusive"))
+		}
+		if clusterName == "" && !unpin && scope == nil {
+			return withExitCode(exitUsage, errors.New("nothing to rebind: pass --cluster, --unpin or --scope"))
+		}
+		if scope != nil && *scope != "cluster" && *scope != "platform" && *scope != "mixed" {
+			return withExitCode(exitUsage, fmt.Errorf("--scope must be cluster, platform or mixed, got %q", *scope))
+		}
+		request := client.RebindAlertIngestCredentialRequest{Scope: scope}
+		if unpin {
+			request.ClusterIDSet = true
+		}
+		if clusterName != "" {
+			cluster, clusterError := apiClient.GetCluster(clusterName)
+			if clusterError != nil {
+				return fmt.Errorf("resolving cluster %q: %w", clusterName, clusterError)
+			}
+			clusterID := cluster.ID
+			request.ClusterID = &clusterID
+			request.ClusterIDSet = true
+		}
+		credential, rebindError := apiClient.RebindAlertIngestCredential(args[0], request)
+		if rebindError != nil {
+			return fmt.Errorf("rebinding alert ingest credential: %w", rebindError)
+		}
+		if rendered, renderError := renderStructured(cmd, credential); rendered || renderError != nil {
+			return renderError
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Alert ingest credential %q rebound: scope %s, cluster %s.\n",
+			credential.Name, credential.Scope, alertIngestCredentialCluster(*credential))
+		return nil
+	},
+}
+
+// alertIngestCredentialCluster renders the pin for a table cell.
+func alertIngestCredentialCluster(credential client.AlertIngestCredential) string {
+	if credential.ClusterName != nil && *credential.ClusterName != "" {
+		return *credential.ClusterName
+	}
+	if credential.ClusterID != nil && *credential.ClusterID != "" {
+		return *credential.ClusterID
+	}
+	return "-"
+}
+
+// alertIngestCredentialPin says whether the pin still points at a cluster
+// that exists: BROKEN is a cluster that is deleted, archived, slated for
+// deletion or gone, not a credential without a pin.
+func alertIngestCredentialPin(credential client.AlertIngestCredential) string {
+	switch {
+	case credential.ClusterUnavailable:
+		return "BROKEN"
+	case credential.ClusterID != nil && *credential.ClusterID != "":
+		return "ok"
+	default:
+		return "-"
+	}
+}
+
+func alertIngestCredentialLastUsed(credential client.AlertIngestCredential) string {
+	if credential.LastUsedAt == nil || *credential.LastUsedAt == "" {
+		return "never"
+	}
+	return *credential.LastUsedAt
+}
+
+func init() {
+	alertsIngestCredentialsRebindCmd.Flags().String("cluster", "", "cluster name to pin the credential to")
+	alertsIngestCredentialsRebindCmd.Flags().Bool("unpin", false, "clear the cluster pin")
+	alertsIngestCredentialsRebindCmd.Flags().String("scope", "", "credential scope: cluster, platform or mixed")
+	alertsIngestCredentialsCmd.AddCommand(alertsIngestCredentialsListCmd)
+	alertsIngestCredentialsCmd.AddCommand(alertsIngestCredentialsRebindCmd)
+	alertsCmd.AddCommand(alertsIngestCredentialsCmd)
+}

--- a/cmd/alerts_ingest_credentials_test.go
+++ b/cmd/alerts_ingest_credentials_test.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type alertIngestCredentialsMock struct {
+	baseMock
+	credentials   []client.AlertIngestCredential
+	clusters      map[string]client.ClusterListItem
+	rebound       string
+	rebindRequest *client.RebindAlertIngestCredentialRequest
+}
+
+func (mock *alertIngestCredentialsMock) ListAlertIngestCredentials() (*client.AlertIngestCredentialList, error) {
+	return &client.AlertIngestCredentialList{Items: mock.credentials}, nil
+}
+
+func (mock *alertIngestCredentialsMock) RebindAlertIngestCredential(credentialID string,
+	request client.RebindAlertIngestCredentialRequest) (*client.AlertIngestCredential, error) {
+	mock.rebound = credentialID
+	mock.rebindRequest = &request
+	scope := "cluster"
+	if request.Scope != nil {
+		scope = *request.Scope
+	}
+	credential := client.AlertIngestCredential{ID: credentialID, Name: "hel1-alertmanager", Scope: scope, Enabled: true}
+	if request.ClusterIDSet && request.ClusterID != nil {
+		credential.ClusterID = request.ClusterID
+		name := "prod-hel1"
+		credential.ClusterName = &name
+	}
+	return &credential, nil
+}
+
+func (mock *alertIngestCredentialsMock) GetCluster(name string) (client.ClusterListItem, error) {
+	cluster, found := mock.clusters[name]
+	if !found {
+		return client.ClusterListItem{}, errors.New("cluster not found")
+	}
+	return cluster, nil
+}
+
+func sampleIngestCredentials() []client.AlertIngestCredential {
+	pinnedName, brokenName, lastUsed := "prod-hel1", "old-prod", "2026-09-04T10:00:00Z"
+	pinnedID, brokenID := "1fa75b8f-f87c-4d21-ab01-d97cfb4d795c", "d8f216ef-b627-4d38-b0f8-ef963d3e24bf"
+	return []client.AlertIngestCredential{
+		{ID: "c1", Name: "hel1-alertmanager", ClusterID: &pinnedID, ClusterName: &pinnedName, Scope: "mixed", Enabled: true, LastUsedAt: &lastUsed},
+		{ID: "c2", Name: "old-alertmanager", ClusterID: &brokenID, ClusterName: &brokenName, ClusterUnavailable: true, Scope: "cluster", Enabled: true},
+		{ID: "c3", Name: "opensearch-monitor", Scope: "platform", Enabled: false},
+	}
+}
+
+func TestAlertsIngestCredentialsListRendersPinsAndBrokenOnes(t *testing.T) {
+	mock := &alertIngestCredentialsMock{credentials: sampleIngestCredentials()}
+	stdout, _, runError := runAlertsCommand(t, mock, "", "alerts", "ingest-credentials", "list")
+	if runError != nil {
+		t.Fatalf("list failed: %v", runError)
+	}
+	for _, fragment := range []string{"hel1-alertmanager", "prod-hel1", "mixed", "old-alertmanager", "BROKEN",
+		"opensearch-monitor", "platform", "never", "2026-09-04T10:00:00Z"} {
+		if !strings.Contains(stdout, fragment) {
+			t.Errorf("expected the table to contain %q, got:\n%s", fragment, stdout)
+		}
+	}
+	empty := &alertIngestCredentialsMock{}
+	stdout, _, runError = runAlertsCommand(t, empty, "", "alerts", "ingest-credentials", "list")
+	if runError != nil || !strings.Contains(stdout, "No alert ingest credentials found.") {
+		t.Fatalf("empty list: %v %q", runError, stdout)
+	}
+}
+
+func TestAlertsIngestCredentialsRebindPinsByClusterNameWithoutTouchingTheToken(t *testing.T) {
+	mock := &alertIngestCredentialsMock{clusters: map[string]client.ClusterListItem{
+		"prod-hel1": {ID: "1fa75b8f-f87c-4d21-ab01-d97cfb4d795c", Name: "prod-hel1"},
+	}}
+	stdout, _, runError := runAlertsCommand(t, mock, "", "alerts", "ingest-credentials", "rebind", "c1",
+		"--cluster", "prod-hel1", "--scope", "mixed")
+	if runError != nil {
+		t.Fatalf("rebind failed: %v", runError)
+	}
+	if mock.rebound != "c1" || mock.rebindRequest == nil || !mock.rebindRequest.ClusterIDSet ||
+		mock.rebindRequest.ClusterID == nil || *mock.rebindRequest.ClusterID != "1fa75b8f-f87c-4d21-ab01-d97cfb4d795c" ||
+		mock.rebindRequest.Scope == nil || *mock.rebindRequest.Scope != "mixed" {
+		t.Fatalf("rebind request = %+v", mock.rebindRequest)
+	}
+	if !strings.Contains(stdout, "rebound: scope mixed, cluster prod-hel1") {
+		t.Fatalf("stdout = %q", stdout)
+	}
+}
+
+func TestAlertsIngestCredentialsRebindUnpinsAndRefusesConflictingFlags(t *testing.T) {
+	mock := &alertIngestCredentialsMock{}
+	if _, _, runError := runAlertsCommand(t, mock, "", "alerts", "ingest-credentials", "rebind", "c2",
+		"--unpin", "--scope", "platform"); runError != nil {
+		t.Fatalf("unpin failed: %v", runError)
+	}
+	if mock.rebindRequest == nil || !mock.rebindRequest.ClusterIDSet || mock.rebindRequest.ClusterID != nil ||
+		mock.rebindRequest.Scope == nil || *mock.rebindRequest.Scope != "platform" {
+		t.Fatalf("unpin request = %+v", mock.rebindRequest)
+	}
+	for name, args := range map[string][]string{
+		"cluster and unpin together": {"rebind", "c2", "--cluster", "x", "--unpin"},
+		"nothing to change":          {"rebind", "c2"},
+		"an unknown scope":           {"rebind", "c2", "--scope", "everything"},
+	} {
+		if _, _, runError := runAlertsCommand(t, &alertIngestCredentialsMock{}, "",
+			append([]string{"alerts", "ingest-credentials"}, args...)...); runError == nil {
+			t.Errorf("%s: expected a usage error", name)
+		}
+	}
+}
+
+func TestRebindAlertIngestCredentialRequestSendsOnlyWhatWasSet(t *testing.T) {
+	scope := "platform"
+	for name, testCase := range map[string]struct {
+		request client.RebindAlertIngestCredentialRequest
+		want    string
+	}{
+		"unpin":      {client.RebindAlertIngestCredentialRequest{ClusterIDSet: true}, `{"cluster_id":null}`},
+		"scope only": {client.RebindAlertIngestCredentialRequest{Scope: &scope}, `{"scope":"platform"}`},
+	} {
+		encoded, marshalError := testCase.request.MarshalJSON()
+		if marshalError != nil || string(encoded) != testCase.want {
+			t.Errorf("%s: %s %v", name, encoded, marshalError)
+		}
+	}
+}

--- a/cmd/alerts_test.go
+++ b/cmd/alerts_test.go
@@ -18,6 +18,8 @@ import (
 // between Execute calls, for resetTreeFlags.
 func alertsCommandTree() []*cobra.Command {
 	return []*cobra.Command{
+		alertsIngestCredentialsListCmd,
+		alertsIngestCredentialsRebindCmd,
 		alertsDestinationsListCmd,
 		alertsDestinationsGetCmd,
 		alertsDestinationsCreateCmd,

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -2374,6 +2374,14 @@ func (m baseMock) ListAlertDestinations(options client.ListAlertDestinationsOpti
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) ListAlertIngestCredentials() (*client.AlertIngestCredentialList, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) RebindAlertIngestCredential(string, client.RebindAlertIngestCredentialRequest) (*client.AlertIngestCredential, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) GetAlertDestination(destinationID string) (*client.AlertDestination, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -690,6 +690,8 @@ type APIClient interface {
 	CreateAlertDestination(request client.CreateAlertDestinationRequest) (*client.AlertDestination, error)
 	UpdateAlertDestination(destinationID string, request client.UpdateAlertDestinationRequest) (*client.AlertDestination, error)
 	DeleteAlertDestination(destinationID string) (*client.DeleteAlertDestinationResult, error)
+	ListAlertIngestCredentials() (*client.AlertIngestCredentialList, error)
+	RebindAlertIngestCredential(credentialID string, request client.RebindAlertIngestCredentialRequest) (*client.AlertIngestCredential, error)
 	TestAlertDestination(destinationID string) (*client.AlertDestinationTestResult, error)
 	TestAlertDestinationURL(request client.TestAlertDestinationURLRequest) (*client.AlertDestinationTestResult, error)
 	ListSlackChannels() (*client.SlackChannelList, error)

--- a/internal/client/alerts.go
+++ b/internal/client/alerts.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"net/http"
 	neturl "net/url"
 	"strconv"
@@ -428,4 +429,77 @@ func (c *Client) TestNotificationRoute(routeID string) (*NotificationRouteTestRe
 		return nil, testError
 	}
 	return &result, nil
+}
+
+// Ingest credentials (ankra-z5cq5.28): the per-credential secrets external
+// notifiers use to deliver alerts into the platform. The token is minted
+// once by the portal; the CLI lists credentials and moves a credential's
+// cluster pin or scope without ever touching the token.
+const alertIngestCredentialsBasePath = "/api/v1/org/alerts/ingest-credentials"
+
+// AlertIngestCredential is one credential row on the wire; the token is
+// never included. ClusterName is served even for a cluster that is no
+// longer available, and ClusterUnavailable says the pin is broken (the
+// cluster is deleted, archived, slated for deletion or gone).
+type AlertIngestCredential struct {
+	ID                 string  `json:"id" yaml:"id"`
+	Name               string  `json:"name" yaml:"name"`
+	ClusterID          *string `json:"cluster_id" yaml:"cluster_id"`
+	ClusterName        *string `json:"cluster_name" yaml:"cluster_name"`
+	ClusterUnavailable bool    `json:"cluster_unavailable" yaml:"cluster_unavailable"`
+	Scope              string  `json:"scope" yaml:"scope"`
+	Enabled            bool    `json:"enabled" yaml:"enabled"`
+	CreatedAt          string  `json:"created_at" yaml:"created_at"`
+	UpdatedAt          string  `json:"updated_at" yaml:"updated_at"`
+	LastUsedAt         *string `json:"last_used_at" yaml:"last_used_at"`
+}
+
+// AlertIngestCredentialList is the list response body.
+type AlertIngestCredentialList struct {
+	Items []AlertIngestCredential `json:"items" yaml:"items"`
+}
+
+// RebindAlertIngestCredentialRequest moves a credential's cluster pin, or
+// its scope, without minting a new token. ClusterIDSet distinguishes
+// "unpin" (cluster_id sent as null) from "leave the pin alone" (absent).
+type RebindAlertIngestCredentialRequest struct {
+	ClusterID    *string
+	ClusterIDSet bool
+	Scope        *string
+}
+
+// MarshalJSON writes cluster_id only when it was set, as null for an
+// unpin, and scope only when given: absent is not cleared.
+func (request RebindAlertIngestCredentialRequest) MarshalJSON() ([]byte, error) {
+	body := map[string]any{}
+	if request.ClusterIDSet {
+		body["cluster_id"] = request.ClusterID
+	}
+	if request.Scope != nil {
+		body["scope"] = *request.Scope
+	}
+	return json.Marshal(body)
+}
+
+type alertIngestCredentialEnvelope struct {
+	Item AlertIngestCredential `json:"item"`
+}
+
+// ListAlertIngestCredentials lists the organisation's ingest credentials.
+func (c *Client) ListAlertIngestCredentials() (*AlertIngestCredentialList, error) {
+	var list AlertIngestCredentialList
+	if listError := c.sendJSON(http.MethodGet, c.BaseURL+alertIngestCredentialsBasePath, nil, &list); listError != nil {
+		return nil, listError
+	}
+	return &list, nil
+}
+
+// RebindAlertIngestCredential moves the credential's cluster pin or scope.
+func (c *Client) RebindAlertIngestCredential(credentialID string, request RebindAlertIngestCredentialRequest) (*AlertIngestCredential, error) {
+	var envelope alertIngestCredentialEnvelope
+	if rebindError := c.sendJSON(http.MethodPatch, c.BaseURL+alertIngestCredentialsBasePath+"/"+neturl.PathEscape(credentialID),
+		request, &envelope); rebindError != nil {
+		return nil, rebindError
+	}
+	return &envelope.Item, nil
 }


### PR DESCRIPTION
Bead: ankra-z5cq5.28

## What this does

Two subcommands under `ankra alerts ingest-credentials`, against the routes the cluster API already serves (ankra-z5cq5.1):

- `list` prints every ingest credential with its scope, the pinned cluster's name, the pin state (`ok`, `-`, or `BROKEN` when the cluster is deleted, archived, slated for deletion or gone), enabled and last used. `-o json` and `-o yaml` render the wire shape.
- `rebind <credential-id>` moves the pin or the scope on the existing credential (`PATCH /org/alerts/ingest-credentials/{id}`) so the values-repo automation can re-pin without minting a new token: `--cluster <name>` resolves the cluster by name, `--unpin` sends `cluster_id: null`, `--scope cluster|platform|mixed` switches the scope. The request body carries only what was set: absent is not cleared.

The token is never read, printed or sent by either command.

## Tests

Table rendering including a broken pin, rebind by cluster name with scope, unpin with scope, the exclusive and empty flag combinations, and the request encoder sending only the fields that were set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
