### PR TITLE
fix(org): ci-settings shows every stored setting and exits 7 on the admin gate (ankra-c1lop, PLA-825)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,21 @@
   the pipeline cluster and the build fallback - were discoverable only by
   asking Ankra: a run that concluded `infra_error` naming the build fallback
   left no command that could show what the fallback was set to. `get` prints
-  all eight settings, says what an unchosen pipeline cluster costs, calls out
-  a chosen cluster that has since been deleted, and reports when every value
-  is still Ankra's own default. `set` writes only the flags you pass, so
-  raising one number cannot clear the image policy; `--cluster` takes a name
-  or an id and an empty value clears it, and `--allowed-image-prefix` is
-  repeatable and replaces the whole policy list. Reading needs organisation
-  membership, changing needs organisation admin.
+  every setting the platform stores - the pipeline cluster, the build
+  fallback, both parallelism limits, the image policy, the private egress
+  allow-list, the artifact, cache and run-history retentions, the image gate
+  and its unfixed-findings floor - says what an unchosen pipeline cluster
+  costs, calls out a chosen cluster that has since been deleted, and reports
+  when every value is still Ankra's own default; `-o json` is the whole
+  record. `set` writes only the flags you pass, so raising one number cannot
+  clear the image policy; `--cluster` takes a name or an id and an empty
+  value clears it, `--allowed-image-prefix` and `--egress-allowed-cidr` are
+  repeatable and replace their whole list, and `--ignore-unfixed=false` is a
+  write while an untouched flag is not. Reading needs organisation
+  membership, changing needs organisation admin: a member's attempt is
+  refused with the platform's own sentence and exit code 7, the RBAC code,
+  rather than the re-login code. Both act on the selected organisation, or on
+  another you administer with the global `--org` flag.
 
 - **The Security Center's remaining surfaces reach the terminal.** Until
   now the portal could acknowledge a finding, accept its risk, switch a

--- a/cmd/org_ci_settings.go
+++ b/cmd/org_ci_settings.go
@@ -41,7 +41,9 @@ The two that decide whether a run can start at all:
                                            organisations whose source may not
                                            leave their own infrastructure
 
-Reading requires organisation membership; changing requires organisation admin.`,
+Reading requires organisation membership; changing requires organisation admin.
+Both act on the selected organisation; pass the global --org flag to read or
+change another organisation you administer.`,
 }
 
 var orgCISettingsGetCmd = &cobra.Command{
@@ -78,13 +80,21 @@ pipeline cluster with an empty value:
   ankra org ci-settings set --build-fallback none
   ankra org ci-settings set --allowed-image-prefix ghcr.io/ankraio --allowed-image-prefix docker.io/library
   ankra org ci-settings set --allowed-image-prefix ""
+  ankra org ci-settings set --egress-allowed-cidr 10.0.0.0/8 --egress-allowed-cidr 192.168.10.0/24
+  ankra org ci-settings set --run-retention-days 180
+  ankra org ci-settings set --ignore-unfixed=false
 
---allowed-image-prefix replaces the whole policy list rather than adding to it,
-because a policy you can only grow is one you cannot correct. Passing it once
-with an empty value clears the list, which means no organisation-level
-restriction.
+--allowed-image-prefix and --egress-allowed-cidr replace their whole list
+rather than adding to it, because a list you can only grow is one you cannot
+correct. Passing either once with an empty value clears it: no image
+restriction, or no private egress beyond the public internet.
 
-Requires organisation admin.`,
+--ignore-unfixed is the floor under every pipeline's image gate. It is true by
+default, letting a gate stage leave findings with no available fix out of its
+verdict; set it to false and every unfixed finding blocks, whatever any
+pipeline asks for.
+
+Requires organisation admin. A member's attempt is refused with exit code 7.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		changes, changesError := organisationCISettingsChanges(cmd)
@@ -95,7 +105,8 @@ Requires organisation admin.`,
 			return withExitCode(exitUsage, errors.New(
 				"pass at least one setting to change: --cluster, --build-fallback, "+
 					"--max-parallel-runs, --max-parallel-steps, --allowed-image-prefix, "+
-					"--artifact-retention-days, --cache-retention-days or --image-gate"))
+					"--egress-allowed-cidr, --artifact-retention-days, --cache-retention-days, "+
+					"--run-retention-days, --image-gate or --ignore-unfixed"))
 		}
 
 		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
