### PR TITLE
ci: bound race-test compile memory so the Depot runner survives a cold cache (ankra-vn0bd)

### DIFF
--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -25,6 +25,24 @@ jobs:
     # its Depot slot until someone notices: run 34042422066 sat on master for
     # ~6h before a human cancelled it. Fail fast and give the runner back.
     timeout-minutes: 45
+    env:
+      # ankra/cmd is one 105k-line package, and the two heavy steps both hold
+      # it in memory whole: golangci-lint's type-check, and the race+coverage
+      # test compile, which is a single `compile` process. Measured cold, that
+      # compile peaks near 10GB and reaches 11.5GB given room, against this
+      # runner's 8GB. Over budget it thrashes (29m41s to reach
+      # `ok ankra/cmd 7.879s` in run 34061025005, versus 25s warm in run
+      # 33973454824) or the runner is killed outright ("the self-hosted runner
+      # lost communication with the server ... starves it for CPU/Memory",
+      # runs 34059805725 and 34061027039).
+      # GOMEMLIMIT is a soft ceiling, inherited by every Go child process: it
+      # costs nothing until the heap approaches it, then trades CPU for
+      # footprint. Measured cold on ./...: 9886MiB peak in 82s unset, 7381MiB
+      # in 160s at 5GiB. Job-scoped so golangci-lint gets the same ceiling.
+      # -p/GOMAXPROCS deliberately not used: they bound how many packages build
+      # at once, not one package's compile. Measured, `-p 1` still peaked at
+      # 10037MiB, and the runner's 2 vCPUs already make -p 2 the default.
+      GOMEMLIMIT: 5GiB
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -39,24 +57,6 @@ jobs:
         with:
           version: v2.12.2
       - name: Run tests
-        env:
-          # ankra/cmd is one 105k-line package, so its race+coverage test
-          # binary is produced by a single `compile` process; measured cold it
-          # peaks near 10GB of heap and reaches 11.5GB when given room, against
-          # this runner's 8GB. Over budget the compile thrashes (29m41s to
-          # reach `ok ankra/cmd 7.879s` in run 34061025005, versus 25s warm in
-          # run 33973454824) or the runner is killed outright ("the self-hosted
-          # runner lost communication with the server ... starves it for
-          # CPU/Memory", runs 34059805725 and 34061027039).
-          # GOMEMLIMIT is a soft ceiling: it is inherited by the child compile
-          # processes and costs nothing until the heap approaches it, then
-          # trades CPU for footprint. Measured cold on ./...: 9886MiB peak in
-          # 82s unset, 7381MiB in 160s at 5GiB.
-          # -p/GOMAXPROCS deliberately not used: they bound how many packages
-          # build at once, not one package's compile. Measured, `-p 1` still
-          # peaked at 10037MiB, and the runner's 2 vCPUs already make -p 2 the
-          # default.
-          GOMEMLIMIT: 5GiB
         run: go test -race -count=1 -timeout=120s -coverprofile=coverage.out ./...
       - name: Check coverage
         run: go tool cover -func=coverage.out

--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -11,9 +11,20 @@ on:
 permissions:
   contents: read
 
+# Superseded runs used to keep their runner for the full race compile, so a
+# branch pushed three times held three Depot runners at once and later runs
+# queued for hours (run 34059805725 waited 3h17m for a runner).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-test-build:
     runs-on: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
+    # A starved runner stops reporting rather than failing, so the job holds
+    # its Depot slot until someone notices: run 34042422066 sat on master for
+    # ~6h before a human cancelled it. Fail fast and give the runner back.
+    timeout-minutes: 45
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -28,6 +39,24 @@ jobs:
         with:
           version: v2.12.2
       - name: Run tests
