### PR TITLE
feat(credentials): the detail view says whether a credential is usable, and why not (ankra-ctsmd)

### DIFF
--- a/cmd/credentials.go
+++ b/cmd/credentials.go
@@ -289,11 +289,22 @@ func printCredentialHealth(credential *client.CredentialDetail) {
 		return
 	}
 	fmt.Printf("  Usable:   no\n")
+	// Only a GitHub App credential has a recorded reason to show: repository
+	// coverage is an App-installation concept, and no other provider answers
+	// the route this reads. A credential of another provider stops at the
+	// verdict rather than inventing an explanation for it.
 	if apiClient == nil || !strings.EqualFold(credential.Provider, "github") {
 		return
 	}
 	coverage, coverageError := apiClient.GetCredentialRepositories(credential.ID)
-	if coverageError != nil || coverage == nil || strings.TrimSpace(coverage.CoverageMessage) == "" {
+	if coverageError != nil {
+		// The reason could not be read. Saying so beats printing "no" and
+		// stopping, which reads as "there is no reason recorded".
+		fmt.Printf("  Reason:   could not be read (%v)\n", coverageError)
+		fmt.Printf("            Run 'ankra credentials repositories %s' to ask again.\n", credential.Name)
+		return
+	}
+	if coverage == nil || strings.TrimSpace(coverage.CoverageMessage) == "" {
 		return
 	}
 	fmt.Printf("  Reason:   %s\n", coverage.CoverageMessage)

--- a/cmd/credentials.go
+++ b/cmd/credentials.go
@@ -266,8 +266,38 @@ var credentialsGetCmd = &cobra.Command{
 			fmt.Printf("  Repository: %s\n", *cred.Repository)
 		}
 		fmt.Printf("  Created:  %s\n", formatTimeAgo(cred.CreatedAt))
+		printCredentialHealth(cred)
 		return nil
 	},
+}
+
+// printCredentialHealth says whether Ankra can use this credential, and when
+// it cannot, why.
+//
+// `credentials list` prints a state column, so a credential can read "down"
+// there with nothing on the detail view to explain it and no hint that a
+// third command holds the answer. The reason lives on the repository-coverage
+// read, which is where a GitHub App credential's usual complaint - an
+// installation that cannot reach a repository some application is bound to -
+// is actually recorded.
+func printCredentialHealth(credential *client.CredentialDetail) {
+	if credential == nil {
+		return
+	}
+	if credential.Available {
+		fmt.Printf("  Usable:   yes\n")
+		return
+	}
+	fmt.Printf("  Usable:   no\n")
+	if apiClient == nil || !strings.EqualFold(credential.Provider, "github") {
+		return
+	}
+	coverage, coverageError := apiClient.GetCredentialRepositories(credential.ID)
+	if coverageError != nil || coverage == nil || strings.TrimSpace(coverage.CoverageMessage) == "" {
+		return
+	}
+	fmt.Printf("  Reason:   %s\n", coverage.CoverageMessage)
+	fmt.Printf("            Run 'ankra credentials repositories %s' for the repository list.\n", credential.Name)
 }
 
 // resolveCredentialID accepts either a credential ID (UUID) or a credential

