### PR TITLE
fix(client): spell out the cluster security paths so the route census can see them (ankra-79xak)

### DIFF
--- a/internal/client/security_cluster.go
+++ b/internal/client/security_cluster.go
@@ -218,15 +218,17 @@ type SecurityPodPosture struct {
 	Containers   []SecurityPodSecurityContainer `json:"containers" yaml:"containers"`
 }
 
-func importedClusterSecurityURL(base string, clusterID string, path string) string {
-	return fmt.Sprintf("%s/api/v1/org/clusters/imported/%s%s", base, neturl.PathEscape(clusterID), path)
-}
+// The security reads spell out their full /api/v1 path at each call site:
+// the cluster route census (cluster_routes_test.go) only sees what a string
+// literal holds, so a helper that takes the route suffix as a value hides
+// every one of these paths from the check.
 
 // ListClusterSecurityStacks reads a cluster's security posture broken down
 // by stack, with the outside-any-stack remainder.
 func (c *Client) ListClusterSecurityStacks(clusterID string) (*SecurityClusterStackList, error) {
 	var list SecurityClusterStackList
-	if err := c.getJSON(importedClusterSecurityURL(c.BaseURL, clusterID, "/security/stacks"), &list); err != nil {
+	endpoint := fmt.Sprintf("%s/api/v1/org/clusters/imported/%s/security/stacks", c.BaseURL, neturl.PathEscape(clusterID))
+	if err := c.getJSON(endpoint, &list); err != nil {
 		return nil, fmt.Errorf("cluster security stacks request failed: %w", err)
 	}
 	if list.Stacks == nil {
@@ -238,8 +240,9 @@ func (c *Client) ListClusterSecurityStacks(clusterID string) (*SecurityClusterSt
 // GetStackSecurity reads one stack's security posture.
 func (c *Client) GetStackSecurity(clusterID string, stackName string) (*SecurityStackPosture, error) {
 	var posture SecurityStackPosture
-	path := "/stacks/" + neturl.PathEscape(stackName) + "/security"
-	if err := c.getJSON(importedClusterSecurityURL(c.BaseURL, clusterID, path), &posture); err != nil {
+	endpoint := fmt.Sprintf("%s/api/v1/org/clusters/imported/%s/stacks/%s/security",
+		c.BaseURL, neturl.PathEscape(clusterID), neturl.PathEscape(stackName))
+	if err := c.getJSON(endpoint, &posture); err != nil {
 		return nil, fmt.Errorf("stack security request failed: %w", err)
 	}
 	if posture.Members == nil {
@@ -252,8 +255,9 @@ func (c *Client) GetStackSecurity(clusterID string, stackName string) (*Security
 // resolved to.
 func (c *Client) ListStackSecurityWorkloads(clusterID string, stackName string) (*SecurityStackWorkloadList, error) {
 	var list SecurityStackWorkloadList
-	path := "/stacks/" + neturl.PathEscape(stackName) + "/security/workloads"
-	if err := c.getJSON(importedClusterSecurityURL(c.BaseURL, clusterID, path), &list); err != nil {
+	endpoint := fmt.Sprintf("%s/api/v1/org/clusters/imported/%s/stacks/%s/security/workloads",
+		c.BaseURL, neturl.PathEscape(clusterID), neturl.PathEscape(stackName))
+	if err := c.getJSON(endpoint, &list); err != nil {
 		return nil, fmt.Errorf("stack security workloads request failed: %w", err)
 	}
 	if list.Result == nil {
@@ -265,8 +269,9 @@ func (c *Client) ListStackSecurityWorkloads(clusterID string, stackName string) 
 // GetPodSecurity reads one pod's security posture, container by container.
 func (c *Client) GetPodSecurity(clusterID string, namespace string, podName string) (*SecurityPodPosture, error) {
 	var posture SecurityPodPosture
-	path := "/security/pods/" + neturl.PathEscape(namespace) + "/" + neturl.PathEscape(podName)
-	if err := c.getJSON(importedClusterSecurityURL(c.BaseURL, clusterID, path), &posture); err != nil {
+	endpoint := fmt.Sprintf("%s/api/v1/org/clusters/imported/%s/security/pods/%s/%s",
+		c.BaseURL, neturl.PathEscape(clusterID), neturl.PathEscape(namespace), neturl.PathEscape(podName))
+	if err := c.getJSON(endpoint, &posture); err != nil {
 		return nil, fmt.Errorf("pod security request failed: %w", err)
 	}
 	if posture.Containers == nil {


### PR DESCRIPTION
Bead: ankra-79xak

## Why

`master` has been red since efb84df (#237, 2026-09-07 10:40): runs 34112694072 and 34118503572 fail `Run tests` on `TestClusterRoutesAreRegistered` (the census check from #245) with one unresolved path:

```
/api/v1/org/clusters/imported/%s%s  (internal/client/security_cluster.go)
```

`importedClusterSecurityURL` took the route suffix as a runtime value, so the only literal the scanner could see was `imported/%s%s`, which matches nothing.

## What

The four security reads in `security_cluster.go` now spell out their full `/api/v1` path in their own literal, so the census can check each one. All four resolve against the cluster's `routes.json` (`security/stacks`, `stacks/{}/security`, `stacks/{}/security/workloads`, `security/pods/{}/{}`). Nothing changes on the wire.

Verified locally with the census fetched from `ankraio/cluster` main: `ANKRA_CLUSTER_ROUTES_JSON=routes.json make test` green, `golangci-lint run` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
