### PR TITLE
feat(pipeline): run and list read the application and the commit from the checkout (ankra-ctsmd)

### DIFF
--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -151,9 +151,15 @@ func pipelineSelectorFromWorkingDirectory(requestContext context.Context) (clien
 	fullName := repository.Owner + "/" + repository.Name
 	matchedIDs := []string{}
 	matchedNames := []string{}
+	listingExhausted := false
+	// The listing is walked unfiltered: the server-side `search` matches an
+	// application's NAME, and an application is free to be called something
+	// other than the repository it builds, so filtering by the repository
+	// name would silently miss exactly those. The walk is bounded the same
+	// way resolveApplicationID's is.
 	for page := 1; page <= maxApplicationLookupPages; page++ {
 		payload, listError := apiClient.ListApplicationsRaw(
-			requestContext, page, maxApplicationLookupPageSize, repository.Name)
+			requestContext, page, maxApplicationLookupPageSize, "")
 		if listError != nil {
 			return client.PipelineSelector{}, "", nil
 		}
@@ -169,8 +175,16 @@ func pipelineSelectorFromWorkingDirectory(requestContext context.Context) (clien
 			}
 		}
 		if listing.Pagination.TotalPages <= page || len(listing.Result) == 0 {
+			listingExhausted = true
 			break
 		}
+	}
+	// A listing that ran past the page cap was only partly read, so "no
+	// application on this repository" is not something this walk knows. It
+	// answers nothing and the caller asks for the flag, rather than treating
+	// an unread page as an absence.
+	if !listingExhausted {
+		return client.PipelineSelector{}, "", nil
 	}
 	if len(matchedIDs) > 1 {
 		// The checkout answered the question and the answer was "more than

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -16,8 +16,11 @@ package cmd
 // it takes no PipelineSelector.
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"ankra/internal/client"
@@ -109,9 +112,110 @@ func resolvePipelineSelector(command *cobra.Command) (client.PipelineSelector, e
 		}
 		return client.PipelineSelector{RepositoryID: repositoryID}, nil
 	default:
+		// Neither flag: the working directory usually answers the question.
+		// A user standing in the checkout they want built has already told
+		// the shell which application they mean, and making them repeat it
+		// as --application is the kind of step this command can simply take
+		// off them (ankra-ctsmd). Nothing is guessed silently - the caller
+		// prints what was inferred - and an ambiguous or absent answer falls
+		// through to the same usage error as before.
+		selector, inferred, inferError := pipelineSelectorFromWorkingDirectory(command.Context())
+		if inferError != nil {
+			return client.PipelineSelector{}, inferError
+		}
+		if inferred != "" {
+			reportInferredPipelineTarget(command, inferred)
+			return selector, nil
+		}
 		return client.PipelineSelector{}, withExitCode(exitUsage,
 			errors.New("one of --application or --repository is required"))
 	}
