### PR TITLE
feat(org): ai-spend-cap show and set, the organisation's daily AI money and token caps (ankra-z5cq5.37)

### DIFF
--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -2382,6 +2382,14 @@ func (m baseMock) RebindAlertIngestCredential(string, client.RebindAlertIngestCr
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) GetAISpendCap() (*client.AISpendCap, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) UpdateAISpendCap(client.AISpendCapUpdate) (*client.AISpendCap, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) GetAlertDestination(destinationID string) (*client.AlertDestination, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/org_ai_spend_cap.go
+++ b/cmd/org_ai_spend_cap.go
@@ -1,0 +1,173 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+
+	"ankra/internal/client"
+)
+
+var orgAISpendCapCmd = &cobra.Command{
+	Use:   "ai-spend-cap",
+	Short: "Show or set the organisation's daily AI money and token caps",
+	Long: `The organisation's daily AI caps. The money cap bounds what chat may spend
+per UTC day; the token caps bound the unattended runs: past the soft cap
+every run degrades to the quick tier for the rest of the day, past the hard
+cap new runs are refused until midnight UTC.`,
+}
+
+var orgAISpendCapShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show the caps and today's spend",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		spendCap, getError := apiClient.GetAISpendCap()
+		if getError != nil {
+			return fmt.Errorf("reading the AI spend cap: %w", getError)
+		}
+		if rendered, renderError := renderStructured(cmd, spendCap); rendered || renderError != nil {
+			return renderError
+		}
+		renderAISpendCap(cmd, spendCap)
+		return nil
+	},
+}
+
+var orgAISpendCapSetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set or clear a cap; a cap not named is kept",
+	Long: `Set one or more caps. Each flag takes a number or "none" to clear that cap;
+a cap whose flag is not passed is left as it is. The hard token cap can
+never be set below the soft one.
+
+  ankra org ai-spend-cap set --daily-usd 25
+  ankra org ai-spend-cap set --token-soft-cap 2000000 --token-hard-cap 5000000
+  ankra org ai-spend-cap set --token-hard-cap none`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		update := client.AISpendCapUpdate{}
+		if raw := changedStringFlag(cmd, "daily-usd"); raw != nil {
+			value, parseError := parseOptionalFloat(*raw)
+			if parseError != nil {
+				return withExitCode(exitUsage, fmt.Errorf("--daily-usd: %w", parseError))
+			}
+			update.DailyChatUSDCapSet, update.DailyChatUSDCap = true, value
+		}
+		if raw := changedStringFlag(cmd, "token-soft-cap"); raw != nil {
+			value, parseError := parseOptionalTokens(*raw)
+			if parseError != nil {
+				return withExitCode(exitUsage, fmt.Errorf("--token-soft-cap: %w", parseError))
+			}
+			update.DailyTokenSoftCapSet, update.DailyTokenSoftCap = true, value
+		}
+		if raw := changedStringFlag(cmd, "token-hard-cap"); raw != nil {
+			value, parseError := parseOptionalTokens(*raw)
+			if parseError != nil {
+				return withExitCode(exitUsage, fmt.Errorf("--token-hard-cap: %w", parseError))
+			}
+			update.DailyTokenHardCapSet, update.DailyTokenHardCap = true, value
+		}
+		if !update.DailyChatUSDCapSet && !update.DailyTokenSoftCapSet && !update.DailyTokenHardCapSet {
+			return withExitCode(exitUsage, errors.New("nothing to set: pass --daily-usd, --token-soft-cap or --token-hard-cap"))
+		}
+		spendCap, updateError := apiClient.UpdateAISpendCap(update)
+		if updateError != nil {
+			return fmt.Errorf("updating the AI spend cap: %w", updateError)
+		}
+		if rendered, renderError := renderStructured(cmd, spendCap); rendered || renderError != nil {
+			return renderError
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "AI caps updated.")
+		renderAISpendCap(cmd, spendCap)
+		return nil
+	},
+}
+
+// parseOptionalFloat reads a money flag: "none" clears, otherwise a
+// positive number.
+func parseOptionalFloat(raw string) (*float64, error) {
+	if strings.EqualFold(strings.TrimSpace(raw), "none") {
+		return nil, nil
+	}
+	value, parseError := strconv.ParseFloat(strings.TrimSpace(raw), 64)
+	if parseError != nil {
+		return nil, fmt.Errorf("expected a number or none, got %q", raw)
+	}
+	return &value, nil
+}
+
+// parseOptionalTokens reads a token flag: "none" clears, otherwise a whole
+// number of tokens, with an optional k or m suffix (thousands, millions).
+func parseOptionalTokens(raw string) (*int64, error) {
+	text := strings.ToLower(strings.TrimSpace(raw))
+	if text == "none" {
+		return nil, nil
+	}
+	multiplier := int64(1)
+	switch {
+	case strings.HasSuffix(text, "m"):
+		multiplier, text = 1_000_000, strings.TrimSuffix(text, "m")
+	case strings.HasSuffix(text, "k"):
+		multiplier, text = 1_000, strings.TrimSuffix(text, "k")
+	}
+	value, parseError := strconv.ParseInt(text, 10, 64)
+	if parseError != nil {
+		return nil, fmt.Errorf("expected a whole number of tokens (optionally with k or m) or none, got %q", raw)
+	}
+	value *= multiplier
+	return &value, nil
+}
+
+func renderAISpendCap(cmd *cobra.Command, spendCap *client.AISpendCap) {
+	writer := table.NewWriter()
+	writer.SetOutputMirror(cmd.OutOrStdout())
+	writer.SetStyle(table.StyleRounded)
+	writer.AppendHeader(table.Row{"Cap", "Value", "Today"})
+	writer.AppendRow(table.Row{"Daily money cap (USD)", formatOptionalFloat(spendCap.DailyChatUSDCap, spendCap.PlanDefaultUSD),
+		fmt.Sprintf("%.2f spent", spendCap.SpentTodayUSD)})
+	writer.AppendRow(table.Row{"Daily token soft cap", formatOptionalTokens(spendCap.DailyTokenSoftCap), formatTokensToday(spendCap)})
+	writer.AppendRow(table.Row{"Daily token hard cap", formatOptionalTokens(spendCap.DailyTokenHardCap), "budget " + spendCap.TokenBudgetState})
+	if spendCap.MonthlyFreeUSD != nil {
+		writer.AppendRow(table.Row{"Monthly free allowance (USD)", fmt.Sprintf("%.2f", *spendCap.MonthlyFreeUSD),
+			fmt.Sprintf("%.2f used, resets %s", spendCap.MonthlyPlatformSpentUSD, spendCap.MonthlyResetsAt)})
+	}
+	writer.Render()
+}
+
+func formatOptionalFloat(value *float64, planDefault *float64) string {
+	if value != nil {
+		return fmt.Sprintf("%.2f", *value)
+	}
+	if planDefault != nil {
+		return fmt.Sprintf("plan default (%.2f)", *planDefault)
+	}
+	return "none"
+}
+
+func formatOptionalTokens(value *int64) string {
+	if value == nil {
+		return "none"
+	}
+	return strconv.FormatInt(*value, 10)
+}
+
+func formatTokensToday(spendCap *client.AISpendCap) string {
+	if spendCap.TokensToday == nil {
+		return "usage unreadable"
+	}
+	return strconv.FormatInt(*spendCap.TokensToday, 10) + " tokens"
+}
+
+func init() {
+	orgAISpendCapSetCmd.Flags().String("daily-usd", "", "daily money cap in USD, or none to clear")
+	orgAISpendCapSetCmd.Flags().String("token-soft-cap", "", "daily token soft cap (runs degrade to quick past it), or none to clear")
+	orgAISpendCapSetCmd.Flags().String("token-hard-cap", "", "daily token hard cap (runs are refused past it), or none to clear")
+	orgAISpendCapCmd.AddCommand(orgAISpendCapShowCmd)
+	orgAISpendCapCmd.AddCommand(orgAISpendCapSetCmd)
+	orgCmd.AddCommand(orgAISpendCapCmd)
+}