@@ -186,6 +197,29 @@ func organisationCISettingsChanges(cmd *cobra.Command) (map[string]any, error) {
 		changes["ci_allowed_image_prefixes"] = prefixes
 	}
 
+	if cmd.Flags().Changed("egress-allowed-cidr") {
+		raw, _ := cmd.Flags().GetStringArray("egress-allowed-cidr")
+		cidrs := make([]string, 0, len(raw))
+		for _, cidr := range raw {
+			if trimmed := strings.TrimSpace(cidr); trimmed != "" {
+				cidrs = append(cidrs, trimmed)
+			}
+		}
+		// Same contract as the image policy: [] is "no private egress", not
+		// "leave it alone". The platform owns the CIDR rules (network
+		// address, private range, at most 32) and refuses with a sentence
+		// naming them, so nothing is re-validated here.
+		changes["ci_egress_allowed_cidrs"] = cidrs
+	}
+
+	if cmd.Flags().Changed("ignore-unfixed") {
+		// A bool flag has no absent state of its own, so presence is read
+		// from Changed rather than from the value: --ignore-unfixed=false is
+		// a write, an untouched flag is not.
+		ignoreUnfixed, _ := cmd.Flags().GetBool("ignore-unfixed")
+		changes["ci_ignore_unfixed"] = ignoreUnfixed
+	}
+
 	return changes, nil
 }
 
@@ -197,6 +231,7 @@ var organisationCISettingsIntFields = map[string]string{
 	"max-parallel-steps":      "ci_max_parallel_steps",
 	"artifact-retention-days": "ci_artifact_retention_days",
 	"cache-retention-days":    "ci_cache_retention_days",
+	"run-retention-days":      "ci_run_retention_days",
 }
 
 // organisationCISettingsIntUsage is the help string for each field in
