### PR TITLE
ci: run on the organisation's self-hosted ARC scale set instead of Depot (ankra-k7vll)

### DIFF
--- a/.github/scripts/install-tooling.sh
+++ b/.github/scripts/install-tooling.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Installs the GitHub CLI (from GitHub's own apt repository, so the version does
+# not depend on the distribution's package) plus any extra apt packages named
+# as arguments, on whichever host the job landed on: as root inside a job
+# container (golang:1.26) or through sudo on the bare self-hosted runner image.
+# Depot's images ship gh preinstalled; there this is a no-op.
+set -euo pipefail
+
+if [ "$(id -u)" -eq 0 ]; then
+    SUDO=""
+else
+    SUDO="sudo"
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    ${SUDO} mkdir -p /etc/apt/keyrings
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        | ${SUDO} tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
+    ${SUDO} chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        | ${SUDO} tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+    set -- gh "$@"
+fi
+
+if [ "$#" -gt 0 ]; then
+    ${SUDO} apt-get update -qq >/dev/null
+    DEBIAN_FRONTEND=noninteractive ${SUDO} apt-get install -y -qq --no-install-recommends "$@" >/dev/null
+fi
+gh --version | head -n 1

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -20,13 +20,19 @@ permissions:
 jobs:
   sync-docs:
     name: Generate and PR CLI reference
-    runs-on: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
+    runs-on: ${{ vars.CLI_RUNNER || 'arc-runner-set' }}
+    container:
+      image: golang:1.26
+    timeout-minutes: 20
     steps:
       - name: Checkout ankra-cli
         uses: actions/checkout@v6
         with:
           # Full history so manual runs can name a version via git describe.
           fetch-depth: 0
+
+      - name: Install tooling (gh)
+        run: .github/scripts/install-tooling.sh
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -3,17 +3,35 @@ name: Lint, Test and Build
 on:
   push:
     branches:
-      - '**'
+      - master
   pull_request:
     branches:
       - '**'
+
+# One run per commit: a pull request commit used to run twice (push + pull_request),
+# which doubled the load on the shared self-hosted pool. A superseded run on a
+# branch is cancelled; master runs complete.
+concurrency:
+  group: lint-build-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 permissions:
   contents: read
 
 jobs:
   lint-test-build:
-    runs-on: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
+    # Runs on the organisation's self-hosted ARC scale set (runner group
+    # arc-privileged-build, registered for github.com/ankraio). Set the
+    # repository variable CLI_RUNNER to another label (e.g. depot-ubuntu-24.04)
+    # to move it without a code change. The Go image carries make, gcc (the
+    # race detector needs cgo) and git, which the bare runner image does not.
+    runs-on: ${{ vars.CLI_RUNNER || 'arc-runner-set' }}
+    container:
+      image: golang:1.26
+    # A starved runner used to hold this job for hours (2026-09-05: a 20 s test
+    # step took 20 min, and one job never finished); every step here completes
+    # in well under five minutes on a healthy runner.
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,16 @@ jobs:
     name: Create release
     permissions:
       contents: write
-    runs-on: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
+    runs-on: ${{ vars.CLI_RUNNER || 'arc-runner-set' }}
+    container:
+      image: golang:1.26
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Install tooling (gh)
+        run: .github/scripts/install-tooling.sh
 
       - name: Extract release notes from CHANGELOG.md
         run: |
@@ -62,21 +68,26 @@ jobs:
     needs: create-release
     permissions:
       contents: write
+    # Linux and Windows binaries build on the self-hosted pool without a job
+    # container: the matrix shares this job with the macOS legs, which keep
+    # macos-latest because ad-hoc codesign is macOS-only. CGO_ENABLED=0 needs
+    # only the Go toolchain, which setup-go installs on either host.
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
+          - os: ${{ vars.CLI_RUNNER || 'arc-runner-set' }}
             goos: linux
             goarch: amd64
-          - os: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
+          - os: ${{ vars.CLI_RUNNER || 'arc-runner-set' }}
             goos: linux
             goarch: arm64
-          - os: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
+          - os: ${{ vars.CLI_RUNNER || 'arc-runner-set' }}
             goos: windows
             goarch: amd64
-          - os: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
+          - os: ${{ vars.CLI_RUNNER || 'arc-runner-set' }}
             goos: windows
             goarch: arm64
           - os: macos-latest
@@ -93,6 +104,10 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+
+      - name: Install tooling (gh) on Linux
+        if: runner.os == 'Linux'
+        run: .github/scripts/install-tooling.sh
 
       - name: Build binary
         env:
@@ -156,10 +171,16 @@ jobs:
     if: ${{ !contains(github.ref_name, '-') }}
     permissions:
       contents: read
-    runs-on: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
+    runs-on: ${{ vars.CLI_RUNNER || 'arc-runner-set' }}
+    container:
+      image: golang:1.26
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Install tooling (gh, ssh client)
+        run: .github/scripts/install-tooling.sh openssh-client
 
       - name: Render formula from template
         env:

--- a/.github/workflows/systemtest.yml
+++ b/.github/workflows/systemtest.yml
@@ -31,7 +31,9 @@ concurrency:
 jobs:
   lifecycle-system-test:
     name: Cloud lifecycle system test
-    runs-on: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
+    runs-on: ${{ vars.CLI_RUNNER || 'arc-runner-set' }}
+    container:
+      image: golang:1.26
     timeout-minutes: 240
     env:
       ANKRA_SYSTEMTEST_CONFIRM: 'yes'


### PR DESCRIPTION
## What & why

On 2026-09-05 every ankra-cli job on `depot-ubuntu-24.04` ran 20-60x slower than usual: `golangci-lint` 19 min for a 17 s step, `go test` 20 min for a 23 s step, and a master run died after 46 min with the tests step never concluding. Other repositories on the same Depot label (ankra-docs, cluster PRs) were normal at the same time, so this was per-repository starvation on Depot's side with nothing to pull on ours.

Neither repository has been on GitHub-hosted runners since August (ankra-cli#121 / ankra-docs#162, ankra-lo47s - now closed as stale; GitHub billing is restored, the v0.15.0-rc1 darwin legs ran on `macos-latest` on 2026-09-03). This PR moves ankra-cli's CI onto Ankra's own runners.

- **`runs-on: ${{ vars.CLI_RUNNER || 'arc-runner-set' }}`** on every Linux job. `arc-runner-set` is the ARC scale set registered for `github.com/ankraio` (runner group `arc-privileged-build`, max 6 runners, DinD); the group has been granted to this repository. Setting the repository variable `CLI_RUNNER` moves the jobs elsewhere without a code change.
- **Go jobs run in `golang:1.26`** (lint-test-build, docs-sync, systemtest, create-release, publish-homebrew), the same pattern as cluster's ARC jobs: the bare runner image has no make, gcc (the race detector needs cgo) or Go.
- **`.github/scripts/install-tooling.sh`** installs `gh` from GitHub's apt repository plus any extra packages (the homebrew job needs an ssh client), as root in the container or via sudo on the bare runner; a no-op where gh is preinstalled (Depot). Verified inside `golang:1.26`.
- **Release matrix**: the linux/windows legs move to the knob without a container (the job is shared with the macOS legs); `gh` is installed on Linux legs only. The **darwin legs stay on `macos-latest`**: ad-hoc `codesign` is macOS-only.
- **`timeout-minutes`** on every job (20/15/30), so a starved runner fails in minutes instead of holding a job for six hours.
- **lint-build runs once per commit**: push on `master`, `pull_request` elsewhere, with superseded branch runs cancelled. It used to run twice per PR commit, which matters on a six-runner pool.

Not in this PR: ankra-docs. It is healthy on Depot, and its jobs need Python, Node, buildx/QEMU and pip-installed scanners the minimal ARC image lacks, so moving it is a separate containerising change.

Bead: ankra-k7vll

## Test plan

- This PR's own `lint-test-build` is the proof: it must run on an `arc-runner-set` runner (check the job's runner name) and finish in the usual ~1-2 min.
- `actionlint` clean on all four workflows; `bash -n` on the script; the script run end-to-end in `golang:1.26` (gh, ssh, git, make, gcc present afterwards).
- Release path is exercised by the next tag; the darwin legs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)