### PR TITLE
test(cmd): alerts ingest credentials sub-cases no longer share the root command's flags (ankra-vn0bd)

### DIFF
--- a/cmd/alerts_ingest_credentials_test.go
+++ b/cmd/alerts_ingest_credentials_test.go
@@ -103,14 +103,20 @@ func TestAlertsIngestCredentialsRebindUnpinsAndRefusesConflictingFlags(t *testin
 		mock.rebindRequest.Scope == nil || *mock.rebindRequest.Scope != "platform" {
 		t.Fatalf("unpin request = %+v", mock.rebindRequest)
 	}
-	for name, args := range map[string][]string{
-		"cluster and unpin together": {"rebind", "c2", "--cluster", "x", "--unpin"},
-		"nothing to change":          {"rebind", "c2"},
-		"an unknown scope":           {"rebind", "c2", "--scope", "everything"},
+	// A slice, not a map: "nothing to change" only reads as nothing when no
+	// earlier case's flags are still on the shared command, and randomised
+	// map iteration would decide that.
+	for _, testCase := range []struct {
+		name      string
+		arguments []string
+	}{
+		{name: "cluster and unpin together", arguments: []string{"rebind", "c2", "--cluster", "x", "--unpin"}},
+		{name: "nothing to change", arguments: []string{"rebind", "c2"}},
+		{name: "an unknown scope", arguments: []string{"rebind", "c2", "--scope", "everything"}},
 	} {
 		if _, _, runError := runAlertsCommand(t, &alertIngestCredentialsMock{}, "",
-			append([]string{"alerts", "ingest-credentials"}, args...)...); runError == nil {
-			t.Errorf("%s: expected a usage error", name)
+			append([]string{"alerts", "ingest-credentials"}, testCase.arguments...)...); runError == nil {
+			t.Errorf("%s: expected a usage error", testCase.name)
 		}
 	}
 }

--- a/cmd/alerts_test.go
+++ b/cmd/alerts_test.go
@@ -39,8 +39,10 @@ func alertsCommandTree() []*cobra.Command {
 
 // runAlertsCommand executes rootCmd with the given stdin and separate
 // stdout/stderr captures, so structured-output tests can prove stdout stays
-// parseable. The alerts flag tree is reset afterwards so Changed markers do
-// not leak between cases.
+// parseable. Flag values and their Changed markers survive an Execute call on
+// the shared tree, so the alerts tree is reset before every run as well as
+// after the test: a case that passes no flags must see none set, whatever the
+// case before it passed.
 func runAlertsCommand(t *testing.T, mock APIClient, input string, args ...string) (string, string, error) {
 	t.Helper()
 	withTempHome(t)
@@ -51,6 +53,7 @@ func runAlertsCommand(t *testing.T, mock APIClient, input string, args ...string
 	rootCmd.SetErr(stderr)
 	rootCmd.SetIn(strings.NewReader(input))
 	rootCmd.SetArgs(args)
+	resetTreeFlags(t, alertsCommandTree()...)
 	t.Cleanup(func() { resetTreeFlags(t, alertsCommandTree()...) })
 	executeError := rootCmd.Execute()
 	return stdout.String(), stderr.String(), executeError

--- a/cmd/proxmox_cluster_test.go
+++ b/cmd/proxmox_cluster_test.go
@@ -98,6 +98,10 @@ func TestProxmoxCreate_MapsFlagsToRequest(t *testing.T) {
 }
 
 func TestProxmoxCreate_IncludeNetworkingCanBeDisabled(t *testing.T) {
+	// The opt-out lands on the shared command, so put the whole create tree
+	// back on its defaults: without this, any test ordered after this one
+	// (go test -shuffle=on) sees include_networking already false.
+	t.Cleanup(func() { resetTreeFlags(t, proxmoxCreateCmd) })
 	mock := &proxmoxCreateMock{}
 	out, runError := runWithInput(t, mock, "",
 		"cluster", "proxmox", "create",
@@ -218,11 +222,20 @@ func TestProxmoxCreate_MapsOverlayFlags(t *testing.T) {
 // checks: a mesh without a site address, a site address without a mesh, and
 // an unknown mode are refused before any request is sent.
 func TestProxmoxCreate_RefusesInconsistentOverlayFlags(t *testing.T) {
-	for name, flags := range map[string][]string{
-		"mesh without site address": {"--network-mode", "wireguard_mesh"},
-		"site address without mesh": {"--site-public-ip", "203.0.113.7"},
-		"unknown mode":              {"--network-mode", "vxlan", "--site-public-ip", "203.0.113.7"},
+	// A slice, not a map, and a full flag reset per case: the create command
+	// is shared across the binary, so a case is only the flags it passes when
+	// the previous case's are gone, and randomised map iteration would decide
+	// which case that bites.
+	t.Cleanup(func() { resetTreeFlags(t, proxmoxCreateCmd) })
+	for _, testCase := range []struct {
+		name  string
+		flags []string
+	}{
+		{name: "mesh without site address", flags: []string{"--network-mode", "wireguard_mesh"}},
+		{name: "site address without mesh", flags: []string{"--site-public-ip", "203.0.113.7"}},
+		{name: "unknown mode", flags: []string{"--network-mode", "vxlan", "--site-public-ip", "203.0.113.7"}},
 	} {
+		resetTreeFlags(t, proxmoxCreateCmd)
 		mock := &proxmoxCreateMock{}
 		arguments := append([]string{
 			"cluster", "proxmox", "create",
@@ -231,12 +244,11 @@ func TestProxmoxCreate_RefusesInconsistentOverlayFlags(t *testing.T) {
 			"--ssh-key-credential-id", "ssh-1",
 			"--node", "pve",
 			"--bridge", "ankra",
-		}, flags...)
+		}, testCase.flags...)
 		_, runError := runWithInput(t, mock, "", arguments...)
 		if runError == nil || mock.called {
-			t.Errorf("%s must be refused before the request is sent (error=%v called=%v)", name, runError, mock.called)
+			t.Errorf("%s must be refused before the request is sent (error=%v called=%v)",
+				testCase.name, runError, mock.called)
 		}
-		_ = proxmoxCreateCmd.Flags().Set("network-mode", "")
-		_ = proxmoxCreateCmd.Flags().Set("site-public-ip", "")
 	}
 }


### PR DESCRIPTION
## What & why

`TestAlertsIngestCredentialsRebindUnpinsAndRefusesConflictingFlags` failed on
roughly one CI run in ten. `runAlertsCommand` drives the package-level
`rootCmd` and reset the alerts flag tree only in `t.Cleanup`, which fires once
the whole test function is over — so the sub-cases in that test inherited each
other's `--unpin` / `--scope` / `--cluster`. The first call in the test sets
`--unpin --scope platform`; whether the later `"nothing to change"` case (which
passes no flags and must be refused) still saw them set came down to Go's
randomised map iteration:

- `"cluster and unpin together"` first — it leaves `--cluster x` set, so
  `"nothing to change"` trips the `--cluster`/`--unpin` exclusivity check and
  the assertion passes by accident.
- `"nothing to change"` first — it sees the leaked `--unpin` and
  `--scope platform`, the command has something to rebind, no usage error, and
  the test fails.

For a three-entry map in one bucket Go's randomised start offset picks the bad
rotation about one time in eight, which matches the measured rate.

Two fixes, both kept because they close the hole from different sides:

1. `runAlertsCommand` now resets the alerts tree **before** every run as well
   as after the test — the pattern `runOrgAISpendCapCommand` already uses. Any
   alerts test that invokes the command more than once now starts each call
   from the flag defaults.
2. The refusal cases iterate a deterministic slice instead of a map, so the
   ordering is no longer part of the contract and a failure names its case.

The fix is not ordering luck: with the cases deliberately reordered so
`"nothing to change"` runs **first** (the worst case), 100/100 runs pass on
this branch.

### Other loops found by the audit

Swept every `range map[` loop and every rootCmd-driving test helper in `cmd/`.

| Site | Verdict |
| --- | --- |
| `cmd/alerts_ingest_credentials_test.go:106` refusal loop | **The defect.** Fixed (helper reset + deterministic slice). |
| `cmd/proxmox_cluster_test.go` `TestProxmoxCreate_RefusesInconsistentOverlayFlags` | **Same shape, fixed.** Map-driven over the shared `proxmoxCreateCmd`, hand-resetting two flag *values* per iteration and never their `Changed` markers. Order-independent only by luck of what the command reads. Now a deterministic slice with a full `resetTreeFlags` per case. |
| `cmd/proxmox_cluster_test.go` `TestProxmoxCreate_IncludeNetworkingCanBeDisabled` | **Pre-existing order bug, fixed.** It leaked `--include-networking=false` into every later test in the binary (its neighbour `IncludeDNSCanBeDisabled` already restores its own flag; this one did not). Invisible in source order, but `go test -shuffle=1 -run TestProxmoxCreate ./cmd/` fails on 4 of 6 seeds on `master` and passes on all 6 here. |
| `cmd/alerts_ingest_credentials_test.go:120` `TestRebindAlertIngestCredentialRequestSendsOnlyWhatWasSet` | Clean. Pure `MarshalJSON` cases, no shared command state. |
| `cmd/application_demo_test.go:137`, `cmd/pipeline_test.go:606` | Clean. `runApplicationCommand` / `runPipelineCommand` build a fresh command tree per call (`newApplicationCommand()` / `newPipelineCommand()`), so nothing is shared. |
| `cmd/cluster_debug_test.go:69`, `cmd/backup_vaults_test.go:86`, `cmd/helm_registries_list_test.go:42`, `cmd/stack_profiles_apply_test.go:43` | Clean. These maps are the bodies of reset helpers — order-independent by construction. |
| `cmd/apply_test.go`, `cmd/clone_integration_test.go`, `cmd/migrate_export_test.go`, `cmd/migrate_restore_test.go`, `cmd/security_sbom_test.go:322`, `cmd/application_lane_parity_test.go:135` | Clean. Fixture/pure-function maps, no command execution. |

## Test plan

Flake counts, on the exact reproducer, same machine:

```
go test -run TestAlertsIngestCredentialsRebindUnpinsAndRefusesConflictingFlags -count=300 ./cmd/
  before:  28 / 300 failed  (all "nothing to change: expected a usage error")
  after:    0 / 300 failed
```

Order-independence proof (temporary reorder, reverted — not in the diff):

```
"nothing to change" moved to the front of the slice, -count=100 → 100/100 pass
```

Pre-existing shuffle bug, before and after:

```
go test -run TestProxmoxCreate -shuffle=<1..6> ./cmd/
  master:      seeds 1, 3, 5, 6 FAIL ("include_networking should default to true")
  this branch: all 6 seeds pass
```

Gates, all from the worktree:

```
gofmt -l (go1.26.6, the go.mod toolchain)   clean on all three files
golangci-lint run (v2.13.2)                 0 issues
go vet ./...                                clean
go build ./...                              ok
go test -race -count=1 ./...                ok (all packages)
go test -run 'TestAlerts|TestRebindAlertIngestCredential|TestProxmox' -count=50 ./cmd/   ok
```

Test-only change; no CHANGELOG entry (nothing user-visible).

## Follow-ups

`go test -shuffle=on ./cmd/` still fails on the package as a whole — a wider
family of tests share cobra's package-level flag tree without resetting it
(cluster debug, org list, gitops status, chat actions, morpheus/upcloud create,
some security sbom cases). Same seed: 4 failures on `master`, 3 here. CI runs in
source order so none of these are live, but the package would benefit from
either shuffle-clean resets or the `newXCommand()` constructor pattern that the
application and pipeline test helpers already use. Out of scope here.

## Docs checklist

- [x] No user-facing command/flag changes — no docs needed

Bead: ankra-vn0bd