@@ -207,6 +242,7 @@ var organisationCISettingsIntUsage = map[string]string{
 	"max-parallel-steps":      "How many steps of one run may be in flight at once",
 	"artifact-retention-days": "How long a run's artifacts survive",
 	"cache-retention-days":    "How long a run's caches survive",
+	"run-retention-days":      "How long a repository's concluded run history survives (7-365)",
 }
 
 func renderOrganisationCISettings(cmd *cobra.Command, settings *client.OrganisationCISettings) {
@@ -235,9 +271,17 @@ func renderOrganisationCISettings(cmd *cobra.Command, settings *client.Organisat
 		_, _ = fmt.Fprintf(out, "Allowed image prefixes:  %s\n",
 			strings.Join(settings.AllowedImagePrefixes, ", "))
 	}
+	if len(settings.EgressAllowedCIDRs) == 0 {
+		_, _ = fmt.Fprintln(out, "Egress allowed CIDRs:    (none - steps reach the public internet only)")
+	} else {
+		_, _ = fmt.Fprintf(out, "Egress allowed CIDRs:    %s\n",
+			strings.Join(settings.EgressAllowedCIDRs, ", "))
+	}
 	_, _ = fmt.Fprintf(out, "Artifact retention:      %d days\n", settings.ArtifactRetentionDays)
 	_, _ = fmt.Fprintf(out, "Cache retention:         %d days\n", settings.CacheRetentionDays)
+	_, _ = fmt.Fprintf(out, "Run retention:           %d days\n", settings.RunRetentionDays)
 	_, _ = fmt.Fprintf(out, "Image gate:              %s\n", settings.ImageGate)
+	_, _ = fmt.Fprintf(out, "Ignore unfixed findings: %s\n", yesNo(settings.IgnoreUnfixed))
 
 	if settings.IsDefault {
 		_, _ = fmt.Fprintln(out,
@@ -255,11 +299,9 @@ func renderOrganisationCISettings(cmd *cobra.Command, settings *client.Organisat
 	// setting that was already correct (PLA-825).
 	if settings.BuildFallback == client.CIBuildFallbackPlatformBuilders {
 		_, _ = fmt.Fprintln(out,
-			"\nThe Ankra-operated build fallback also needs the platform-builders capability\n"+
-				"enabled for this organisation, which is not one of these settings and is not\n"+
-				"shown above. If a build step fails with \"the organisation's build fallback is\n"+
-				"'none'\" while this says platform_builders, the setting is not what is missing -\n"+
-				"ask Ankra support to enable the capability.")
+			"\nNote: platform_builders also needs the platform-builders capability, which these\n"+
+				"settings do not show. A build step that fails with \"build fallback is 'none'\"\n"+
+				"while this reads platform_builders is missing the capability, not the setting.")
 	}
 }
 
@@ -274,6 +316,10 @@ func init() {
 		"Image prefix a step may name (repeatable); replaces the list, empty clears it")
 	orgCISettingsSetCmd.Flags().String("image-gate", "",
 		"Which image findings block a publish: app, all or off")
+	orgCISettingsSetCmd.Flags().StringArray("egress-allowed-cidr", nil,
+		"Private CIDR pipeline steps may reach (repeatable); replaces the list, empty clears it")
+	orgCISettingsSetCmd.Flags().Bool("ignore-unfixed", true,
+		"Let a gate stage leave findings with no available fix out of its verdict; =false makes every unfixed finding block")
 	// Both directions of drift are fatal: walking the field map catches a
 	// field with no usage string, the count check catches a usage string
 	// naming a flag that writes nothing.

--- a/cmd/org_ci_settings_test.go
+++ b/cmd/org_ci_settings_test.go
@@ -293,3 +293,90 @@ func TestRunOrgCISettingsSet_RefusesAWriteThatNamesNothing(t *testing.T) {
 		t.Errorf("nothing may be written, got %v", mock.updateSeen)
 	}
 }
+
+// The platform stores eleven settings; a `get` that showed eight would read as
+// the whole record to anyone who did not already know the other three existed,
+// which is the discoverability gap this command exists to close.
+func TestRunOrgCISettingsGet_ShowsEveryStoredSetting(t *testing.T) {
+	settings := defaultCISettings()
+	settings.IsDefault = false
+	settings.RunRetentionDays = 180
+	settings.IgnoreUnfixed = false
+	settings.EgressAllowedCIDRs = []string{"10.0.0.0/8", "192.168.10.0/24"}
+	mock := &orgCISettingsMock{settings: settings}
+	output, executeError := runOrgCISettings(t, mock, "org", "ci-settings", "get")
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	for _, want := range []string{
+		"Run retention:           180 days",
+		"Egress allowed CIDRs:    10.0.0.0/8, 192.168.10.0/24",
+		"Ignore unfixed findings: no",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("missing %q in:\n%s", want, output)
+		}
+	}
+}
+
+func TestRunOrgCISettingsGet_SaysWhatAnEmptyEgressListMeans(t *testing.T) {
+	mock := &orgCISettingsMock{settings: defaultCISettings()}
+	output, executeError := runOrgCISettings(t, mock, "org", "ci-settings", "get")
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	if !strings.Contains(output, "public internet only") {
+		t.Errorf("an empty egress list must say what it permits, got %s", output)
+	}
+}
+
+// A bool flag has no absent state, so the write must come from Changed and
+// carry the false: dropping it as a zero value would make "turn the floor off"
+// silently a no-op.
+func TestRunOrgCISettingsSet_SendsAnExplicitFalseForIgnoreUnfixed(t *testing.T) {
+	mock := &orgCISettingsMock{settings: defaultCISettings()}
+	output, executeError := runOrgCISettings(t, mock,
+		"org", "ci-settings", "set", "--ignore-unfixed=false")
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	changes := mock.updateSeen[0]
+	if len(changes) != 1 {
+		t.Fatalf("only ci_ignore_unfixed may be written, got %v", changes)
+	}
+	if value, isPresent := changes["ci_ignore_unfixed"]; !isPresent || value != false {
+		t.Errorf("expected ci_ignore_unfixed false, got %v", changes)
+	}
+}
+
+func TestRunOrgCISettingsSet_DoesNotWriteIgnoreUnfixedWhenUntouched(t *testing.T) {
+	mock := &orgCISettingsMock{settings: defaultCISettings()}
+	output, executeError := runOrgCISettings(t, mock,
+		"org", "ci-settings", "set", "--run-retention-days", "30")
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	changes := mock.updateSeen[0]
+	if _, isPresent := changes["ci_ignore_unfixed"]; isPresent {
+		t.Errorf("an untouched bool flag must not reach the body, got %v", changes)
+	}
+	if changes["ci_run_retention_days"] != 30 {
+		t.Errorf("expected ci_run_retention_days 30, got %v", changes)
+	}
+}
+
+func TestRunOrgCISettingsSet_ClearsTheEgressListWithAnEmptyValue(t *testing.T) {
+	mock := &orgCISettingsMock{settings: defaultCISettings()}
+	output, executeError := runOrgCISettings(t, mock,
+		"org", "ci-settings", "set", "--egress-allowed-cidr", "")
+	if executeError != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", executeError, output)
+	}
+	cidrs, isList := mock.updateSeen[0]["ci_egress_allowed_cidrs"].([]string)
+	if !isList {
+		t.Fatalf("the egress list must be sent as a list, got %v", mock.updateSeen[0])
+	}
+	if len(cidrs) != 0 {
+		t.Errorf("an empty value clears the list, got %v", cidrs)
+	}
+}

