### PR TITLE
feat(agent): ankra cluster agent ci get|set - pipeline-step workers set through Ankra (ankra-vn0bd)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@
 
 ### Added
 
+- **`ankra cluster agent ci get|set` sizes the cluster agent's pipeline-step
+  workers from Ankra instead of a hand-run Helm command.** The agent runs
+  Ankra Pipelines steps itself, and how many it runs at once
+  (`--workers`, 0 disables the scheduler) plus the storage class its step
+  workspaces are carved from (`--storage-class`) used to live only in the
+  agent's chart values - so the only way to enable CI workers was
+  `helm upgrade --set`, and the next platform-driven agent upgrade rendered
+  the default back over it. Both settings are now stored on the platform and
+  carried by every install and upgrade command Ankra generates for the
+  cluster. `set` says what happened to the setting as well as storing it: an
+  online agent new enough to accept chart values re-renders its release
+  immediately, an older one takes it at its next upgrade, and an offline one
+  when it reconnects. `get` shows the stored values, the agent version that
+  has to honour them, and whether that agent currently advertises it can run
+  pipeline steps - which stays "not advertised" until the agent has actually
+  re-rendered, so a stored worker count is never mistaken for a working one.
+  `--storage-class` is only sent when you pass it, so changing the worker
+  count keeps a storage class set earlier; `-o json|yaml` works on both, and
+  a 403, 404 or 422 from the platform prints verbatim rather than being
+  reworded.
+
 - **`ankra stack-profiles import --as-draft` stages a file-authored profile
   for review instead of publishing it.** The document opens as a builder
   draft on the named profile: when your organisation already has a profile

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ per command family:
 | [ankra application](https://docs.ankra.ai/reference/cli/application) | Manage applications |
 | [ankra charts](https://docs.ankra.ai/reference/cli/charts) | Browse Helm charts |
 | [ankra chat](https://docs.ankra.ai/reference/cli/chat) | AI-powered chat for troubleshooting and assistance |
-| [ankra cluster](https://docs.ankra.ai/reference/cli/cluster) | Cluster operations: stacks, manifests, addons, operations, variables, access, SOPS encryption, provider (Hetzner/OVH/UpCloud/DigitalOcean) lifecycle |
+| [ankra cluster](https://docs.ankra.ai/reference/cli/cluster) | Cluster operations: stacks, manifests, addons, operations, variables, access, SOPS encryption, agent status, upgrade and pipeline-step CI settings (`cluster agent ci get\|set` - how many Ankra Pipelines steps the cluster's agent runs at once and the storage class their workspaces use, stored on the platform so an agent upgrade no longer renders the setting away), provider (Hetzner/OVH/UpCloud/DigitalOcean) lifecycle |
 | [ankra completion](https://docs.ankra.ai/reference/cli/completion) | Generate or install shell completion scripts |
 | [ankra config](https://docs.ankra.ai/reference/cli/config) | Manage Ankra CLI settings |
 | [ankra credentials](https://docs.ankra.ai/reference/cli/credentials) | Manage credentials (platform, provider API, SSH keys) |

--- a/cmd/agent_ci.go
+++ b/cmd/agent_ci.go
@@ -1,0 +1,238 @@
+package cmd
+
+// `ankra cluster agent ci get|set` (ankra-vn0bd, item 5 of the agent CI
+// settings contract): the CLI surface over GET/PUT
+// /api/v1/org/clusters/{cluster_id}/agent/ci-settings, which size the
+// cluster agent's own pipeline-step scheduler.
+//
+// Before these routes existed the agent's `ci_worker_count` chart value
+// could only be raised with a hand-run `helm upgrade --set`, and the next
+// platform-driven agent install or upgrade rendered the chart default (0)
+// back over it - so a cluster stopped running pipeline steps for no reason
+// anyone could see in Ankra. The setting now lives on the platform, every
+// generated Helm command carries it, and this pair of verbs is how it is
+// read and written.
+//
+// The cluster is resolved exactly like the sibling `cluster agent
+// status|upgrade` verbs, through the shared --cluster override.
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"ankra/internal/client"
+)
+
+// The sentences the platform's three apply states are reported with. They
+// are frozen by the agent CI settings contract and shared by both verbs, so
+// the state a `set` reports and the state a later `get` reports cannot drift
+// into two vocabularies for the same thing.
+const (
+	agentCIAppliedSentence = "The agent is re-rendering its release with %d pipeline-step workers; " +
+		"it advertises the capability on its next check-in."
+	agentCIPendingUpgradeSentence = "The agent on this cluster predates chart values; " +
+		"the setting is stored and takes effect with the next agent upgrade."
+	agentCIAgentOfflineSentence = "The agent on this cluster is offline; " +
+		"the setting is stored and applies when it reconnects and is upgraded."
+)
+
+// agentCIApplyStateSentence renders one apply state. An apply state this
+// build does not know is a newer platform's, not a broken response, so it is
+// reported as itself rather than swallowed.
+func agentCIApplyStateSentence(settings *client.AgentCISettings) string {
+	switch settings.ApplyState {
+	case client.AgentCIApplyStateApplied:
+		return fmt.Sprintf(agentCIAppliedSentence, settings.CIWorkerCount)
+	case client.AgentCIApplyStatePendingUpgrade:
+		return agentCIPendingUpgradeSentence
+	case client.AgentCIApplyStateAgentOffline:
+		return agentCIAgentOfflineSentence
+	case "":
+		return ""
+	default:
+		return fmt.Sprintf("The platform reports apply state %q, which this CLI version does not recognise; "+
+			"the setting is stored.", settings.ApplyState)
+	}
+}
+
+func newClusterAgentCICommand() *cobra.Command {
+	ciCommand := &cobra.Command{
+		Use:   "ci",
+		Short: "Read and set the cluster agent's pipeline-step CI settings",
+		Long: `The cluster agent runs Ankra Pipelines steps itself, and these settings
+size that: how many steps it runs at once, and the storage class its step
+workspaces are carved from.
+
+Both are stored on the platform, so every install or upgrade command Ankra
+generates for this cluster carries them - unlike a hand-run
+'helm upgrade --set ci_worker_count=...', which the next agent upgrade
+renders away again.`,
+	}
+	ciCommand.AddCommand(newClusterAgentCIGetCommand(), newClusterAgentCISetCommand())
+	return ciCommand
+}
+
+func newClusterAgentCIGetCommand() *cobra.Command {
+	getCommand := &cobra.Command{
+		Use:   "get",
+		Short: "Show the cluster agent's pipeline-step CI settings",
+		Long: `Show the stored worker count and storage class, the agent version that has
+to honour them, whether that agent currently advertises it can run pipeline
+steps, and how the last write was applied.
+
+An agent that has not yet re-rendered its release reports pipeline steps as
+not advertised even with a non-zero worker count stored: the capability is
+what the agent reported on its last check-in, not what the settings ask for.`,
+		Example: `  ankra cluster agent ci get
+  ankra cluster agent ci get --cluster edge-01 -o json`,
+		Args: cobra.NoArgs,
+		RunE: func(command *cobra.Command, arguments []string) error {
+			return runClusterAgentCIGet(command)
+		},
+	}
+	registerStructuredOutputFlags(getCommand)
+	return getCommand
+}
+
+func runClusterAgentCIGet(command *cobra.Command) error {
+	format, formatError := structuredFormatFromFlags(command)
+	if formatError != nil {
+		return formatError
+	}
+	cluster, resolveError := resolveActiveCluster(command)
+	if resolveError != nil {
+		return resolveError
+	}
+	settings, getError := apiClient.GetAgentCISettings(command.Context(), cluster.ID)
+	if getError != nil {
+		// Returned as it came: the platform owns this surface's refusals
+		// (an RBAC 403 naming agents.manage, a 404 for a cluster outside
+		// the organisation, a 422 naming the value it rejected) and
+		// rewording them here would only put a second, staler vocabulary
+		// in front of the user.
+		return getError
+	}
+	if settings == nil {
+		return fmt.Errorf("the platform returned no agent CI settings for cluster %q", cluster.Name)
+	}
+	if format != outputDefault {
+		return encodeStructured(command.OutOrStdout(), format, settings)
+	}
+	out := command.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "Agent CI settings for cluster '%s':\n\n", cluster.Name)
+	printAgentCISettings(out, settings)
+	return nil
+}
+
+func newClusterAgentCISetCommand() *cobra.Command {
+	setCommand := &cobra.Command{
+		Use:   "set",
+		Short: "Set the cluster agent's pipeline-step CI settings",
+		Long: `Store how many pipeline steps this cluster's agent runs at once, and
+optionally the storage class its step workspaces are carved from.
+
+--workers 0 disables the agent's pipeline-step scheduler; the cluster keeps
+its agent and everything else it does. --storage-class is only sent when you
+pass it, so setting the worker count alone keeps the storage class already
+stored; pass an empty value to fall back to the cluster's default class.
+
+The write always stores the values. Whether they reach the agent now depends
+on the agent: an online agent new enough to accept chart values re-renders
+its release immediately, an older one picks them up at its next upgrade, and
+an offline one when it reconnects. The command says which of the three
+happened.`,
+		Example: `  ankra cluster agent ci set --workers 2
+  ankra cluster agent ci set --workers 4 --storage-class proxmox-csi
+  ankra cluster agent ci set --workers 0 --cluster edge-01`,
+		Args: cobra.NoArgs,
+		RunE: func(command *cobra.Command, arguments []string) error {
+			return runClusterAgentCISet(command)
+		},
+	}
+	setCommand.Flags().Int("workers", 0, "Number of pipeline steps the agent runs at once (0 disables the scheduler)")
+	setCommand.Flags().String("storage-class", "",
+		"Storage class for pipeline step workspaces; pass empty to use the cluster default (omit the flag to keep the stored value)")
+	_ = setCommand.MarkFlagRequired("workers")
+	registerStructuredOutputFlags(setCommand)
+	return setCommand
+}
+
+func runClusterAgentCISet(command *cobra.Command) error {
+	format, formatError := structuredFormatFromFlags(command)
+	if formatError != nil {
+		return formatError
+	}
+	cluster, resolveError := resolveActiveCluster(command)
+	if resolveError != nil {
+		return resolveError
+	}
+
+	// --workers is required, so it is always sent; --storage-class is only
+	// sent when named, which is what keeps a worker-count change from
+	// resetting a storage class someone set earlier.
+	update := client.AgentCISettingsUpdate{
+		CIWorkerCount:  changedIntFlag(command, "workers"),
+		CIStorageClass: changedStringFlag(command, "storage-class"),
+	}
+
+	settings, updateError := apiClient.UpdateAgentCISettings(command.Context(), cluster.ID, update)
+	if updateError != nil {
+		return updateError
+	}
+	if settings == nil {
+		return fmt.Errorf("the platform returned no agent CI settings for cluster %q", cluster.Name)
+	}
+	if format != outputDefault {
+		return encodeStructured(command.OutOrStdout(), format, settings)
+	}
+	out := command.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "Agent CI settings updated for cluster '%s'.\n\n", cluster.Name)
+	printAgentCISettings(out, settings)
+	return nil
+}
+
+func printAgentCISettings(out io.Writer, settings *client.AgentCISettings) {
+	_, _ = fmt.Fprintf(out, "  Pipeline-step workers: %d\n", settings.CIWorkerCount)
+	_, _ = fmt.Fprintf(out, "  Storage class:         %s\n", agentCIStorageClassLabel(settings.CIStorageClass))
+	_, _ = fmt.Fprintf(out, "  Agent version:         %s\n", agentCIVersionLabel(settings.AgentVersion))
+	_, _ = fmt.Fprintf(out, "  Pipeline steps:        %s\n", agentCICapabilityLabel(settings.SupportsPipelineSteps))
+	if settings.UpdatedAt != nil && *settings.UpdatedAt != "" {
+		_, _ = fmt.Fprintf(out, "  Last changed:          %s\n", formatTimeAgo(*settings.UpdatedAt))
+	} else {
+		_, _ = fmt.Fprintln(out, "  Last changed:          never")
+	}
+	if sentence := agentCIApplyStateSentence(settings); sentence != "" {
+		_, _ = fmt.Fprintf(out, "\n%s\n", sentence)
+	}
+}
+
+// agentCIStorageClassLabel says which class step workspaces land on. An
+// empty stored value is the cluster's default class, not a missing setting.
+func agentCIStorageClassLabel(storageClass string) string {
+	if storageClass == "" {
+		return "cluster default"
+	}
+	return storageClass
+}
+
+func agentCIVersionLabel(agentVersion string) string {
+	if agentVersion == "" {
+		return "unknown (the agent has not checked in)"
+	}
+	return agentVersion
+}
+
+// agentCICapabilityLabel reports the capability the agent advertised, which
+// is a fact about the running agent rather than about the stored settings.
+func agentCICapabilityLabel(supportsPipelineSteps bool) string {
+	if supportsPipelineSteps {
+		return "advertised"
+	}
+	return "not advertised"
+}
+
+func init() {
+	clusterAgentCmd.AddCommand(newClusterAgentCICommand())
+}

--- a/cmd/agent_ci_test.go
+++ b/cmd/agent_ci_test.go
@@ -1,0 +1,318 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"ankra/internal/client"
+)
+
+type agentCIMock struct {
+	baseMock
+	settings    *client.AgentCISettings
+	getError    error
+	updateError error
+
+	getCalls      int
+	updateCalls   int
+	lastClusterID string
+	lastUpdate    client.AgentCISettingsUpdate
+}
+
+func (mock *agentCIMock) GetAgentCISettings(requestContext context.Context,
+	clusterID string) (*client.AgentCISettings, error) {
+	mock.getCalls++
+	mock.lastClusterID = clusterID
+	if mock.getError != nil {
+		return nil, mock.getError
+	}
+	return mock.settings, nil
+}
+
+func (mock *agentCIMock) UpdateAgentCISettings(requestContext context.Context, clusterID string,
+	update client.AgentCISettingsUpdate) (*client.AgentCISettings, error) {
+	mock.updateCalls++
+	mock.lastClusterID = clusterID
+	mock.lastUpdate = update
+	if mock.updateError != nil {
+		return nil, mock.updateError
+	}
+	return mock.settings, nil
+}
+
+// agentCICommands collects the `cluster agent ci` tree so a test can put its
+// flags back: the commands are built once in init and shared by the whole
+// package, so a --workers left set would leak into the next test.
+func agentCICommands(t *testing.T) []*cobra.Command {
+	t.Helper()
+	for _, candidate := range clusterAgentCmd.Commands() {
+		if candidate.Name() == "ci" {
+			return append([]*cobra.Command{candidate}, candidate.Commands()...)
+		}
+	}
+	t.Fatalf("the 'cluster agent ci' command is not registered")
+	return nil
+}
+
+func runAgentCICommand(t *testing.T, mock APIClient, arguments ...string) (string, error) {
+	t.Helper()
+	writeSelectedClusterJSON(t)
+	setMockClient(t, mock)
+	t.Cleanup(func() { resetTreeFlags(t, agentCICommands(t)...) })
+	return executeCommand(arguments...)
+}
+
+func newAgentCISettings() *client.AgentCISettings {
+	updatedAt := "2026-09-06T10:00:00Z"
+	return &client.AgentCISettings{
+		CIWorkerCount:         2,
+		CIStorageClass:        "proxmox-csi",
+		AgentVersion:          "2.1.1107",
+		SupportsPipelineSteps: true,
+		ApplyState:            client.AgentCIApplyStateApplied,
+		UpdatedAt:             &updatedAt,
+	}
+}
+
+func TestClusterAgentCIGetPrintsTheSettingsAndTheApplyState(t *testing.T) {
+	mock := &agentCIMock{settings: newAgentCISettings()}
+
+	output, runError := runAgentCICommand(t, mock, "cluster", "agent", "ci", "get")
+	if runError != nil {
+		t.Fatalf("expected success, got %v", runError)
+	}
+	if mock.getCalls != 1 || mock.lastClusterID != "test-cluster-id" {
+		t.Fatalf("expected one read of the selected cluster, got %d for %q", mock.getCalls, mock.lastClusterID)
+	}
+	for _, want := range []string{
+		"Agent CI settings for cluster 'test-cluster'",
+		"Pipeline-step workers: 2",
+		"Storage class:         proxmox-csi",
+		"Agent version:         2.1.1107",
+		"Pipeline steps:        advertised",
+		"The agent is re-rendering its release with 2 pipeline-step workers; " +
+			"it advertises the capability on its next check-in.",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+// The two "not set" states have to read as defaults rather than as failures:
+// an empty storage class is the cluster's own default class, and an agent
+// that has not re-rendered its release yet simply has not advertised the
+// capability.
+func TestClusterAgentCIGetNamesTheDefaultsAndTheMissingCapability(t *testing.T) {
+	mock := &agentCIMock{settings: &client.AgentCISettings{
+		CIWorkerCount: 0,
+		AgentVersion:  "2.1.900",
+		ApplyState:    client.AgentCIApplyStatePendingUpgrade,
+	}}
+
+	output, runError := runAgentCICommand(t, mock, "cluster", "agent", "ci", "get")
+	if runError != nil {
+		t.Fatalf("expected success, got %v", runError)
+	}
+	for _, want := range []string{
+		"Storage class:         cluster default",
+		"Pipeline steps:        not advertised",
+		"Last changed:          never",
+		"The agent on this cluster predates chart values; " +
+			"the setting is stored and takes effect with the next agent upgrade.",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestClusterAgentCIGetStructuredOutputStaysParseable(t *testing.T) {
+	mock := &agentCIMock{settings: newAgentCISettings()}
+
+	output, runError := runAgentCICommand(t, mock, "cluster", "agent", "ci", "get", "-o", "json")
+	if runError != nil {
+		t.Fatalf("expected success, got %v", runError)
+	}
+	var decoded client.AgentCISettings
+	if decodeError := json.Unmarshal([]byte(output), &decoded); decodeError != nil {
+		t.Fatalf("stdout is not parseable JSON (%v):\n%s", decodeError, output)
+	}
+	if decoded.CIWorkerCount != 2 || decoded.ApplyState != client.AgentCIApplyStateApplied {
+		t.Errorf("decoded = %+v", decoded)
+	}
+}
+
+func TestClusterAgentCISetSendsTheWorkerCountAndReportsTheApplyState(t *testing.T) {
+	cases := []struct {
+		name         string
+		applyState   string
+		workerCount  int
+		wantSentence string
+	}{
+		{
+			name:        "applied",
+			applyState:  client.AgentCIApplyStateApplied,
+			workerCount: 4,
+			wantSentence: "The agent is re-rendering its release with 4 pipeline-step workers; " +
+				"it advertises the capability on its next check-in.",
+		},
+		{
+			name:        "pending upgrade",
+			applyState:  client.AgentCIApplyStatePendingUpgrade,
+			workerCount: 4,
+			wantSentence: "The agent on this cluster predates chart values; " +
+				"the setting is stored and takes effect with the next agent upgrade.",
+		},
+		{
+			name:        "agent offline",
+			applyState:  client.AgentCIApplyStateAgentOffline,
+			workerCount: 4,
+			wantSentence: "The agent on this cluster is offline; " +
+				"the setting is stored and applies when it reconnects and is upgraded.",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			mock := &agentCIMock{settings: &client.AgentCISettings{
+				CIWorkerCount: testCase.workerCount,
+				AgentVersion:  "2.1.1107",
+				ApplyState:    testCase.applyState,
+			}}
+
+			output, runError := runAgentCICommand(t, mock, "cluster", "agent", "ci", "set", "--workers", "4")
+			if runError != nil {
+				t.Fatalf("expected success, got %v", runError)
+			}
+			if mock.updateCalls != 1 {
+				t.Fatalf("expected one update, got %d", mock.updateCalls)
+			}
+			if mock.lastUpdate.CIWorkerCount == nil || *mock.lastUpdate.CIWorkerCount != 4 {
+				t.Errorf("worker count sent = %v, want 4", mock.lastUpdate.CIWorkerCount)
+			}
+			if !strings.Contains(output, "Agent CI settings updated for cluster 'test-cluster'.") {
+				t.Errorf("output missing the confirmation:\n%s", output)
+			}
+			if !strings.Contains(output, testCase.wantSentence) {
+				t.Errorf("output missing %q:\n%s", testCase.wantSentence, output)
+			}
+		})
+	}
+}
+
+// A worker-count change must not carry a storage class the caller never
+// named: the platform would take it as a write and reset one someone set
+// earlier.
+func TestClusterAgentCISetOnlySendsTheStorageClassWhenNamed(t *testing.T) {
+	mock := &agentCIMock{settings: newAgentCISettings()}
+	if _, runError := runAgentCICommand(t, mock, "cluster", "agent", "ci", "set", "--workers", "2"); runError != nil {
+		t.Fatalf("expected success, got %v", runError)
+	}
+	if mock.lastUpdate.CIStorageClass != nil {
+		t.Errorf("storage class sent as %q when the flag was not passed", *mock.lastUpdate.CIStorageClass)
+	}
+
+	named := &agentCIMock{settings: newAgentCISettings()}
+	if _, runError := runAgentCICommand(t, named, "cluster", "agent", "ci", "set",
+		"--workers", "2", "--storage-class", "proxmox-csi"); runError != nil {
+		t.Fatalf("expected success, got %v", runError)
+	}
+	if named.lastUpdate.CIStorageClass == nil || *named.lastUpdate.CIStorageClass != "proxmox-csi" {
+		t.Errorf("storage class sent = %v, want proxmox-csi", named.lastUpdate.CIStorageClass)
+	}
+}
+
+// Zero workers is a real setting (it disables the agent's pipeline-step
+// scheduler), so it has to reach the platform rather than reading as
+// "nothing to send".
+func TestClusterAgentCISetSendsZeroWorkers(t *testing.T) {
+	mock := &agentCIMock{settings: &client.AgentCISettings{ApplyState: client.AgentCIApplyStateApplied}}
+
+	if _, runError := runAgentCICommand(t, mock, "cluster", "agent", "ci", "set", "--workers", "0"); runError != nil {
+		t.Fatalf("expected success, got %v", runError)
+	}
+	if mock.lastUpdate.CIWorkerCount == nil || *mock.lastUpdate.CIWorkerCount != 0 {
+		t.Errorf("worker count sent = %v, want an explicit 0", mock.lastUpdate.CIWorkerCount)
+	}
+}
+
+func TestClusterAgentCISetWithoutWorkersIsAUsageError(t *testing.T) {
+	mock := &agentCIMock{settings: newAgentCISettings()}
+
+	_, runError := runAgentCICommand(t, mock, "cluster", "agent", "ci", "set")
+	if runError == nil {
+		t.Fatal("expected --workers to be required")
+	}
+	if exitCode := exitCodeFor(runError); exitCode != exitUsage {
+		t.Errorf("exit code = %d, want %d (usage)", exitCode, exitUsage)
+	}
+	if !strings.Contains(runError.Error(), "workers") {
+		t.Errorf("error should name the missing flag, got %v", runError)
+	}
+	if mock.updateCalls != 0 {
+		t.Errorf("expected no update without --workers, got %d", mock.updateCalls)
+	}
+}
+
+func TestClusterAgentCIRefusalsReachTheUserUnchanged(t *testing.T) {
+	t.Run("403 keeps the permission and exits 7", func(t *testing.T) {
+		mock := &agentCIMock{updateError: &client.PermissionDeniedError{Permission: "agents.manage"}}
+
+		_, runError := runAgentCICommand(t, mock, "cluster", "agent", "ci", "set", "--workers", "2")
+		if runError == nil {
+			t.Fatal("expected the RBAC refusal to fail the command")
+		}
+		if exitCode := exitCodeFor(runError); exitCode != exitForbidden {
+			t.Errorf("exit code = %d, want %d (RBAC)", exitCode, exitForbidden)
+		}
+		if !strings.Contains(runError.Error(), `"agents.manage"`) {
+			t.Errorf("error should name the permission, got %v", runError)
+		}
+	})
+
+	t.Run("404 exits 3", func(t *testing.T) {
+		mock := &agentCIMock{getError: client.NewUnexpectedResponseError(404, "cluster not found in this organisation")}
+
+		_, runError := runAgentCICommand(t, mock, "cluster", "agent", "ci", "get")
+		if runError == nil {
+			t.Fatal("expected the not-found refusal to fail the command")
+		}
+		if exitCode := exitCodeFor(runError); exitCode != exitNotFound {
+			t.Errorf("exit code = %d, want %d (not found)", exitCode, exitNotFound)
+		}
+		if runError.Error() != "cluster not found in this organisation" {
+			t.Errorf("error = %q, want the server's wording unchanged", runError.Error())
+		}
+	})
+
+	t.Run("422 keeps the validation wording", func(t *testing.T) {
+		mock := &agentCIMock{updateError: errors.New("ci_worker_count must be between 0 and 32")}
+
+		_, runError := runAgentCICommand(t, mock, "cluster", "agent", "ci", "set", "--workers", "99")
+		if runError == nil {
+			t.Fatal("expected the validation refusal to fail the command")
+		}
+		if runError.Error() != "ci_worker_count must be between 0 and 32" {
+			t.Errorf("error = %q, want the server's wording unchanged", runError.Error())
+		}
+	})
+}
+
+// An apply state a newer platform introduces is reported as itself rather
+// than disappearing, so the operator can see that something was stored even
+// when this build has no sentence for it.
+func TestAgentCIApplyStateSentenceHandlesUnknownAndAbsentStates(t *testing.T) {
+	if sentence := agentCIApplyStateSentence(&client.AgentCISettings{ApplyState: ""}); sentence != "" {
+		t.Errorf("absent apply state should print nothing, got %q", sentence)
+	}
+	sentence := agentCIApplyStateSentence(&client.AgentCISettings{ApplyState: "queued_behind_upgrade"})
+	if !strings.Contains(sentence, "queued_behind_upgrade") {
+		t.Errorf("an unknown apply state should be reported as itself, got %q", sentence)
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1282,6 +1282,15 @@ func (m baseMock) UpgradeClusterAgent(ctx context.Context, clusterID string) (*c
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) GetAgentCISettings(ctx context.Context, clusterID string) (*client.AgentCISettings, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m baseMock) UpdateAgentCISettings(ctx context.Context, clusterID string,
+	update client.AgentCISettingsUpdate) (*client.AgentCISettings, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) CreateHetznerCluster(req client.CreateHetznerClusterRequest) (*client.CreateHetznerClusterResponse, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -385,6 +385,8 @@ type APIClient interface {
 	GetAgentToken(clusterID string) (*client.AgentToken, error)
 	GenerateAgentToken(ctx context.Context, clusterID string) (*client.AgentToken, error)
 	UpgradeClusterAgent(ctx context.Context, clusterID string) (*client.UpgradeAgentResult, error)
+	GetAgentCISettings(ctx context.Context, clusterID string) (*client.AgentCISettings, error)
+	UpdateAgentCISettings(ctx context.Context, clusterID string, update client.AgentCISettingsUpdate) (*client.AgentCISettings, error)
 
 	CreateHetznerCluster(req client.CreateHetznerClusterRequest) (*client.CreateHetznerClusterResponse, error)
 	DeprovisionHetznerCluster(clusterID string, force bool) (*client.DeprovisionHetznerClusterResponse, error)

--- a/internal/client/agent_ci_settings.go
+++ b/internal/client/agent_ci_settings.go
@@ -1,0 +1,109 @@
+package client
+
+// The per-cluster agent CI settings surface (ankra-vn0bd, item 5 of the
+// agent CI settings contract): GET/PUT
+// /api/v1/org/clusters/{cluster_id}/agent/ci-settings, the bearer twin of
+// the routes the cluster-api mounts alongside the agent upgrade route.
+//
+// The settings size the agent's own pipeline-step scheduler - how many
+// pipeline steps it runs at once (chart value `ci_worker_count`, env
+// AGENT_CI_WORKER_COUNT) and the storage class its step workspaces are
+// carved from (`ci_storage_class`). Before these routes existed the only way
+// to set either was a hand-run `helm upgrade --set`, which the next
+// platform-driven agent upgrade rendered away again.
+//
+// A PUT stores the values and then tries to apply them, and ApplyState says
+// which of the three outcomes happened: the agent is re-rendering its
+// release now (applied), it is too old to accept chart values and the next
+// upgrade will carry them (pending_upgrade), or it is not connected
+// (agent_offline). The stored values are kept in all three cases, so a
+// refusal to apply is never a refusal to store.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// The apply states the platform reports for a stored CI setting. A newer
+// platform may add one, so callers render an unrecognised state rather than
+// treating the set as closed.
+const (
+	// AgentCIApplyStateApplied means the agent was online and new enough:
+	// the platform published an upgrade at the agent's current version so
+	// it re-renders its own release with the stored values.
+	AgentCIApplyStateApplied = "applied"
+	// AgentCIApplyStatePendingUpgrade means the agent predates chart
+	// values; the stored values ride the next agent upgrade instead.
+	AgentCIApplyStatePendingUpgrade = "pending_upgrade"
+	// AgentCIApplyStateAgentOffline means the agent is not connected; the
+	// stored values apply once it reconnects and is upgraded.
+	AgentCIApplyStateAgentOffline = "agent_offline"
+)
+
+// AgentCISettings is the wire shape both the GET and the PUT answer with:
+// the stored settings plus what the platform currently knows about the
+// agent that has to honour them.
+//
+// SupportsPipelineSteps is what the agent advertised on its last check-in,
+// not what the settings ask for: an agent that has not yet re-rendered its
+// release still reports false with a non-zero CIWorkerCount stored.
+// AgentVersion is empty for a cluster whose agent has never checked in, and
+// UpdatedAt is nil until the settings are written for the first time.
+type AgentCISettings struct {
+	CIWorkerCount         int     `json:"ci_worker_count" yaml:"ci_worker_count"`
+	CIStorageClass        string  `json:"ci_storage_class" yaml:"ci_storage_class"`
+	AgentVersion          string  `json:"agent_version" yaml:"agent_version"`
+	SupportsPipelineSteps bool    `json:"supports_pipeline_steps" yaml:"supports_pipeline_steps"`
+	ApplyState            string  `json:"apply_state" yaml:"apply_state"`
+	UpdatedAt             *string `json:"updated_at" yaml:"updated_at"`
+}
+
+// AgentCISettingsUpdate is a partial write: a nil member is left out of the
+// body entirely and the platform keeps the value it has, so setting the
+// worker count never silently resets the storage class.
+//
+// Both members are pointers rather than plain values precisely because zero
+// is meaningful on this surface - 0 workers disables the pipeline-step
+// scheduler and an empty storage class means "the cluster default" - and
+// `omitempty` on a pointer only drops a nil one, so a pointer to 0 or to ""
+// is still sent.
+type AgentCISettingsUpdate struct {
+	CIWorkerCount  *int    `json:"ci_worker_count,omitempty"`
+	CIStorageClass *string `json:"ci_storage_class,omitempty"`
+}
+
+// agentCISettingsURL builds the settings URL for one cluster. The id is
+// escaped because it reaches the client straight from --cluster resolution.
+func agentCISettingsURL(baseURL string, clusterID string) string {
+	return fmt.Sprintf("%s/api/v1/org/clusters/%s/agent/ci-settings", baseURL, url.PathEscape(clusterID))
+}
+
+// GetAgentCISettings reads one cluster's stored agent CI settings.
+func (c *Client) GetAgentCISettings(ctx context.Context, clusterID string) (*AgentCISettings, error) {
+	var settings AgentCISettings
+	if getError := c.sendJSONContext(ctx, http.MethodGet,
+		agentCISettingsURL(c.BaseURL, clusterID), nil, &settings); getError != nil {
+		return nil, getError
+	}
+	return &settings, nil
+}
+
+// UpdateAgentCISettings stores a partial change to one cluster's agent CI
+// settings and returns the resulting state, including how the platform
+// applied it.
+//
+// The platform owns the vocabulary this write is validated against - the
+// worker range and the storage class's DNS-1123 shape - so a rejected value
+// comes back as the server's own 422 detail rather than a message this
+// client invents and then has to keep in step.
+func (c *Client) UpdateAgentCISettings(ctx context.Context, clusterID string,
+	update AgentCISettingsUpdate) (*AgentCISettings, error) {
+	var settings AgentCISettings
+	if putError := c.sendJSONContext(ctx, http.MethodPut,
+		agentCISettingsURL(c.BaseURL, clusterID), update, &settings); putError != nil {
+		return nil, putError
+	}
+	return &settings, nil
+}

--- a/internal/client/agent_ci_settings_test.go
+++ b/internal/client/agent_ci_settings_test.go
@@ -1,0 +1,220 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+)
+
+// The agent CI settings lane parity table. A path or method typo here fails
+// as a 404 against a real platform and passes every command-wiring test that
+// only checks the flag plumbing, so both routes are pinned on the request
+// itself the way the bearer-lane application operations are.
+func TestAgentCISettingsLaneParity(t *testing.T) {
+	workerCount := 2
+	storageClass := "proxmox-csi"
+
+	lanes := []struct {
+		name       string
+		wantMethod string
+		wantBody   map[string]any
+		call       func(testClient *Client) error
+	}{
+		{
+			name:       "get reads the cluster's settings",
+			wantMethod: http.MethodGet,
+			call: func(testClient *Client) error {
+				_, getError := testClient.GetAgentCISettings(context.Background(), "cluster-1")
+				return getError
+			},
+		},
+		{
+			name:       "set sends both members when both are named",
+			wantMethod: http.MethodPut,
+			wantBody:   map[string]any{"ci_worker_count": float64(2), "ci_storage_class": "proxmox-csi"},
+			call: func(testClient *Client) error {
+				_, updateError := testClient.UpdateAgentCISettings(context.Background(), "cluster-1",
+					AgentCISettingsUpdate{CIWorkerCount: &workerCount, CIStorageClass: &storageClass})
+				return updateError
+			},
+		},
+		{
+			// The whole point of the tri-state: a worker-count change must
+			// not carry a storage class the caller never named, or it
+			// resets one someone set earlier.
+			name:       "set omits the storage class the caller did not name",
+			wantMethod: http.MethodPut,
+			wantBody:   map[string]any{"ci_worker_count": float64(2)},
+			call: func(testClient *Client) error {
+				_, updateError := testClient.UpdateAgentCISettings(context.Background(), "cluster-1",
+					AgentCISettingsUpdate{CIWorkerCount: &workerCount})
+				return updateError
+			},
+		},
+	}
+
+	for _, lane := range lanes {
+		t.Run(lane.name, func(t *testing.T) {
+			var seenMethod, seenPath string
+			var seenBody map[string]any
+			testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
+				seenMethod, seenPath = request.Method, request.URL.Path
+				if request.Method != http.MethodGet {
+					if decodeError := json.NewDecoder(request.Body).Decode(&seenBody); decodeError != nil {
+						t.Fatalf("decode request body: %v", decodeError)
+					}
+				}
+				jsonResponse(t, writer, http.StatusOK, AgentCISettings{ApplyState: AgentCIApplyStateApplied})
+			})
+
+			if callError := lane.call(testClient); callError != nil {
+				t.Fatalf("call error = %v", callError)
+			}
+			if seenMethod != lane.wantMethod {
+				t.Errorf("method = %s, want %s", seenMethod, lane.wantMethod)
+			}
+			if seenPath != "/api/v1/org/clusters/cluster-1/agent/ci-settings" {
+				t.Errorf("path = %s", seenPath)
+			}
+			if lane.wantBody == nil {
+				return
+			}
+			if len(seenBody) != len(lane.wantBody) {
+				t.Fatalf("body = %v, want exactly %v", seenBody, lane.wantBody)
+			}
+			for key, want := range lane.wantBody {
+				if seenBody[key] != want {
+					t.Errorf("body[%q] = %v, want %v", key, seenBody[key], want)
+				}
+			}
+		})
+	}
+}
+
+// Zero is a real value on both members - 0 workers disables the scheduler
+// and an empty storage class means the cluster default - so a pointer to a
+// zero value has to survive marshalling rather than being dropped as empty.
+func TestUpdateAgentCISettingsSendsExplicitZeroValues(t *testing.T) {
+	workerCount := 0
+	storageClass := ""
+	var seenBody map[string]any
+	testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		if decodeError := json.NewDecoder(request.Body).Decode(&seenBody); decodeError != nil {
+			t.Fatalf("decode request body: %v", decodeError)
+		}
+		jsonResponse(t, writer, http.StatusOK, AgentCISettings{})
+	})
+
+	if _, updateError := testClient.UpdateAgentCISettings(context.Background(), "cluster-1",
+		AgentCISettingsUpdate{CIWorkerCount: &workerCount, CIStorageClass: &storageClass}); updateError != nil {
+		t.Fatalf("UpdateAgentCISettings error = %v", updateError)
+	}
+	if _, present := seenBody["ci_worker_count"]; !present {
+		t.Errorf("ci_worker_count 0 was dropped from the body: %v", seenBody)
+	}
+	if _, present := seenBody["ci_storage_class"]; !present {
+		t.Errorf("ci_storage_class \"\" was dropped from the body: %v", seenBody)
+	}
+}
+
+func TestGetAgentCISettingsDecodesTheResponse(t *testing.T) {
+	updatedAt := "2026-09-06T10:00:00Z"
+	testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		jsonResponse(t, writer, http.StatusOK, AgentCISettings{
+			CIWorkerCount:         4,
+			CIStorageClass:        "proxmox-csi",
+			AgentVersion:          "2.1.1107",
+			SupportsPipelineSteps: true,
+			ApplyState:            AgentCIApplyStateApplied,
+			UpdatedAt:             &updatedAt,
+		})
+	})
+
+	settings, getError := testClient.GetAgentCISettings(context.Background(), "cluster-1")
+	if getError != nil {
+		t.Fatalf("GetAgentCISettings error = %v", getError)
+	}
+	if settings.CIWorkerCount != 4 || settings.CIStorageClass != "proxmox-csi" {
+		t.Errorf("settings = %+v", settings)
+	}
+	if !settings.SupportsPipelineSteps || settings.ApplyState != AgentCIApplyStateApplied {
+		t.Errorf("capability/apply state = %+v", settings)
+	}
+	if settings.UpdatedAt == nil || *settings.UpdatedAt != updatedAt {
+		t.Errorf("updated_at = %v", settings.UpdatedAt)
+	}
+}
+
+// The three refusals the routes can answer with reach the caller as
+// themselves: the RBAC 403 as a typed permission denial naming
+// agents.manage, and the 404 and 422 carrying the server's own wording so
+// the CLI never has to guess at a rule the platform owns.
+func TestAgentCISettingsRefusalsSurfaceVerbatim(t *testing.T) {
+	t.Run("403 names the permission", func(t *testing.T) {
+		testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
+			jsonResponse(t, writer, http.StatusForbidden,
+				map[string]any{"detail": "permission_denied", "permission": "agents.manage"})
+		})
+
+		_, updateError := testClient.UpdateAgentCISettings(context.Background(), "cluster-1",
+			AgentCISettingsUpdate{})
+		var denied *PermissionDeniedError
+		if !errors.As(updateError, &denied) {
+			t.Fatalf("error = %v, want *PermissionDeniedError", updateError)
+		}
+		if denied.Permission != "agents.manage" {
+			t.Errorf("permission = %q, want agents.manage", denied.Permission)
+		}
+	})
+
+	t.Run("404 keeps the server's wording and status", func(t *testing.T) {
+		testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
+			jsonResponse(t, writer, http.StatusNotFound,
+				map[string]any{"detail": "cluster not found in this organisation"})
+		})
+
+		_, getError := testClient.GetAgentCISettings(context.Background(), "cluster-1")
+		var unexpected *UnexpectedResponseError
+		if !errors.As(getError, &unexpected) {
+			t.Fatalf("error = %v, want *UnexpectedResponseError", getError)
+		}
+		if unexpected.StatusCode != http.StatusNotFound {
+			t.Errorf("status = %d, want 404", unexpected.StatusCode)
+		}
+		if unexpected.Error() != "cluster not found in this organisation" {
+			t.Errorf("message = %q, want the server's detail verbatim", unexpected.Error())
+		}
+	})
+
+	t.Run("422 keeps the server's validation wording", func(t *testing.T) {
+		testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
+			jsonResponse(t, writer, http.StatusUnprocessableEntity,
+				map[string]any{"detail": "ci_worker_count must be between 0 and 32"})
+		})
+
+		_, updateError := testClient.UpdateAgentCISettings(context.Background(), "cluster-1",
+			AgentCISettingsUpdate{})
+		if updateError == nil || updateError.Error() != "ci_worker_count must be between 0 and 32" {
+			t.Fatalf("error = %v, want the server's detail verbatim", updateError)
+		}
+	})
+}
+
+// A cluster id reaches the client straight from --cluster resolution, so it
+// is escaped rather than concatenated into the path.
+func TestAgentCISettingsEscapesTheClusterID(t *testing.T) {
+	var seenPath string
+	testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		seenPath = request.URL.EscapedPath()
+		jsonResponse(t, writer, http.StatusOK, AgentCISettings{})
+	})
+
+	if _, getError := testClient.GetAgentCISettings(context.Background(), "a/../b"); getError != nil {
+		t.Fatalf("GetAgentCISettings error = %v", getError)
+	}
+	if seenPath != "/api/v1/org/clusters/a%2F..%2Fb/agent/ci-settings" {
+		t.Errorf("path = %s, want the id escaped into one segment", seenPath)
+	}
+}

