### PR TITLE
feat(application): add --wait follows the analysis and prints the setup pull request (ankra-ctsmd)

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -9,6 +10,7 @@ import (
 	"os/exec"
 	"sort"
 	"strings"
+	"time"
 
 	"ankra/internal/client"
 
@@ -71,6 +73,12 @@ registry added later leaves a workflow that logs in with the wrong one.`,
 		RunE: runApplicationAdd,
 	}
 	registerApplicationAddFlags(addCommand)
+	// --timeout is registered here rather than in registerApplicationAddFlags
+	// because `application ship` shares that helper and already carries a
+	// --timeout of its own, which --wait reads there instead; pflag panics on
+	// the second registration of a name.
+	addCommand.Flags().Duration("timeout", applicationAnalysisDefaultTimeout,
+		"How long --wait waits before giving up")
 	registerStructuredOutputFlags(addCommand)
 	return addCommand
 }
@@ -83,6 +91,8 @@ func registerApplicationAddFlags(command *cobra.Command) {
 	command.Flags().String("credential", "", "GitHub credential name or ID (auto-detected when omitted)")
 	command.Flags().String("branch", "", "Repository branch (auto-detected when omitted)")
 	command.Flags().String("remote", "origin", "Git remote used to identify the GitHub repository")
+	command.Flags().Bool("wait", false,
+		"Wait for Ankra to finish analysing the repository, then print the setup pull request")
 	command.Flags().String("registry-url", "",
 		"Registry project the application publishes to, as oci://<host>/<project>")
 	command.Flags().String("registry-credential", "",
@@ -297,7 +307,10 @@ func runApplicationAdd(command *cobra.Command, arguments []string) error {
 		return createError
 	}
 	if rendered, renderError := renderStructured(command, result); rendered || renderError != nil {
-		return renderError
+		if renderError != nil {
+			return renderError
+		}
+		return waitForApplicationAnalysis(command, result.ID)
 	}
 
 	output := command.OutOrStdout()
@@ -311,7 +324,106 @@ func runApplicationAdd(command *cobra.Command, arguments []string) error {
 		_, _ = fmt.Fprintf(output, "  Registry:   %s\n", result.RegistryURL)
 	}
 	_, _ = fmt.Fprintln(output, "\nAnkra is now analyzing the repository.")
-	return nil
+	return waitForApplicationAnalysis(command, result.ID)
+}
+
+// analysisStatusComplete and analysisStatusFailed are the terminal answers an
+// application's analysis reaches; anything else (absent, or "pending") is
+// still in flight.
+const (
+	analysisStatusComplete = "complete"
+	analysisStatusFailed   = "failed"
+)
+
+// applicationAnalysisPollInterval is how often --wait asks the platform. The
+// analysis takes tens of seconds when the AI lane answers and longer when it
+// falls back, so this is slow enough not to hammer the API and fast enough to
+// feel live.
+const applicationAnalysisPollInterval = 5 * time.Second
+
+// applicationAnalysisDefaultTimeout bounds --wait when the command carries no
+// --timeout of its own.
+const applicationAnalysisDefaultTimeout = 15 * time.Minute
+
+// applicationAnalysisState is the part of an application read that says
+// whether Ankra has finished looking at the repository, and what it produced.
+type applicationAnalysisState struct {
+	AnalysisStatus   string `json:"analysis_status"`
+	ErrorMessage     string `json:"error_message"`
+	PullRequestURL   string `json:"pull_request_url"`
+	CreationProgress string `json:"creation_progress"`
+}
+
+// waitForApplicationAnalysis follows the analysis `application add` starts,
+// when --wait was given.
+//
+// Without it the command ends on "Ankra is now analyzing the repository" and
+// the user has no way to know when that finished or where the setup pull
+// request went, short of refreshing the portal. Progress goes to stderr so a
+// structured run's stdout stays exactly what a caller can parse.
+func waitForApplicationAnalysis(command *cobra.Command, applicationID string) error {
+	wait, waitError := command.Flags().GetBool("wait")
+	if waitError != nil || !wait {
+		return nil
+	}
+	// `application ship` carries the same --wait through the shared add-flag
+	// helper and its own --timeout, which this reads there.
+	timeout := applicationAnalysisDefaultTimeout
+	if command.Flags().Lookup("timeout") != nil {
+		if configured, timeoutError := command.Flags().GetDuration("timeout"); timeoutError == nil {
+			timeout = configured
+		}
+	}
+	errorOutput := command.ErrOrStderr()
+	_, _ = fmt.Fprintln(errorOutput, "Waiting for the analysis to finish.")
+	waitContext, cancelWait := context.WithTimeout(command.Context(), timeout)
+	defer cancelWait()
+
+	reportedProgress := ""
+	for {
+		payload, readError := apiClient.GetApplicationRaw(waitContext, applicationID)
+		if readError != nil {
+			if waitContext.Err() != nil {
+				return applicationAnalysisTimeout(applicationID, timeout)
+			}
+			return fmt.Errorf("reading application %s: %w", applicationID, readError)
+		}
+		var state applicationAnalysisState
+		if unmarshalError := json.Unmarshal(payload, &state); unmarshalError != nil {
+			return fmt.Errorf("reading the analysis of application %s: %w", applicationID, unmarshalError)
+		}
+		if progress := strings.TrimSpace(state.CreationProgress); progress != "" && progress != reportedProgress {
+			_, _ = fmt.Fprintf(errorOutput, "  %s\n", progress)
+			reportedProgress = progress
+		}
+		switch strings.TrimSpace(state.AnalysisStatus) {
+		case analysisStatusComplete:
+			_, _ = fmt.Fprintln(errorOutput, "Analysis complete.")
+			if pullRequest := strings.TrimSpace(state.PullRequestURL); pullRequest != "" {
+				_, _ = fmt.Fprintf(errorOutput, "Review the setup pull request: %s\n", pullRequest)
+			}
+			return nil
+		case analysisStatusFailed:
+			message := strings.TrimSpace(state.ErrorMessage)
+			if message == "" {
+				message = "the platform recorded no reason"
+			}
+			return fmt.Errorf("the repository could not be analysed: %s", message)
+		}
+		select {
+		case <-waitContext.Done():
+			return applicationAnalysisTimeout(applicationID, timeout)
+		case <-time.After(applicationAnalysisPollInterval):
+		}
+	}
+}
+
+// applicationAnalysisTimeout says the wait gave up without claiming the
+// analysis failed: it is still running, and the application exists either way.
+func applicationAnalysisTimeout(applicationID string, timeout time.Duration) error {
+	return fmt.Errorf(
+		"the analysis of application %s had not finished after %s; it is still running - "+
+			"check it with 'ankra application get %s'", applicationID, timeout, applicationID)
 }
 
 func inspectLocalApplicationRepository(

--- a/cmd/application_add_wait_test.go
+++ b/cmd/application_add_wait_test.go
@@ -1,0 +1,119 @@
+package cmd
+
+// The --wait flag on `application add`.
+//
+// Without it the command ends on "Ankra is now analyzing the repository" and
+// nothing says when that finished or where the setup pull request went. These
+// pin the three answers the wait can reach.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+// resetApplicationAddFlags puts the add command's flags back to their
+// defaults. The root command is shared across invocations in this package, so
+// a --wait set by one case is still Changed in the next one without it.
+func resetApplicationAddFlags(t *testing.T) {
+	t.Helper()
+	for _, applicationCommand := range rootCmd.Commands() {
+		if applicationCommand.Name() != "application" {
+			continue
+		}
+		for _, command := range applicationCommand.Commands() {
+			if command.Name() == "add" {
+				resetTreeFlags(t, command)
+				return
+			}
+		}
+	}
+}
+
+// serveApplicationAnalysis answers the create route once and then the
+// application read route with each supplied body in turn, repeating the last.
+func serveApplicationAnalysis(t *testing.T, readBodies ...string) {
+	t.Helper()
+	var reads atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		responseWriter.Header().Set("Content-Type", "application/json")
+		if request.Method == http.MethodPost {
+			_, _ = responseWriter.Write([]byte(`{"id":"application-id"}`))
+			return
+		}
+		if strings.Contains(request.URL.Path, "/credentials") {
+			_, _ = responseWriter.Write([]byte(`[{"id":"credential-acme","name":"github-acme","provider":"github",` +
+				`"available":true,"account_login":"acme","created_at":"2026-09-01T00:00:00Z"}]`))
+			return
+		}
+		index := int(reads.Add(1)) - 1
+		if index >= len(readBodies) {
+			index = len(readBodies) - 1
+		}
+		_, _ = responseWriter.Write([]byte(readBodies[index]))
+	}))
+	previousClient := apiClient
+	previousBaseURL := baseURL
+	apiClient = client.New("test-token", server.URL)
+	baseURL = server.URL
+	t.Cleanup(func() {
+		apiClient = previousClient
+		baseURL = previousBaseURL
+		server.Close()
+	})
+}
+
+func TestApplicationAddWaitReportsTheSetupPullRequest(t *testing.T) {
+	repositoryPath := createTestGitRepository(t, "main", "https://github.com/acme/payments.git")
+	resetApplicationAddFlags(t)
+	t.Cleanup(func() { resetApplicationAddFlags(t) })
+	serveApplicationAnalysis(t,
+		`{"analysis_status":"pending","creation_progress":"Reading the repository"}`,
+		`{"analysis_status":"complete","pull_request_url":"https://github.com/acme/payments/pull/7"}`)
+
+	output, executeError := executeCommand("application", "add", repositoryPath, "--wait", "--timeout", "30s")
+	if executeError != nil {
+		t.Fatalf("application add --wait = %v", executeError)
+	}
+	if !strings.Contains(output, "Analysis complete.") {
+		t.Errorf("output does not report completion:\n%s", output)
+	}
+	if !strings.Contains(output, "https://github.com/acme/payments/pull/7") {
+		t.Errorf("output does not carry the setup pull request:\n%s", output)
+	}
+}
+
+func TestApplicationAddWaitReportsAFailedAnalysis(t *testing.T) {
+	repositoryPath := createTestGitRepository(t, "main", "https://github.com/acme/payments.git")
+	resetApplicationAddFlags(t)
+	t.Cleanup(func() { resetApplicationAddFlags(t) })
+	serveApplicationAnalysis(t,
+		`{"analysis_status":"failed","error_message":"no Dockerfile and no recipe could be generated"}`)
+
+	_, executeError := executeCommand("application", "add", repositoryPath, "--wait", "--timeout", "30s")
+	if executeError == nil {
+		t.Fatal("a failed analysis must fail the command")
+	}
+	if !strings.Contains(executeError.Error(), "no Dockerfile") {
+		t.Errorf("error does not carry the platform's reason: %v", executeError)
+	}
+}
+
+func TestApplicationAddWithoutWaitReturnsImmediately(t *testing.T) {
+	repositoryPath := createTestGitRepository(t, "main", "https://github.com/acme/payments.git")
+	resetApplicationAddFlags(t)
+	t.Cleanup(func() { resetApplicationAddFlags(t) })
+	serveApplicationAnalysis(t, `{"analysis_status":"pending"}`)
+
+	output, executeError := executeCommand("application", "add", repositoryPath)
+	if executeError != nil {
+		t.Fatalf("application add = %v", executeError)
+	}
+	if strings.Contains(output, "Waiting for the analysis") {
+		t.Errorf("the default must not wait:\n%s", output)
+	}
+}

--- a/cmd/application_add_wait_test.go
+++ b/cmd/application_add_wait_test.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
-
-	"ankra/internal/client"
 )
 
 // resetApplicationAddFlags puts the add command's flags back to their
@@ -56,15 +54,12 @@ func serveApplicationAnalysis(t *testing.T, readBodies ...string) {
 		}
 		_, _ = responseWriter.Write([]byte(readBodies[index]))
 	}))
-	previousClient := apiClient
-	previousBaseURL := baseURL
-	apiClient = client.New("test-token", server.URL)
-	baseURL = server.URL
-	t.Cleanup(func() {
-		apiClient = previousClient
-		baseURL = previousBaseURL
-		server.Close()
-	})
+	// useTestClient satisfies the root command's auth gate as well as pointing
+	// the client at the server: the gate reads the token, so without it these
+	// fail with "not logged in" wherever no real credentials exist, which is
+	// every CI runner.
+	useTestClient(t, server.URL)
+	t.Cleanup(server.Close)
 }
 
 func TestApplicationAddWaitReportsTheSetupPullRequest(t *testing.T) {


### PR DESCRIPTION
## What this fixes

`ankra application add .` ends here:

```
Application added successfully.
  ID:         b4b8a257-...
  ...
Ankra is now analyzing the repository.
```

And that is all the user gets. Nothing says when the analysis finished, whether it succeeded, or where the setup pull request went. The only way to find out is to refresh the portal.

## After

```
$ ankra application add . --wait
Application added successfully.
  ...
Ankra is now analyzing the repository.
Waiting for the analysis to finish.
  Reading the repository
Analysis complete.
Review the setup pull request: https://github.com/acme/payments/pull/7
```

- The creation progress is reported as it changes, so a long analysis is visibly alive.
- A completed analysis prints the setup pull request's URL, which is the next thing the user has to act on.
- A failed analysis fails the command and carries the reason the platform recorded.
- A wait that runs out of time says the analysis is still running rather than claiming it failed, and names the command that checks it.

## Notes

- Progress goes to **stderr**, so a structured run's stdout stays exactly what a caller can parse.
- `--wait` rides the shared add-flag helper, so `application ship` carries it too, as `TestApplicationShipCarriesTheAddFlagContract` requires. Only `--timeout` is registered on `add` alone, because ship already carries a `--timeout` of its own and that is the one the wait reads there.
- Default timeout is 15 minutes; the poll interval is 5 seconds.

## Tests

`TestApplicationAddWaitReportsTheSetupPullRequest`, `TestApplicationAddWaitReportsAFailedAnalysis` and `TestApplicationAddWithoutWaitReturnsImmediately`, against an httptest server that answers the create route and then a sequence of application reads. The cases reset the add command's flags between runs, since the root command is shared across invocations in this package. Full `go test ./cmd/ ./internal/...` and `golangci-lint` green via the pre-commit hook.

Bead: ankra-ctsmd