--- a/internal/client/org_ci_settings.go
+++ b/internal/client/org_ci_settings.go
@@ -15,22 +15,40 @@ import (
 // (GET/PUT /api/v1/org/ci-settings): which cluster pipeline steps run on,
 // whether the Ankra-operated build cluster stays available when that cluster
 // cannot build, how much of the run and step schedulers the organisation may
-// occupy, which images its steps may name, how long artifacts and caches
-// survive, and which image findings block a publish.
+// occupy, which images its steps may name and which private networks they may
+// reach, how long artifacts, caches and run history survive, and which image
+// findings block a publish.
+//
+// Every field the platform stores is carried, so `-o json` is the whole
+// record rather than a subset a reader would have to know was incomplete.
 //
 // ClusterID is nil when the organisation has chosen no pipeline cluster.
 // ClusterName alone is nil when the chosen cluster has since been deleted,
 // which is why the id is carried separately rather than dropped with it.
 type OrganisationCISettings struct {
-	ClusterID             *string  `json:"ci_cluster_id" yaml:"ci_cluster_id"`
-	ClusterName           *string  `json:"ci_cluster_name" yaml:"ci_cluster_name"`
-	BuildFallback         string   `json:"ci_build_fallback" yaml:"ci_build_fallback"`
-	MaxParallelRuns       int      `json:"ci_max_parallel_runs" yaml:"ci_max_parallel_runs"`
-	MaxParallelSteps      int      `json:"ci_max_parallel_steps" yaml:"ci_max_parallel_steps"`
-	AllowedImagePrefixes  []string `json:"ci_allowed_image_prefixes" yaml:"ci_allowed_image_prefixes"`
+	ClusterID            *string  `json:"ci_cluster_id" yaml:"ci_cluster_id"`
+	ClusterName          *string  `json:"ci_cluster_name" yaml:"ci_cluster_name"`
+	BuildFallback        string   `json:"ci_build_fallback" yaml:"ci_build_fallback"`
+	MaxParallelRuns      int      `json:"ci_max_parallel_runs" yaml:"ci_max_parallel_runs"`
+	MaxParallelSteps     int      `json:"ci_max_parallel_steps" yaml:"ci_max_parallel_steps"`
+	AllowedImagePrefixes []string `json:"ci_allowed_image_prefixes" yaml:"ci_allowed_image_prefixes"`
+	// EgressAllowedCIDRs are the private networks every pipeline step may
+	// reach on top of the public internet; each becomes a peer on the step's
+	// NetworkPolicy, so the platform bounds the list and refuses anything
+	// outside RFC 1918 / fd00::/8.
+	EgressAllowedCIDRs    []string `json:"ci_egress_allowed_cidrs" yaml:"ci_egress_allowed_cidrs"`
 	ArtifactRetentionDays int      `json:"ci_artifact_retention_days" yaml:"ci_artifact_retention_days"`
 	CacheRetentionDays    int      `json:"ci_cache_retention_days" yaml:"ci_cache_retention_days"`
-	ImageGate             string   `json:"ci_image_gate" yaml:"ci_image_gate"`
+	// RunRetentionDays is how long a repository's concluded run history is
+	// kept; a live run and a repository's newest concluded run are never
+	// deleted whatever this says.
+	RunRetentionDays int    `json:"ci_run_retention_days" yaml:"ci_run_retention_days"`
+	ImageGate        string `json:"ci_image_gate" yaml:"ci_image_gate"`
+	// IgnoreUnfixed is the organisation-wide floor under the image gate: true
+	// (Ankra's default) lets a pipeline's own gate stage leave findings with
+	// no available fix out of the verdict; false keeps every unfixed finding
+	// blocking whatever any pipeline asks for.
+	IgnoreUnfixed bool `json:"ci_ignore_unfixed" yaml:"ci_ignore_unfixed"`
 
 	// IsDefault reports that every answer above is Ankra's own default, so a
 	// caller can say "this organisation runs on Ankra's defaults" without
@@ -136,7 +154,17 @@ func (c *Client) doCISettingsRequest(ctx context.Context, method string, body []
 		return responseBody, nil
 	case http.StatusUnauthorized:
 		return nil, ErrUnauthorized
-	case http.StatusForbidden, http.StatusBadRequest, http.StatusUnprocessableEntity:
+	case http.StatusForbidden:
+		// The admin gate is an RBAC refusal: the caller is who they say they
+		// are and it is their role that falls short. That is exit 7, "ask an
+		// admin", not the exit-6 "re-login" a bare 403 would earn. The gate
+		// writes its own sentence rather than the {"detail":
+		// "permission_denied"} shape, so the sentence rides along verbatim.
+		if denied := PermissionDeniedFromResponse(response.StatusCode, responseBody); denied != nil {
+			return nil, denied
+		}
+		return nil, &PermissionDeniedError{Detail: ciSettingsRefusalDetail(responseBody)}
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
 		// The refusals this endpoint writes all name the setting they
 		// refused - the admin gate, an unknown build fallback, a value out of
 		// range. Relaying the detail verbatim is the whole point: the

--- a/internal/client/org_ci_settings_test.go
+++ b/internal/client/org_ci_settings_test.go
@@ -1,0 +1,254 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// The organisation CI settings lane parity table. A path or method typo here
+// fails as a 404 against a real platform and passes every command-wiring test
+// that only checks the flag plumbing, so both routes are pinned on the request
+// itself, the way the agent CI settings lane is.
+func TestOrganisationCISettingsLaneParity(t *testing.T) {
+	lanes := []struct {
+		name       string
+		wantMethod string
+		wantBody   map[string]any
+		call       func(testClient *Client) error
+	}{
+		{
+			name:       "get reads the organisation's settings",
+			wantMethod: http.MethodGet,
+			call: func(testClient *Client) error {
+				_, getError := testClient.GetOrganisationCISettings(context.Background())
+				return getError
+			},
+		},
+		{
+			// The endpoint reads presence, so the body must carry exactly
+			// the keys the caller named and nothing it did not.
+			name:       "set sends only the named setting",
+			wantMethod: http.MethodPut,
+			wantBody:   map[string]any{"ci_build_fallback": "none"},
+			call: func(testClient *Client) error {
+				_, updateError := testClient.UpdateOrganisationCISettings(context.Background(),
+					map[string]any{"ci_build_fallback": "none"})
+				return updateError
+			},
+		},
+		{
+			// Clearing the pipeline cluster is a present key with a null
+			// value; an absent key would leave the cluster untouched.
+			name:       "set clears the cluster with an explicit null",
+			wantMethod: http.MethodPut,
+			wantBody:   map[string]any{"ci_cluster_id": nil},
+			call: func(testClient *Client) error {
+				_, updateError := testClient.UpdateOrganisationCISettings(context.Background(),
+					map[string]any{"ci_cluster_id": nil})
+				return updateError
+			},
+		},
+	}
+
+	for _, lane := range lanes {
+		t.Run(lane.name, func(t *testing.T) {
+			var seenMethod, seenPath string
+			var seenBody map[string]any
+			testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
+				seenMethod, seenPath = request.Method, request.URL.Path
+				if request.Method != http.MethodGet {
+					if decodeError := json.NewDecoder(request.Body).Decode(&seenBody); decodeError != nil {
+						t.Fatalf("decode request body: %v", decodeError)
+					}
+				}
+				jsonResponse(t, writer, http.StatusOK, OrganisationCISettings{
+					BuildFallback: CIBuildFallbackPlatformBuilders})
+			})
+
+			if callError := lane.call(testClient); callError != nil {
+				t.Fatalf("call error = %v", callError)
+			}
+			if seenMethod != lane.wantMethod {
+				t.Errorf("method = %s, want %s", seenMethod, lane.wantMethod)
+			}
+			if seenPath != "/api/v1/org/ci-settings" {
+				t.Errorf("path = %s", seenPath)
+			}
+			if lane.wantBody == nil {
+				return
+			}
+			if len(seenBody) != len(lane.wantBody) {
+				t.Fatalf("body = %v, want exactly %v", seenBody, lane.wantBody)
+			}
+			for key, want := range lane.wantBody {
+				got, isPresent := seenBody[key]
+				if !isPresent {
+					t.Errorf("body is missing %q: %v", key, seenBody)
+					continue
+				}
+				if got != want {
+					t.Errorf("body[%q] = %v, want %v", key, got, want)
+				}
+			}
+		})
+	}
+}
+
+// The wire record as production serves it today, every field included. A
+// struct that dropped a field would still decode cleanly, so the only test
+// that catches the omission is one that asserts the whole record.
+func TestGetOrganisationCISettingsDecodesEveryField(t *testing.T) {
+	const productionShape = `{
+		"ci_cluster_id": "858f9fb3-b2d1-4568-86e4-600de3944130",
+		"ci_cluster_name": "launch-week-2026",
+		"ci_build_fallback": "platform_builders",
+		"ci_max_parallel_runs": 4,
+		"ci_max_parallel_steps": 8,
+		"ci_allowed_image_prefixes": ["ghcr.io/ankraio"],
+		"ci_artifact_retention_days": 30,
+		"ci_cache_retention_days": 14,
+		"ci_run_retention_days": 90,
+		"ci_image_gate": "app",
+		"ci_ignore_unfixed": true,
+		"ci_egress_allowed_cidrs": ["10.0.0.0/8"],
+		"is_default": false,
+		"updated_at": "2026-09-06T19:45:53.034986Z"
+	}`
+	testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write([]byte(productionShape))
+	})
+
+	settings, getError := testClient.GetOrganisationCISettings(context.Background())
+	if getError != nil {
+		t.Fatalf("GetOrganisationCISettings error = %v", getError)
+	}
+	if settings.ClusterID == nil || *settings.ClusterID != "858f9fb3-b2d1-4568-86e4-600de3944130" {
+		t.Errorf("ClusterID = %v", settings.ClusterID)
+	}
+	if settings.ClusterName == nil || *settings.ClusterName != "launch-week-2026" {
+		t.Errorf("ClusterName = %v", settings.ClusterName)
+	}
+	if settings.BuildFallback != CIBuildFallbackPlatformBuilders {
+		t.Errorf("BuildFallback = %q", settings.BuildFallback)
+	}
+	if settings.MaxParallelRuns != 4 || settings.MaxParallelSteps != 8 {
+		t.Errorf("parallelism = %d/%d", settings.MaxParallelRuns, settings.MaxParallelSteps)
+	}
+	if len(settings.AllowedImagePrefixes) != 1 || settings.AllowedImagePrefixes[0] != "ghcr.io/ankraio" {
+		t.Errorf("AllowedImagePrefixes = %v", settings.AllowedImagePrefixes)
+	}
+	if len(settings.EgressAllowedCIDRs) != 1 || settings.EgressAllowedCIDRs[0] != "10.0.0.0/8" {
+		t.Errorf("EgressAllowedCIDRs = %v", settings.EgressAllowedCIDRs)
+	}
+	if settings.ArtifactRetentionDays != 30 || settings.CacheRetentionDays != 14 || settings.RunRetentionDays != 90 {
+		t.Errorf("retention = %d/%d/%d", settings.ArtifactRetentionDays,
+			settings.CacheRetentionDays, settings.RunRetentionDays)
+	}
+	if settings.ImageGate != CIImageGateApplicationDependencies {
+		t.Errorf("ImageGate = %q", settings.ImageGate)
+	}
+	if !settings.IgnoreUnfixed {
+		t.Errorf("IgnoreUnfixed = false, want true")
+	}
+	if settings.IsDefault {
+		t.Errorf("IsDefault = true, want false")
+	}
+	if settings.UpdatedAt == nil {
+		t.Errorf("UpdatedAt was dropped")
+	}
+}
+
+// A member changing the settings is refused by the admin gate. That is an RBAC
+// refusal - the caller's identity is fine, their role is not - so it must be
+// the exit-7 PermissionDeniedError, not the exit-6 "re-login" a bare 403
+// earns, and the platform's own sentence must survive the trip.
+func TestUpdateOrganisationCISettingsAdminGateIsAPermissionDenial(t *testing.T) {
+	const gateSentence = "Changing the organisation's CI settings requires the admin role."
+	testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		jsonResponse(t, writer, http.StatusForbidden, map[string]string{"detail": gateSentence})
+	})
+
+	_, updateError := testClient.UpdateOrganisationCISettings(context.Background(),
+		map[string]any{"ci_build_fallback": "none"})
+	var denied *PermissionDeniedError
+	if !errors.As(updateError, &denied) {
+		t.Fatalf("error = %T %v, want *PermissionDeniedError", updateError, updateError)
+	}
+	if !strings.Contains(updateError.Error(), gateSentence) {
+		t.Errorf("the gate's own sentence must be relayed, got %q", updateError.Error())
+	}
+}
+
+// The platform's RBAC shape for a 403 keeps its existing handling: the
+// permission it names is what the caller reads.
+func TestUpdateOrganisationCISettingsKeepsTheRBACPermissionName(t *testing.T) {
+	testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		jsonResponse(t, writer, http.StatusForbidden, map[string]string{
+			"detail": "permission_denied", "permission": "organisation.settings.write"})
+	})
+
+	_, updateError := testClient.UpdateOrganisationCISettings(context.Background(),
+		map[string]any{"ci_build_fallback": "none"})
+	var denied *PermissionDeniedError
+	if !errors.As(updateError, &denied) {
+		t.Fatalf("error = %T %v, want *PermissionDeniedError", updateError, updateError)
+	}
+	if denied.Permission != "organisation.settings.write" {
+		t.Errorf("Permission = %q", denied.Permission)
+	}
+}
+
+// The endpoint writes two refusal shapes - a single sentence for the frozen
+// refusals and a per-member list for validation - and the whole point of
+// relaying them is that they name the setting and its bounds. Both shapes
+// must reach the caller as words, not as a status code.
+func TestOrganisationCISettingsRelaysBothRefusalShapes(t *testing.T) {
+	shapes := []struct {
+		name   string
+		status int
+		body   any
+		want   string
+	}{
+		{
+			name:   "single sentence",
+			status: http.StatusUnprocessableEntity,
+			body:   map[string]string{"detail": "Run retention must be between 7 and 365 days."},
+			want:   "between 7 and 365 days",
+		},
+		{
+			name:   "per-member list",
+			status: http.StatusUnprocessableEntity,
+			body: map[string]any{"detail": []map[string]string{
+				{"msg": "Each allowed egress CIDR must sit inside private address space"},
+				{"msg": "Run retention must be between 7 and 365 days."},
+			}},
+			want: "private address space; Run retention",
+		},
+	}
+	for _, shape := range shapes {
+		t.Run(shape.name, func(t *testing.T) {
+			testClient := newTestClient(t, func(writer http.ResponseWriter, request *http.Request) {
+				jsonResponse(t, writer, shape.status, shape.body)
+			})
+			_, updateError := testClient.UpdateOrganisationCISettings(context.Background(),
+				map[string]any{"ci_run_retention_days": 1})
+			if updateError == nil {
+				t.Fatal("a refused write must return an error")
+			}
+			var unexpected *UnexpectedResponseError
+			if !errors.As(updateError, &unexpected) || unexpected.StatusCode != shape.status {
+				t.Fatalf("error = %T %v, want *UnexpectedResponseError with status %d",
+					updateError, updateError, shape.status)
+			}
+			if !strings.Contains(updateError.Error(), shape.want) {
+				t.Errorf("refusal vocabulary must be relayed, got %q", updateError.Error())
+			}
+		})
+	}
+}