+}
+
+// pipelineSelectorFromWorkingDirectory answers the application whose
+// repository is checked out in the working directory, and the "owner/name"
+// it matched so the caller can say so.
+//
+// Every way of not getting a confident answer - not inside a checkout, no
+// origin remote, no application on that repository, or more than one - is an
+// empty answer rather than an error, because the caller has a perfectly good
+// usage error to fall back on and a wrong inference is worse than none.
+func pipelineSelectorFromWorkingDirectory(requestContext context.Context) (client.PipelineSelector, string, error) {
+	if apiClient == nil {
+		return client.PipelineSelector{}, "", nil
+	}
+	repository, inspectError := inspectLocalApplicationRepository(requestContext, ".", "origin", "")
+	if inspectError != nil {
+		return client.PipelineSelector{}, "", nil
+	}
+	fullName := repository.Owner + "/" + repository.Name
+	matchedIDs := []string{}
+	matchedNames := []string{}
+	for page := 1; page <= maxApplicationLookupPages; page++ {
+		payload, listError := apiClient.ListApplicationsRaw(
+			requestContext, page, maxApplicationLookupPageSize, repository.Name)
+		if listError != nil {
+			return client.PipelineSelector{}, "", nil
+		}
+		var listing applicationRepositoryListingPage
+		if unmarshalError := json.Unmarshal(payload, &listing); unmarshalError != nil {
+			return client.PipelineSelector{}, "", nil
+		}
+		for _, application := range listing.Result {
+			if strings.EqualFold(strings.TrimSpace(application.RepositoryOwner), repository.Owner) &&
+				strings.EqualFold(strings.TrimSpace(application.RepositoryName), repository.Name) {
+				matchedIDs = append(matchedIDs, application.ID)
+				matchedNames = append(matchedNames, applicationLabel(application.Name, application.ID))
+			}
+		}
+		if listing.Pagination.TotalPages <= page || len(listing.Result) == 0 {
+			break
+		}
+	}
+	if len(matchedIDs) > 1 {
+		// The checkout answered the question and the answer was "more than
+		// one". Saying so beats repeating the generic usage line, which
+		// would leave the user re-reading a flag they were about to pass.
+		sort.Strings(matchedNames)
+		return client.PipelineSelector{}, "", withExitCode(exitUsage, fmt.Errorf(
+			"%s has %d applications in this organisation (%s); pass --application to say which",
+			fullName, len(matchedNames), strings.Join(matchedNames, ", ")))
+	}
+	if len(matchedIDs) == 0 {
+		return client.PipelineSelector{}, "", nil
+	}
+	return client.PipelineSelector{ApplicationID: matchedIDs[0]}, fullName, nil
+}
+
+// applicationRepositoryListingPage is the applications listing read for the
+// repository each application is bound to, beside the id.
+type applicationRepositoryListingPage struct {
+	Result []struct {
+		ID              string `json:"id"`
+		Name            string `json:"name"`
+		RepositoryOwner string `json:"app_repo_owner"`
+		RepositoryName  string `json:"app_repo_name"`
+	} `json:"result"`
+	Pagination struct {
+		TotalPages int `json:"total_pages"`
+	} `json:"pagination"`
+}
+
+// applicationLabel names an application by its name, falling back to its id
+// for an application whose definition carries none.
+func applicationLabel(name string, id string) string {
+	if strings.TrimSpace(name) != "" {
+		return strings.TrimSpace(name)
+	}
+	return id
+}
+
+// reportInferredPipelineTarget says on stderr which application the working
+// directory resolved to. Stderr, not stdout, so a structured -o json output
+// stays exactly what a caller can parse.
+func reportInferredPipelineTarget(command *cobra.Command, fullName string) {
+	_, _ = fmt.Fprintf(command.ErrOrStderr(),
+		"Using the application bound to %s (pass --application to choose another).\n", fullName)
 }
 
 // parsePipelineInputFlags parses repeated --input key=value flags into the