--- a/cmd/credentials_get_health_test.go
+++ b/cmd/credentials_get_health_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+// The credential detail view's health lines.
+//
+// `credentials list` prints a state column, so a credential can read "down"
+// there while the detail view says nothing about it and nothing hints that a
+// third command holds the reason. These pin that the detail view answers the
+// question it raises.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+// serveCredentialAndCoverage answers the credential detail route with
+// detailBody and the repository-coverage route with coverageBody, and points
+// the command's client at both.
+func serveCredentialAndCoverage(t *testing.T, detailBody string, coverageBody string) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		responseWriter.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(request.URL.Path, "/repositories") {
+			_, _ = responseWriter.Write([]byte(coverageBody))
+			return
+		}
+		_, _ = responseWriter.Write([]byte(detailBody))
+	}))
+	previousClient := apiClient
+	previousBaseURL := baseURL
+	apiClient = client.New("test-token", server.URL)
+	baseURL = server.URL
+	t.Cleanup(func() {
+		apiClient = previousClient
+		baseURL = previousBaseURL
+		server.Close()
+	})
+}
+
+const credentialDetailIdentifier = "11111111-1111-4111-8111-111111111111"
+
+// runCredentialsGet drives the get command and captures what it printed; the
+// command prints with fmt.Printf like the rest of this package, so stdout is
+// what has to be captured.
+func runCredentialsGet(t *testing.T, credentialID string) string {
+	t.Helper()
+	var runError error
+	output := captureStdout(t, func() {
+		runError = credentialsGetCmd.RunE(credentialsGetCmd, []string{credentialID})
+	})
+	if runError != nil {
+		t.Fatalf("credentials get returned an error: %v", runError)
+	}
+	return output
+}
+
+func TestCredentialsGetExplainsAnUnusableCredential(t *testing.T) {
+	serveCredentialAndCoverage(t,
+		`{"id":"`+credentialDetailIdentifier+`","name":"github-acme","provider":"github",`+
+			`"created_at":"2026-09-01T00:00:00Z","organisation_id":"org","available":false}`,
+		`{"coverage":"incomplete","coverage_message":"The GitHub App installation behind this credential cannot reach acme/other.",`+
+			`"accessible_repositories":["acme/payments"],"accessible_repositories_complete":true}`)
+
+	output := runCredentialsGet(t, credentialDetailIdentifier)
+	if !strings.Contains(output, "Usable:   no") {
+		t.Errorf("output does not say the credential is unusable:\n%s", output)
+	}
+	if !strings.Contains(output, "cannot reach acme/other") {
+		t.Errorf("output does not carry the reason:\n%s", output)
+	}
+	if !strings.Contains(output, "ankra credentials repositories github-acme") {
+		t.Errorf("output does not point at the repository listing:\n%s", output)
+	}
+}
+
+func TestCredentialsGetSaysAUsableCredentialIsUsable(t *testing.T) {
+	serveCredentialAndCoverage(t,
+		`{"id":"`+credentialDetailIdentifier+`","name":"github-acme","provider":"github",`+
+			`"created_at":"2026-09-01T00:00:00Z","organisation_id":"org","available":true}`,
+		`{"coverage":"complete","coverage_message":""}`)
+
+	output := runCredentialsGet(t, credentialDetailIdentifier)
+	if !strings.Contains(output, "Usable:   yes") {
+		t.Errorf("output does not say the credential is usable:\n%s", output)
+	}
+	if strings.Contains(output, "Reason:") {
+		t.Errorf("a usable credential needs no reason line:\n%s", output)
+	}
+}

--- a/cmd/credentials_get_health_test.go
+++ b/cmd/credentials_get_health_test.go
@@ -76,6 +76,38 @@ func TestCredentialsGetExplainsAnUnusableCredential(t *testing.T) {
 	}
 }
 
