### PR TITLE
feat(cluster): ankra cluster patch <kind> <name> patches a live object through the agent (ankra-ylfxx)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@
   weekly|monthly --recipient <email>...` creates or replaces it (`--disabled`
   stores it paused); `send` queues one report now. Both writes confirm unless
   `--yes`. Needs the bearer twins from cluster#2789.
+- **`ankra cluster patch <kind> <name> [name...]` corrects one field on a
+  live object without kubectl.** The patch half of the kubernetes write lane
+  that `cluster delete` opened: `--patch '<json or yaml>'` or `--patch-file
+  <path>` is sent as a `--type strategic` (default), `merge` (RFC 7386) or
+  `json` (RFC 6902) patch through the cluster's Ankra agent, after a `[y/N]`
+  prompt naming the patch type and the object (`--yes` skips it, `--dry-run`
+  reports without changing). A patch touches only the fields it names and
+  does not go through server-side apply, so a value the API server defaulted
+  on an older chart - a Service left at `ipFamilyPolicy: RequireDualStack` on
+  a single-stack cluster - can be put right without taking the object over
+  from Helm or deleting it. The kind takes the kubectl spellings and custom
+  resources take `--group` and `--api-version`; a JSON patch that is not a
+  list of operations, or a merge patch that is, is refused before anything
+  reaches the cluster (exit 2). Per-object outcomes and exit codes match
+  `cluster delete`: 0 patched, 3 not found, 1 refused.
 
 ## v0.15.0-rc5 — 2026-09-07
 

--- a/cmd/cluster_patch.go
+++ b/cmd/cluster_patch.go
@@ -1,0 +1,207 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// patchTypeLabels spells out each patch type the relay accepts, in the words
+// the confirmation prompt and the usage error use. The keys are the exact
+// values the platform's resources/patch route and the agent understand.
+var patchTypeLabels = map[string]string{
+	"strategic": "strategic merge patch",
+	"merge":     "JSON merge patch",
+	"json":      "JSON patch",
+}
+
+var patchWording = mutationWording{noun: "patch", pastTense: "patched", progressive: "patching"}
+
+var clusterPatchCmd = &cobra.Command{
+	Use:   "patch <kind> <name> [name...]",
+	Short: "Patch live Kubernetes resources in the active cluster",
+	Long: `Patch one or more live Kubernetes resources in the active cluster.
+
+This is 'kubectl patch': the document given with --patch (inline, JSON or
+YAML) or --patch-file is sent to the API server as a patch of the chosen
+--type - 'strategic' (the default, the kubectl default too), 'merge' (RFC
+7386 JSON merge patch) or 'json' (RFC 6902 JSON patch, a list of operations).
+A patch changes only the fields it names and does not go through
+server-side apply, so it is the way to correct a field on an object another
+manager owns - a value the API server defaulted on an older chart, a label a
+release left behind - without taking that object over or deleting it.
+
+The kind takes the kubectl spellings - pod, deployment, deploy, service, svc,
+configmap, cm, node, ... - and a custom resource is reachable with --group
+and --api-version, exactly like 'cluster get resources' and 'cluster delete'.
+The patch goes through the cluster's Ankra agent: no kubeconfig is needed and
+the same organisation permissions as the portal apply.
+
+Each object reports its own outcome. The command exits 0 when everything was
+patched, 3 when one of the objects did not exist, and 1 when the cluster
+refused a patch.
+
+Examples:
+  ankra cluster patch deployment web -n prod --patch '{"spec":{"replicas":3}}'
+  ankra cluster patch service redis-headless -n data --type merge \
+    --patch '{"spec":{"ipFamilyPolicy":"SingleStack","ipFamilies":["IPv4"]}}'
+  ankra cluster patch configmap settings -n prod --patch-file settings-patch.yaml --yes
+  ankra cluster patch deployment web -n prod --type json \
+    --patch '[{"op":"remove","path":"/metadata/annotations/deprecated"}]'
+  ankra cluster patch node worker-1 --patch '{"metadata":{"labels":{"tier":"gpu"}}}' --dry-run
+  ankra cluster patch Certificate web-tls -n prod --group cert-manager.io --api-version v1 \
+    --patch '{"spec":{"renewBefore":"720h"}}'`,
+	Args:        cobra.MinimumNArgs(2),
+	Annotations: map[string]string{"group": "kubernetes"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		namespace, _ := cmd.Flags().GetString("namespace")
+		yes, _ := cmd.Flags().GetBool("yes")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		apiGroup, _ := cmd.Flags().GetString("group")
+		apiVersion, _ := cmd.Flags().GetString("api-version")
+		inlinePatch, _ := cmd.Flags().GetString("patch")
+		patchFile, _ := cmd.Flags().GetString("patch-file")
+		patchType, _ := cmd.Flags().GetString("type")
+
+		resolvedKind, kindError := resolveK8sKind(args[0], apiGroup, apiVersion)
+		if kindError != nil {
+			return kindError
+		}
+		names := args[1:]
+		if !resolvedKind.clusterScoped && namespace == "" {
+			return withExitCode(exitUsage, fmt.Errorf("--namespace (-n) is required to patch a %s", resolvedKind.kind))
+		}
+		if resolvedKind.clusterScoped {
+			namespace = ""
+		}
+
+		patchType = strings.ToLower(strings.TrimSpace(patchType))
+		if _, isKnownPatchType := patchTypeLabels[patchType]; !isKnownPatchType {
+			return withExitCode(exitUsage, fmt.Errorf(
+				"--type must be strategic, merge or json, got %q", patchType))
+		}
+		patch, patchError := loadPatchDocument(inlinePatch, patchFile, patchType)
+		if patchError != nil {
+			return patchError
+		}
+
+		cluster, err := resolveActiveCluster(cmd)
+		if err != nil {
+			return err
+		}
+
+		if !dryRun {
+			prompt := patchResourcesPrompt(resolvedKind, names, namespace, cluster.Name, patchType)
+			if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(), prompt, yes); err != nil {
+				return err
+			}
+		}
+
+		return runResourceMutations(cmd, resolvedKind, names, namespace, patchWording,
+			func(name string) (*client.ResourceMutationResponse, error) {
+				return apiClient.PatchResource(cluster.ID, client.PatchResourceRequest{
+					Kind:      resolvedKind.kind,
+					Group:     resolvedKind.group,
+					Version:   resolvedKind.version,
+					Resource:  resolvedKind.resource,
+					Namespace: namespace,
+					Name:      name,
+					Patch:     patch,
+					PatchType: patchType,
+					DryRun:    dryRun,
+				})
+			})
+	},
+}
+
+// loadPatchDocument reads the patch from exactly one of --patch or
+// --patch-file and checks it has the shape its type needs before anything
+// reaches the cluster: a JSON patch is a list of operations, the two merge
+// patches are an object. YAML is accepted because JSON is YAML, so the same
+// flag takes either.
+func loadPatchDocument(inlinePatch string, patchFile string, patchType string) (interface{}, error) {
+	hasInline := strings.TrimSpace(inlinePatch) != ""
+	hasFile := strings.TrimSpace(patchFile) != ""
+	switch {
+	case hasInline && hasFile:
+		return nil, withExitCode(exitUsage, errors.New("--patch and --patch-file are mutually exclusive"))
+	case !hasInline && !hasFile:
+		return nil, withExitCode(exitUsage, errors.New("a patch is required: pass --patch '<json>' or --patch-file <path>"))
+	}
+
+	document := []byte(inlinePatch)
+	source := "--patch"
+	if hasFile {
+		content, readError := os.ReadFile(patchFile)
+		if readError != nil {
+			return nil, withExitCode(exitUsage, fmt.Errorf("could not read the patch file: %w", readError))
+		}
+		document = content
+		source = fmt.Sprintf("patch file %q", patchFile)
+	}
+
+	var patch interface{}
+	if unmarshalError := yaml.Unmarshal(document, &patch); unmarshalError != nil {
+		return nil, withExitCode(exitUsage, fmt.Errorf("%s is not valid JSON or YAML: %w", source, unmarshalError))
+	}
+	if patch == nil {
+		return nil, withExitCode(exitUsage, fmt.Errorf("%s is empty", source))
+	}
+
+	switch patchType {
+	case "json":
+		operations, isList := patch.([]interface{})
+		if !isList || len(operations) == 0 {
+			return nil, withExitCode(exitUsage, fmt.Errorf(
+				"%s must be a non-empty list of operations for --type json, e.g. [{\"op\":\"replace\",\"path\":\"/spec/replicas\",\"value\":3}]", source))
+		}
+		for index, operation := range operations {
+			fields, isObject := operation.(map[string]interface{})
+			if !isObject {
+				return nil, withExitCode(exitUsage, fmt.Errorf("%s: operation %d is not an object", source, index+1))
+			}
+			if operationName, _ := fields["op"].(string); operationName == "" {
+				return nil, withExitCode(exitUsage, fmt.Errorf("%s: operation %d has no \"op\"", source, index+1))
+			}
+		}
+	default:
+		fields, isObject := patch.(map[string]interface{})
+		if !isObject || len(fields) == 0 {
+			return nil, withExitCode(exitUsage, fmt.Errorf(
+				"%s must be a non-empty object for a %s; a list of operations needs --type json", source, patchTypeLabels[patchType]))
+		}
+	}
+	return patch, nil
+}
+
+func patchResourcesPrompt(kind k8sKind, names []string, namespace, clusterName, patchType string) string {
+	where := fmt.Sprintf("on cluster %q", clusterName)
+	if namespace != "" {
+		where = fmt.Sprintf("in namespace %q on cluster %q", namespace, clusterName)
+	}
+	if len(names) == 1 {
+		return fmt.Sprintf("Apply a %s to %s %q %s? [y/N]: ",
+			patchTypeLabels[patchType], strings.ToLower(kind.kind), names[0], where)
+	}
+	return fmt.Sprintf("Apply a %s to %d %s (%s) %s? [y/N]: ",
+		patchTypeLabels[patchType], len(names), pluralKindLabel(kind), strings.Join(names, ", "), where)
+}
+
+func init() {
+	clusterPatchCmd.Flags().StringP("namespace", "n", "", "Kubernetes namespace (required for namespaced kinds)")
+	clusterPatchCmd.Flags().StringP("patch", "p", "", "The patch document, inline, as JSON or YAML")
+	clusterPatchCmd.Flags().String("patch-file", "", "Read the patch document from a JSON or YAML file instead of --patch")
+	clusterPatchCmd.Flags().String("type", "strategic", "Patch type: strategic (default), merge (RFC 7386) or json (RFC 6902)")
+	clusterPatchCmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
+	clusterPatchCmd.Flags().Bool("dry-run", false, "Report what would change without changing anything")
+	clusterPatchCmd.Flags().String("group", "", "API group for a kind outside the built-in set (e.g. cert-manager.io)")
+	clusterPatchCmd.Flags().String("api-version", "", "API version for a kind outside the built-in set (e.g. v1, v1beta1)")
+
+	clusterCmd.AddCommand(clusterPatchCmd)
+}

--- a/cmd/cluster_patch_test.go
+++ b/cmd/cluster_patch_test.go
@@ -1,0 +1,344 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+type patchCommandMock struct {
+	baseMock
+	requests  []client.PatchResourceRequest
+	responses map[string]*client.ResourceMutationResponse
+}
+
+func (m *patchCommandMock) GetCluster(name string) (client.ClusterListItem, error) {
+	return client.ClusterListItem{ID: "cluster-abc", Name: name}, nil
+}
+
+func (m *patchCommandMock) PatchResource(clusterID string, request client.PatchResourceRequest) (*client.ResourceMutationResponse, error) {
+	m.requests = append(m.requests, request)
+	if response, ok := m.responses[request.Name]; ok {
+		return response, nil
+	}
+	return &client.ResourceMutationResponse{Status: "success"}, nil
+}
+
+func runPatch(t *testing.T, mock APIClient, input string, extraArgs ...string) (string, error) {
+	t.Helper()
+	resetConfirmFlag(t, clusterPatchCmd, clusterCmd)
+	args := append([]string{"cluster", "patch"}, extraArgs...)
+	return runWithInput(t, mock, input, args...)
+}
+
+func TestPatch_DeclineDoesNotCallAPI(t *testing.T) {
+	mock := &patchCommandMock{}
+	_, err := runPatch(t, mock, "n\n", "deployment", "web", "-n", "prod", "--cluster", "prod-cluster",
+		"--patch", `{"spec":{"replicas":3}}`)
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled on decline, got %v", err)
+	}
+	if len(mock.requests) != 0 {
+		t.Errorf("expected no patch call when declined, got %d", len(mock.requests))
+	}
+}
+
+func TestPatch_DefaultIsStrategicWithParsedDocument(t *testing.T) {
+	mock := &patchCommandMock{}
+	out, err := runPatch(t, mock, "y\n", "deploy", "web", "-n", "prod", "--cluster", "prod-cluster",
+		"--patch", `{"spec":{"replicas":3}}`)
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if len(mock.requests) != 1 {
+		t.Fatalf("expected one patch call, got %d", len(mock.requests))
+	}
+	request := mock.requests[0]
+	if request.Kind != "Deployment" || request.Group != "apps" || request.Version != "v1" || request.Namespace != "prod" || request.Name != "web" {
+		t.Errorf("request = %+v, want apps/v1 Deployment web in prod", request)
+	}
+	if request.PatchType != "strategic" {
+		t.Errorf("patch_type should default to strategic, got %q", request.PatchType)
+	}
+	if request.DryRun {
+		t.Error("dry_run must be false without --dry-run")
+	}
+	spec, _ := request.Patch.(map[string]interface{})["spec"].(map[string]interface{})
+	if replicas, _ := spec["replicas"].(int); replicas != 3 {
+		t.Errorf("patch should carry spec.replicas=3 as a decoded document, got %#v", request.Patch)
+	}
+	if !strings.Contains(out, "Apply a strategic merge patch to deployment \"web\" in namespace \"prod\"") {
+		t.Errorf("prompt should name the patch type and the object, got: %s", out)
+	}
+	if !strings.Contains(out, `deployment "web" patched in namespace "prod"`) {
+		t.Errorf("expected a patched line, got: %s", out)
+	}
+}
+
+func TestPatch_MergeTypeAcceptsYAMLDocument(t *testing.T) {
+	mock := &patchCommandMock{}
+	out, err := runPatch(t, mock, "", "svc", "redis-headless", "-n", "data", "--cluster", "prod-cluster", "--yes",
+		"--type", "merge", "--patch", "spec:\n  ipFamilyPolicy: SingleStack\n  ipFamilies: [IPv4]\n")
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	request := mock.requests[0]
+	if request.Kind != "Service" || request.PatchType != "merge" {
+		t.Errorf("expected a merge patch on a Service, got %+v", request)
+	}
+	spec, _ := request.Patch.(map[string]interface{})["spec"].(map[string]interface{})
+	if policy, _ := spec["ipFamilyPolicy"].(string); policy != "SingleStack" {
+		t.Errorf("YAML patch should decode to the same document as JSON, got %#v", request.Patch)
+	}
+	if !strings.Contains(out, `service "redis-headless" patched in namespace "data"`) {
+		t.Errorf("expected a patched line, got: %s", out)
+	}
+}
+
+func TestPatch_JSONTypeSendsOperationList(t *testing.T) {
+	mock := &patchCommandMock{}
+	out, err := runPatch(t, mock, "", "deployment", "web", "-n", "prod", "--cluster", "prod-cluster", "--yes",
+		"--type", "json", "--patch", `[{"op":"remove","path":"/metadata/annotations/deprecated"}]`)
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	request := mock.requests[0]
+	if request.PatchType != "json" {
+		t.Errorf("patch_type should be json, got %q", request.PatchType)
+	}
+	operations, isList := request.Patch.([]interface{})
+	if !isList || len(operations) != 1 {
+		t.Fatalf("a JSON patch must travel as the list of operations, got %#v", request.Patch)
+	}
+	if operationName, _ := operations[0].(map[string]interface{})["op"].(string); operationName != "remove" {
+		t.Errorf("expected the remove operation, got %#v", operations[0])
+	}
+	if !strings.Contains(out, "Apply a JSON patch to") && !strings.Contains(out, `deployment "web" patched`) {
+		t.Errorf("expected a patched line, got: %s", out)
+	}
+}
+
+func TestPatch_JSONTypeRejectsObjectDocument(t *testing.T) {
+	mock := &patchCommandMock{}
+	_, err := runPatch(t, mock, "", "deployment", "web", "-n", "prod", "--cluster", "prod-cluster", "--yes",
+		"--type", "json", "--patch", `{"spec":{"replicas":3}}`)
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("an object with --type json should exit %d, got %d (err=%v)", exitUsage, got, err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "list of operations") {
+		t.Errorf("error should explain the JSON patch shape, got %v", err)
+	}
+	if len(mock.requests) != 0 {
+		t.Error("a malformed patch must be rejected before any API call")
+	}
+}
+
+func TestPatch_MergeTypeRejectsOperationList(t *testing.T) {
+	mock := &patchCommandMock{}
+	_, err := runPatch(t, mock, "", "deployment", "web", "-n", "prod", "--cluster", "prod-cluster", "--yes",
+		"--patch", `[{"op":"remove","path":"/metadata/annotations/deprecated"}]`)
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("a list without --type json should exit %d, got %d (err=%v)", exitUsage, got, err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "--type json") {
+		t.Errorf("error should point at --type json, got %v", err)
+	}
+	if len(mock.requests) != 0 {
+		t.Error("a malformed patch must be rejected before any API call")
+	}
+}
+
+func TestPatch_InvalidDocumentExitsUsage(t *testing.T) {
+	mock := &patchCommandMock{}
+	_, err := runPatch(t, mock, "", "deployment", "web", "-n", "prod", "--cluster", "prod-cluster", "--yes",
+		"--patch", `{"spec": [}`)
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("an unparseable patch should exit %d, got %d (err=%v)", exitUsage, got, err)
+	}
+	if len(mock.requests) != 0 {
+		t.Error("an unparseable patch must be rejected before any API call")
+	}
+}
+
+func TestPatch_RequiresExactlyOnePatchSource(t *testing.T) {
+	mock := &patchCommandMock{}
+	_, err := runPatch(t, mock, "", "deployment", "web", "-n", "prod", "--cluster", "prod-cluster", "--yes")
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("no patch should exit %d, got %d (err=%v)", exitUsage, got, err)
+	}
+
+	patchPath := filepath.Join(t.TempDir(), "patch.json")
+	if writeError := os.WriteFile(patchPath, []byte(`{"spec":{"replicas":2}}`), 0o600); writeError != nil {
+		t.Fatal(writeError)
+	}
+	_, err = runPatch(t, mock, "", "deployment", "web", "-n", "prod", "--cluster", "prod-cluster", "--yes",
+		"--patch", `{"spec":{"replicas":3}}`, "--patch-file", patchPath)
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("both sources should exit %d, got %d (err=%v)", exitUsage, got, err)
+	}
+	if len(mock.requests) != 0 {
+		t.Error("a missing or ambiguous patch must be rejected before any API call")
+	}
+}
+
+func TestPatch_PatchFileIsRead(t *testing.T) {
+	patchPath := filepath.Join(t.TempDir(), "settings-patch.yaml")
+	if writeError := os.WriteFile(patchPath, []byte("data:\n  LOG_LEVEL: debug\n"), 0o600); writeError != nil {
+		t.Fatal(writeError)
+	}
+	mock := &patchCommandMock{}
+	out, err := runPatch(t, mock, "", "cm", "settings", "-n", "prod", "--cluster", "prod-cluster", "--yes",
+		"--patch-file", patchPath)
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	request := mock.requests[0]
+	if request.Kind != "ConfigMap" {
+		t.Errorf("cm should resolve to ConfigMap, got %+v", request)
+	}
+	data, _ := request.Patch.(map[string]interface{})["data"].(map[string]interface{})
+	if level, _ := data["LOG_LEVEL"].(string); level != "debug" {
+		t.Errorf("patch file content should be the document sent, got %#v", request.Patch)
+	}
+}
+
+func TestPatch_MissingPatchFileExitsUsage(t *testing.T) {
+	mock := &patchCommandMock{}
+	_, err := runPatch(t, mock, "", "cm", "settings", "-n", "prod", "--cluster", "prod-cluster", "--yes",
+		"--patch-file", filepath.Join(t.TempDir(), "absent.yaml"))
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("an unreadable patch file should exit %d, got %d (err=%v)", exitUsage, got, err)
+	}
+	if len(mock.requests) != 0 {
+		t.Error("an unreadable patch file must be rejected before any API call")
+	}
+}
+
+func TestPatch_UnknownTypeExitsUsage(t *testing.T) {
+	mock := &patchCommandMock{}
+	_, err := runPatch(t, mock, "", "deployment", "web", "-n", "prod", "--cluster", "prod-cluster", "--yes",
+		"--type", "apply", "--patch", `{"spec":{"replicas":3}}`)
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("an unknown --type should exit %d, got %d (err=%v)", exitUsage, got, err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "strategic, merge or json") {
+		t.Errorf("error should list the accepted types, got %v", err)
+	}
+	if len(mock.requests) != 0 {
+		t.Error("an unknown patch type must be rejected before any API call")
+	}
+}
+
+func TestPatch_MissingNamespaceExitsUsage(t *testing.T) {
+	mock := &patchCommandMock{}
+	_, err := runPatch(t, mock, "", "deployment", "web", "--cluster", "prod-cluster", "--yes",
+		"--patch", `{"spec":{"replicas":3}}`)
+	if got := exitCodeFor(err); got != exitUsage {
+		t.Errorf("missing namespace should exit %d, got %d (err=%v)", exitUsage, got, err)
+	}
+	if len(mock.requests) != 0 {
+		t.Error("missing namespace must be rejected before any API call")
+	}
+}
+
+func TestPatch_ClusterScopedKindNeedsNoNamespace(t *testing.T) {
+	mock := &patchCommandMock{}
+	out, err := runPatch(t, mock, "y\n", "node", "worker-1", "--cluster", "prod-cluster",
+		"--patch", `{"metadata":{"labels":{"tier":"gpu"}}}`)
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if len(mock.requests) != 1 || mock.requests[0].Namespace != "" || mock.requests[0].Kind != "Node" {
+		t.Fatalf("expected one cluster-scoped Node patch, got %+v", mock.requests)
+	}
+	if !strings.Contains(out, `node "worker-1" patched`) || strings.Contains(out, "in namespace") {
+		t.Errorf("expected a patched line without a namespace suffix, got: %s", out)
+	}
+}
+
+func TestPatch_CustomResourcePassesGroupAndVersion(t *testing.T) {
+	mock := &patchCommandMock{}
+	out, err := runPatch(t, mock, "", "Certificate", "web-tls", "-n", "prod", "--cluster", "prod-cluster", "--yes",
+		"--group", "cert-manager.io", "--api-version", "v1", "--patch", `{"spec":{"renewBefore":"720h"}}`)
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	request := mock.requests[0]
+	if request.Kind != "Certificate" || request.Group != "cert-manager.io" || request.Version != "v1" {
+		t.Errorf("custom resource should pass the overrides through, got %+v", request)
+	}
+}
+
+func TestPatch_DryRunSkipsPromptAndSendsDryRun(t *testing.T) {
+	mock := &patchCommandMock{responses: map[string]*client.ResourceMutationResponse{
+		"web": {Status: "dry_run"},
+	}}
+	out, err := runPatch(t, mock, "", "deployment", "web", "-n", "prod", "--cluster", "prod-cluster", "--dry-run",
+		"--patch", `{"spec":{"replicas":3}}`)
+	if err != nil {
+		t.Fatalf("dry run must not prompt or fail: %v\noutput: %s", err, out)
+	}
+	if len(mock.requests) != 1 || !mock.requests[0].DryRun {
+		t.Fatalf("expected one dry_run=true request, got %+v", mock.requests)
+	}
+	if strings.Contains(out, "[y/N]") {
+		t.Errorf("dry run must not show the confirmation prompt, got: %s", out)
+	}
+	if !strings.Contains(out, "would be patched") {
+		t.Errorf("expected a dry-run line, got: %s", out)
+	}
+}
+
+func TestPatch_MultipleObjectsEachPatched(t *testing.T) {
+	mock := &patchCommandMock{}
+	out, err := runPatch(t, mock, "y\n", "deployments", "web", "api", "-n", "prod", "--cluster", "prod-cluster",
+		"--patch", `{"spec":{"replicas":2}}`)
+	if err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out)
+	}
+	if len(mock.requests) != 2 || mock.requests[0].Name != "web" || mock.requests[1].Name != "api" {
+		t.Fatalf("expected patches for web and api in order, got %+v", mock.requests)
+	}
+	if !strings.Contains(out, "Apply a strategic merge patch to 2 deployments (web, api)") {
+		t.Errorf("expected the bulk prompt to name every object, got: %s", out)
+	}
+}
+
+func TestPatch_NotFoundExitsNotFound(t *testing.T) {
+	mock := &patchCommandMock{responses: map[string]*client.ResourceMutationResponse{
+		"gone": {Status: "not_found"},
+	}}
+	out, err := runPatch(t, mock, "", "deployment", "web", "gone", "-n", "prod", "--cluster", "prod-cluster", "--yes",
+		"--patch", `{"spec":{"replicas":2}}`)
+	if got := exitCodeFor(err); got != exitNotFound {
+		t.Fatalf("a missing object should exit %d, got %d (err=%v)", exitNotFound, got, err)
+	}
+	if len(mock.requests) != 2 {
+		t.Errorf("a missing object must not stop the remaining patches, got %d requests", len(mock.requests))
+	}
+	if !strings.Contains(out, `deployment "web" patched`) || !strings.Contains(out, `deployment "gone" not found`) {
+		t.Errorf("expected per-object outcomes, got: %s", out)
+	}
+}
+
+func TestPatch_RefusedVerdictExitsError(t *testing.T) {
+	message := "deployments.apps is forbidden: User cannot patch resource"
+	mock := &patchCommandMock{responses: map[string]*client.ResourceMutationResponse{
+		"web": {Status: "error", Message: &message},
+	}}
+	_, err := runPatch(t, mock, "", "deployment", "web", "-n", "prod", "--cluster", "prod-cluster", "--yes",
+		"--patch", `{"spec":{"replicas":2}}`)
+	if err == nil {
+		t.Fatal("an error verdict must not be reported as success")
+	}
+	if got := exitCodeFor(err); got != exitError {
+		t.Errorf("refused patch should exit %d, got %d", exitError, got)
+	}
+	if !strings.Contains(err.Error(), message) {
+		t.Errorf("error should carry the agent's reason, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Why

Smartoptics (PLA-823 / ticket #1145, cluster so-development) hit a Helm-created Service that the API server had defaulted to `ipFamilyPolicy: RequireDualStack` on a single-stack cluster. The next chart upgrade was rejected, a stack manifest redefining the Service was refused by server-side apply (`conflicts with "helm"`), and there was no Ankra-native way to correct the one field: `ankra cluster delete` (cli#224) covers the delete half of the ask, but nothing patched a live object short of `kubectl`. The customer's recovery was to drive the value through `addons upgrade --set` so Helm performed the downgrade - correct, but it only works when the owning chart exposes the field.

## What

`ankra cluster patch <kind> <name> [name...]` - `kubectl patch` through the cluster's Ankra agent, on the existing `POST /api/v1/clusters/{cluster_id}/kubernetes/resources/patch` relay route the portal's cordon toggle and `cluster restart` already use (`client.PatchResource`; no new route, no client change, the route census is untouched).

- `--patch '<json or yaml>'` or `--patch-file <path>`, exactly one of them.
- `--type strategic` (default, kubectl's default too), `merge` (RFC 7386) or `json` (RFC 6902). The shape is checked before anything reaches the cluster: a JSON patch must be a non-empty list of operations each carrying `op`, a merge patch must be a non-empty object - the wrong shape exits 2 with the fix in the message.
- A patch does not go through server-side apply, so it changes only the fields it names and leaves field ownership where it is - which is the recovery this ticket needed.
- Mirrors `cluster_delete.go`: same kind resolution (`--group`/`--api-version` for custom resources), namespaced kinds need `-n`, cluster-scoped kinds drop it, `[y/N]` prompt naming the patch type and the objects (`--yes` skips, `--dry-run` skips it and sends `dry_run`), per-object outcome lines through the shared `runResourceMutations`, exit 0 patched / 3 not found / 1 refused / 4 declined.

## Tests

`cmd/cluster_patch_test.go`: decline makes no call; default strategic patch with the decoded document; YAML input for a merge patch; JSON patch travels as the operation list; object with `--type json`, list without it, unparseable document, missing/duplicate patch source, unreadable `--patch-file`, unknown `--type`, missing namespace all exit 2 before any API call; cluster-scoped Node needs no namespace; custom resource passes group/version; dry run skips the prompt; multiple objects; not_found exits 3; refused verdict exits 1 with the agent's reason.

## Not in this PR

The `force: true` half of PLA-823 needs no CLI change: the manifest `force` flag is stored on the definition and the agent turns it into `kubectl apply --server-side --force-conflicts`; production shows the customer's manifest was stored with `force: false` from its first version (the key was not on the `manifests[]` entry). Details on the Linear ticket.

Bead: ankra-ylfxx
