### PR TITLE
feat(chat): show tool activity in the session output (ankra-14ar6.12)

### DIFF
--- a/cmd/chat_session.go
+++ b/cmd/chat_session.go
@@ -276,6 +276,14 @@ func renderChatTurn(events <-chan client.ChatStreamEvent, out io.Writer, errOut 
 					printLine("note: " + message)
 				}
 			}
+		case "tool_start":
+			if line := chatToolStartText(event.Data); line != "" {
+				printLine(line)
+			}
+		case "tool_result":
+			if line := chatToolResultText(event.Data); line != "" {
+				printLine(line)
+			}
 		case "action_proposal":
 			proposal, decodeError := decodeActionProposal(event.Data)
 			if decodeError != nil {
@@ -319,4 +327,44 @@ func renderChatTurn(events <-chan client.ChatStreamEvent, out io.Writer, errOut 
 // first question as the title, and none of them is worth a line of output.
 func requestConversationTitle(conversationID string) {
 	_ = apiClient.RegenerateChatTitle(conversationID)
+}
+
+// chatToolStartText renders a tool_start frame as one line, so a reader
+// watching a long turn sees which tool the model reached for instead of a
+// silent gap between status lines.
+func chatToolStartText(data any) string {
+	frame, ok := data.(map[string]any)
+	if !ok {
+		return ""
+	}
+	toolName, _ := frame["tool_name"].(string)
+	if toolName == "" {
+		return ""
+	}
+	return "tool " + toolName + " ..."
+}
+
+// chatToolResultText renders a tool_result frame: the outcome, the
+// error class when the platform stamped one, and the error text on failure.
+func chatToolResultText(data any) string {
+	frame, ok := data.(map[string]any)
+	if !ok {
+		return ""
+	}
+	toolName, _ := frame["tool_name"].(string)
+	if toolName == "" {
+		return ""
+	}
+	success, _ := frame["success"].(bool)
+	if success {
+		return "tool " + toolName + " ok"
+	}
+	line := "tool " + toolName + " failed"
+	if errorClass, _ := frame["error_class"].(string); errorClass != "" {
+		line += " (" + errorClass + ")"
+	}
+	if errorText, _ := frame["error"].(string); errorText != "" {
+		line += ": " + errorText
+	}
+	return line
 }

--- a/cmd/chat_session.go
+++ b/cmd/chat_session.go
@@ -355,7 +355,12 @@ func chatToolResultText(data any) string {
 	if toolName == "" {
 		return ""
 	}
-	success, _ := frame["success"].(bool)
+	success, hasSuccess := frame["success"].(bool)
+	if !hasSuccess {
+		// No boolean success: the frame settled without saying how (an
+		// absent answer is not a failed one).
+		return "tool " + toolName + " settled"
+	}
 	if success {
 		return "tool " + toolName + " ok"
 	}

--- a/cmd/chat_session_test.go
+++ b/cmd/chat_session_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"os"
@@ -679,5 +680,28 @@ func TestChatInteractive_NamesEachConversationOnceAfterItsFirstTurn(t *testing.T
 	if mock.titleCalls[0] != mock.created[0].ConversationID || mock.titleCalls[1] != mock.created[2].ConversationID {
 		t.Fatalf("title calls = %v, want the first and the post-clear conversation ids (%s, %s)",
 			mock.titleCalls, mock.created[0].ConversationID, mock.created[2].ConversationID)
+	}
+}
+
+func TestRenderChatTurnShowsToolActivity(t *testing.T) {
+	events := make(chan client.ChatStreamEvent, 6)
+	events <- client.ChatStreamEvent{Type: "tool_start", Data: map[string]any{"tool_name": "list_node_groups", "status": "preparing"}, Sequence: 1}
+	events <- client.ChatStreamEvent{Type: "tool_result", Data: map[string]any{"tool_name": "list_node_groups", "success": true}, Sequence: 2}
+	events <- client.ChatStreamEvent{Type: "tool_result", Data: map[string]any{"tool_name": "get_pods", "success": false,
+		"error": "Agent timeout while fetching pods.", "error_class": "transient"}, Sequence: 3}
+	events <- contentFrame(4, "The default group autoscaling is on.")
+	events <- endFrame()
+	close(events)
+	var out, errOut bytes.Buffer
+	renderChatTurn(events, &out, &errOut, false)
+	for _, want := range []string{
+		"[tool list_node_groups ...]",
+		"[tool list_node_groups ok]",
+		"[tool get_pods failed (transient): Agent timeout while fetching pods.]",
+		"The default group autoscaling is on.",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output %q lacks %q", out.String(), want)
+		}
 	}
 }

--- a/cmd/chat_session_test.go
+++ b/cmd/chat_session_test.go
@@ -684,12 +684,13 @@ func TestChatInteractive_NamesEachConversationOnceAfterItsFirstTurn(t *testing.T
 }
 
 func TestRenderChatTurnShowsToolActivity(t *testing.T) {
-	events := make(chan client.ChatStreamEvent, 6)
+	events := make(chan client.ChatStreamEvent, 8)
 	events <- client.ChatStreamEvent{Type: "tool_start", Data: map[string]any{"tool_name": "list_node_groups", "status": "preparing"}, Sequence: 1}
 	events <- client.ChatStreamEvent{Type: "tool_result", Data: map[string]any{"tool_name": "list_node_groups", "success": true}, Sequence: 2}
 	events <- client.ChatStreamEvent{Type: "tool_result", Data: map[string]any{"tool_name": "get_pods", "success": false,
 		"error": "Agent timeout while fetching pods.", "error_class": "transient"}, Sequence: 3}
-	events <- contentFrame(4, "The default group autoscaling is on.")
+	events <- client.ChatStreamEvent{Type: "tool_result", Data: map[string]any{"tool_name": "get_events"}, Sequence: 4}
+	events <- contentFrame(5, "The default group autoscaling is on.")
 	events <- endFrame()
 	close(events)
 	var out, errOut bytes.Buffer
@@ -698,6 +699,7 @@ func TestRenderChatTurnShowsToolActivity(t *testing.T) {
 		"[tool list_node_groups ...]",
 		"[tool list_node_groups ok]",
 		"[tool get_pods failed (transient): Agent timeout while fetching pods.]",
+		"[tool get_events settled]",
 		"The default group autoscaling is on.",
 	} {
 		if !strings.Contains(out.String(), want) {


### PR DESCRIPTION
Bead: ankra-14ar6.12

`ankra chat` rendered content, status, notices, proposals and errors, and dropped the `tool_start` / `tool_result` frames, so a long turn read as silent gaps between status lines and a failed tool never showed why (review F9, ankra-14ar6). Each tool call now prints one bracketed line when it starts (`[tool list_node_groups ...]`) and one when it settles (`[tool list_node_groups ok]`, or `[tool get_pods failed (transient): Agent timeout while fetching pods.]` carrying the platform's error class). Test: `TestRenderChatTurnShowsToolActivity`.