### PR TITLE
release: cut v0.15.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,36 +1,18 @@
 # Ankra CLI Changelog
 
-## Unreleased
+## v0.15.0-rc2 — 2026-09-05
 
 ### Added
 
-- **`ankra security sbom findings <image>` lists the CVEs on one image.** The
-  image detail counted findings per component and stopped there; this is the
-  list behind the count: one row per CVE and installed package version,
-  aggregated across the containers running the image, with the fixed version
-  when one exists, the CISA KEV listing and EPSS probability, the worst
-  disposition across its occurrences, and how many workloads and clusters run
-  it. It answers for an image without a bill of materials too - the CVEs come
-  from the vulnerability reports - and says ABSENT in the header so the gap
-  stays visible. `--severity` (repeatable), `--search`, `--sort` and paging
-  narrow it; `-o json` for scripts. Pairs with `ankra security finding <id>`
-  for one CVE in full.
-- **`ankra security namespaces` rows carry `sbom_images`**: the distinct
-  images running in the namespace that have a bill of materials, against the
-  images the scanner reported on, so a namespace's SBOM gap is visible in the
-  breakdown without opening it. The SBOM coverage block on `ankra security
-  sbom`, `sbom images` and `sbom containers` now follows `--namespace`,
-  `--workload-kind` and `--workload-name`, so the headline above a narrowed
-  list is that scope's, not the fleet's.
-- **`ankra pipeline findings <run>`** lists a run's persisted scan findings -
-  the deduplicated Semgrep, Checkov and Trivy results (and the informational
-  SBOM summary) recorded for the run's own commit, the same rows the
-  application's Security tab reads. The table sorts worst severity first and
-  groups by tool; `-o json`/`yaml` prints every field, including each
-  finding's tool-specific detail. `ankra pipeline artifacts` now also shows
-  each row's `KIND` (`step_log` or `artifact`) and `STATUS` (`pending`,
-  `uploaded`, `failed` or `expired`), so a caller can tell a still-archiving
-  or failed row from one `artifacts download` can actually fetch.
+- **`ankra pipeline` now covers the whole Ankra Pipelines lifecycle.** The
+  full verb list as of this release: `run`, `list`, `get`, `logs` (live for a
+  running step, archived replay for a concluded one), `cancel`, `rerun`,
+  `artifacts`, `artifacts download`, `findings`, `validate`, `definition
+  get|put`, `schedules list|create|update|delete`, `repositories
+  connect|list|get|disconnect` and `definitions get|approve`. `ankra
+  application pipeline …` offers the selector-addressed ones by application.
+  The four that are new or newly real in this release are described below.
+
 - **`ankra pipeline repositories` connects a bare Git repository to Ankra
   Pipelines from the terminal.** Cluster PRs #2490 and #2509 added the
   organisation-scoped onboarding routes; `list` and `get` read what the
@@ -54,6 +36,7 @@
   starting new runs without deleting its history - connecting the same
   identity again revives the same row - and refuses (409, the server's own
   message) while a run is still queued or running.
+
 - **`ankra pipeline definitions get|approve` inspects and grants a pipeline
   definition's protected-authority approval.** A pipeline file's logic is
   open - anyone who can push may add stages, scripts and images - but its
@@ -76,6 +59,67 @@
   comment rather than guessing). `-o json` works on both, and a 404/409/403
   from the server prints verbatim rather than being reworded.
 
+- **`ankra pipeline findings <run>`** lists a run's persisted scan findings -
+  the deduplicated Semgrep, Checkov and Trivy results (and the informational
+  SBOM summary) recorded for the run's own commit, the same rows the
+  application's Security tab reads. The table sorts worst severity first and
+  groups by tool; `-o json`/`yaml` prints every field, including each
+  finding's tool-specific detail. `ankra pipeline artifacts` now also shows
+  each row's `KIND` (`step_log` or `artifact`) and `STATUS` (`pending`,
+  `uploaded`, `failed` or `expired`), so a caller can tell a still-archiving
+  or failed row from one `artifacts download` can actually fetch.
+
+- **`ankra alerts ingest-credentials list|rebind` moves an ingest
+  credential's pin or scope without minting a new token.** `list` prints
+  every ingest credential with its scope, the pinned cluster's name, the pin
+  state - `ok`, `-`, or `BROKEN` when the pinned cluster has been deleted,
+  archived, slated for deletion or is simply gone - and whether it is enabled
+  and when it was last used. `rebind <credential-id>` changes the binding on
+  the credential that already exists: `--cluster <name>` re-pins by cluster
+  name, `--unpin` removes the pin, and `--scope cluster|platform|mixed`
+  switches the scope. The request carries only the flags you set, so an
+  absent flag leaves that field alone rather than clearing it - which is what
+  lets values-repo automation re-pin a credential in place. Neither command
+  ever reads, prints or sends the token itself. `-o json`/`yaml` render the
+  wire shape.
+
+- **`ankra security sbom containers` and `sbom export <image>`, and `-o` on
+  every SBOM read.** `sbom containers` lists every running container of the
+  scoped clusters, init containers included, with or without a bill of
+  materials - the ones missing one first, an inventory line that counts the
+  scope before `--status`/`--search` narrow it, and `--status
+  present|absent|any` to pick a side. `sbom export <image>` writes the bill
+  of materials out as CycloneDX 1.5 JSON (or `--format csv`) to the
+  platform's own file name, to `--output-file`, or to `-` for a pipe; an
+  existing target is refused unless `--force` is passed, so a re-run cannot
+  silently destroy a previous download, and a file name the server proposes
+  is reduced to a bare base name rather than trusted as a path.
+  `--workload-kind` and `--workload-name` narrow `sbom` and `sbom images` to
+  one workload. The family's help had promised `-o`/`--output` since it
+  shipped without ever registering the flag, so `-o json` failed with
+  "unknown shorthand flag"; `namespaces`, `pods`, `sbom`, `sbom images`,
+  `sbom image` and `sbom containers` all accept it now.
+
+- **`ankra security sbom findings <image>` lists the CVEs on one image.** The
+  image detail counted findings per component and stopped there; this is the
+  list behind the count: one row per CVE and installed package version,
+  aggregated across the containers running the image, with the fixed version
+  when one exists, the CISA KEV listing and EPSS probability, the worst
+  disposition across its occurrences, and how many workloads and clusters run
+  it. It answers for an image without a bill of materials too - the CVEs come
+  from the vulnerability reports - and says ABSENT in the header so the gap
+  stays visible. `--severity` (repeatable), `--search`, `--sort` and paging
+  narrow it; `-o json` for scripts. Pairs with `ankra security finding <id>`
+  for one CVE in full.
+
+- **`ankra security namespaces` rows carry `sbom_images`**: the distinct
+  images running in the namespace that have a bill of materials, against the
+  images the scanner reported on, so a namespace's SBOM gap is visible in the
+  breakdown without opening it. The SBOM coverage block on `ankra security
+  sbom`, `sbom images` and `sbom containers` now follows `--namespace`,
+  `--workload-kind` and `--workload-name`, so the headline above a narrowed
+  list is that scope's, not the fleet's.
+
 ### Fixed
 
 - **`ankra pipeline logs` on a concluded step now shows its output.** The