--- a/internal/client/unexpected_response.go
+++ b/internal/client/unexpected_response.go
@@ -73,11 +73,19 @@ var ErrUnauthorized = errors.New("unauthorized. Run `ankra login` to re-authenti
 // role change" (exit code 7 vs 6).
 type PermissionDeniedError struct {
 	Permission string
+	// Detail is the platform's own refusal sentence, for routes whose admin
+	// gate writes `{"detail": "..."}` rather than the RBAC shape above. It is
+	// relayed verbatim when set: the platform already says what the caller
+	// lacks, and it stays an exit-7 refusal rather than a re-login prompt.
+	Detail string
 }
 
 func (e *PermissionDeniedError) Error() string {
 	if e == nil {
 		return ""
+	}
+	if e.Detail != "" {
+		return "permission denied: " + e.Detail
 	}
 	if e.Permission == "" {
 		return "permission denied: your role does not permit this action. Ask an organisation admin to change your role"


### PR DESCRIPTION
<!-- ankra-tech-agent:pr -->
Linear: https://linear.app/ankra/issue/PLA-825/1147-cli-has-no-way-to-discover-which-container-image-registry-an-org
Beads: ankra-c1lop
Follows: #236 (merged as c5f42fb0b while this review was in flight; this is the review's findings, rebased onto master)

## Why a follow-up

#236 added `ankra org ci-settings get|set`. Reviewing it before merge turned up three things
that should not ship in a command whose whole purpose is discoverability, and the auto-merge
sweep landed the PR before the fixes could join it. They are here, unchanged, on top of master.

## 1. `get` dropped three of the eleven stored settings

The client struct carried eight fields. The platform stores eleven: `ci_run_retention_days`,
`ci_ignore_unfixed` and `ci_egress_allowed_cidrs` were absent, so `get` never showed them and
`-o json` was a silently incomplete record — the exact gap the command exists to close, one
layer down. All three are carried now. `get` renders them (`Run retention`, `Egress allowed
CIDRs`, `Ignore unfixed findings`); `set` gains `--run-retention-days`, `--egress-allowed-cidr`
(repeatable, replaces the list, empty clears it — same contract as the image policy) and
`--ignore-unfixed`, read through `Changed` so `=false` is a write and an untouched flag is not.

## 2. The admin gate exited 6 ("re-login") instead of 7 (RBAC)

A member changing the settings hits the endpoint's admin gate. `cmd/exitcodes.go` reserves
exit 7 for exactly this — authenticated, role falls short, "ask an admin" — and maps a bare
403 to exit 6, which tells the caller to log in again. The 403 now surfaces as
`PermissionDeniedError`. That type gains an optional `Detail` for gates that write
`{"detail": "..."}` rather than the RBAC `permission_denied` shape, so the platform's own
sentence is relayed verbatim; the RBAC shape keeps its existing handling.

## 3. The client had no tests of its own

`internal/client/org_ci_settings_test.go` is new: a lane-parity table pins method, path and
the presence-only PUT body (including the explicit null that clears the cluster); one test
decodes the full production payload so a dropped field fails again; both 403 shapes map to
`PermissionDeniedError`; both refusal-detail shapes (single sentence, per-member list) are
relayed as words.

Also: the platform-builders caveat `get` prints is cut from five lines to three, and the
command help now says `--org` scopes both verbs to another organisation you administer.

## Validation

- Pre-commit gate on the commit: full `go test ./...` and `golangci-lint run` — pass, 0 issues
- `go vet ./cmd/ ./internal/client/` — clean
- `go test -race -count=1 ./cmd/ ./internal/client/` — pass
- CI on the same commit, run 34147973209 — green

## Related

- **ankra-8atb4** (closed, cluster#2722): the platform's frozen `infra_error` sentence no longer
  names the fallback setting when only the `platform_builds` flag is dark.
- **ankra-vn0bd.3.10.2** (open): expose that capability read-only in `GET /org/ci-settings`,
  so the caveat can become a printed field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
