### PR TITLE
feat(security): licence risk tiers and --license-risk on the SBOM commands (ankra-7olqe)

### DIFF
--- a/cmd/security_sbom.go
+++ b/cmd/security_sbom.go
@@ -552,9 +552,13 @@ func componentFindingsCell(component client.SecuritySBOMComponent) string {
 }
 
 // licenseRiskCell names the tier, red for the two that reach the code
-// hosting the package and yellow for plain copyleft.
+// hosting the package and yellow for plain copyleft. A server that sent
+// no tier at all renders a dash: only the literal unknown tier says the
+// classifier looked and could not read the licence.
 func licenseRiskCell(licenseRisk string) string {
 	switch licenseRisk {
+	case "":
+		return "-"
 	case "network_copyleft":
 		return text.FgRed.Sprint("network copyleft")
 	case "source_available":
@@ -565,14 +569,20 @@ func licenseRiskCell(licenseRisk string) string {
 		return "weak copyleft"
 	case "permissive":
 		return "permissive"
-	default:
+	case "unknown":
 		return "unknown"
+	default:
+		return licenseRisk
 	}
 }
 
 // licenseExposureCell summarises an image's licence tiers, naming only the
-// ones that oblige anything so a clean image reads as a dash.
-func licenseExposureCell(exposure client.SecurityLicenseExposure) string {
+// ones that oblige anything so a clean image reads as a dash; a server
+// that reported no exposure at all reads as not reported, never as clean.
+func licenseExposureCell(exposure *client.SecurityLicenseExposure) string {
+	if exposure == nil {
+		return "not reported"
+	}
 	parts := []string{}
 	if exposure.NetworkCopyleft > 0 {
 		parts = append(parts, text.FgRed.Sprintf("%d network copyleft", exposure.NetworkCopyleft))
@@ -712,8 +722,12 @@ func renderSecuritySbomImageDetail(cmd *cobra.Command, detail *client.SecuritySB
 		_, _ = fmt.Fprintf(out, "Format:      %s %s\n", *image.BomFormat, stringOrEmpty(image.SpecVersion))
 	}
 	_, _ = fmt.Fprintf(out, "Components:  %d (%d dependencies)\n", image.ComponentCount, image.DependencyCount)
-	_, _ = fmt.Fprintf(out, "Licences:    %s (%d permissive, %d unknown)\n",
-		licenseExposureCell(image.LicenseExposure), image.LicenseExposure.Permissive, image.LicenseExposure.Unknown)
+	if image.LicenseExposure == nil {
+		_, _ = fmt.Fprintln(out, "Licences:    not reported")
+	} else {
+		_, _ = fmt.Fprintf(out, "Licences:    %s (%d permissive, %d unknown)\n",
+			licenseExposureCell(image.LicenseExposure), image.LicenseExposure.Permissive, image.LicenseExposure.Unknown)
+	}
 	_, _ = fmt.Fprintf(out, "Findings:    %d observed, %d critical, %d high actionable, %s known exploited\n",
 		image.Observed, image.Actionable.Critical, image.Actionable.High, redIfPositive(image.KnownExploited))
 	_, _ = fmt.Fprintf(out, "Generated:   %s\n", optionalTimeAgo(image.GeneratedAt))

--- a/cmd/security_sbom.go
+++ b/cmd/security_sbom.go
@@ -176,6 +176,7 @@ var securitySbomImageCmd = &cobra.Command{
 		pageSize, _ := cmd.Flags().GetInt("page-size")
 		search, _ := cmd.Flags().GetString("search")
 		packageTypes, _ := cmd.Flags().GetStringSlice("type")
+		licenseRisks, _ := cmd.Flags().GetStringSlice("license-risk")
 		sort, _ := cmd.Flags().GetString("sort")
 		order, _ := cmd.Flags().GetString("order")
 		detail, err := apiClient.GetSecuritySBOMImage(client.SecuritySBOMImageOptions{
@@ -184,6 +185,7 @@ var securitySbomImageCmd = &cobra.Command{
 			PageSize:      pageSize,
 			Search:        search,
 			PackageTypes:  packageTypes,
+			LicenseRisks:  licenseRisks,
 			Sort:          sort,
 			Order:         order,
 		})
@@ -385,6 +387,7 @@ func securitySbomComponentsOptionsFromFlags(cmd *cobra.Command) (client.Security
 	pageSize, _ := cmd.Flags().GetInt("page-size")
 	search, _ := cmd.Flags().GetString("search")
 	packageTypes, _ := cmd.Flags().GetStringSlice("type")
+	licenseRisks, _ := cmd.Flags().GetStringSlice("license-risk")
 	clusterFlag, _ := cmd.Flags().GetString("cluster")
 	namespace, _ := cmd.Flags().GetString("namespace")
 	workloadKind, _ := cmd.Flags().GetString("workload-kind")
@@ -398,6 +401,7 @@ func securitySbomComponentsOptionsFromFlags(cmd *cobra.Command) (client.Security
 		PageSize:      pageSize,
 		Search:        search,
 		PackageTypes:  packageTypes,
+		LicenseRisks:  licenseRisks,
 		Namespace:     namespace,
 		WorkloadKind:  workloadKind,
 		WorkloadName:  workloadName,
@@ -547,6 +551,47 @@ func componentFindingsCell(component client.SecuritySBOMComponent) string {
 	return rendered
 }
 
+// licenseRiskCell names the tier, red for the two that reach the code
+// hosting the package and yellow for plain copyleft.
+func licenseRiskCell(licenseRisk string) string {
+	switch licenseRisk {
+	case "network_copyleft":
+		return text.FgRed.Sprint("network copyleft")
+	case "source_available":
+		return text.FgRed.Sprint("source-available")
+	case "copyleft":
+		return text.FgYellow.Sprint("copyleft")
+	case "weak_copyleft":
+		return "weak copyleft"
+	case "permissive":
+		return "permissive"
+	default:
+		return "unknown"
+	}
+}
+
+// licenseExposureCell summarises an image's licence tiers, naming only the
+// ones that oblige anything so a clean image reads as a dash.
+func licenseExposureCell(exposure client.SecurityLicenseExposure) string {
+	parts := []string{}
+	if exposure.NetworkCopyleft > 0 {
+		parts = append(parts, text.FgRed.Sprintf("%d network copyleft", exposure.NetworkCopyleft))
+	}
+	if exposure.SourceAvailable > 0 {
+		parts = append(parts, text.FgRed.Sprintf("%d source-available", exposure.SourceAvailable))
+	}
+	if exposure.Copyleft > 0 {
+		parts = append(parts, text.FgYellow.Sprintf("%d copyleft", exposure.Copyleft))
+	}
+	if exposure.WeakCopyleft > 0 {
+		parts = append(parts, fmt.Sprintf("%d weak copyleft", exposure.WeakCopyleft))
+	}
+	if len(parts) == 0 {
+		return "-"
+	}
+	return strings.Join(parts, ", ")
+}
+
 func renderSecuritySbomComponents(cmd *cobra.Command, list *client.SecuritySBOMComponentList) {
 	out := cmd.OutOrStdout()
 	renderSbomCoverage(cmd, list.Coverage)
@@ -555,13 +600,14 @@ func renderSecuritySbomComponents(cmd *cobra.Command, list *client.SecuritySBOMC
 		return
 	}
 	writer := newSecurityTable(out)
-	writer.AppendHeader(table.Row{"Package", "Version", "Type", "Licence", "Images", "Workloads", "Clusters", "Findings"})
+	writer.AppendHeader(table.Row{"Package", "Version", "Type", "Licence", "Licence risk", "Images", "Workloads", "Clusters", "Findings"})
 	for _, component := range list.Result {
 		writer.AppendRow(table.Row{
 			component.Name,
 			component.Version,
 			component.PackageType,
 			strings.Join(component.Licenses, ", "),
+			licenseRiskCell(component.LicenseRisk),
 			component.Images,
 			component.Workloads,
 			component.Clusters,
@@ -580,12 +626,13 @@ func renderSecuritySbomImages(cmd *cobra.Command, list *client.SecuritySBOMImage
 		return
 	}
 	writer := newSecurityTable(out)
-	writer.AppendHeader(table.Row{"Image", "OS", "Components", "Workloads", "Clusters", "Namespaces", "Critical", "High", "Known exploited", "Generated"})
+	writer.AppendHeader(table.Row{"Image", "OS", "Components", "Licence risk", "Workloads", "Clusters", "Namespaces", "Critical", "High", "Known exploited", "Generated"})
 	for _, image := range list.Result {
 		writer.AppendRow(table.Row{
 			image.ImageRef,
 			stringOrEmpty(image.OSName),
 			image.ComponentCount,
+			licenseExposureCell(image.LicenseExposure),
 			image.Workloads,
 			image.Clusters,
 			strings.Join(image.Namespaces, ", "),
@@ -665,6 +712,8 @@ func renderSecuritySbomImageDetail(cmd *cobra.Command, detail *client.SecuritySB
 		_, _ = fmt.Fprintf(out, "Format:      %s %s\n", *image.BomFormat, stringOrEmpty(image.SpecVersion))
 	}
 	_, _ = fmt.Fprintf(out, "Components:  %d (%d dependencies)\n", image.ComponentCount, image.DependencyCount)
+	_, _ = fmt.Fprintf(out, "Licences:    %s (%d permissive, %d unknown)\n",
+		licenseExposureCell(image.LicenseExposure), image.LicenseExposure.Permissive, image.LicenseExposure.Unknown)
 	_, _ = fmt.Fprintf(out, "Findings:    %d observed, %d critical, %d high actionable, %s known exploited\n",
 		image.Observed, image.Actionable.Critical, image.Actionable.High, redIfPositive(image.KnownExploited))
 	_, _ = fmt.Fprintf(out, "Generated:   %s\n", optionalTimeAgo(image.GeneratedAt))
@@ -695,13 +744,14 @@ func renderSecuritySbomImageDetail(cmd *cobra.Command, detail *client.SecuritySB
 		return
 	}
 	writer := newSecurityTable(out)
-	writer.AppendHeader(table.Row{"Package", "Version", "Type", "Licence", "Findings"})
+	writer.AppendHeader(table.Row{"Package", "Version", "Type", "Licence", "Licence risk", "Findings"})
 	for _, component := range detail.Components {
 		writer.AppendRow(table.Row{
 			component.Name,
 			component.Version,
 			component.PackageType,
 			strings.Join(component.Licenses, ", "),
+			licenseRiskCell(component.LicenseRisk),
 			componentFindingsCell(component),
 		})
 	}
@@ -821,13 +871,14 @@ func init() {
 
 	securitySbomCmd.Flags().String("search", "", "Match package name or package URL")
 	securitySbomCmd.Flags().StringSlice("type", nil, "Ecosystem filter, repeatable: deb, apk, rpm, npm, pypi, golang, maven, ...")
+	securitySbomCmd.Flags().StringSlice("license-risk", nil, "Licence tier filter, repeatable: network_copyleft (AGPL, SSPL, EUPL, OSL), source_available (BUSL, Elastic, Commons Clause), copyleft (GPL), weak_copyleft (LGPL, MPL, EPL), permissive, unknown")
 	securitySbomCmd.Flags().String("cluster", "", "Only packages in images running on one cluster (name or id)")
 	securitySbomCmd.Flags().String("namespace", "", "Only packages in images running in one namespace")
 	securitySbomCmd.Flags().String("workload-kind", "", "Only packages in images run by workloads of this kind (Deployment, StatefulSet, DaemonSet, CronJob, ...)")
 	securitySbomCmd.Flags().String("workload-name", "", "Only packages in images run by the workload with this name; combine with --workload-kind to pin one workload")
 	securitySbomCmd.Flags().String("image", "", "Only packages in one image (digest or reference)")
 	securitySbomCmd.Flags().String("vulnerable", "any", "Findings filter: true (a finding names the package), false or any")
-	securitySbomCmd.Flags().String("sort", "images", "Sort key: images, workloads, clusters, vulnerable, actionable, name, version, package_type")
+	securitySbomCmd.Flags().String("sort", "images", "Sort key: images, workloads, clusters, vulnerable, actionable, license_risk, name, version, package_type")
 	securitySbomCmd.Flags().String("order", "desc", "Sort order: asc or desc")
 	securitySbomCmd.Flags().Int("page", 1, "Page number")
 	securitySbomCmd.Flags().Int("page-size", 50, "Components per page (max 100)")
@@ -844,7 +895,8 @@ func init() {
 
 	securitySbomImageCmd.Flags().String("search", "", "Match package name or package URL")
 	securitySbomImageCmd.Flags().StringSlice("type", nil, "Ecosystem filter, repeatable")
-	securitySbomImageCmd.Flags().String("sort", "vulnerable", "Sort key: vulnerable, actionable, name, version, package_type")
+	securitySbomImageCmd.Flags().StringSlice("license-risk", nil, "Licence tier filter, repeatable: network_copyleft, source_available, copyleft, weak_copyleft, permissive, unknown")
+	securitySbomImageCmd.Flags().String("sort", "vulnerable", "Sort key: vulnerable, actionable, license_risk, name, version, package_type")
 	securitySbomImageCmd.Flags().String("order", "desc", "Sort order: asc or desc")
 	securitySbomImageCmd.Flags().Int("page", 1, "Page number")
 	securitySbomImageCmd.Flags().Int("page-size", 100, "Components per page (max 100)")

--- a/cmd/security_sbom_test.go
+++ b/cmd/security_sbom_test.go
@@ -74,7 +74,7 @@ func sbomComponent() client.SecuritySBOMComponent {
 	purl := "pkg:deb/debian/openssl@3.0.14"
 	return client.SecuritySBOMComponent{
 		Name: "openssl", Version: "3.0.14", PackageType: "deb", ComponentType: "library", PURL: &purl,
-		Licenses: []string{"Apache-2.0"}, Images: 4, Workloads: 7, Clusters: 2,
+		Licenses: []string{"Apache-2.0"}, LicenseRisk: "permissive", Images: 4, Workloads: 7, Clusters: 2,
 		VulnerableFindings: 2, ActionableFindings: 1, KnownExploited: 1,
 	}
 }
@@ -143,16 +143,17 @@ func TestSecuritySbomMapsFlagsAndRendersCoverage(t *testing.T) {
 		Coverage:   sbomCoverage(),
 	}}
 	output, executeError := runSecurityCommand(t, mock, "security", "sbom",
-		"--search", "openssl", "--type", "deb", "--type", "apk", "--vulnerable", "true", "--namespace", "backend", "--sort", "vulnerable")
+		"--search", "openssl", "--type", "deb", "--type", "apk", "--license-risk", "network_copyleft", "--license-risk", "permissive",
+		"--vulnerable", "true", "--namespace", "backend", "--sort", "vulnerable")
 	if executeError != nil {
 		t.Fatalf("security sbom failed: %v", executeError)
 	}
 	options := mock.componentsOptions
 	if options == nil || options.Search != "openssl" || len(options.PackageTypes) != 2 || options.Vulnerable == nil || !*options.Vulnerable ||
-		options.Namespace != "backend" || options.Sort != "vulnerable" {
+		options.Namespace != "backend" || options.Sort != "vulnerable" || len(options.LicenseRisks) != 2 || options.LicenseRisks[0] != "network_copyleft" {
 		t.Fatalf("component options = %+v", options)
 	}
-	for _, expected := range []string{"1 of 3 scanned clusters publish one", "trivy_sbom_generation_enabled", "openssl", "2 (1 actionable)", "KEV", "Page 1 of 1 · 1 components"} {
+	for _, expected := range []string{"1 of 3 scanned clusters publish one", "trivy_sbom_generation_enabled", "openssl", "LICENCE RISK", "permissive", "2 (1 actionable)", "KEV", "Page 1 of 1 · 1 components"} {
 		if !strings.Contains(output, expected) {
 			t.Fatalf("output lacks %q:\n%s", expected, output)
 		}
@@ -168,6 +169,7 @@ func TestSecuritySbomImagesAndImageDetail(t *testing.T) {
 		ImageIdentity: digest, ImageRef: "registry.example.com/backend/api:1.0.0", ImageDigest: &digest, OSName: &osName,
 		ComponentCount: 212, DependencyCount: 180, Workloads: 2, Clusters: 1, Namespaces: []string{"backend"},
 		Observed: 5, Actionable: client.SecuritySeverityCounts{Critical: 1, High: 2}, KnownExploited: 1,
+		LicenseExposure: client.SecurityLicenseExposure{NetworkCopyleft: 2, Copyleft: 1, Permissive: 200, Unknown: 9},
 	}
 	mock := &securitySbomMock{
 		images: &client.SecuritySBOMImageList{
@@ -186,19 +188,20 @@ func TestSecuritySbomImagesAndImageDetail(t *testing.T) {
 	if executeError != nil {
 		t.Fatalf("security sbom images failed: %v", executeError)
 	}
-	for _, expected := range []string{"registry.example.com/backend/api:1.0.0", "debian 12.7", "backend", "Page 1 of 1 · 1 images"} {
+	for _, expected := range []string{"registry.example.com/backend/api:1.0.0", "debian 12.7", "backend", "LICENCE RISK", "2 network copyleft", "1 copyleft", "Page 1 of 1 · 1 images"} {
 		if !strings.Contains(output, expected) {
 			t.Fatalf("images output lacks %q:\n%s", expected, output)
 		}
 	}
-	output, executeError = runSecurityCommand(t, mock, "security", "sbom", "image", digest, "--type", "deb")
+	output, executeError = runSecurityCommand(t, mock, "security", "sbom", "image", digest, "--type", "deb", "--license-risk", "copyleft")
 	if executeError != nil {
 		t.Fatalf("security sbom image failed: %v", executeError)
 	}
-	if mock.detailOptions == nil || mock.detailOptions.ImageIdentity != digest || len(mock.detailOptions.PackageTypes) != 1 {
+	if mock.detailOptions == nil || mock.detailOptions.ImageIdentity != digest || len(mock.detailOptions.PackageTypes) != 1 ||
+		len(mock.detailOptions.LicenseRisks) != 1 || mock.detailOptions.LicenseRisks[0] != "copyleft" {
 		t.Fatalf("detail options = %+v", mock.detailOptions)
 	}
-	for _, expected := range []string{"Digest:      sha256:abc", "212 (180 dependencies)", "No workload currently runs this image", "openssl", "Page 1 of 1 · 1 components"} {
+	for _, expected := range []string{"Digest:      sha256:abc", "212 (180 dependencies)", "Licences:    ", "2 network copyleft", "(200 permissive, 9 unknown)", "No workload currently runs this image", "openssl", "Page 1 of 1 · 1 components"} {
 		if !strings.Contains(output, expected) {
 			t.Fatalf("detail output lacks %q:\n%s", expected, output)
 		}

--- a/cmd/security_sbom_test.go
+++ b/cmd/security_sbom_test.go
@@ -163,13 +163,23 @@ func TestSecuritySbomMapsFlagsAndRendersCoverage(t *testing.T) {
 	}
 }
 
+func TestSecuritySbomCellsKeepAnAbsentAnswerApartFromAClean(t *testing.T) {
+	if licenseRiskCell("") != "-" || licenseRiskCell("unknown") != "unknown" {
+		t.Fatalf("an absent tier is a dash, the unknown tier is unknown: %q %q", licenseRiskCell(""), licenseRiskCell("unknown"))
+	}
+	if licenseExposureCell(nil) != "not reported" || licenseExposureCell(&client.SecurityLicenseExposure{}) != "-" {
+		t.Fatalf("a missing exposure is not reported, an empty one is clean: %q %q",
+			licenseExposureCell(nil), licenseExposureCell(&client.SecurityLicenseExposure{}))
+	}
+}
+
 func TestSecuritySbomImagesAndImageDetail(t *testing.T) {
 	digest, osName := "sha256:abc", "debian 12.7"
 	image := client.SecuritySBOMImage{
 		ImageIdentity: digest, ImageRef: "registry.example.com/backend/api:1.0.0", ImageDigest: &digest, OSName: &osName,
 		ComponentCount: 212, DependencyCount: 180, Workloads: 2, Clusters: 1, Namespaces: []string{"backend"},
 		Observed: 5, Actionable: client.SecuritySeverityCounts{Critical: 1, High: 2}, KnownExploited: 1,
-		LicenseExposure: client.SecurityLicenseExposure{NetworkCopyleft: 2, Copyleft: 1, Permissive: 200, Unknown: 9},
+		LicenseExposure: &client.SecurityLicenseExposure{NetworkCopyleft: 2, Copyleft: 1, Permissive: 200, Unknown: 9},
 	}
 	mock := &securitySbomMock{
 		images: &client.SecuritySBOMImageList{

--- a/internal/client/security_sbom.go
+++ b/internal/client/security_sbom.go
@@ -96,6 +96,7 @@ type SecuritySBOMComponent struct {
 	ComponentType      string   `json:"component_type" yaml:"component_type"`
 	PURL               *string  `json:"purl" yaml:"purl"`
 	Licenses           []string `json:"licenses" yaml:"licenses"`
+	LicenseRisk        string   `json:"license_risk" yaml:"license_risk"`
 	Images             int      `json:"images" yaml:"images"`
 	Workloads          int      `json:"workloads" yaml:"workloads"`
 	Clusters           int      `json:"clusters" yaml:"clusters"`
@@ -116,9 +117,28 @@ type SecuritySBOMCoverage struct {
 	LatestGeneratedAt *string `json:"latest_generated_at" yaml:"latest_generated_at"`
 }
 
-// SecuritySBOMComponentFacets mirrors the component filters.
+// SecuritySBOMComponentFacets mirrors the component filters; LicenseRisk
+// lists the licence tiers present, most consequential first.
 type SecuritySBOMComponentFacets struct {
 	PackageType []SecurityFacetCount `json:"package_type" yaml:"package_type"`
+	LicenseRisk []SecurityFacetCount `json:"license_risk" yaml:"license_risk"`
+}
+
+// SecurityLicenseExposure counts an image's components per licence tier.
+// network_copyleft (AGPL, SSPL, EUPL, OSL) obliges publishing the source
+// of a service that links it; source_available (BUSL, Elastic, Redis
+// Source Available, Commons Clause) needs a commercial licence to host as
+// a service; copyleft (GPL) is safe on a private backend and must be
+// open-sourced when shipped to users; weak_copyleft reaches only
+// modifications of the component; permissive obliges nothing; unknown is
+// unrecognised or not yet classified.
+type SecurityLicenseExposure struct {
+	NetworkCopyleft int `json:"network_copyleft" yaml:"network_copyleft"`
+	SourceAvailable int `json:"source_available" yaml:"source_available"`
+	Copyleft        int `json:"copyleft" yaml:"copyleft"`
+	WeakCopyleft    int `json:"weak_copyleft" yaml:"weak_copyleft"`
+	Permissive      int `json:"permissive" yaml:"permissive"`
+	Unknown         int `json:"unknown" yaml:"unknown"`
 }
 
 // SecuritySBOMComponentList is the paginated component inventory.
@@ -132,27 +152,28 @@ type SecuritySBOMComponentList struct {
 // SecuritySBOMImage is one image with a bill of materials, where it runs and
 // the actionable findings the scanner attributes to it.
 type SecuritySBOMImage struct {
-	ImageIdentity   string                 `json:"image_identity" yaml:"image_identity"`
-	ImageRef        string                 `json:"image_ref" yaml:"image_ref"`
-	ImageRepository *string                `json:"image_repository" yaml:"image_repository"`
-	ImageTag        *string                `json:"image_tag" yaml:"image_tag"`
-	ImageDigest     *string                `json:"image_digest" yaml:"image_digest"`
-	Registry        *string                `json:"registry" yaml:"registry"`
-	OSFamily        *string                `json:"os_family" yaml:"os_family"`
-	OSName          *string                `json:"os_name" yaml:"os_name"`
-	BomFormat       *string                `json:"bom_format" yaml:"bom_format"`
-	SpecVersion     *string                `json:"spec_version" yaml:"spec_version"`
-	ComponentCount  int                    `json:"component_count" yaml:"component_count"`
-	DependencyCount int                    `json:"dependency_count" yaml:"dependency_count"`
-	Workloads       int                    `json:"workloads" yaml:"workloads"`
-	Clusters        int                    `json:"clusters" yaml:"clusters"`
-	Namespaces      []string               `json:"namespaces" yaml:"namespaces"`
-	Observed        int                    `json:"observed" yaml:"observed"`
-	Actionable      SecuritySeverityCounts `json:"actionable" yaml:"actionable"`
-	KnownExploited  int                    `json:"known_exploited" yaml:"known_exploited"`
-	GeneratedAt     *string                `json:"generated_at" yaml:"generated_at"`
-	FirstSeenAt     string                 `json:"first_seen_at" yaml:"first_seen_at"`
-	LastSeenAt      string                 `json:"last_seen_at" yaml:"last_seen_at"`
+	ImageIdentity   string                  `json:"image_identity" yaml:"image_identity"`
+	ImageRef        string                  `json:"image_ref" yaml:"image_ref"`
+	ImageRepository *string                 `json:"image_repository" yaml:"image_repository"`
+	ImageTag        *string                 `json:"image_tag" yaml:"image_tag"`
+	ImageDigest     *string                 `json:"image_digest" yaml:"image_digest"`
+	Registry        *string                 `json:"registry" yaml:"registry"`
+	OSFamily        *string                 `json:"os_family" yaml:"os_family"`
+	OSName          *string                 `json:"os_name" yaml:"os_name"`
+	BomFormat       *string                 `json:"bom_format" yaml:"bom_format"`
+	SpecVersion     *string                 `json:"spec_version" yaml:"spec_version"`
+	ComponentCount  int                     `json:"component_count" yaml:"component_count"`
+	DependencyCount int                     `json:"dependency_count" yaml:"dependency_count"`
+	Workloads       int                     `json:"workloads" yaml:"workloads"`
+	Clusters        int                     `json:"clusters" yaml:"clusters"`
+	Namespaces      []string                `json:"namespaces" yaml:"namespaces"`
+	Observed        int                     `json:"observed" yaml:"observed"`
+	Actionable      SecuritySeverityCounts  `json:"actionable" yaml:"actionable"`
+	KnownExploited  int                     `json:"known_exploited" yaml:"known_exploited"`
+	LicenseExposure SecurityLicenseExposure `json:"license_exposure" yaml:"license_exposure"`
+	GeneratedAt     *string                 `json:"generated_at" yaml:"generated_at"`
+	FirstSeenAt     string                  `json:"first_seen_at" yaml:"first_seen_at"`
+	LastSeenAt      string                  `json:"last_seen_at" yaml:"last_seen_at"`
 }
 
 // SecuritySBOMImageList is the paginated image inventory.
@@ -279,6 +300,7 @@ type SecuritySBOMComponentsOptions struct {
 	PageSize      int
 	Search        string
 	PackageTypes  []string
+	LicenseRisks  []string
 	ClusterID     string
 	Namespace     string
 	WorkloadKind  string
@@ -331,8 +353,19 @@ type SecuritySBOMImageOptions struct {
 	PageSize      int
 	Search        string
 	PackageTypes  []string
+	LicenseRisks  []string
 	Sort          string
 	Order         string
+}
+
+// addLicenseRisks appends the licence tier filter, lower-cased so the
+// server sees one spelling of each tier.
+func addLicenseRisks(query neturl.Values, licenseRisks []string) {
+	for _, licenseRisk := range licenseRisks {
+		if trimmed := strings.ToLower(strings.TrimSpace(licenseRisk)); trimmed != "" {
+			query.Add("license_risk", trimmed)
+		}
+	}
 }
 
 func setListControls(query neturl.Values, search string, sort string, order string) {
@@ -401,6 +434,7 @@ func (c *Client) ListSecuritySBOMComponents(options SecuritySBOMComponentsOption
 			query.Add("package_type", trimmed)
 		}
 	}
+	addLicenseRisks(query, options.LicenseRisks)
 	if options.ClusterID != "" {
 		query.Set("cluster_id", options.ClusterID)
 	}
@@ -457,6 +491,7 @@ func (c *Client) GetSecuritySBOMImage(options SecuritySBOMImageOptions) (*Securi
 			query.Add("package_type", trimmed)
 		}
 	}
+	addLicenseRisks(query, options.LicenseRisks)
 	var detail SecuritySBOMImageDetail
 	if err := c.getJSON(securityURL(c.BaseURL, "/sbom/image", query), &detail); err != nil {
 		return nil, fmt.Errorf("security sbom image request failed: %w", err)

--- a/internal/client/security_sbom.go
+++ b/internal/client/security_sbom.go
@@ -152,28 +152,28 @@ type SecuritySBOMComponentList struct {
 // SecuritySBOMImage is one image with a bill of materials, where it runs and
 // the actionable findings the scanner attributes to it.
 type SecuritySBOMImage struct {
-	ImageIdentity   string                  `json:"image_identity" yaml:"image_identity"`
-	ImageRef        string                  `json:"image_ref" yaml:"image_ref"`
-	ImageRepository *string                 `json:"image_repository" yaml:"image_repository"`
-	ImageTag        *string                 `json:"image_tag" yaml:"image_tag"`
-	ImageDigest     *string                 `json:"image_digest" yaml:"image_digest"`
-	Registry        *string                 `json:"registry" yaml:"registry"`
-	OSFamily        *string                 `json:"os_family" yaml:"os_family"`
-	OSName          *string                 `json:"os_name" yaml:"os_name"`
-	BomFormat       *string                 `json:"bom_format" yaml:"bom_format"`
-	SpecVersion     *string                 `json:"spec_version" yaml:"spec_version"`
-	ComponentCount  int                     `json:"component_count" yaml:"component_count"`
-	DependencyCount int                     `json:"dependency_count" yaml:"dependency_count"`
-	Workloads       int                     `json:"workloads" yaml:"workloads"`
-	Clusters        int                     `json:"clusters" yaml:"clusters"`
-	Namespaces      []string                `json:"namespaces" yaml:"namespaces"`
-	Observed        int                     `json:"observed" yaml:"observed"`
-	Actionable      SecuritySeverityCounts  `json:"actionable" yaml:"actionable"`
-	KnownExploited  int                     `json:"known_exploited" yaml:"known_exploited"`
-	LicenseExposure SecurityLicenseExposure `json:"license_exposure" yaml:"license_exposure"`
-	GeneratedAt     *string                 `json:"generated_at" yaml:"generated_at"`
-	FirstSeenAt     string                  `json:"first_seen_at" yaml:"first_seen_at"`
-	LastSeenAt      string                  `json:"last_seen_at" yaml:"last_seen_at"`
+	ImageIdentity   string                   `json:"image_identity" yaml:"image_identity"`
+	ImageRef        string                   `json:"image_ref" yaml:"image_ref"`
+	ImageRepository *string                  `json:"image_repository" yaml:"image_repository"`
+	ImageTag        *string                  `json:"image_tag" yaml:"image_tag"`
+	ImageDigest     *string                  `json:"image_digest" yaml:"image_digest"`
+	Registry        *string                  `json:"registry" yaml:"registry"`
+	OSFamily        *string                  `json:"os_family" yaml:"os_family"`
+	OSName          *string                  `json:"os_name" yaml:"os_name"`
+	BomFormat       *string                  `json:"bom_format" yaml:"bom_format"`
+	SpecVersion     *string                  `json:"spec_version" yaml:"spec_version"`
+	ComponentCount  int                      `json:"component_count" yaml:"component_count"`
+	DependencyCount int                      `json:"dependency_count" yaml:"dependency_count"`
+	Workloads       int                      `json:"workloads" yaml:"workloads"`
+	Clusters        int                      `json:"clusters" yaml:"clusters"`
+	Namespaces      []string                 `json:"namespaces" yaml:"namespaces"`
+	Observed        int                      `json:"observed" yaml:"observed"`
+	Actionable      SecuritySeverityCounts   `json:"actionable" yaml:"actionable"`
+	KnownExploited  int                      `json:"known_exploited" yaml:"known_exploited"`
+	LicenseExposure *SecurityLicenseExposure `json:"license_exposure" yaml:"license_exposure"`
+	GeneratedAt     *string                  `json:"generated_at" yaml:"generated_at"`
+	FirstSeenAt     string                   `json:"first_seen_at" yaml:"first_seen_at"`
+	LastSeenAt      string                   `json:"last_seen_at" yaml:"last_seen_at"`
 }
 
 // SecuritySBOMImageList is the paginated image inventory.


### PR DESCRIPTION
## What

`ankra security sbom` and `ankra security sbom image` show each component's **licence risk tier** and take `--license-risk` (repeatable: `network_copyleft`, `source_available`, `copyleft`, `weak_copyleft`, `permissive`, `unknown`); `ankra security sbom images` and the image detail summarise each image's obliging tiers ("2 network copyleft, 1 copyleft", red for the two that reach the hosting service, yellow for plain copyleft).

Bead: ankra-7olqe

Pairs with the cluster PR of the same branch name (`license_risk`, `license_exposure` and the `license_risk` query parameter on the SBOM reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