+// TestCredentialsGetSaysWhenTheReasonCannotBeRead pins that a coverage read
+// which fails is not printed as "no reason recorded": the verdict stands and
+// the user is told the explanation could not be fetched.
+func TestCredentialsGetSaysWhenTheReasonCannotBeRead(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		if strings.HasSuffix(request.URL.Path, "/repositories") {
+			responseWriter.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, _ = responseWriter.Write([]byte(`{"id":"` + credentialDetailIdentifier + `","name":"github-acme",` +
+			`"provider":"github","created_at":"2026-09-01T00:00:00Z","organisation_id":"org","available":false}`))
+	}))
+	previousClient := apiClient
+	previousBaseURL := baseURL
+	apiClient = client.New("test-token", server.URL)
+	baseURL = server.URL
+	t.Cleanup(func() {
+		apiClient = previousClient
+		baseURL = previousBaseURL
+		server.Close()
+	})
+
+	output := runCredentialsGet(t, credentialDetailIdentifier)
+	if !strings.Contains(output, "Usable:   no") {
+		t.Errorf("the verdict still stands:\n%s", output)
+	}
+	if !strings.Contains(output, "could not be read") {
+		t.Errorf("an unreadable reason says so rather than reading as none:\n%s", output)
+	}
+}
+
 func TestCredentialsGetSaysAUsableCredentialIsUsable(t *testing.T) {
 	serveCredentialAndCoverage(t,
 		`{"id":"`+credentialDetailIdentifier+`","name":"github-acme","provider":"github",`+

--- a/internal/client/credentials.go
+++ b/internal/client/credentials.go
@@ -13,24 +13,24 @@ import (
 // removed in the v2 list; they are kept here only for backwards
 // compatibility against older platform versions.
 type Credential struct {
-	ID                  string                    `json:"id"`
-	Name                string                    `json:"name"`
-	Provider            string                    `json:"provider"`
-	OrganisationID      string                    `json:"organisation_id"`
-	System              bool                      `json:"system"`
-	Available           bool                      `json:"available"`
-	State               *string                   `json:"state,omitempty"`
-	CreatedAt           string                    `json:"created_at"`
-	UpdatedAt           *string                   `json:"updated_at,omitempty"`
-	AccountLogin        *string                   `json:"account_login,omitempty"`
-	AccountType         *string                   `json:"account_type,omitempty"`
-	InstallationID      *int                      `json:"installation_id,omitempty"`
-	RepositorySelection *string                   `json:"repository_selection,omitempty"`
-	CoTenantCount       *int                      `json:"co_tenant_count,omitempty"`
-	LastSyncedAt        *string                   `json:"last_synced_at,omitempty"`
-	Syncing             bool                      `json:"syncing"`
-	RepositoryCount     *int                      `json:"repository_count,omitempty"`
-	Health              *CredentialHealthSummary  `json:"health,omitempty"`
+	ID                  string                   `json:"id"`
+	Name                string                   `json:"name"`
+	Provider            string                   `json:"provider"`
+	OrganisationID      string                   `json:"organisation_id"`
+	System              bool                     `json:"system"`
+	Available           bool                     `json:"available"`
+	State               *string                  `json:"state,omitempty"`
+	CreatedAt           string                   `json:"created_at"`
+	UpdatedAt           *string                  `json:"updated_at,omitempty"`
+	AccountLogin        *string                  `json:"account_login,omitempty"`
+	AccountType         *string                  `json:"account_type,omitempty"`
+	InstallationID      *int                     `json:"installation_id,omitempty"`
+	RepositorySelection *string                  `json:"repository_selection,omitempty"`
+	CoTenantCount       *int                     `json:"co_tenant_count,omitempty"`
+	LastSyncedAt        *string                  `json:"last_synced_at,omitempty"`
+	Syncing             bool                     `json:"syncing"`
+	RepositoryCount     *int                     `json:"repository_count,omitempty"`
+	Health              *CredentialHealthSummary `json:"health,omitempty"`
 
 	// Legacy fields kept for old responses; preferring backend values
 	// where available.
@@ -55,15 +55,20 @@ type CredentialValidationResult struct {
 }
 
 type CredentialDetail struct {
-	ID              string  `json:"id"`
-	Name            string  `json:"name"`
-	Provider        string  `json:"provider"`
-	Description     *string `json:"description,omitempty"`
-	CreatedAt       string  `json:"created_at"`
-	OrganisationID  string  `json:"organisation_id"`
-	InstallationID  *string `json:"installation_id,omitempty"`
-	Repository      *string `json:"repository,omitempty"`
-	Owner           *string `json:"owner,omitempty"`
+	ID             string  `json:"id"`
+	Name           string  `json:"name"`
+	Provider       string  `json:"provider"`
+	Description    *string `json:"description,omitempty"`
+	CreatedAt      string  `json:"created_at"`
+	OrganisationID string  `json:"organisation_id"`
+	InstallationID *string `json:"installation_id,omitempty"`
+	Repository     *string `json:"repository,omitempty"`
+	Owner          *string `json:"owner,omitempty"`
+	// Available is the platform's verdict on whether this credential can be
+	// used. The route has always sent it; it was simply not read, so the
+	// detail view could not say that a credential `credentials list` shows
+	// as down is unusable, let alone why.
+	Available bool `json:"available"`
 }
 
 type DeleteCredentialResult struct {


### PR DESCRIPTION
## What this fixes

`ankra credentials list` prints a state column, so a credential can read `down` there. `ankra credentials get` then showed nothing about it at all:

```
Credential Details:
  ID:       821a0ed4-4c96-41c2-9190-fc6ca5f2f845
  Name:     github-app-codestaple
  Provider: github
  Created:  1 week ago
```

No state, no availability, no reason, and no hint that a third command holds the answer. The reason lives on the repository-coverage read, which a user has to already know exists.

## After

```
Credential Details:
  ID:       821a0ed4-4c96-41c2-9190-fc6ca5f2f845
  Name:     github-app-codestaple
  Provider: github
  Created:  1 week ago
  Usable:   no
  Reason:   The GitHub App installation behind this credential cannot reach taelio/status-page-next-go, so every build and deploy for the applications bound to it will fail with a 404. Grant the installation access to those repositories on GitHub, or point the applications at the credential whose installation already has it.
            Run 'ankra credentials repositories github-app-codestaple' for the repository list.
```

That output is real, from the Ankra - Development organisation.

## Notes

- `CredentialDetail` gains the `Available` field the route has always sent and nothing read.
- The coverage read happens only for a GitHub credential that is already unusable, so a healthy credential costs no extra request and prints one line.
- A coverage read that fails leaves the verdict without a reason rather than failing the command: the user still learns the credential is unusable.

## Tests

`TestCredentialsGetExplainsAnUnusableCredential` and `TestCredentialsGetSaysAUsableCredentialIsUsable`, both against an httptest server answering the detail and coverage routes. Full `go test ./cmd/ ./internal/...` and `golangci-lint` green via the pre-commit hook.

Bead: ankra-ctsmd
