### PR TITLE
release: cut v0.15.0-rc6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Ankra CLI Changelog
 
-## Unreleased
+## v0.15.0-rc6 — 2026-09-08
 
 ### Added
 


### PR DESCRIPTION
Promotes the current `## Unreleased` section to `## v0.15.0-rc6 — 2026-09-08` so the tag can be pushed. Carries everything on master after v0.15.0-rc5: #267 `ankra cluster patch` (PLA-823), #266, #265, #263, #264, #254.

Release-notes extractor dry-run (the workflow's awk) returns the 31-line section; heading matches `^## v?0.15.0-rc6([[:space:]]|$)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)