--- a/cmd/org_ai_spend_cap_test.go
+++ b/cmd/org_ai_spend_cap_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type aiSpendCapMock struct {
+	baseMock
+	spendCap client.AISpendCap
+	update   *client.AISpendCapUpdate
+}
+
+func (mock *aiSpendCapMock) GetAISpendCap() (*client.AISpendCap, error) {
+	spendCap := mock.spendCap
+	return &spendCap, nil
+}
+
+func (mock *aiSpendCapMock) UpdateAISpendCap(update client.AISpendCapUpdate) (*client.AISpendCap, error) {
+	mock.update = &update
+	spendCap := mock.spendCap
+	if update.DailyTokenSoftCapSet {
+		spendCap.DailyTokenSoftCap = update.DailyTokenSoftCap
+	}
+	if update.DailyTokenHardCapSet {
+		spendCap.DailyTokenHardCap = update.DailyTokenHardCap
+	}
+	if update.DailyChatUSDCapSet {
+		spendCap.DailyChatUSDCap = update.DailyChatUSDCap
+	}
+	return &spendCap, nil
+}
+
+func runOrgAISpendCapCommand(t *testing.T, mock APIClient, args ...string) (string, error) {
+	t.Helper()
+	withTempHome(t)
+	setMockClient(t, mock)
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs(args)
+	// Flags keep their Changed markers between Execute calls on the shared
+	// tree, so reset before every run as well as after the test.
+	resetTreeFlags(t, orgAISpendCapShowCmd, orgAISpendCapSetCmd)
+	t.Cleanup(func() { resetTreeFlags(t, orgAISpendCapShowCmd, orgAISpendCapSetCmd) })
+	executeError := rootCmd.Execute()
+	return stdout.String(), executeError
+}
+
+func sampleAISpendCap() client.AISpendCap {
+	usd, planDefault, soft, today := 25.0, 10.0, int64(2000000), int64(345678)
+	return client.AISpendCap{DailyChatUSDCap: &usd, PlanDefaultUSD: &planDefault, EffectiveUSD: &usd, SpentTodayUSD: 3.5,
+		DailyTokenSoftCap: &soft, TokensToday: &today, TokenBudgetState: "under", MonthlyResetsAt: "2026-10-01T00:00:00Z"}
+}
+
+func TestOrgAISpendCapShowRendersCapsAndTodaysUsage(t *testing.T) {
+	mock := &aiSpendCapMock{spendCap: sampleAISpendCap()}
+	stdout, runError := runOrgAISpendCapCommand(t, mock, "org", "ai-spend-cap", "show")
+	if runError != nil {
+		t.Fatalf("show failed: %v", runError)
+	}
+	for _, fragment := range []string{"25.00", "3.50 spent", "2000000", "345678 tokens", "none", "budget under"} {
+		if !strings.Contains(stdout, fragment) {
+			t.Errorf("expected the table to contain %q, got:\n%s", fragment, stdout)
+		}
+	}
+	unreadable := sampleAISpendCap()
+	unreadable.TokensToday, unreadable.TokenBudgetState = nil, "unknown"
+	stdout, _ = runOrgAISpendCapCommand(t, &aiSpendCapMock{spendCap: unreadable}, "org", "ai-spend-cap", "show")
+	if !strings.Contains(stdout, "usage unreadable") || !strings.Contains(stdout, "budget unknown") {
+		t.Fatalf("an unreadable usage is said, not shown as zero:\n%s", stdout)
+	}
+}
+
+func TestOrgAISpendCapSetSendsOnlyTheFlagsPassed(t *testing.T) {
+	mock := &aiSpendCapMock{spendCap: sampleAISpendCap()}
+	stdout, runError := runOrgAISpendCapCommand(t, mock, "org", "ai-spend-cap", "set", "--token-hard-cap", "5m")
+	if runError != nil || mock.update == nil {
+		t.Fatalf("set failed: %v", runError)
+	}
+	if mock.update.DailyChatUSDCapSet || mock.update.DailyTokenSoftCapSet || !mock.update.DailyTokenHardCapSet ||
+		mock.update.DailyTokenHardCap == nil || *mock.update.DailyTokenHardCap != 5000000 {
+		t.Fatalf("update = %+v", *mock.update)
+	}
+	if !strings.Contains(stdout, "AI caps updated.") || !strings.Contains(stdout, "5000000") {
+		t.Fatalf("stdout = %s", stdout)
+	}
+	encoded, _ := json.Marshal(*mock.update)
+	if string(encoded) != `{"daily_token_hard_cap":5000000}` {
+		t.Fatalf("body = %s", encoded)
+	}
+
+	mock = &aiSpendCapMock{spendCap: sampleAISpendCap()}
+	if _, runError = runOrgAISpendCapCommand(t, mock, "org", "ai-spend-cap", "set", "--daily-usd", "none", "--token-soft-cap", "250k"); runError != nil {
+		t.Fatalf("clear failed: %v", runError)
+	}
+	encoded, _ = json.Marshal(*mock.update)
+	if string(encoded) != `{"daily_chat_usd_cap":null,"daily_token_soft_cap":250000}` {
+		t.Fatalf("clear body = %s", encoded)
+	}
+}
+
+func TestOrgAISpendCapSetRefusesNothingAndBadNumbers(t *testing.T) {
+	mock := &aiSpendCapMock{spendCap: sampleAISpendCap()}
+	if _, runError := runOrgAISpendCapCommand(t, mock, "org", "ai-spend-cap", "set"); runError == nil || !strings.Contains(runError.Error(), "nothing to set") {
+		t.Fatalf("no flags: %v", runError)
+	}
+	if _, runError := runOrgAISpendCapCommand(t, mock, "org", "ai-spend-cap", "set", "--token-soft-cap", "lots"); runError == nil || !strings.Contains(runError.Error(), "whole number") {
+		t.Fatalf("bad tokens: %v", runError)
+	}
+	if mock.update != nil {
+		t.Fatal("nothing was sent")
+	}
+}

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -692,6 +692,8 @@ type APIClient interface {
 	DeleteAlertDestination(destinationID string) (*client.DeleteAlertDestinationResult, error)
 	ListAlertIngestCredentials() (*client.AlertIngestCredentialList, error)
 	RebindAlertIngestCredential(credentialID string, request client.RebindAlertIngestCredentialRequest) (*client.AlertIngestCredential, error)
+	GetAISpendCap() (*client.AISpendCap, error)
+	UpdateAISpendCap(update client.AISpendCapUpdate) (*client.AISpendCap, error)
 	TestAlertDestination(destinationID string) (*client.AlertDestinationTestResult, error)
 	TestAlertDestinationURL(request client.TestAlertDestinationURLRequest) (*client.AlertDestinationTestResult, error)
 	ListSlackChannels() (*client.SlackChannelList, error)

--- a/internal/client/billing.go
+++ b/internal/client/billing.go
@@ -1,0 +1,79 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// aiSpendCapPath is the bearer twin of the organisation's AI cap surface.
+const aiSpendCapPath = "/api/v1/org/billing/ai-spend-cap"
+
+// AISpendCap is the organisation's daily AI money and token caps with
+// today's spend, as GET /api/v1/org/billing/ai-spend-cap returns it.
+type AISpendCap struct {
+	DailyChatUSDCap *float64 `json:"daily_chat_usd_cap"`
+	PlanDefaultUSD  *float64 `json:"plan_default_usd"`
+	EffectiveUSD    *float64 `json:"effective_usd"`
+	SpentTodayUSD   float64  `json:"spent_today_usd"`
+	// The daily token budget: past the soft cap unattended runs degrade to
+	// the quick tier for the rest of the UTC day, past the hard cap new
+	// unattended runs are refused until it resets.
+	DailyTokenSoftCap *int64 `json:"daily_token_soft_cap"`
+	DailyTokenHardCap *int64 `json:"daily_token_hard_cap"`
+	// TokensToday is null when today's usage could not be read.
+	TokensToday *int64 `json:"tokens_today"`
+	// TokenBudgetState is unlimited, under, soft, hard or unknown.
+	TokenBudgetState        string   `json:"token_budget_state"`
+	MonthlyFreeUSD          *float64 `json:"monthly_free_usd"`
+	MonthlyPlatformSpentUSD float64  `json:"monthly_platform_spent_usd"`
+	MonthlyResetsAt         string   `json:"monthly_resets_at"`
+	MonthlyExhausted        bool     `json:"monthly_exhausted"`
+	AllowanceExempt         bool     `json:"allowance_exempt"`
+	ByokConfigured          bool     `json:"byok_configured"`
+}
+
+// AISpendCapUpdate is a partial write of the caps: a field whose Set flag
+// is false is not sent and so is kept by the platform; a Set field with a
+// nil value is sent as null and clears the cap.
+type AISpendCapUpdate struct {
+	DailyChatUSDCapSet   bool
+	DailyChatUSDCap      *float64
+	DailyTokenSoftCapSet bool
+	DailyTokenSoftCap    *int64
+	DailyTokenHardCapSet bool
+	DailyTokenHardCap    *int64
+}
+
+// MarshalJSON sends only the fields that were set.
+func (update AISpendCapUpdate) MarshalJSON() ([]byte, error) {
+	body := map[string]any{}
+	if update.DailyChatUSDCapSet {
+		body["daily_chat_usd_cap"] = update.DailyChatUSDCap
+	}
+	if update.DailyTokenSoftCapSet {
+		body["daily_token_soft_cap"] = update.DailyTokenSoftCap
+	}
+	if update.DailyTokenHardCapSet {
+		body["daily_token_hard_cap"] = update.DailyTokenHardCap
+	}
+	return json.Marshal(body)
+}
+
+// GetAISpendCap reads the organisation's daily AI caps.
+func (c *Client) GetAISpendCap() (*AISpendCap, error) {
+	var spendCap AISpendCap
+	if getError := c.sendJSON(http.MethodGet, c.BaseURL+aiSpendCapPath, nil, &spendCap); getError != nil {
+		return nil, getError
+	}
+	return &spendCap, nil
+}
+
+// UpdateAISpendCap applies a partial write of the organisation's daily AI
+// caps and returns the resulting state.
+func (c *Client) UpdateAISpendCap(update AISpendCapUpdate) (*AISpendCap, error) {
+	var spendCap AISpendCap
+	if putError := c.sendJSON(http.MethodPut, c.BaseURL+aiSpendCapPath, update, &spendCap); putError != nil {
+		return nil, putError
+	}
+	return &spendCap, nil
+}


### PR DESCRIPTION
Bead: ankra-z5cq5.37

The CLI half of the token caps: `ankra org ai-spend-cap show` and `ankra org ai-spend-cap set`, over the new `/api/v1/org/billing/ai-spend-cap` bearer twins (ankraio/cluster, the `feat(billing)` PR for the same bead).

- `show` renders the daily money cap (or the plan default it falls back to), the token soft and hard caps, today's spend and tokens, the budget state, and the monthly allowance when the plan carries one. An unreadable usage is said (`usage unreadable`, `budget unknown`), never rendered as zero.
- `set` takes `--daily-usd`, `--token-soft-cap`, `--token-hard-cap`, each a number or `none` to clear; token counts accept a `k` or `m` suffix. Only the flags passed are sent (`AISpendCapUpdate.MarshalJSON` emits exactly the set keys), so a cap not named is kept by the platform. No flag at all, or a value that is not a number, is a usage error before anything is sent.
- `--output json` works on both.

Tests: the table fragments and the unreadable-usage wording; a single-flag set sends exactly one key with the suffix expanded; a clear sends null beside a value; no flags and a bad number send nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
