### PR TITLE
fix(skills): give ankra-cicd a branch for a pipeline that produced no run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Ankra CLI Changelog
 
+## Unreleased
+
+### Fixed
+
+- **The `ankra-cicd` skill now answers "the merge produced no run" instead of
+  leaving an assistant to invent a workflow.** Ankra Pipelines run on the
+  cluster agent's own step scheduler, whose `ci_worker_count` default is 0, so
+  a freshly imported cluster accepts a pipeline and runs nothing - with no
+  error anywhere that says why. The skill had no branch for that symptom and
+  never mentioned `ankra pipeline`, `ankra cluster agent ci` or the approval
+  gate, so an assistant that met it read zero runs as "Ankra cannot build
+  here" and hand-rolled a GitHub Actions workflow, forking the deploy contract
+  away from the Semgrep and image scans, the chart publish and the managed
+  registry auth. The skill now walks the three gates - workers, definition
+  approval, dispatch - names the human-actor rule that stops an agent at
+  approval, states outright that a second build is not a fallback, and covers
+  the rootlesskit/AppArmor build wall and the `--build-fallback
+  platform_builders` escape. `ankra-applications` §5 carries the same branch
+  from the empty-`workflow-runs` side.
+
 ## v0.15.0-rc6 — 2026-09-08
 
 ### Added

--- a/internal/skills/embedded/skills/ankra-applications/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-applications/SKILL.md
@@ -135,6 +135,16 @@ is protected and the pipeline gates on tests.
 The organisation's CI runner label decides which GitHub Actions runner the generated pipelines
 request — change it when GitHub-hosted runners are unavailable to you.
 
+**If `workflow-runs` stays empty after a merge**, the pipeline is not failing — it has nowhere to
+run. Ankra Pipelines execute on the cluster agent's own step scheduler, whose `ci_worker_count`
+defaults to 0, so a freshly imported cluster produces zero runs and no error. Check with
+`ankra cluster agent ci get --cluster <cluster>`, raise it with
+`ankra cluster agent ci set --workers 2`, and dispatch with
+`ankra pipeline run --application <application> --sha <full-sha>`. Do not answer an empty run list
+by hand-writing a GitHub Actions workflow — that forks the deploy contract away from the scans,
+chart publish and managed registry auth this application already has. `ankra-cicd`, "The merge
+produced no run", is the full branch.
+
 ## 5b. Building without the repository's CI
 
 Everything above routes the build through the workflow Ankra generated into the repository, which

--- a/internal/skills/embedded/skills/ankra-applications/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-applications/SKILL.md
@@ -139,7 +139,7 @@ request — change it when GitHub-hosted runners are unavailable to you.
 run. Ankra Pipelines execute on the cluster agent's own step scheduler, whose `ci_worker_count`
 defaults to 0, so a freshly imported cluster produces zero runs and no error. Check with
 `ankra cluster agent ci get --cluster <cluster>`, raise it with
-`ankra cluster agent ci set --workers 2`, and dispatch with
+`ankra cluster agent ci set --workers 2 --cluster <cluster>`, and dispatch with
 `ankra pipeline run --application <application> --sha <full-sha>`. Do not answer an empty run list
 by hand-writing a GitHub Actions workflow — that forks the deploy contract away from the scans,
 chart publish and managed registry auth this application already has. `ankra-cicd`, "The merge

--- a/internal/skills/embedded/skills/ankra-cicd/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-cicd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ankra-cicd
-description: Build CI/CD pipelines (GitHub Actions or GitLab CI) that build a container image, push it with an immutable tag, and bump that tag in the Ankra GitOps repository so the Ankra engine syncs the change - rather than running kubectl/helm against the cluster from CI. For an application repository, reach for `ankra application add` FIRST - it generates this whole pipeline (build, security scans, immutable sha- tags, managed registry login) plus the deploy contract, with push-to-deploy built in; use the manual pattern here when the repository is not an Ankra application or the pipeline must stay hand-rolled. Use when the user wires CI/CD for an Ankra-managed app, mentions GitHub Actions or GitLab CI with Ankra, or asks how to deploy on push.
+description: Build CI/CD pipelines (GitHub Actions or GitLab CI) that build a container image, push it with an immutable tag, and bump that tag in the Ankra GitOps repository so the Ankra engine syncs the change - rather than running kubectl/helm against the cluster from CI. For an application repository, reach for `ankra application add` FIRST - it generates this whole pipeline (build, security scans, immutable sha- tags, managed registry login) plus the deploy contract, with push-to-deploy built in; use the manual pattern here when the repository is not an Ankra application or the pipeline must stay hand-rolled. Use when the user wires CI/CD for an Ankra-managed app, mentions GitHub Actions or GitLab CI with Ankra, or asks how to deploy on push - and whenever an Ankra pipeline produced no run, no build was triggered by a merge, or a build step dies on a rootlesskit mount permission error, since those are cluster CI-worker and approval gates rather than reasons to hand-roll a workflow.
 ---
 
 # Ankra CI/CD