+        env:
+          # ankra/cmd is one 105k-line package, so its race+coverage test
+          # binary is produced by a single `compile` process; measured cold it
+          # peaks near 10GB of heap and reaches 11.5GB when given room, against
+          # this runner's 8GB. Over budget the compile thrashes (29m41s to
+          # reach `ok ankra/cmd 7.879s` in run 34061025005, versus 25s warm in
+          # run 33973454824) or the runner is killed outright ("the self-hosted
+          # runner lost communication with the server ... starves it for
+          # CPU/Memory", runs 34059805725 and 34061027039).
+          # GOMEMLIMIT is a soft ceiling: it is inherited by the child compile
+          # processes and costs nothing until the heap approaches it, then
+          # trades CPU for footprint. Measured cold on ./...: 9886MiB peak in
+          # 82s unset, 7381MiB in 160s at 5GiB.
+          # -p/GOMAXPROCS deliberately not used: they bound how many packages
+          # build at once, not one package's compile. Measured, `-p 1` still
+          # peaked at 10037MiB, and the runner's 2 vCPUs already make -p 2 the
+          # default.
+          GOMEMLIMIT: 5GiB
         run: go test -race -count=1 -timeout=120s -coverprofile=coverage.out ./...
       - name: Check coverage
         run: go tool cover -func=coverage.out


### PR DESCRIPTION
## What

`.github/workflows/lint-build.yml` only. Three changes, no source or test changes:

1. `GOMEMLIMIT: 5GiB` on the **Run tests** step — bounds the one compile that blows the runner's memory budget.
2. A `concurrency` group with `cancel-in-progress` — superseded pushes stop holding Depot runners.
3. `timeout-minutes: 45` on the job — a starved runner is returned instead of sitting for hours.

`-race`, `-count=1`, `-timeout=120s` and `-coverprofile=coverage.out` are unchanged, and the runner label is untouched.

## Root cause

`ankra/cmd` is **105,319 lines across 318 files in a single Go package** (58k source + 47k test). `go test -race -coverprofile ./...` therefore has to build one race- and coverage-instrumented test binary for that package in **one `compile` process**, and that process is the whole problem.

Measured cold, on the exact CI command:

| Configuration | Peak RSS of the biggest compile | Wall |
| --- | --- | --- |
| as CI runs it today | 9,886 MiB | 82s |
| given 16GB of room (container) | 11,506 MiB | — |
| `GOMEMLIMIT=5GiB` | 7,381 MiB | 160s |
| `GOMEMLIMIT=3GiB` | 7,145 MiB | 225s |

`depot-ubuntu-24.04` is **2 vCPU / 8 GB**, and Depot spends 2 GB of that on a RAM-backed disk accelerator. A compile that wants 10-11.5 GB against ~6 GB of usable RAM either thrashes or gets the runner killed — which is exactly the observed pair of symptoms:

- **Thrash:** run `34061025005` printed `ok ankra/cmd 7.879s` **29m41s** after the step began. The tests ran in 7.9 seconds; the other 29.5 minutes was the compile. Every remaining package then finished within the next 7 seconds.
- **Kill:** runs `34059805725` and `34061027039` died in the same step with the job annotation *"The self-hosted runner lost communication with the server. Verify the machine is running and has a healthy network connection. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error."*
- **Warm contrast:** run `33973454824` (2026-09-05, same label) ran the whole test step in **25 seconds**, because nothing needed compiling.

The 120s per-binary timeout proves no test hangs — a hung test would fail within two minutes.

### On the cache

I checked the setup-go cache lines in both runs, and the "cold cache" framing needs a correction. The cache is a **hit**, not a miss, in both the 29.5-minute run and the 25-second run:

```
Cache hit for: setup-go-Linux-x64-ubuntu24-go-1.26.6-b41ac59a...
Cache Size: ~226 MB
Cache restored successfully
...
Cache hit occurred on the primary key setup-go-... , not saving cache.
```