@@ -90,6 +134,7 @@
   longer reads as if the step had never recorded one, and it reads the
   step's current log rather than an upload a re-dispatch of the same step
   had already superseded.
+
 - **`ankra pipeline artifacts` and `artifacts download` talk to the real
   artifact store.** Both were wired against the wire contract before the
   store existed, and said so in their help text; the store has since
@@ -101,6 +146,17 @@
   is now refused on both listings rather than dropped on the way to the
   query, which used to hand back the server's default page as though the
   flag had been honoured.
+
+- **Hetzner `cluster deprovision --force` now says what it deletes.** Its
+  help still carried a pre-teardown-sweep meaning - "use only when the
+  cluster agent is permanently offline; cloud resources may leak" - which is
+  wrong in the dangerous direction: `--force` is the mode in which resources
+  do *not* leak, because it also deletes the cluster's CSI storage volumes
+  and load balancers, destroying the data on them. The one fact an operator
+  most needs before running it was the one the text omitted. Hetzner was the
+  last provider still saying this; UpCloud, DigitalOcean and OVH already
+  named the volumes and load balancers, and a parity test across all four
+  now pins the wording so a later rewrite cannot drop it again.
 
 ## v0.15.0-rc1 — 2026-09-03
 


### PR DESCRIPTION
## What this does

Cuts `v0.15.0-rc2` by replacing the `## Unreleased` heading with
`## v0.15.0-rc2 — 2026-09-05`. CHANGELOG.md is the only file touched. No tag
is created here — tagging stays a separate, deliberate step.

## What is in the release

Everything above the `v0.15.0-rc1` tag on master:

- **`ankra pipeline` completed** — #234 (logs replay a concluded step's
  archived log, `artifacts`/`artifacts download` talk to the real store,
  `findings` is a verb), #229 (`repositories connect|list|get|disconnect`),
  #231 (`definitions get|approve`).
- **Security SBOM reads** — #233 (`sbom findings <image>`, `namespaces` rows
  carrying `sbom_images`) and #232 (`sbom containers`, `sbom export <image>`,
  `--workload-kind`/`--workload-name`, and `-o` on every SBOM read).
- **Alerts** — #240 (`alerts ingest-credentials list|rebind`).
- **Hetzner** — #230 (`cluster deprovision --force` help now says it deletes
  the cluster's CSI volumes and load balancers).

#238 is a `.gitignore` chore with no user-visible surface and deliberately
gets no entry.

## How the section was built

The five `### Added` and two `### Fixed` entries already under `## Unreleased`
are carried over **verbatim** — `git diff -U0` on this branch shows exactly
one line removed and not re-added anywhere, and it is `## Unreleased` itself.
Everything else in the diff is those entries moving so the pipeline, alerts
and security blocks read together.

Three entries were written at cut time because the PRs shipped without one:
**#232**, **#240** and **#230**. A fourth, new entry opens the section with
the complete `ankra pipeline` verb inventory as it now stands — rc1's
description of that surface is no longer accurate — and points at the
detailed entries below rather than restating them.

`## Unreleased` is replaced outright rather than left behind empty, matching
how `v0.15.0-rc1` (#228) and `v0.15.0-rc0` (#217) were cut.

## Test plan

Dry-ran the exact release-notes extractor from `.github/workflows/release.yml`
against the committed file:

```
awk -v version="0.15.0-rc2" '
  $0 ~ "^## v?"version"([[:space:]]|$)" {found=1; next}
  found && /^## / {exit}
  found {print}
' CHANGELOG.md
```

- 157 lines extracted, 11 bullets (8 Added, 3 Fixed)
- passes the workflow's `[ -s release-notes.md ]` non-empty guard
- stops cleanly at `## v0.15.0-rc1`; zero rc1 content captured
- the new section wraps at ≤79 columns, matching the file

## Docs

No CLI behaviour changes here, so no `ankra-docs` update is needed; the
generated CLI reference is unaffected.
