### PR TITLE
release: cut v0.15.0-rc5 ankra-f53p5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,32 @@
 # Ankra CLI Changelog
 
-## Unreleased
+## v0.15.0-rc5 — 2026-09-07
 
 ### Added
 
+- **`ankra security sbom` grades every component's licence risk, and
+  `--license-risk` filters on it.** `sbom` and `sbom image` show each
+  component's tier - network copyleft, source-available, copyleft, weak
+  copyleft, permissive or unknown - and take `--license-risk <tier>`
+  (repeatable) to keep only the ones you are asking about; `sbom images` and
+  the image detail summarise the obliging tiers per image ("2 network
+  copyleft, 1 copyleft"), red for the two that reach the hosting service and
+  yellow for plain copyleft. A licence question no longer means exporting the
+  bill of materials and grepping it.
+- **`ankra security sbom component <name> --version <v> --type <ecosystem>`
+  follows one exact package to where it runs.** The row `sbom` shows was a
+  dead end; the new read lists the images carrying that package, every
+  workload container running those images (cluster, namespace, workload,
+  container, image, last seen) and the clusters they run on, and says when a
+  list was capped. `-o json` and `-o yaml` carry the full read, so "where is
+  this vulnerable version actually deployed" is one command.
+- **`ankra chat` shows what its tools are doing.** The session output
+  rendered content, status, notices, proposals and errors but dropped the
+  tool frames, so a long turn read as silent gaps between status lines and a
+  failed tool never said why. Each tool call now prints one bracketed line
+  when it starts (`[tool list_node_groups ...]`) and one when it settles
+  (`[tool list_node_groups ok]`, or `[tool get_pods failed (transient): Agent
+  timeout while fetching pods.]` carrying the platform's error class).
 - **`ankra org ci-settings get|set` reads and changes the organisation's
   Ankra Pipelines settings.** The platform has served `GET/PUT
   /org/ci-settings` since the pipelines lane shipped and nothing in the CLI


### PR DESCRIPTION
## What & why

Cuts `v0.15.0-rc5`. `v0.15.0-rc4` was tagged earlier today and eleven commits have landed above it, including the whole Security Center parity lane, `ankra org ci-settings`, chat tool activity and the playground destroy confirmation - none of which has been in any RC yet. This PR promotes `## Unreleased` to `## v0.15.0-rc5 — 2026-09-07` (changelog only, per the release recipe) and writes the entries three merged PRs shipped without: #247 (licence-risk tiers, `--license-risk`), #257 (`security sbom component`), #259 (chat tool activity).

Above the tag: #256, #237, #257, #247, #236, #261, #259, #255, #260, #245, #258.

Bead: ankra-f53p5

## Test plan

- Release-notes extractor dry run (`awk -v version="0.15.0-rc5" ...`) prints the rc5 section starting at `### Added` - the heading matches `^## v?0.15.0-rc5([[:space:]]|$)`, so the workflow will not silently fall back to `--generate-notes`.
- After merge: annotated tag `v0.15.0-rc5` on the squash commit; the release workflow publishes 13 assets as a prerelease; verify the darwin-arm64 binary by sha256, `ankra version`, and a real command against prod.

## Docs checklist

- [x] No user-facing command/flag changes — no docs needed (changelog only)
- [ ] Command/flag changes — n/a
- [ ] Broader behaviour changes — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
