### PR TITLE
release: cut v0.15.0-rc4 (ankra-vn0bd)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Ankra CLI Changelog
 
-## Unreleased
+## v0.15.0-rc4 — 2026-09-07
 
 ### Fixed
 


### PR DESCRIPTION
## What this does

Cuts `v0.15.0-rc4` by replacing the `## Unreleased` heading with
`## v0.15.0-rc4 — 2026-09-07`. CHANGELOG.md is the only file touched, and the
only line that changes is that heading. No tag is created here — tagging stays
a separate, deliberate step.

## What is in the release

Everything above the `v0.15.0-rc3` tag on master:

- **`ankra pipeline logs` replays a concluded step from the platform stream
  when no archived log exists** — #250. A finished step's output was only ever
  read from its archived `step_log` artifact, and archiving one needs a ready
  backup vault, so a new organisation was told "No archived log was recorded"
  for a build whose output Ankra was still holding. The same PR adds
  `--replay`, which shows what a running step printed before you connected,
  and stops a platform that never ends a replay from hanging the command
  forever.
- **`ankra pipeline logs --follow` waits for a step that has not started** —
  #251. The moment a live tail is worth asking for is the moment the run was
  dispatched, when the step is still blocked or unclaimed; `--follow` now polls
  and attaches as soon as the step starts, under a 30-minute total budget. The
  same PR resolves a retried step's newest attempt, so `--step <key>` no longer
  prints the lost attempt's log and `--follow` picks the retry up.

#252 is a test-only change (the alerts ingest credentials sub-cases no longer
share the root command's flags, which is what made that test flaky). It has no
user-visible surface and deliberately gets no entry, the same call rc3 made for
CI-only #248, rc2 for the #238 `.gitignore` chore and rc1 for CI-only #221.

## How the section was built

The four `### Fixed` entries and the one `### Added` entry already under
`## Unreleased` are carried over **verbatim** — `git diff` on this branch is a
single line removed and a single line added, and the removed line is
`## Unreleased` itself. Nothing was reordered and nothing was written at cut
time: both user-visible PRs above the rc3 tag shipped their own entries (#250
added 36 lines, #251 added 32).

`## Unreleased` is replaced outright rather than left behind empty, matching how
`v0.15.0-rc3` (#249), `v0.15.0-rc2` (#243), `v0.15.0-rc1` (#228) and
`v0.15.0-rc0` (#217) were cut.

## Test plan

Dry-ran the exact release-notes extractor from `.github/workflows/release.yml`
against the committed file:

```
awk -v version="0.15.0-rc4" '
  $0 ~ "^## v?"version"([[:space:]]|$)" {found=1; next}
  found && /^## / {exit}
  found {print}
' CHANGELOG.md
```

- 67 lines extracted, 5 bullets (4 Fixed, 1 Added) under 2 `###` headings
- passes the workflow's `[ -s release-notes.md ]` non-empty guard, so the notes
  come from the changelog rather than silently falling back to
  `--generate-notes`
- it stops cleanly at `## v0.15.0-rc3 — 2026-09-07` with zero rc3 content
  captured

Local gates on the branch: `go build ./...`, `go test ./...` (all packages ok)
and `golangci-lint run ./...` (0 issues) — the repo's pre-commit hook ran the
latter two again on the commit itself.

## Docs

No CLI behaviour changes here, so no `ankra-docs` update is needed; the
generated CLI reference is unaffected.

Bead: ankra-vn0bd
