### PR TITLE
release: cut v0.15.0-rc3 (ankra-vn0bd)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Ankra CLI Changelog
 
-## Unreleased
+## v0.15.0-rc3 — 2026-09-07
 
 ### Added
 


### PR DESCRIPTION
## What this does

Cuts `v0.15.0-rc3` by replacing the `## Unreleased` heading with
`## v0.15.0-rc3 — 2026-09-07`. CHANGELOG.md is the only file touched, and the
only line that changes is that heading. No tag is created here — tagging stays
a separate, deliberate step.

## What is in the release

Everything above the `v0.15.0-rc2` tag on master:

- **`ankra cluster agent ci get|set`** — #246. Per-cluster pipeline-step worker
  count and step-workspace storage class are stored on the platform and carried
  by every install and upgrade command Ankra generates, instead of living only
  in the agent's chart values where a `helm upgrade --set` was the only way to
  set them and the next platform-driven upgrade rendered the default back over
  it.
- **`ankra stack-profiles import --as-draft`** — #241. A file-authored profile
  document opens as a builder draft for review rather than publishing straight
  away.
- **`ankra stack-profiles list` paging footer** — #235. A 25-row first page no
  longer reads as the whole catalogue.

#248 is a CI-only change (job-scoped `GOMEMLIMIT` and a `timeout-minutes` bound
so the Depot runner survives a cold-cache race+coverage compile). It has no
user-visible surface and deliberately gets no entry, the same call rc2 made for
the #238 `.gitignore` chore and rc1 for CI-only #221.

## How the section was built

The two `### Added` entries and the one `### Fixed` entry already under
`## Unreleased` are carried over **verbatim** — `git diff` on this branch is a
single line removed and a single line added, and the removed line is
`## Unreleased` itself. Nothing was reordered and nothing was written at cut
time: all three user-visible PRs above the rc2 tag shipped their own entry.

`## Unreleased` is replaced outright rather than left behind empty, matching how
`v0.15.0-rc2` (#243), `v0.15.0-rc1` (#228) and `v0.15.0-rc0` (#217) were cut.

## Test plan

Dry-ran the exact release-notes extractor from `.github/workflows/release.yml`
against the committed file:

```
awk -v version="0.15.0-rc3" '
  $0 ~ "^## v?"version"([[:space:]]|$)" {found=1; next}
  found && /^## / {exit}
  found {print}
' CHANGELOG.md
```

- 48 lines extracted, 3 bullets (2 Added, 1 Fixed)
- passes the workflow's `[ -s release-notes.md ]` non-empty guard, so the notes
  come from the changelog rather than silently falling back to
  `--generate-notes`
- output is byte-identical to lines 4–51 of the file; it stops cleanly at
  `## v0.15.0-rc2 — 2026-09-05` with zero rc2 content captured
- longest line is 76 columns, matching the file's wrap

Local gates on the branch: `go build ./...`, `go test ./...` (all packages ok)
and `golangci-lint run ./...` (0 issues) — the repo's pre-commit hook ran the
latter two again on the commit itself.

## Docs

No CLI behaviour changes here, so no `ankra-docs` update is needed; the
generated CLI reference is unaffected.

Bead: ankra-vn0bd