@@ -47,6 +47,9 @@ For full, copy-pasteable GitHub Actions and GitLab CI examples, see [reference.m
 - **Least-privilege secrets.** CI needs registry push and GitOps-repo write; it does not need cluster admin.
 - **One image, many environments.** Promote by committing the same tag to the next environment's path, don't rebuild.
 - **Encrypt any secret** that lands in the repo with SOPS (`ankra-sops-secrets`).
+- **Never hand-roll a workflow to route around Ankra CI.** For an application registered with
+  `ankra application add`, a pipeline that produces no run is a cluster capacity or approval
+  problem — see "The merge produced no run". Fix the runner; do not add a second build.
 
 ## AI pipeline-failure investigation and auto-fix PRs
 
@@ -58,6 +61,103 @@ For an application registered with `ankra application add`, Ankra writes the Doc
 and the build workflow itself, and `ankra application auto-deploy` decides whether a build on the
 tracked branch rolls itself out. Read `ankra-applications` first in that case — this skill is the
 shape to aim for, and the reference below is for pipelines you own by hand.
+
+## The merge produced no run
+
+Ankra Pipelines execute **on the cluster agent's own step scheduler**, and the agent chart's
+`ci_worker_count` default is **0**. A cluster that has just been imported therefore accepts the
+pipeline definition and runs nothing: the merge produces no run, no failure, and no message
+anywhere that says why. Nothing is broken — the cluster has no CI workers yet.
+
+Zero runs is a **capacity or approval** symptom, never a verdict that Ankra CI cannot build this
+repository. Work the three gates in order before concluding anything.
+
+**1. Workers on the build cluster.**
+
+```bash
+ankra cluster agent ci get --cluster <cluster>
+```
+
+`supports_pipeline_steps: false` or `ci_worker_count: 0` is the blocker:
+
+```bash
+ankra cluster agent ci set --workers 2 --cluster <cluster>
+```
+
+Store it here, not with `helm upgrade --set ci_worker_count=...` — the platform re-renders the
+agent's release from the stored value, so a hand-set one is rendered away at the next agent
+upgrade. `get` reports the capability the agent advertised at its **last check-in**, so it stays
+`false` for a few seconds after the write while the agent re-renders; re-read rather than reading
+that as a failed write. Which cluster the organisation builds on is `ankra org ci-settings get`
+(`ankra org ci-settings set --cluster <cluster>` moves it).
+
+**2. The definition's protected sections are approved.**
+
+```bash
+ankra pipeline definitions get <definition-id>
+```
+
+Until they are approved the build is given no `registry_auth` and cannot push. Approving requires
+`pipelines.manage` **and a human actor — a service-account or agent token is refused**, so if you
+are an agent this is where you stop and ask. Only the repository's current default-branch
+definition can be approved, and only once; a stale or already-approved one answers 409.
+
+```bash
+ankra pipeline definitions approve <definition-id>
+```
+
+**3. Dispatch a run.**
+
+```bash
+ankra pipeline run --application <application> --sha <full-sha> --wait
+```
+
+`--sha` is required outside a checkout of the repository. Follow with
+`ankra pipeline list --application <application>`, `ankra pipeline get <run>` and
+`ankra pipeline logs <run>`.
+
+### Do not route around this with a hand-rolled workflow
+
+For a repository registered with `ankra application add`, adding your own
+`.github/workflows/*.yml` that builds and pushes the image is **not a fallback**. It forks the
+deploy contract away from Ankra permanently:
+
+- the generated pipeline's **Semgrep scan and image scan** stop gating what ships;
+- the **Helm chart** the application publishes stops being packaged and pushed;
+- the image is pushed with credentials you now own and rotate by hand, instead of the managed
+  registry auth Ankra mints per build;
+- Ankra still reports an application whose pipeline never runs, so the next person meets the same
+  zero runs and the same dead end — now with a second, divergent build to reconcile.
+
+An unrunnable pipeline is a one-command capacity fix; a hand-rolled workflow hides it. Fix the
+runner. Write a workflow by hand only where this skill's manual pattern genuinely applies — the
+repository is **not** an Ankra application.
+
+### A missing `ankra` command is an old CLI, not an absent feature
+
+`ankra pipeline`, `ankra cluster agent ci` and `ankra application build` are recent. A binary that
+answers `unknown command` predates them; that is not evidence the platform cannot do it, and it is
+not a reason to leave the Ankra path. Check with `ankra --version` and take the current release
+with `ankra upgrade`, then re-run.
+
+### When the in-cluster build itself fails
+
+A build step that exits within ~30s with
+`[rootlesskit:child] error: failed to share mount point: /: permission denied` is the node's
+container-runtime confinement (containerd's AppArmor profile on Ubuntu/Debian, or kubelet
+`seccompDefault`) confining the builder pod, which deliberately names no profile because Pod
+Security Baseline forbids `Unconfined`. **Do not widen the node's policy to get past it.** Either
+build on a cluster whose nodes do not impose it, or let the organisation fall back to Ankra's own
+builders:
+
+```bash
+ankra org ci-settings get
+ankra org ci-settings set --build-fallback platform_builders
+```
+
+`platform_builders` also needs the platform-builders capability enabled for the organisation: a
+build that still refuses while this setting reads `platform_builders` is missing the capability,
+not the setting.
 
 ## When there is no pipeline to run
 
@@ -73,7 +173,10 @@ where the application publishes one, packages and pushes a **Helm chart**; the b
 neither. Replacing the image build is safe; retiring the pipeline means deciding where those two go
 first.
 
-Behind the `platform_builds` organisation flag, off by default. See `ankra-applications` §5b.
+Behind the `platform_builds` organisation flag, off by default. See `ankra-applications` §5b. That
+flag gates this managed-build lane only — it is **not** what makes a repository's own Ankra
+pipeline run, so do not chase it when the symptom is zero runs. That is the agent's worker count,
+above.
 
 ## Related skills
 


### PR DESCRIPTION
## The flaw

A Codex session on `ankraio/ankra-redesign` (2026-09-08) did everything right up to the point the skills stopped helping:

1. `ankra application add` generated the pipeline, manifests and deploy contract; the setup PR merged.
2. **No pipeline run appeared.** No error, no failed run — nothing.
3. It correctly diagnosed `AGENT_CI_WORKER_COUNT=0` on the target cluster…
4. …and then, finding no guidance for that state, **hand-rolled a GitHub Actions workflow** to build and push the image itself.

Step 4 is the failure, and the skills caused it. `ankra-cicd` never mentioned `ankra pipeline`, `ankra cluster agent ci`, or `ci_worker_count` — not once. Its only documented answer to "no pipeline to run" was `ankra application build start`, behind the `platform_builds` flag, which the installed CLI did not have. So the skill's own decision tree dead-ended exactly where the session did, and the escape hatch it took is the one the skill's description explicitly warns against.

The cost is not cosmetic: a second build forks the deploy contract away from the Semgrep and image scans, the chart publish and the per-build managed registry auth — permanently — while leaving the real cause (one command) in place for the next person.

## The fix

`ankra-cicd` gains **"The merge produced no run"**: zero runs is a capacity or approval symptom, never a verdict on Ankra CI. Three gates, in order:

1. **Workers** — `ankra cluster agent ci get|set --workers N`, why it is stored on the platform rather than `helm upgrade --set`, and that the capability reflects the agent's *last check-in* so it lags the write by seconds.
2. **Approval** — `ankra pipeline definitions get|approve`; unapproved means no `registry_auth`, and approving **requires a human actor**, so an agent stops and asks here.
3. **Dispatch** — `ankra pipeline run --application <app> --sha <full-sha> --wait`, `--sha` required outside a checkout.

Plus three things that also bit this session:

- **"Do not route around this with a hand-rolled workflow"**, spelling out what the fork costs — and a matching entry in Rules.
- **"A missing `ankra` command is an old CLI, not an absent feature"** — `ankra upgrade`, not abandon the platform path.
- **The rootlesskit/AppArmor build wall** (`failed to share mount point: /: permission denied`) with the `--build-fallback platform_builders` escape, and an explicit *do not widen the node's policy*.

The `platform_builds` line is corrected: it gates the managed-build lane only and is **not** what makes a repository's pipeline run — the misdirection that cost three days on PLA-825.

`ankra-applications` §5 carries the same branch from the empty-`workflow-runs` side.

## Verification

- `go test ./cmd/ -run TestSkills` — passes. `TestSkillsDocumentOnlyRealCommands` resolves every `ankra …` invocation in the skills against the real cobra tree, so each new command is confirmed to exist at this revision, not assumed.
- Pre-commit gate (full `go test ./...` + `golangci-lint run`) clean.
- Every command and behavioural claim checked against `origin/master` source: `cmd/agent_ci.go`, `cmd/org_ci_settings.go`, `cmd/pipeline_run.go`, `cmd/pipeline_definitions.go`, `internal/client/agent_ci_settings.go`.

Docs only — no code paths touched.
