### PR TITLE
fix: playground destroy asks first and status takes -o json ankra-stril

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,17 @@
   out, rather than either claiming the step runs with no egress - which is
   its own tier, `none`.
 
+### Fixed
+
+- **`ankra cluster playground destroy` asks before tearing down.** It was
+  the one destructive verb that ran the moment you pressed enter - a
+  mistyped id or the wrong selected organisation took the environment, and
+  everything deployed in it, with no way back. It now prompts like
+  `deprovision` does, naming the playground you passed; declining exits 4,
+  and `--yes` skips the prompt for scripts. `status` and `destroy` also take
+  `-o json|yaml`, so the poll loop the create hint tells you to run can read
+  the phase without scraping the human text.
+
 ## v0.15.0-rc4 — 2026-09-07
 
 ### Fixed

--- a/cmd/cluster_playground.go
+++ b/cmd/cluster_playground.go
@@ -186,9 +186,15 @@ var clusterPlaygroundDestroyCmd = &cobra.Command{
 			return err
 		}
 		yes, _ := cmd.Flags().GetBool("yes")
+		// A name resolves to an id before the request; the prompt names both
+		// so what the user confirms is the cluster the API is asked to destroy.
+		target := fmt.Sprintf("%q", args[0])
+		if clusterID != args[0] {
+			target = fmt.Sprintf("%q (cluster %s)", args[0], clusterID)
+		}
 		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
-			fmt.Sprintf("Destroy playground %q? Everything deployed in it, including its storage, "+
-				"is deleted and cannot be recovered. [y/N]: ", args[0]),
+			fmt.Sprintf("Destroy playground %s? Everything deployed in it, including its storage, "+
+				"is deleted and cannot be recovered. [y/N]: ", target),
 			yes); err != nil {
 			return err
 		}