--- a/cmd/pipeline_run.go
+++ b/cmd/pipeline_run.go
@@ -29,9 +29,12 @@ func newPipelineRunCommand() *cobra.Command {
 		Short: "Dispatch a manual pipeline run",
 		Long: `Dispatch a manual run of a pipeline's stored definition.
 
---sha is mandatory: resolving a ref to a commit belongs to the trigger lane
-(push/PR/tag webhooks), so a dispatch that names no commit is refused rather
-than run against whatever commit the platform happens to have stored last.`,
+A run is always dispatched at one named commit: resolving a ref to a commit
+belongs to the trigger lane (push/PR/tag webhooks), so a dispatch never runs
+against whatever commit the platform happens to have stored last. Inside a Git
+checkout the commit is read from HEAD, and --application is read from the
+repository the checkout points at, so 'ankra pipeline run' on its own runs
+what you are looking at. Outside a checkout, name them with --sha and --application.`,
 		Args: cobra.NoArgs,
 		RunE: func(command *cobra.Command, arguments []string) error {
 			selector, selectorError := resolvePipelineSelector(command)
@@ -51,11 +54,35 @@ than run against whatever commit the platform happens to have stored last.`,
 // `application pipeline run`.
 func registerPipelineRunDispatchFlags(command *cobra.Command) {
 	command.Flags().String("ref", "", "Git reference to run at (defaults to the repository's default branch)")
-	command.Flags().String("sha", "", "Full commit sha to run (required)")
+	command.Flags().String("sha", "", "Full commit sha to run (defaults to the working directory's HEAD)")
 	command.Flags().StringArray("input", nil, "Dispatch input as key=value (repeatable)")
 	command.Flags().String("reason", "", "Human note recorded on the run")
 	command.Flags().String("spec-file", "", "Run this pipeline definition instead of the stored one (requires pipelines.manage)")
 	command.Flags().Bool("wait", false, "Wait for the run to conclude before returning")
+}
+
+// localHeadCommit answers the working directory's HEAD commit and the branch
+// it is on, or empty strings when there is no checkout to read. A detached
+// HEAD has a commit and no branch name, which is exactly what the dispatch
+// wants: the sha is what runs, and the ref is a label on it.
+func localHeadCommit(requestContext context.Context) (string, string) {
+	repositoryRoot, rootError := executeGit(requestContext, ".", "rev-parse", "--show-toplevel")
+	if rootError != nil {
+		return "", ""
+	}
+	headSHA, shaError := executeGit(requestContext, repositoryRoot, "rev-parse", "HEAD")
+	if shaError != nil {
+		return "", ""
+	}
+	headSHA = strings.TrimSpace(headSHA)
+	if headSHA == "" {
+		return "", ""
+	}
+	branch, branchError := executeGit(requestContext, repositoryRoot, "rev-parse", "--abbrev-ref", "HEAD")
+	if branchError != nil || strings.TrimSpace(branch) == "HEAD" {
+		return headSHA, ""
+	}
+	return headSHA, strings.TrimSpace(branch)
 }
 
 // runPipelineDispatch reads the dispatch flags and drives the shared
@@ -75,7 +102,24 @@ func runPipelineDispatch(command *cobra.Command, selector client.PipelineSelecto
 
 	sha = strings.TrimSpace(sha)
 	if sha == "" {
-		return withExitCode(exitUsage, fmt.Errorf("--sha is required: a pipeline run needs the full commit sha to run at"))
+		// The commit still has to be named - resolving a ref belongs to the
+		// trigger lane, and that contract is unchanged. What changed is who
+		// names it: a user standing in the checkout has the sha under their
+		// cursor, and asking them to paste `git rev-parse HEAD` back is a
+		// step the command can take off them (ankra-ctsmd). Outside a
+		// checkout there is nothing to read and --sha is required exactly as
+		// before.
+		localSHA, localRef := localHeadCommit(command.Context())
+		if localSHA == "" {
+			return withExitCode(exitUsage, fmt.Errorf(
+				"--sha is required: a pipeline run needs the full commit sha to run at"))
+		}
+		sha = localSHA
+		if strings.TrimSpace(ref) == "" {
+			ref = localRef
+		}
+		_, _ = fmt.Fprintf(command.ErrOrStderr(),
+			"Running at the working directory's HEAD %s (pass --sha to choose another).\n", sha)
 	}
 	inputs, inputsError := parsePipelineInputFlags(rawInputs)
 	if inputsError != nil {

--- a/cmd/pipeline_run.go
+++ b/cmd/pipeline_run.go
@@ -109,15 +109,21 @@ func runPipelineDispatch(command *cobra.Command, selector client.PipelineSelecto
 		// step the command can take off them (ankra-ctsmd). Outside a
 		// checkout there is nothing to read and --sha is required exactly as
 		// before.
-		localSHA, localRef := localHeadCommit(command.Context())
+		// A --ref the user named is NOT paired with whatever the working
+		// directory happens to have checked out: asking to run "release-2.0"
+		// from a checkout sitting on main would otherwise dispatch main's
+		// commit under the release ref, which is worse than being asked for
+		// the sha. The checkout answers only when it is the whole question.
+		localSHA, localRef := "", ""
+		if strings.TrimSpace(ref) == "" {
+			localSHA, localRef = localHeadCommit(command.Context())
+		}
 		if localSHA == "" {
 			return withExitCode(exitUsage, fmt.Errorf(
 				"--sha is required: a pipeline run needs the full commit sha to run at"))
 		}
 		sha = localSHA
-		if strings.TrimSpace(ref) == "" {
-			ref = localRef
-		}
+		ref = localRef
 		_, _ = fmt.Fprintf(command.ErrOrStderr(),
 			"Running at the working directory's HEAD %s (pass --sha to choose another).\n", sha)
 	}

--- a/cmd/pipeline_test.go
+++ b/cmd/pipeline_test.go
@@ -518,7 +518,13 @@ func TestPipelineGetNotFound(t *testing.T) {
 	}
 }
 
+// TestPipelineRunRequiresSHA pins that OUTSIDE a Git checkout the commit must
+// still be named: a dispatch never runs against whatever commit the platform
+// stored last. Inside a checkout the sha is read from HEAD instead
+// (TestPipelineRunReadsTheWorkingDirectoryHead), so this case runs from a
+// directory that is not a repository.
 func TestPipelineRunRequiresSHA(t *testing.T) {
+	t.Chdir(t.TempDir())
 	mockClient := &pipelineLaneMock{}
 	_, executeError := runPipelineCommand(t, mockClient, "run", "--application", testApplicationID, "--ref", "main")
 	if executeError == nil {
@@ -529,6 +535,36 @@ func TestPipelineRunRequiresSHA(t *testing.T) {
 	}
 	if mockClient.createCalls != 0 {
 		t.Errorf("CreatePipelineRun calls = %d, want 0", mockClient.createCalls)
+	}
+}
+
+// TestPipelineRunReadsTheWorkingDirectoryHead pins the simplification: inside
+// a checkout the dispatch runs the commit under the user's cursor, and says
+// so, instead of making them paste `git rev-parse HEAD` back (ankra-ctsmd).
+func TestPipelineRunReadsTheWorkingDirectoryHead(t *testing.T) {
+	repositoryPath := createTestGitRepository(t, "main", "https://github.com/acme/payments.git")
+	if writeError := os.WriteFile(filepath.Join(repositoryPath, "service.txt"), []byte("payments\n"), 0o600); writeError != nil {
+		t.Fatalf("seeding the checkout: %v", writeError)
+	}
+	runTestGit(t, repositoryPath, "add", "service.txt")
+	runTestGit(t, repositoryPath, "-c", "user.email=test@example.com", "-c", "user.name=Test",
+		"commit", "-m", "Add the service")
+	t.Chdir(repositoryPath)
+	mockClient := &pipelineLaneMock{createResult: &client.CreatePipelineRunResult{
+		RunID: "umbrella-1", PipelineRunID: "run-1", RunNumber: 1,
+	}}
+	if _, executeError := runPipelineCommand(t, mockClient, "run",
+		"--application", testApplicationID); executeError != nil {
+		t.Fatalf("dispatch inside a checkout = %v, want the HEAD commit used", executeError)
+	}
+	if mockClient.createCalls != 1 {
+		t.Fatalf("CreatePipelineRun calls = %d, want 1", mockClient.createCalls)
+	}
+	if len(mockClient.createRequest.HeadSHA) != 40 {
+		t.Errorf("dispatched sha = %q, want the checkout's full HEAD sha", mockClient.createRequest.HeadSHA)
+	}
+	if mockClient.createRequest.Ref != "main" {
+		t.Errorf("dispatched ref = %q, want the checked-out branch", mockClient.createRequest.Ref)
 	}
 }
 

--- a/cmd/pipeline_test.go
+++ b/cmd/pipeline_test.go
@@ -568,6 +568,33 @@ func TestPipelineRunReadsTheWorkingDirectoryHead(t *testing.T) {
 	}
 }
 
+// TestPipelineRunDoesNotPairANamedRefWithTheLocalHead pins that a ref the
+// user named is never dispatched against whatever the checkout happens to
+// have: running "release-2.0" from a checkout sitting on main must ask for
+// the sha rather than send main's commit under the release ref (ankra-ctsmd).
+func TestPipelineRunDoesNotPairANamedRefWithTheLocalHead(t *testing.T) {
+	repositoryPath := createTestGitRepository(t, "main", "https://github.com/acme/payments.git")
+	if writeError := os.WriteFile(filepath.Join(repositoryPath, "service.txt"), []byte("payments\n"), 0o600); writeError != nil {
+		t.Fatalf("seeding the checkout: %v", writeError)
+	}
+	runTestGit(t, repositoryPath, "add", "service.txt")
+	runTestGit(t, repositoryPath, "-c", "user.email=test@example.com", "-c", "user.name=Test",
+		"commit", "-m", "Add the service")
+	t.Chdir(repositoryPath)
+	mockClient := &pipelineLaneMock{}
+	_, executeError := runPipelineCommand(t, mockClient, "run",
+		"--application", testApplicationID, "--ref", "release-2.0")
+	if executeError == nil {
+		t.Fatal("a named ref with no sha must be refused, not paired with the local HEAD")
+	}
+	if exitCodeFor(executeError) != exitUsage {
+		t.Errorf("exit code = %d, want %d", exitCodeFor(executeError), exitUsage)
+	}
+	if mockClient.createCalls != 0 {
+		t.Errorf("CreatePipelineRun calls = %d, want 0", mockClient.createCalls)
+	}
+}
+
 func TestPipelineRunPassesInputsAndSelector(t *testing.T) {
 	mockClient := &pipelineLaneMock{createResult: &client.CreatePipelineRunResult{
 		RunID: "umbrella-1", PipelineRunID: "run-1", RunNumber: 7,


### PR DESCRIPTION
## What this fixes

Dispatching a run meant assembling two facts the shell already had:

```
ankra pipeline run --application shipfortune --sha $(git rev-parse HEAD)
```

Both now default from the working directory:

```
$ ankra pipeline list
Using the application bound to CodeStaple/vela (pass --application to choose another).
╭──────────────────────────────────────┬───────┬───────────┬─────────┬─────────────────┬──────────────╮
│ ID                                   │ RUN # │ STATUS    │ TRIGGER │ REF             │ SHA          │
```

- **The application** is the one bound to the checkout's `origin` repository, matched on owner and name against the organisation's applications.
- **The commit** is the checkout's `HEAD`, and the ref defaults to the checked-out branch (a detached HEAD contributes a sha and no ref, which is exactly what a dispatch wants).

## What it does not do

Nothing is inferred silently: each inference prints what it used, on **stderr**, so a structured `-o json` output stays exactly what a caller can parse.

Nothing is guessed either. Outside a checkout, with no `origin` remote, or when no application is bound to the repository, the command asks for the flag exactly as before. When the repository has **several** applications the refusal names them rather than repeating the generic line:

```
Error: CodeStaple/shipfortune has 2 applications in this organisation (shipfortune, shipfortune2); pass --application to say which
```

The dispatch contract is unchanged. A run is still dispatched at one named commit, because resolving a ref to a commit belongs to the trigger lane and a dispatch must never run against whatever commit the platform stored last. What changed is only who reads the sha: the CLI, from the checkout in front of it, instead of the user pasting it back.

## Tests

`TestPipelineRunReadsTheWorkingDirectoryHead` (a seeded checkout dispatches its HEAD and branch) and `TestPipelineRunRequiresSHA` re-pointed to run from a directory that is not a repository, which is where that contract still holds. Full `go test ./cmd/ ./internal/...` and `golangci-lint` green via the pre-commit hook.

Verified live against the Ankra - Development organisation: the two outputs above are real, from `CodeStaple/vela` (one application) and `CodeStaple/shipfortune` (two).

Bead: ankra-ctsmd
