### PR TITLE
feat(security): security sbom component follows a package to where it runs (ankra-8gcv9)

### DIFF
--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1006,6 +1006,10 @@ func (m baseMock) GetSecuritySBOMImage(client.SecuritySBOMImageOptions) (*client
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) GetSecuritySBOMComponent(client.SecuritySBOMComponentOptions) (*client.SecuritySBOMComponentDetail, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m baseMock) ListSecuritySBOMContainers(client.SecuritySBOMContainersOptions) (*client.SecuritySBOMContainerList, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/security_sbom.go
+++ b/cmd/security_sbom.go
@@ -167,6 +167,34 @@ var securitySbomImagesCmd = &cobra.Command{
 	},
 }
 
+var securitySbomComponentCmd = &cobra.Command{
+	Use:   "component <name>",
+	Short: "Where one package runs: the images carrying it, the workload containers running them, and their clusters",
+	Long: "Follow one exact package - the name, --version and --type a `security sbom` row shows - to the images whose " +
+		"bill of materials names it, every workload container currently running those images, and the clusters they run on.",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		version, _ := cmd.Flags().GetString("version")
+		packageType, _ := cmd.Flags().GetString("type")
+		if strings.TrimSpace(packageType) == "" {
+			return withExitCode(exitUsage, fmt.Errorf("--type is required: the ecosystem the component list shows (deb, apk, npm, ...)"))
+		}
+		detail, err := apiClient.GetSecuritySBOMComponent(client.SecuritySBOMComponentOptions{
+			Name:        strings.TrimSpace(args[0]),
+			Version:     version,
+			PackageType: packageType,
+		})
+		if err != nil {
+			return fmt.Errorf("reading where the package runs: %w", err)
+		}
+		if rendered, err := renderStructured(cmd, detail); rendered || err != nil {
+			return err
+		}
+		renderSecuritySbomComponentDetail(cmd, detail)
+		return nil
+	},
+}
+
 var securitySbomImageCmd = &cobra.Command{
 	Use:   "image <digest or reference>",
 	Short: "One image's bill of materials: its identity, the workloads running it and every component",
@@ -773,6 +801,86 @@ func renderSecuritySbomImageDetail(cmd *cobra.Command, detail *client.SecuritySB
 	_, _ = fmt.Fprintf(out, "Page %d of %d · %d components\n", detail.Pagination.Page, detail.Pagination.TotalPages, detail.Pagination.TotalCount)
 }
 
+func renderSecuritySbomComponentDetail(cmd *cobra.Command, detail *client.SecuritySBOMComponentDetail) {
+	out := cmd.OutOrStdout()
+	component := detail.Component
+	version := component.Version
+	if version == "" {
+		version = "(no version)"
+	}
+	_, _ = fmt.Fprintln(out, text.Bold.Sprint(component.Name+" "+version))
+	_, _ = fmt.Fprintf(out, "Ecosystem:   %s\n", component.PackageType)
+	if component.PURL != nil {
+		_, _ = fmt.Fprintf(out, "PURL:        %s\n", *component.PURL)
+	}
+	_, _ = fmt.Fprintf(out, "Licence:     %s (%s)\n", strings.Join(component.Licenses, ", "), licenseRiskCell(component.LicenseRisk))
+	_, _ = fmt.Fprintf(out, "Runs in:     %d image(s), %d workload(s), %d cluster(s)\n", component.Images, component.Workloads, component.Clusters)
+	_, _ = fmt.Fprintf(out, "Findings:    %s\n", componentFindingsCell(component))
+
+	_, _ = fmt.Fprintln(out)
+	if len(detail.Images) == 0 {
+		_, _ = fmt.Fprintln(out, "No stored bill of materials names this package any more.")
+	} else {
+		heading := fmt.Sprintf("Images carrying it (%d):", len(detail.Images))
+		if detail.ImagesCapped {
+			heading = fmt.Sprintf("Images carrying it (first %d of %d):", len(detail.Images), component.Images)
+		}
+		_, _ = fmt.Fprintln(out, heading)
+		writer := newSecurityTable(out)
+		writer.AppendHeader(table.Row{"Image", "OS", "Components", "Licence risk", "Workloads", "Clusters", "Known exploited"})
+		for _, image := range detail.Images {
+			writer.AppendRow(table.Row{
+				image.ImageRef,
+				stringOrEmpty(image.OSName),
+				image.ComponentCount,
+				licenseExposureCell(image.LicenseExposure),
+				image.Workloads,
+				image.Clusters,
+				redIfPositive(image.KnownExploited),
+			})
+		}
+		writer.Render()
+	}
+
+	_, _ = fmt.Fprintln(out)
+	if len(detail.Workloads) == 0 {
+		_, _ = fmt.Fprintln(out, "No workload currently runs an image carrying this package; the bill of materials is kept from the last scan that saw it.")
+	} else {
+		heading := fmt.Sprintf("Where it runs (%d container(s)):", len(detail.Workloads))
+		if detail.WorkloadsCapped {
+			heading = fmt.Sprintf("Where it runs (first %d containers):", len(detail.Workloads))
+		}
+		_, _ = fmt.Fprintln(out, heading)
+		writer := newSecurityTable(out)
+		writer.AppendHeader(table.Row{"Cluster", "Namespace", "Workload", "Container", "Image", "Last seen"})
+		for _, workload := range detail.Workloads {
+			label := "cluster-scoped image"
+			if workload.WorkloadName != nil {
+				label = strings.TrimSpace(stringOrEmpty(workload.WorkloadKind) + " " + *workload.WorkloadName)
+			}
+			writer.AppendRow(table.Row{
+				workload.ClusterName,
+				stringOrEmpty(workload.WorkloadNamespace),
+				label,
+				stringOrEmpty(workload.ContainerName),
+				workload.ImageRef,
+				formatTimeAgo(workload.LastSeenAt),
+			})
+		}
+		writer.Render()
+	}
+
+	_, _ = fmt.Fprintln(out)
+	if len(detail.Clusters) == 0 {
+		_, _ = fmt.Fprintln(out, "No live cluster runs it.")
+		return
+	}
+	_, _ = fmt.Fprintf(out, "Clusters (%d):\n", len(detail.Clusters))
+	for _, cluster := range detail.Clusters {
+		_, _ = fmt.Fprintf(out, "  - %s: %d workload(s), %d image(s)\n", cluster.ClusterName, cluster.Workloads, cluster.Images)
+	}
+}
+
 func renderSecuritySbomImageFindings(cmd *cobra.Command, list *client.SecuritySBOMImageFindingList) {
 	out := cmd.OutOrStdout()
 	image := list.Image
@@ -856,6 +964,9 @@ func intelligenceCaveats(intelligence client.SecurityIntelligenceStatus) []strin
 
 func init() {
 	securityCmd.AddCommand(securityNamespacesCmd, securityPodsCmd, securitySbomCmd)
+	securitySbomComponentCmd.Flags().String("version", "", "The exact installed version the component list shows; omit when the list shows none")
+	securitySbomComponentCmd.Flags().String("type", "", "The ecosystem the component list shows (deb, apk, rpm, npm, pypi, golang, maven, ...); required")
+	securitySbomCmd.AddCommand(securitySbomComponentCmd)
 	securitySbomCmd.AddCommand(securitySbomImagesCmd, securitySbomImageCmd, securitySbomFindingsCmd,
 		securitySbomContainersCmd, securitySbomExportCmd)
 	registerStructuredOutputFlags(securityNamespacesCmd, securityPodsCmd, securitySbomCmd,

--- a/cmd/security_sbom.go
+++ b/cmd/security_sbom.go
@@ -176,14 +176,23 @@ var securitySbomComponentCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		version, _ := cmd.Flags().GetString("version")
 		packageType, _ := cmd.Flags().GetString("type")
+		clusterFlag, _ := cmd.Flags().GetString("cluster")
 		if strings.TrimSpace(packageType) == "" {
 			return withExitCode(exitUsage, fmt.Errorf("--type is required: the ecosystem the component list shows (deb, apk, npm, ...)"))
 		}
-		detail, err := apiClient.GetSecuritySBOMComponent(client.SecuritySBOMComponentOptions{
+		options := client.SecuritySBOMComponentOptions{
 			Name:        strings.TrimSpace(args[0]),
 			Version:     version,
 			PackageType: packageType,
-		})
+		}
+		if clusterFlag != "" {
+			clusterID, err := resolveClusterID(clusterFlag)
+			if err != nil {
+				return err
+			}
+			options.ClusterID = clusterID
+		}
+		detail, err := apiClient.GetSecuritySBOMComponent(options)
 		if err != nil {
 			return fmt.Errorf("reading where the package runs: %w", err)
 		}
@@ -848,7 +857,7 @@ func renderSecuritySbomComponentDetail(cmd *cobra.Command, detail *client.Securi
 	} else {
 		heading := fmt.Sprintf("Where it runs (%d container(s)):", len(detail.Workloads))
 		if detail.WorkloadsCapped {
-			heading = fmt.Sprintf("Where it runs (first %d containers):", len(detail.Workloads))
+			heading = fmt.Sprintf("Where it runs (first %d containers of %d workload(s)):", len(detail.Workloads), component.Workloads)
 		}
 		_, _ = fmt.Fprintln(out, heading)
 		writer := newSecurityTable(out)
@@ -877,7 +886,7 @@ func renderSecuritySbomComponentDetail(cmd *cobra.Command, detail *client.Securi
 	}
 	_, _ = fmt.Fprintf(out, "Clusters (%d):\n", len(detail.Clusters))
 	for _, cluster := range detail.Clusters {
-		_, _ = fmt.Fprintf(out, "  - %s: %d workload(s), %d image(s)\n", cluster.ClusterName, cluster.Workloads, cluster.Images)
+		_, _ = fmt.Fprintf(out, "  - %s: %d workload(s) in %d container(s), %d image(s)\n", cluster.ClusterName, cluster.Workloads, cluster.Containers, cluster.Images)
 	}
 }
 
@@ -966,11 +975,12 @@ func init() {
 	securityCmd.AddCommand(securityNamespacesCmd, securityPodsCmd, securitySbomCmd)
 	securitySbomComponentCmd.Flags().String("version", "", "The exact installed version the component list shows; omit when the list shows none")
 	securitySbomComponentCmd.Flags().String("type", "", "The ecosystem the component list shows (deb, apk, rpm, npm, pypi, golang, maven, ...); required")
+	securitySbomComponentCmd.Flags().String("cluster", "", "Only the images, workload containers and clusters on one cluster (name or id)")
 	securitySbomCmd.AddCommand(securitySbomComponentCmd)
 	securitySbomCmd.AddCommand(securitySbomImagesCmd, securitySbomImageCmd, securitySbomFindingsCmd,
 		securitySbomContainersCmd, securitySbomExportCmd)
 	registerStructuredOutputFlags(securityNamespacesCmd, securityPodsCmd, securitySbomCmd,
-		securitySbomImagesCmd, securitySbomImageCmd, securitySbomFindingsCmd, securitySbomContainersCmd)
+		securitySbomImagesCmd, securitySbomImageCmd, securitySbomComponentCmd, securitySbomFindingsCmd, securitySbomContainersCmd)
 
 	securitySbomFindingsCmd.Flags().String("search", "", "Match CVE id, package name or title")
 	securitySbomFindingsCmd.Flags().StringSlice("severity", nil, "Severity filter, repeatable: critical, high, medium, low, unknown")

--- a/cmd/security_sbom_test.go
+++ b/cmd/security_sbom_test.go
@@ -18,6 +18,8 @@ type securitySbomMock struct {
 	images            *client.SecuritySBOMImageList
 	detail            *client.SecuritySBOMImageDetail
 	detailOptions     *client.SecuritySBOMImageOptions
+	component         *client.SecuritySBOMComponentDetail
+	componentOptions  *client.SecuritySBOMComponentOptions
 	imagesOptions     *client.SecuritySBOMImagesOptions
 	containers        *client.SecuritySBOMContainerList
 	containersOptions *client.SecuritySBOMContainersOptions
@@ -59,6 +61,11 @@ func (m *securitySbomMock) ListSecuritySBOMImageFindings(options client.Security
 func (m *securitySbomMock) ExportSecuritySBOMImage(options client.SecuritySBOMExportOptions) (*client.SecuritySBOMExport, error) {
 	m.exportOptions = &options
 	return m.export, nil
+}
+
+func (m *securitySbomMock) GetSecuritySBOMComponent(options client.SecuritySBOMComponentOptions) (*client.SecuritySBOMComponentDetail, error) {
+	m.componentOptions = &options
+	return m.component, nil
 }
 
 func (m *securitySbomMock) GetSecuritySBOMImage(options client.SecuritySBOMImageOptions) (*client.SecuritySBOMImageDetail, error) {
@@ -170,6 +177,42 @@ func TestSecuritySbomCellsKeepAnAbsentAnswerApartFromAClean(t *testing.T) {
 	if licenseExposureCell(nil) != "not reported" || licenseExposureCell(&client.SecurityLicenseExposure{}) != "-" {
 		t.Fatalf("a missing exposure is not reported, an empty one is clean: %q %q",
 			licenseExposureCell(nil), licenseExposureCell(&client.SecurityLicenseExposure{}))
+	}
+}
+
+func TestSecuritySbomComponentFollowsAPackageToWhereItRuns(t *testing.T) {
+	digest, osName, namespace, name, container := "sha256:abc", "debian 12.7", "backend", "api", "app"
+	kind := "Deployment"
+	mock := &securitySbomMock{component: &client.SecuritySBOMComponentDetail{
+		Component: sbomComponent(),
+		Images: []client.SecuritySBOMImage{{
+			ImageIdentity: digest, ImageRef: "registry.example.com/backend/api:1.0.0", OSName: &osName, ComponentCount: 212,
+			Workloads: 2, Clusters: 1, LicenseExposure: &client.SecurityLicenseExposure{Permissive: 200},
+		}},
+		Workloads: []client.SecuritySBOMComponentWorkload{{
+			SecuritySBOMWorkload: client.SecuritySBOMWorkload{ClusterID: "c1", ClusterName: "prod", ReportScope: "namespaced",
+				WorkloadKind: &kind, WorkloadNamespace: &namespace, WorkloadName: &name, ContainerName: &container, LastSeenAt: "2026-09-07T00:00:00Z"},
+			ImageIdentity: digest, ImageRef: "registry.example.com/backend/api:1.0.0",
+		}},
+		WorkloadsCapped: true,
+		Clusters:        []client.SecuritySBOMComponentCluster{{ClusterID: "c1", ClusterName: "prod", Workloads: 2, Images: 1}},
+	}}
+	output, executeError := runSecurityCommand(t, mock, "security", "sbom", "component", "openssl", "--version", "3.0.14", "--type", "DEB")
+	if executeError != nil {
+		t.Fatalf("security sbom component failed: %v", executeError)
+	}
+	if mock.componentOptions == nil || mock.componentOptions.Name != "openssl" || mock.componentOptions.Version != "3.0.14" ||
+		mock.componentOptions.PackageType != "DEB" {
+		t.Fatalf("component options = %+v", mock.componentOptions)
+	}
+	for _, expected := range []string{"openssl 3.0.14", "Runs in:     4 image(s), 7 workload(s), 2 cluster(s)", "Images carrying it (1):",
+		"registry.example.com/backend/api:1.0.0", "Where it runs (first 1 containers):", "Deployment api", "backend", "prod: 2 workload(s), 1 image(s)"} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("output lacks %q:\n%s", expected, output)
+		}
+	}
+	if _, executeError := runSecurityCommand(t, mock, "security", "sbom", "component", "openssl", "--type", ""); executeError == nil {
+		t.Fatal("expected a missing --type to be refused")
 	}
 }
 

--- a/cmd/security_sbom_test.go
+++ b/cmd/security_sbom_test.go
@@ -195,7 +195,7 @@ func TestSecuritySbomComponentFollowsAPackageToWhereItRuns(t *testing.T) {
 			ImageIdentity: digest, ImageRef: "registry.example.com/backend/api:1.0.0",
 		}},
 		WorkloadsCapped: true,
-		Clusters:        []client.SecuritySBOMComponentCluster{{ClusterID: "c1", ClusterName: "prod", Workloads: 2, Images: 1}},
+		Clusters:        []client.SecuritySBOMComponentCluster{{ClusterID: "c1", ClusterName: "prod", Workloads: 2, Containers: 3, Images: 1}},
 	}}
 	output, executeError := runSecurityCommand(t, mock, "security", "sbom", "component", "openssl", "--version", "3.0.14", "--type", "DEB")
 	if executeError != nil {
@@ -206,13 +206,20 @@ func TestSecuritySbomComponentFollowsAPackageToWhereItRuns(t *testing.T) {
 		t.Fatalf("component options = %+v", mock.componentOptions)
 	}
 	for _, expected := range []string{"openssl 3.0.14", "Runs in:     4 image(s), 7 workload(s), 2 cluster(s)", "Images carrying it (1):",
-		"registry.example.com/backend/api:1.0.0", "Where it runs (first 1 containers):", "Deployment api", "backend", "prod: 2 workload(s), 1 image(s)"} {
+		"registry.example.com/backend/api:1.0.0", "Where it runs (first 1 containers of 7 workload(s)):", "Deployment api", "backend", "prod: 2 workload(s) in 3 container(s), 1 image(s)"} {
 		if !strings.Contains(output, expected) {
 			t.Fatalf("output lacks %q:\n%s", expected, output)
 		}
 	}
 	if _, executeError := runSecurityCommand(t, mock, "security", "sbom", "component", "openssl", "--type", ""); executeError == nil {
 		t.Fatal("expected a missing --type to be refused")
+	}
+	structured, executeError := runSecurityCommand(t, mock, "security", "sbom", "component", "openssl", "--version", "3.0.14", "--type", "deb", "-o", "json")
+	if executeError != nil {
+		t.Fatalf("structured output failed: %v", executeError)
+	}
+	if !strings.Contains(structured, "\"workloads_capped\": true") {
+		t.Fatalf("-o json must carry the full read, got:\n%s", structured)
 	}
 }
 

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -48,6 +48,7 @@ type APIClient interface {
 	ListSecuritySBOMComponents(options client.SecuritySBOMComponentsOptions) (*client.SecuritySBOMComponentList, error)
 	ListSecuritySBOMImages(options client.SecuritySBOMImagesOptions) (*client.SecuritySBOMImageList, error)
 	GetSecuritySBOMImage(options client.SecuritySBOMImageOptions) (*client.SecuritySBOMImageDetail, error)
+	GetSecuritySBOMComponent(options client.SecuritySBOMComponentOptions) (*client.SecuritySBOMComponentDetail, error)
 	ListSecuritySBOMContainers(options client.SecuritySBOMContainersOptions) (*client.SecuritySBOMContainerList, error)
 	ListSecuritySBOMImageFindings(options client.SecuritySBOMImageFindingsOptions) (*client.SecuritySBOMImageFindingList, error)
 	ExportSecuritySBOMImage(options client.SecuritySBOMExportOptions) (*client.SecuritySBOMExport, error)

--- a/internal/client/security_sbom.go
+++ b/internal/client/security_sbom.go
@@ -212,6 +212,7 @@ type SecuritySBOMComponentOptions struct {
 	Name        string
 	Version     string
 	PackageType string
+	ClusterID   string
 }
 
 // SecuritySBOMComponentWorkload is one workload container running an image
@@ -222,11 +223,14 @@ type SecuritySBOMComponentWorkload struct {
 	ImageRef             string `json:"image_ref" yaml:"image_ref"`
 }
 
-// SecuritySBOMComponentCluster is one cluster running the component.
+// SecuritySBOMComponentCluster is one cluster running the component:
+// distinct workloads (the measure the component row counts), the workload
+// containers behind them, and images.
 type SecuritySBOMComponentCluster struct {
 	ClusterID   string `json:"cluster_id" yaml:"cluster_id"`
 	ClusterName string `json:"cluster_name" yaml:"cluster_name"`
 	Workloads   int    `json:"workloads" yaml:"workloads"`
+	Containers  int    `json:"containers" yaml:"containers"`
 	Images      int    `json:"images" yaml:"images"`
 }
 
@@ -523,6 +527,9 @@ func (c *Client) GetSecuritySBOMComponent(options SecuritySBOMComponentOptions) 
 	query.Set("name", strings.TrimSpace(options.Name))
 	query.Set("version", strings.TrimSpace(options.Version))
 	query.Set("package_type", strings.ToLower(strings.TrimSpace(options.PackageType)))
+	if options.ClusterID != "" {
+		query.Set("cluster_id", options.ClusterID)
+	}
 	var detail SecuritySBOMComponentDetail
 	if err := c.getJSON(securityURL(c.BaseURL, "/sbom/component", query), &detail); err != nil {
 		return nil, fmt.Errorf("security sbom component request failed: %w", err)

--- a/internal/client/security_sbom.go
+++ b/internal/client/security_sbom.go
@@ -205,6 +205,42 @@ type SecuritySBOMImageDetail struct {
 	Workloads  []SecuritySBOMWorkload      `json:"workloads" yaml:"workloads"`
 }
 
+// SecuritySBOMComponentOptions names one exact package: the name as the
+// component list shows it, its version (empty when the list shows none)
+// and its ecosystem.
+type SecuritySBOMComponentOptions struct {
+	Name        string
+	Version     string
+	PackageType string
+}
+
+// SecuritySBOMComponentWorkload is one workload container running an image
+// that carries the component, with the image so both can be followed.
+type SecuritySBOMComponentWorkload struct {
+	SecuritySBOMWorkload `yaml:",inline"`
+	ImageIdentity        string `json:"image_identity" yaml:"image_identity"`
+	ImageRef             string `json:"image_ref" yaml:"image_ref"`
+}
+
+// SecuritySBOMComponentCluster is one cluster running the component.
+type SecuritySBOMComponentCluster struct {
+	ClusterID   string `json:"cluster_id" yaml:"cluster_id"`
+	ClusterName string `json:"cluster_name" yaml:"cluster_name"`
+	Workloads   int    `json:"workloads" yaml:"workloads"`
+	Images      int    `json:"images" yaml:"images"`
+}
+
+// SecuritySBOMComponentDetail is one package followed to where it runs.
+// The lists are capped and say so: a capped list is not the whole answer.
+type SecuritySBOMComponentDetail struct {
+	Component       SecuritySBOMComponent           `json:"component" yaml:"component"`
+	Images          []SecuritySBOMImage             `json:"images" yaml:"images"`
+	ImagesCapped    bool                            `json:"images_capped" yaml:"images_capped"`
+	Workloads       []SecuritySBOMComponentWorkload `json:"workloads" yaml:"workloads"`
+	WorkloadsCapped bool                            `json:"workloads_capped" yaml:"workloads_capped"`
+	Clusters        []SecuritySBOMComponentCluster  `json:"clusters" yaml:"clusters"`
+}
+
 // SecuritySBOMImageFindingsOptions narrows the vulnerabilities on one image.
 type SecuritySBOMImageFindingsOptions struct {
 	ImageIdentity string
@@ -478,6 +514,20 @@ func (c *Client) ListSecuritySBOMImages(options SecuritySBOMImagesOptions) (*Sec
 		list.Result = []SecuritySBOMImage{}
 	}
 	return &list, nil
+}
+
+// GetSecuritySBOMComponent follows one exact package to the images,
+// workload containers and clusters that carry it.
+func (c *Client) GetSecuritySBOMComponent(options SecuritySBOMComponentOptions) (*SecuritySBOMComponentDetail, error) {
+	query := neturl.Values{}
+	query.Set("name", strings.TrimSpace(options.Name))
+	query.Set("version", strings.TrimSpace(options.Version))
+	query.Set("package_type", strings.ToLower(strings.TrimSpace(options.PackageType)))
+	var detail SecuritySBOMComponentDetail
+	if err := c.getJSON(securityURL(c.BaseURL, "/sbom/component", query), &detail); err != nil {
+		return nil, fmt.Errorf("security sbom component request failed: %w", err)
+	}
+	return &detail, nil
 }
 
 // GetSecuritySBOMImage reads one image's bill of materials.


### PR DESCRIPTION
## What

`ankra security sbom component <name> --version <v> --type <ecosystem>` follows one exact package - the row `ankra security sbom` shows - to the images carrying it, every workload container running those images (cluster, namespace, workload, container, image, last seen) and the clusters they run on, and says when a list was capped. `-o json` / `-o yaml` carry the full read.

Bead: ankra-8gcv9

Pairs with the cluster PR of the same branch name (`GET /org/security/sbom/component`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