--- a/cmd/cluster_playground.go
+++ b/cmd/cluster_playground.go
@@ -192,7 +192,8 @@ var clusterPlaygroundDestroyCmd = &cobra.Command{
 		if clusterID != args[0] {
 			target = fmt.Sprintf("%q (cluster %s)", args[0], clusterID)
 		}
-		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+		// The prompt goes to stderr so `-o json` keeps stdout parseable.
+		if err := confirmPrompt(cmd.InOrStdin(), cmd.ErrOrStderr(),
 			fmt.Sprintf("Destroy playground %s? Everything deployed in it, including its storage, "+
 				"is deleted and cannot be recovered. [y/N]: ", target),
 			yes); err != nil {

--- a/cmd/cluster_playground.go
+++ b/cmd/cluster_playground.go
@@ -137,6 +137,9 @@ var clusterPlaygroundStatusCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("reading the playground status: %w", err)
 		}
+		if handled, renderError := renderStructured(cmd, status); handled || renderError != nil {
+			return renderError
+		}
 		fmt.Printf("Cluster ID: %s\n", status.ClusterID)
 		fmt.Printf("Phase:      %s\n", status.Phase)
 		if status.Plan != nil {
@@ -168,7 +171,9 @@ var clusterPlaygroundStatusCmd = &cobra.Command{
 var clusterPlaygroundDestroyCmd = &cobra.Command{
 	Use:   "destroy <cluster_id|name>",
 	Short: "Destroy your organisation's playground",
-	Long: "Tear the organisation's playground down. Teardown runs in the background: poll " +
+	Long: "Tear the organisation's playground down. Everything deployed in it, including its " +
+		"storage, is deleted and cannot be recovered, so the command asks first; pass --yes to " +
+		"skip the prompt in scripts. Teardown runs in the background: poll " +
 		"`ankra cluster playground status <cluster_id>` until the phase reaches removed.\n\n" +
 		"This is also how a refused `ankra org domain set` is cleared. A playground publishes a " +
 		"wildcard DNS record in the organisation's zone, and that record is reconciled rather " +
@@ -180,9 +185,19 @@ var clusterPlaygroundDestroyCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		yes, _ := cmd.Flags().GetBool("yes")
+		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
+			fmt.Sprintf("Destroy playground %q? Everything deployed in it, including its storage, "+
+				"is deleted and cannot be recovered. [y/N]: ", args[0]),
+			yes); err != nil {
+			return err
+		}
 		result, err := apiClient.DestroyPlayground(clusterID)
 		if err != nil {
 			return fmt.Errorf("destroying the playground: %w", err)
+		}
+		if handled, renderError := renderStructured(cmd, result); handled || renderError != nil {
+			return renderError
 		}
 		// cmd.OutOrStdout() rather than fmt.Printf: the destroy verb is the
 		// one this group's output is asserted on, and a bare Printf writes
@@ -198,6 +213,8 @@ func init() {
 		"size to order, from `ankra cluster playground plans` (default: the free trial)")
 	clusterPlaygroundResizeCmd.Flags().StringVar(&clusterPlaygroundResizeSize, "size", "",
 		"the new size, from `ankra cluster playground plans`")
+	clusterPlaygroundDestroyCmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
+	registerStructuredOutputFlags(clusterPlaygroundStatusCmd, clusterPlaygroundDestroyCmd)
 	clusterPlaygroundCmd.AddCommand(clusterPlaygroundCreateCmd)
 	clusterPlaygroundCmd.AddCommand(clusterPlaygroundPlansCmd)
 	clusterPlaygroundCmd.AddCommand(clusterPlaygroundResizeCmd)

--- a/cmd/cluster_playground_test.go
+++ b/cmd/cluster_playground_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -250,9 +251,11 @@ func TestPlaygroundDestroyPrintsTheClusterIDAndPhase(t *testing.T) {
 	output := new(bytes.Buffer)
 	clusterPlaygroundDestroyCmd.SetOut(output)
 	clusterPlaygroundDestroyCmd.SetErr(output)
+	clusterPlaygroundDestroyCmd.SetIn(strings.NewReader("y\n"))
 	t.Cleanup(func() {
 		clusterPlaygroundDestroyCmd.SetOut(nil)
 		clusterPlaygroundDestroyCmd.SetErr(nil)
+		clusterPlaygroundDestroyCmd.SetIn(nil)
 	})
 
 	if runError := clusterPlaygroundDestroyCmd.RunE(
@@ -271,8 +274,114 @@ func TestPlaygroundDestroyPrintsTheClusterIDAndPhase(t *testing.T) {
 	}
 }
 
+// Destroy is irreversible - the tenant's storage goes with it - so it has to
+// ask like every other destructive verb does (ankra-stril). Declining is the
+// shared cancelled error (exit 4) and must not reach the API at all.
+func TestPlaygroundDestroyAsksFirstAndADeclineNeverReachesTheAPI(t *testing.T) {
+	mock := &playgroundMock{
+		destroyResult: &client.DestroyPlaygroundResult{ClusterID: playgroundTestClusterID, Phase: "deprovisioning"},
+	}
+	withPlaygroundMock(t, mock)
+	output := new(bytes.Buffer)
+	clusterPlaygroundDestroyCmd.SetOut(output)
+	clusterPlaygroundDestroyCmd.SetIn(strings.NewReader("n\n"))
+	t.Cleanup(func() {
+		clusterPlaygroundDestroyCmd.SetOut(nil)
+		clusterPlaygroundDestroyCmd.SetIn(nil)
+	})
+
+	runError := clusterPlaygroundDestroyCmd.RunE(clusterPlaygroundDestroyCmd, []string{playgroundTestClusterID})
+	if !errors.Is(runError, errCancelled) {
+		t.Fatalf("a declined prompt must return errCancelled, got %v", runError)
+	}
+	if mock.destroyRequested != "" {
+		t.Errorf("a declined destroy must not call the API, but it asked for %q", mock.destroyRequested)
+	}
+	if !strings.Contains(output.String(), "Destroy playground") || !strings.Contains(output.String(), "[y/N]") {
+		t.Errorf("expected the confirmation prompt in the output, got: %s", output.String())
+	}
+}
+
+// --yes is the scripting escape hatch: no prompt is printed and stdin is
+// never read, so a script with a closed stdin still tears down.
+func TestPlaygroundDestroyYesSkipsThePrompt(t *testing.T) {
+	mock := &playgroundMock{
+		destroyResult: &client.DestroyPlaygroundResult{ClusterID: playgroundTestClusterID, Phase: "deprovisioning"},
+	}
+	withPlaygroundMock(t, mock)
+	output := new(bytes.Buffer)
+	clusterPlaygroundDestroyCmd.SetOut(output)
+	// An empty stdin would read as a decline if the prompt ran.
+	clusterPlaygroundDestroyCmd.SetIn(strings.NewReader(""))
+	if err := clusterPlaygroundDestroyCmd.Flags().Set("yes", "true"); err != nil {
+		t.Fatalf("setting --yes: %v", err)
+	}
+	t.Cleanup(func() {
+		clusterPlaygroundDestroyCmd.SetOut(nil)
+		clusterPlaygroundDestroyCmd.SetIn(nil)
+		_ = clusterPlaygroundDestroyCmd.Flags().Set("yes", "false")
+	})
+
+	if runError := clusterPlaygroundDestroyCmd.RunE(clusterPlaygroundDestroyCmd, []string{playgroundTestClusterID}); runError != nil {
+		t.Fatalf("destroy --yes failed: %v", runError)
+	}
+	if mock.destroyRequested != playgroundTestClusterID {
+		t.Errorf("destroy --yes asked for %q, want "+playgroundTestClusterID, mock.destroyRequested)
+	}
+	if strings.Contains(output.String(), "[y/N]") {
+		t.Errorf("--yes must not print the prompt, got: %s", output.String())
+	}
+}
+
+// Status is the command a script polls in a loop, so it is the one that most
+// needs a parseable shape: -o json emits the API's status document verbatim
+// and none of the human labels.
+func TestPlaygroundStatusRendersJSONOnRequest(t *testing.T) {
+	withPlaygroundMock(t, &playgroundMock{status: &client.PlaygroundStatus{
+		ClusterID: playgroundTestClusterID,
+		Phase:     "ready",
+		ExpiresAt: "2026-08-14T09:00:00Z",
+		Plan:      &client.PlaygroundOrderedPlan{ID: "trial", DisplayName: "Trial", Vcpus: 1, MemoryGB: 2},
+	}})
+	if err := clusterPlaygroundStatusCmd.Flags().Set("output", "json"); err != nil {
+		t.Fatalf("setting -o json: %v", err)
+	}
+	// The structured renderer writes to the command's own writer, which
+	// falls back to whatever a parent command last had set - so capture it
+	// here rather than on os.Stdout, or the test depends on run order.
+	buffer := &strings.Builder{}
+	clusterPlaygroundStatusCmd.SetOut(buffer)
+	t.Cleanup(func() {
+		clusterPlaygroundStatusCmd.SetOut(nil)
+		_ = clusterPlaygroundStatusCmd.Flags().Set("output", "")
+	})
+
+	if err := clusterPlaygroundStatusCmd.RunE(clusterPlaygroundStatusCmd, []string{playgroundTestClusterID}); err != nil {
+		t.Fatalf("status -o json failed: %v", err)
+	}
+	output := buffer.String()
+	var decoded struct {
+		ClusterID string `json:"cluster_id"`
+		Phase     string `json:"phase"`
+		Plan      *struct {
+			ID string `json:"id"`
+		} `json:"plan"`
+	}
+	if err := json.Unmarshal([]byte(output), &decoded); err != nil {
+		t.Fatalf("-o json must emit a JSON document, got %v from: %s", err, output)
+	}
+	if decoded.ClusterID != playgroundTestClusterID || decoded.Phase != "ready" || decoded.Plan == nil || decoded.Plan.ID != "trial" {
+		t.Errorf("unexpected JSON document: %s", output)
+	}
+	if strings.Contains(output, "Cluster ID:") {
+		t.Errorf("-o json must not mix in the human labels, got: %s", output)
+	}
+}
+
 func TestPlaygroundDestroySurfacesTheServerError(t *testing.T) {
 	withPlaygroundMock(t, &playgroundMock{destroyError: errors.New("Playground not found.")})
+	clusterPlaygroundDestroyCmd.SetIn(strings.NewReader("y\n"))
+	t.Cleanup(func() { clusterPlaygroundDestroyCmd.SetIn(nil) })
 	runError := clusterPlaygroundDestroyCmd.RunE(clusterPlaygroundDestroyCmd, []string{playgroundTestClusterID})
 	if runError == nil {
 		t.Fatal("expected an error")
@@ -350,6 +459,8 @@ func TestPlaygroundCommandsResolveAClusterName(t *testing.T) {
 	if mock.statusRequested != playgroundTestClusterID {
 		t.Errorf("status must resolve the name to the id, requested %q", mock.statusRequested)
 	}
+	clusterPlaygroundDestroyCmd.SetIn(strings.NewReader("y\n"))
+	t.Cleanup(func() { clusterPlaygroundDestroyCmd.SetIn(nil) })
 	captureStdout(t, func() {
 		if err := clusterPlaygroundDestroyCmd.RunE(clusterPlaygroundDestroyCmd, []string{"playground"}); err != nil {
 			t.Fatalf("destroy by name failed: %v", err)

--- a/cmd/cluster_playground_test.go
+++ b/cmd/cluster_playground_test.go
@@ -302,6 +302,33 @@ func TestPlaygroundDestroyAsksFirstAndADeclineNeverReachesTheAPI(t *testing.T) {
 	}
 }
 
+// A name is resolved to an id before the request, so the prompt has to name
+// the resolved cluster too: what the user confirms must be what the API is
+// asked to destroy, not just the word they typed.
+func TestPlaygroundDestroyPromptNamesTheResolvedClusterID(t *testing.T) {
+	mock := &playgroundMock{
+		clusters: []client.ClusterListItem{{ID: playgroundTestClusterID, Name: "playground"}},
+	}
+	withPlaygroundMock(t, mock)
+	output := new(bytes.Buffer)
+	clusterPlaygroundDestroyCmd.SetOut(output)
+	clusterPlaygroundDestroyCmd.SetIn(strings.NewReader("n\n"))
+	t.Cleanup(func() {
+		clusterPlaygroundDestroyCmd.SetOut(nil)
+		clusterPlaygroundDestroyCmd.SetIn(nil)
+	})
+
+	runError := clusterPlaygroundDestroyCmd.RunE(clusterPlaygroundDestroyCmd, []string{"playground"})
+	if !errors.Is(runError, errCancelled) {
+		t.Fatalf("expected the declined prompt, got %v", runError)
+	}
+	for _, expected := range []string{`"playground"`, "cluster " + playgroundTestClusterID} {
+		if !strings.Contains(output.String(), expected) {
+			t.Errorf("expected %s in the prompt, got: %s", expected, output.String())
+		}
+	}
+}
+
 // --yes is the scripting escape hatch: no prompt is printed and stdin is
 // never read, so a script with a closed stdin still tears down.
 func TestPlaygroundDestroyYesSkipsThePrompt(t *testing.T) {

--- a/cmd/cluster_playground_test.go
+++ b/cmd/cluster_playground_test.go
@@ -282,11 +282,14 @@ func TestPlaygroundDestroyAsksFirstAndADeclineNeverReachesTheAPI(t *testing.T) {
 		destroyResult: &client.DestroyPlaygroundResult{ClusterID: playgroundTestClusterID, Phase: "deprovisioning"},
 	}
 	withPlaygroundMock(t, mock)
-	output := new(bytes.Buffer)
-	clusterPlaygroundDestroyCmd.SetOut(output)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	clusterPlaygroundDestroyCmd.SetOut(stdout)
+	clusterPlaygroundDestroyCmd.SetErr(stderr)
 	clusterPlaygroundDestroyCmd.SetIn(strings.NewReader("n\n"))
 	t.Cleanup(func() {
 		clusterPlaygroundDestroyCmd.SetOut(nil)
+		clusterPlaygroundDestroyCmd.SetErr(nil)
 		clusterPlaygroundDestroyCmd.SetIn(nil)
 	})
 
@@ -297,8 +300,13 @@ func TestPlaygroundDestroyAsksFirstAndADeclineNeverReachesTheAPI(t *testing.T) {
 	if mock.destroyRequested != "" {
 		t.Errorf("a declined destroy must not call the API, but it asked for %q", mock.destroyRequested)
 	}
-	if !strings.Contains(output.String(), "Destroy playground") || !strings.Contains(output.String(), "[y/N]") {
-		t.Errorf("expected the confirmation prompt in the output, got: %s", output.String())
+	// The prompt is human text, so it belongs on stderr: a `-o json` caller
+	// must never find it mixed into the document on stdout.
+	if !strings.Contains(stderr.String(), "Destroy playground") || !strings.Contains(stderr.String(), "[y/N]") {
+		t.Errorf("expected the confirmation prompt on stderr, got: %s", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("a declined destroy must leave stdout empty, got: %s", stdout.String())
 	}
 }
 
@@ -311,10 +319,10 @@ func TestPlaygroundDestroyPromptNamesTheResolvedClusterID(t *testing.T) {
 	}
 	withPlaygroundMock(t, mock)
 	output := new(bytes.Buffer)
-	clusterPlaygroundDestroyCmd.SetOut(output)
+	clusterPlaygroundDestroyCmd.SetErr(output)
 	clusterPlaygroundDestroyCmd.SetIn(strings.NewReader("n\n"))
 	t.Cleanup(func() {
-		clusterPlaygroundDestroyCmd.SetOut(nil)
+		clusterPlaygroundDestroyCmd.SetErr(nil)
 		clusterPlaygroundDestroyCmd.SetIn(nil)
 	})
 


### PR DESCRIPTION
## What & why

`ankra cluster playground destroy` was the one destructive verb in the CLI that ran the moment you pressed enter: no prompt, no `--yes`. `cluster deprovision` and every other delete confirm first (the CLAUDE.md invariant). A mistyped id or the wrong selected organisation took the environment and everything deployed in it, including its storage, and there is no restore lane yet.

- `destroy` now prompts through the shared `confirmPrompt` helper, naming the playground as passed. Declining returns `errCancelled` (exit 4) **before** any request is made; `--yes` skips the prompt for scripts.
- `status` and `destroy` take `-o json|yaml` via `renderStructured`. The `create` hint tells you to poll `status` in a loop, and that was the one command in the group that rejected `-o`, so scripts had to scrape the human text.

Found during a live create/destroy pass on 2026-09-07 (org ankra-ab-development): destroy of a ready trial returned in 0.09s with nothing asked.

Bead: ankra-stril

## Test plan

- New tests: declined prompt returns `errCancelled` and never reaches the API; `--yes` skips the prompt with an empty stdin; `status -o json` emits the API document with none of the human labels.
- Existing destroy tests now answer the prompt (`y\n` on the command's stdin).
- `go test -race -count=1 ./...` green locally (one test-order dependence in the first draft of the JSON test fixed by capturing the command's own writer rather than `os.Stdout`).
- `gofmt -l` clean; pre-commit hook (tests + golangci-lint) passed on commit.

## Docs checklist

- [ ] No user-facing command/flag changes — no docs needed
- [x] Command/flag changes — the CLI reference regenerates automatically on release (`tools/gendocs`); `Long` on `destroy` now documents the prompt and `--yes`
- [ ] Broader behaviour changes — docs updated in [ankra-docs](https://github.com/ankraio/ankra-docs) (link the PR): n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