--- a/internal/client/helpers.go
+++ b/internal/client/helpers.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -82,6 +83,13 @@ func parseJSON(data []byte, target interface{}) error {
 // into target (nil target discards the body). Non-2xx responses surface the
 // backend's detail string, and RBAC 403s map to PermissionDeniedError.
 func (c *Client) sendJSON(method string, url string, payload any, target any) error {
+	return c.sendJSONContext(context.Background(), method, url, payload, target)
+}
+
+// sendJSONContext is sendJSON bound to a caller's context, so a command that
+// owns a deadline or a cancellable context can stop the request instead of
+// waiting out the shared client's timeout.
+func (c *Client) sendJSONContext(ctx context.Context, method string, url string, payload any, target any) error {
 	var bodyReader *bytes.Reader
 	if payload != nil {
 		encoded, marshalError := json.Marshal(payload)
@@ -93,7 +101,7 @@ func (c *Client) sendJSON(method string, url string, payload any, target any) er
 		bodyReader = bytes.NewReader(nil)
 	}
 
-	request, requestError := http.NewRequest(method, url, bodyReader)
+	request, requestError := http.NewRequestWithContext(ctx, method, url, bodyReader)
 	if requestError != nil {
 		return fmt.Errorf("create request: %w", requestError)
 	}


### PR DESCRIPTION
## What & why

The cluster agent runs Ankra Pipelines steps itself, and how many it runs at once is the
chart value `ci_worker_count` (env `AGENT_CI_WORKER_COUNT`, default 0), with
`ci_storage_class` deciding where step workspaces land. Neither had a platform surface, so
the only way to enable CI workers was a hand-run `helm upgrade --set` — and every
platform-driven agent install or upgrade renders chart defaults, so the next upgrade
silently reset it. Agent configuration goes through Ankra.

This adds the CLI half:

- `ankra cluster agent ci get [--cluster C]` — the stored worker count and storage class,
  the agent version that has to honour them, whether that agent currently advertises it can
  run pipeline steps, and the apply state.
- `ankra cluster agent ci set --workers N [--storage-class NAME] [--cluster C]` — stores the
  values and says which of the three apply outcomes the platform reached.

Both speak the bearer twin of `GET`/`PUT /api/v1/org/clusters/{cluster_id}/agent/ci-settings`
and resolve the cluster through the shared `--cluster` override, exactly like the sibling
`cluster agent status|upgrade` verbs. `-o json|yaml` on both.

Design notes:

- The three apply-state sentences are the ones the shared contract freezes, rendered from a
  single helper so `set` and a later `get` cannot drift into two vocabularies. An apply state
  a newer platform introduces is reported as itself rather than disappearing.
- `--storage-class` is only sent when it is passed, so changing the worker count never resets
  a storage class someone set earlier. The update members are pointers because zero is
  meaningful on both — `--workers 0` disables the scheduler and an empty storage class means
  the cluster default — and `omitempty` on a pointer only drops a nil one.
- Refusals reach the user unchanged rather than being reworded: an RBAC 403 naming
  `agents.manage` exits 7, a 404 for a cluster outside the organisation exits 3, and a 422
  prints the platform's own validation wording. The worker range and the DNS-1123 storage
  class shape are the platform's vocabulary; duplicating them client-side would only add a
  second copy to keep in step.
- `SupportsPipelineSteps` is rendered as what the agent advertised on its last check-in, not
  as what the settings ask for, so a stored worker count is never mistaken for a working one.

Plan: item 5 of the agent CI settings contract, epic `ankra-vn0bd`. The cluster-side routes
and the agent-side `chart_values` handling land in sibling PRs; this was built against the
contract with fakes in tests.

Shared file touched (called out per the program's concurrency rule): `internal/client/helpers.go`
gains `sendJSONContext`, which is `sendJSON` bound to a caller's context. `sendJSON` now
delegates to it with `context.Background()`, so no existing call site changes behaviour.

## Test plan

New tests, all with the repo's existing fake-client patterns:

- `internal/client/agent_ci_settings_test.go` — a lane parity table pinning method, path and
  exact request body for both routes (`GET` and `PUT`, including the tri-state case where the
  storage class the caller did not name is absent from the body); explicit-zero marshalling;
  response decoding; the 403/404/422 refusals surfacing verbatim with their status codes; and
  cluster-id escaping.
- `cmd/agent_ci_test.go` — `get` default rendering and the "cluster default"/"not advertised"/
  "never" fallbacks; `-o json` staying parseable; `set` over all three apply states and their
  frozen sentences; `--storage-class` only sent when named; an explicit `--workers 0` reaching
  the client; missing `--workers` as exit 2 with no call made; 403 → exit 7 naming
  `agents.manage`, 404 → exit 3, 422 → the server's wording unchanged; and the unknown/absent
  apply-state rendering.

Gates run locally from the branch worktree:

```
golangci-lint run                      # 0 issues (v2.13.2)
go vet ./...                           # clean
go build -buildvcs=false ./...         # clean
go test -race -count=1 ./...           # all packages ok
make verify-skills                     # skipped (ankra-skills sibling absent; embedded copy canonical)
gofmt (go1.26.6, the go.mod toolchain) # clean on every file this PR touches
```

Example output:

```
$ ankra cluster agent ci get
Agent CI settings for cluster 'prod-hel1':

  Pipeline-step workers: 2
  Storage class:         proxmox-csi
  Agent version:         2.1.1107
  Pipeline steps:        advertised
  Last changed:          10 hours ago

The agent is re-rendering its release with 2 pipeline-step workers; it advertises the capability on its next check-in.

$ ankra cluster agent ci set --workers 4
Agent CI settings updated for cluster 'prod-hel1'.

  Pipeline-step workers: 4
  Storage class:         cluster default
  Agent version:         2.1.900
  Pipeline steps:        not advertised
  Last changed:          never

The agent on this cluster predates chart values; the setting is stored and takes effect with the next agent upgrade.
```

Heads-up, unrelated to this PR: `TestAlertsIngestCredentialsRebindUnpinsAndRefusesConflictingFlags`
is flaky on `master` at roughly 10% (31 failures in 300 isolated runs on an unmodified checkout
of that test). It iterates a Go map of sub-cases while sharing one `rootCmd` flag tree, so a
`--unpin`/`--scope` left set from the first invocation makes the "nothing to change" case
succeed instead of erroring. If a CI run here goes red on that test alone, it is that flake,
not this change.

## Docs checklist

- [ ] No user-facing command/flag changes — no docs needed
- [x] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); `Short`/`Long`/`Example` are written for docs readers on both new commands
- [ ] Broader behaviour changes — docs updated in [ankra-docs](https://github.com/ankraio/ankra-docs) (link the PR): the guides page is item 6 of the contract and ships with the cluster-side PR

Bead: ankra-vn0bd