Two consequences. `actions/setup-go` keys that archive on `go.sum`, which last changed on **2026-08-29** (`934eb31`), so the key is frozen and the post step never re-saves — the archive can never pick up newer build output. And it does not actually matter, because Depot's runner image sets `GOCACHEPROG='/usr/local/bin/depot gocache'`, so Go's build cache is redirected to Depot's own service and the restored `~/.cache/go-build` directory is not what Go reads. `GOCACHEPROG` was identical on the fast 2026-09-05 run, so it is not a regression.

So the variable is not cache warmth in the setup-go sense — it is whether `ankra/cmd` changed. When it has not, everything is a cache hit and the step is 25 seconds. When it has (most PRs, and every PR in the current pipeline-program push), the 10 GB compile runs and the runner is over budget.

### Why not `-p 2` / `GOMAXPROCS`

The brief suggested bounding compile parallelism. I measured it and it does not work here, so I deliberately did not add it:

- `-p` bounds how many **packages** build concurrently. The peak is one package's single `compile` process, so `-p 1` still peaked at **10,037 MiB** (vs 10,268 MiB at the default) while roughly doubling wall time.
- `go test -p` already defaults to `GOMAXPROCS`, which on a 2-vCPU runner is **2**. `-p 2` would be a literal no-op on this runner, and `GOMAXPROCS=2` likewise.

`GOMEMLIMIT` is the lever that actually applies: it is a *soft* ceiling inherited by the child `compile` processes, so it costs nothing until the heap approaches it and only then trades CPU for footprint. That keeps fast runs fast and stops the pathological one from being killed. 5GiB is chosen from the table above — 3GiB buys 236 MiB more for another 65s.

### Runner starvation

Two secondary findings, both from the run list rather than any single run:

- Queue times have collapsed the pool. Run `34061025005` was created at 21:25:24Z and its job did not start until **23:16:17Z (1h50m queued)**; `34059805725` waited **3h17m**. Long jobs from superseded pushes were holding the runners, hence the `concurrency` group.
- Run `34042422066` on `master` held a runner for about **6 hours** before a human cancelled it, hence `timeout-minutes`.

## The runner-size option (a cost decision, not taken here)

I deliberately did **not** change the runner. The honest read of the numbers is that this module has outgrown a 2 vCPU / 8 GB runner: the build wants 11.5 GB when you give it room. Switching `CI_RUNNER_2` to **`depot-ubuntu-24.04-4` (4 vCPU / 16 GB)** would remove the memory pressure outright and make `GOMEMLIMIT` unnecessary, at roughly double the per-minute rate — but on runs that currently take 30 minutes instead of 2, it would very likely be cheaper overall. That is a call for a human; the org variable already exists so it is a one-value change with no code edit.

The durable fix is to split `cmd` into several packages, so no single `compile` has to hold 105k lines of race-instrumented code at once. Worth a follow-up bead.

## Follow-up worth considering (not in this PR)

The workflow triggers on both `push: '**'` and `pull_request: '**'`, so every commit on a PR branch from this repo runs the job **twice** — visible as run pairs 3-4 seconds apart (`34061027039`/`34061025005`, `33989403118`/`33989399696`, `33986559209`/`33986556631`). Restricting `push` to `master` would halve the load on the pool. I left it out because it drops CI for branches that have no PR yet, which is a team policy call rather than a fix.

## Verification

- `actionlint .github/workflows/lint-build.yml` — clean.
- `python3 -c "import yaml; yaml.safe_load(...)"` — parses; confirmed the test command and runner label are byte-identical and only the `Run tests` step gained `env`.
- Pre-commit gate (`go test ./...` + `golangci-lint run`) — all 9 packages pass, 0 lint issues.
- Measurements above were taken with a `mktemp` `GOCACHE` per run (verified empty at start) and per-process RSS sampled from `ps`, plus containerised runs pinned to 8 GB / 2 CPU and 16 GB / 4 CPU to mimic the two runner sizes.
- This PR's own "Lint, Test and Build" run exercises the changed workflow; step timings reported in a comment below.

Bead: ankra-vn0bd
