### PR TITLE
fix(cluster encrypt): seal the whole encrypted_paths declaration, and stop calling every 422 a git push failure (ankra-bfvfy, PLA-830)

### DIFF
--- a/cmd/cluster_encrypt.go
+++ b/cmd/cluster_encrypt.go
@@ -170,7 +170,10 @@ Two modes:
 
   File mode (-f cluster.yaml): rewrite a local cluster.yaml's referenced
     from_file in place, adding the key to encrypted_paths in the file. Used by
-    GitOps workflows where the source of truth is on disk.
+    GitOps workflows where the source of truth is on disk. Every key the file
+    already declares in encrypted_paths is sealed together with --key, so a
+    document decrypted with "ankra cluster decrypt" (which leaves the
+    declaration in place) is sealed whole again.
 
 In cluster mode, --set applies value edits in-memory BEFORE encrypting, so the
 new secret value and its encryption land in a single commit - the plaintext
@@ -243,7 +246,8 @@ Two modes:
     partial-stack PATCH endpoint. The owning stack is resolved automatically.
 
   File mode (-f cluster.yaml): rewrite the local addon values file referenced
-    by the cluster.yaml in place, adding the key to encrypted_paths.
+    by the cluster.yaml in place, adding the key to encrypted_paths. Keys the
+    file already declares are sealed together with --key.
 
 Examples:
   # Cluster mode against the selected cluster
@@ -669,7 +673,8 @@ func runEncryptManifestFile(cmd *cobra.Command, manifestName string, leafKeys []
 
 	fmt.Printf("Encrypting %s in manifest %q...\n", describeEncryptKeys(leafKeys), manifestName)
 
-	encryptedContent, err := apiClient.EncryptYAML(string(manifestContent), leafKeys)
+	pathsToSeal := pathsToSealWithDeclared(encryptAnnounceWriter(cmd), leafKeys, foundManifest.EncryptedPaths)
+	encryptedContent, err := apiClient.EncryptYAML(string(manifestContent), pathsToSeal)
 	if err != nil {
 		return fmt.Errorf("encryption failed: %w", err)
 	}
@@ -787,7 +792,9 @@ func runEncryptAddonFile(cmd *cobra.Command, leafKeys []string) error {
 
 	fmt.Printf("Encrypting %s in addon %q...\n", describeEncryptKeys(leafKeys), encryptAddonName)
 
-	encryptedContent, err := apiClient.EncryptYAML(string(addonContent), leafKeys)
+	pathsToSeal := pathsToSealWithDeclared(encryptAnnounceWriter(cmd), leafKeys,
+		getEncryptedPathsFromConfig(foundAddon.Configuration))
+	encryptedContent, err := apiClient.EncryptYAML(string(addonContent), pathsToSeal)
 	if err != nil {
 		return fmt.Errorf("encryption failed: %w", err)
 	}
@@ -919,25 +926,44 @@ func unionEncryptedPaths(lists ...[]string) []string {
 	return merged
 }
 
-// pathsToSealWithDeclared returns the paths the cluster-mode encrypt sends to
-// the platform's encrypt route: the requested keys plus every encrypted_paths
+// encryptAnnounceWriter is where an encrypt writes its progress lines. File
+// mode's entry points are also called directly, with a nil command, by the
+// tests that exercise the cluster.yaml splice, so the command's writer is
+// used only when there is one; os.Stdout is what the rest of file mode
+// prints to anyway.
+func encryptAnnounceWriter(cmd *cobra.Command) io.Writer {
+	if cmd == nil {
+		return os.Stdout
+	}
+	return cmd.OutOrStdout()
+}
+
+// pathsToSealWithDeclared returns the paths an encrypt sends to the
+// platform's encrypt route: the requested keys plus every encrypted_paths
 // entry the resource already declares, deduplicated by key name, requested
 // keys first.
 //
-// The platform stores a value declared under encrypted_paths as plaintext
-// until its next GitOps push seals it, so the content read back from the
-// cluster can be plaintext under paths declared earlier (a portal or API
-// save). Sealing only the requested keys then hands back a document that
-// carries SOPS metadata with plaintext under those other declared paths. The
-// push lane passes a SOPS document through byte-for-byte rather than sealing
-// it, so the platform's store-time guard refuses that save (before
-// cluster#2647 it was stored and the push refused instead), and the CLI
-// ended in "update stack failed: status 500" with the verdict swallowed
-// (PLA-830, ankra-bfvfy). Sealing the union keeps the stored document
-// consistent with its declaration in one write. A declared entry that
-// selects no key is accepted by the encrypt route and left for the
-// declaration to be corrected separately; only the requested keys are
-// verified afterwards.
+// The declaration, not the document, is what the platform judges a save
+// against, and the two can disagree in both modes:
+//
+//   - Cluster mode: the platform stores a value declared under
+//     encrypted_paths as plaintext until its next GitOps push seals it, so
+//     the content read back from the cluster can be plaintext under paths
+//     declared earlier (a portal or API save).
+//   - File mode: `ankra cluster decrypt` writes the plaintext document back
+//     to disk and deliberately leaves encrypted_paths declared, so the
+//     decrypt-edit-encrypt loop reaches the same shape locally.
+//
+// Sealing only the requested keys then hands back a document that carries
+// SOPS metadata with plaintext under those other declared paths. The push
+// lane passes a SOPS document through byte-for-byte rather than sealing it,
+// so the platform's store-time guard refuses that save (before cluster#2647
+// it was stored and the push refused instead), and the CLI ended in
+// "update stack failed: status 500" with the verdict swallowed (PLA-830,
+// ankra-bfvfy). Sealing the union keeps the document consistent with its
+// declaration in one write. A declared entry that selects no key is
+// accepted by the encrypt route and left for the declaration to be
+// corrected separately; only the requested keys are verified afterwards.
 func pathsToSealWithDeclared(out io.Writer, leafKeys []string, declared []string) []string {
 	merged := unionEncryptedPaths(leafKeys, declared)
 	if len(merged) > len(leafKeys) {

--- a/cmd/cluster_encrypt.go
+++ b/cmd/cluster_encrypt.go
@@ -183,6 +183,12 @@ secret value:
 (compared to "manifests upgrade --set" followed by "encrypt manifest", which
 commits the plaintext value first).
 
+In cluster mode every key the manifest already declares in encrypted_paths is
+sealed together with --key. A value declared in the portal or through the API
+is stored as plaintext until the next GitOps push seals it, and a document
+that carries SOPS metadata with plaintext under a declared path is refused by
+the platform, so sealing only the new key would be rejected.
+
 Examples:
   # Cluster mode against the selected cluster
   ankra cluster encrypt manifest db-secret --key password
@@ -231,8 +237,10 @@ platform.
 
 Two modes:
   Cluster mode (default): fetch the addon's values from a live cluster,
-    encrypt the key, and push the result back via the partial-stack PATCH
-    endpoint. The owning stack is resolved automatically.
+    encrypt the key together with every key the addon already declares in
+    encrypted_paths (a declared value can still be stored as plaintext until
+    the next GitOps push seals it), and push the result back via the
+    partial-stack PATCH endpoint. The owning stack is resolved automatically.
 
   File mode (-f cluster.yaml): rewrite the local addon values file referenced
     by the cluster.yaml in place, adding the key to encrypted_paths.
@@ -911,6 +919,35 @@ func unionEncryptedPaths(lists ...[]string) []string {
 	return merged
 }
 
+// pathsToSealWithDeclared returns the paths the cluster-mode encrypt sends to
+// the platform's encrypt route: the requested keys plus every encrypted_paths
+// entry the resource already declares, deduplicated by key name, requested
+// keys first.
+//
+// The platform stores a value declared under encrypted_paths as plaintext
+// until its next GitOps push seals it, so the content read back from the
+// cluster can be plaintext under paths declared earlier (a portal or API
+// save). Sealing only the requested keys then hands back a document that
+// carries SOPS metadata with plaintext under those other declared paths. The
+// push lane passes a SOPS document through byte-for-byte rather than sealing
+// it, so the platform's store-time guard refuses that save (before
+// cluster#2647 it was stored and the push refused instead), and the CLI
+// ended in "update stack failed: status 500" with the verdict swallowed
+// (PLA-830, ankra-bfvfy). Sealing the union keeps the stored document
+// consistent with its declaration in one write. A declared entry that
+// selects no key is accepted by the encrypt route and left for the
+// declaration to be corrected separately; only the requested keys are
+// verified afterwards.
+func pathsToSealWithDeclared(out io.Writer, leafKeys []string, declared []string) []string {
+	merged := unionEncryptedPaths(leafKeys, declared)
+	if len(merged) > len(leafKeys) {
+		_, _ = fmt.Fprintf(out,
+			"Also sealing the already-declared %s, so the stored document stays consistent with its encrypted_paths.\n",
+			describeEncryptKeys(merged[len(leafKeys):]))
+	}
+	return merged
+}
+
 // encryptedPathLeaf returns the key name an encrypted_paths entry names: the
 // entry with a leading "data." or "stringData." section removed, the two the
 // platform strips when it reads the list. A glob entry is returned as
@@ -1109,7 +1146,8 @@ func runEncryptManifestCluster(cmd *cobra.Command, manifestName string, leafKeys
 	}
 
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Encrypting %s in manifest %q (stack %q)...\n", describeEncryptKeys(leafKeys), manifestName, stack.Name)
-	encryptedYAML, err := apiClient.EncryptYAML(string(decoded), leafKeys)
+	pathsToSeal := pathsToSealWithDeclared(cmd.OutOrStdout(), leafKeys, manifest.EncryptedPaths)
+	encryptedYAML, err := apiClient.EncryptYAML(string(decoded), pathsToSeal)
 	if err != nil {
 		return fmt.Errorf("encryption failed: %w", err)
 	}
@@ -1177,8 +1215,14 @@ func runEncryptAddonCluster(cmd *cobra.Command, addonName string, leafKeys []str
 		return fmt.Errorf("fetch current addon values: %w", err)
 	}
 
+	existingPaths := []string{}
+	if addon.Configuration != nil {
+		existingPaths = addon.Configuration.EncryptedPaths
+	}
+
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Encrypting %s in addon %q (stack %q)...\n", describeEncryptKeys(leafKeys), addonName, stack.Name)
-	encryptedYAML, err := apiClient.EncryptYAML(currentValues, leafKeys)
+	pathsToSeal := pathsToSealWithDeclared(cmd.OutOrStdout(), leafKeys, existingPaths)
+	encryptedYAML, err := apiClient.EncryptYAML(currentValues, pathsToSeal)
 	if err != nil {
 		return fmt.Errorf("encryption failed: %w", err)
 	}
@@ -1189,10 +1233,6 @@ func runEncryptAddonCluster(cmd *cobra.Command, addonName string, leafKeys []str
 		}
 	}
 
-	existingPaths := []string{}
-	if addon.Configuration != nil {
-		existingPaths = addon.Configuration.EncryptedPaths
-	}
 	newPaths := append([]string{}, existingPaths...)
 	for _, leafKey := range leafKeys {
 		if !containsEncryptedPath(newPaths, leafKey) {

--- a/cmd/cluster_encrypt.go
+++ b/cmd/cluster_encrypt.go
@@ -966,10 +966,30 @@ func encryptAnnounceWriter(cmd *cobra.Command) io.Writer {
 // corrected separately; only the requested keys are verified afterwards.
 func pathsToSealWithDeclared(out io.Writer, leafKeys []string, declared []string) []string {
 	merged := unionEncryptedPaths(leafKeys, declared)
-	if len(merged) > len(leafKeys) {
+
+	// What the declaration added is computed by key name, not by slicing off
+	// len(leafKeys): the union deduplicates, so any repetition among the
+	// requested keys would shift that offset and name the wrong entries.
+	// normalizeAndAnnounceEncryptKeys does deduplicate today, but this
+	// helper is not the place to depend on it.
+	requestedKeys := map[string]bool{}
+	for _, leafKey := range leafKeys {
+		requestedKeys[encryptedPathLeaf(leafKey)] = true
+	}
+	addedByDeclaration := make([]string, 0, len(merged))
+	for _, entry := range merged {
+		if !requestedKeys[encryptedPathLeaf(entry)] {
+			addedByDeclaration = append(addedByDeclaration, entry)
+		}
+	}
+
+	if len(addedByDeclaration) > 0 {
+		// "Including ... in the same encrypt" and not "also sealing": a
+		// declared entry that no longer selects a key is passed through and
+		// seals nothing, and the line must not claim otherwise.
 		_, _ = fmt.Fprintf(out,
-			"Also sealing the already-declared %s, so the stored document stays consistent with its encrypted_paths.\n",
-			describeEncryptKeys(merged[len(leafKeys):]))
+			"Including the already-declared %s in the same encrypt, so the stored document stays consistent with its encrypted_paths.\n",
+			describeEncryptKeys(addedByDeclaration))
 	}
 	return merged
 }

--- a/cmd/cluster_encrypt_declared_paths_test.go
+++ b/cmd/cluster_encrypt_declared_paths_test.go
@@ -73,7 +73,7 @@ func TestRunEncryptManifest_ClusterModeSealsTheDeclaredPathsWithTheKey(t *testin
 	if strings.Join(callPaths, ",") != strings.Join(want, ",") {
 		t.Errorf("encrypted paths = %v, want the requested key first and every declared path after it %v", callPaths, want)
 	}
-	if !strings.Contains(out.String(), "Also sealing the already-declared") {
+	if !strings.Contains(out.String(), "Including the already-declared") {
 		t.Errorf("output does not say the declared paths are sealed too:\n%s", out.String())
 	}
 
@@ -145,7 +145,7 @@ func TestRunEncryptManifest_ClusterModeWithoutDeclaredPathsSealsOnlyTheKeys(t *t
 	if len(callPaths) != 1 || callPaths[0] != "password" {
 		t.Errorf("encrypted paths = %v, want [password]", callPaths)
 	}
-	if strings.Contains(out.String(), "Also sealing") {
+	if strings.Contains(out.String(), "Including the already-declared") {
 		t.Errorf("nothing was declared, so nothing extra should be announced:\n%s", out.String())
 	}
 }
@@ -288,7 +288,7 @@ func TestRunEncryptManifest_FileModeSealsTheDeclaredPathsWithTheKey(t *testing.T
 	if strings.Join(callPaths, ",") != strings.Join(want, ",") {
 		t.Errorf("encrypted paths = %v, want the requested key first and every declared entry after it %v", callPaths, want)
 	}
-	if !strings.Contains(out.String(), "Also sealing the already-declared") {
+	if !strings.Contains(out.String(), "Including the already-declared") {
 		t.Errorf("output does not say the declared paths are sealed too:\n%s", out.String())
 	}
 }
@@ -316,7 +316,7 @@ func TestRunEncryptManifest_FileModeWithoutDeclaredPathsSealsOnlyTheKeys(t *test
 	if len(callPaths) != 1 || callPaths[0] != "password" {
 		t.Errorf("encrypted paths = %v, want [password]", callPaths)
 	}
-	if strings.Contains(out.String(), "Also sealing") {
+	if strings.Contains(out.String(), "Including the already-declared") {
 		t.Errorf("nothing was declared, so nothing extra should be announced:\n%s", out.String())
 	}
 }
@@ -406,5 +406,27 @@ func TestMapPatchError_OnlyAMarkedPushFailureIsCalledOne(t *testing.T) {
 	}
 	if !strings.HasPrefix(got, "Invalid encrypted_paths entry") {
 		t.Errorf("unmarked refusal = %q, want the platform detail verbatim", got)
+	}
+}
+
+// The announcement names what the declaration added, worked out by key name.
+// Slicing merged[len(leafKeys):] instead would name the wrong entries the
+// moment the requested keys repeat a name, and could not be reasoned about
+// without checking that normalizeAndAnnounceEncryptKeys still deduplicates.
+func TestPathsToSealWithDeclared_RepeatedRequestedKeysDoNotShiftTheAnnouncement(t *testing.T) {
+	out := new(bytes.Buffer)
+	// "password" and "data.password" are one key; the union collapses them.
+	got := pathsToSealWithDeclared(out, []string{"password", "data.password"}, []string{"OTHER_SECRET", "token"})
+	if strings.Join(got, ",") != "password,OTHER_SECRET,token" {
+		t.Errorf("union = %v, want the repeated request collapsed and the declaration appended", got)
+	}
+	announced := out.String()
+	for _, wanted := range []string{"OTHER_SECRET", "token"} {
+		if !strings.Contains(announced, wanted) {
+			t.Errorf("announcement does not name the declared %q: %q", wanted, announced)
+		}
+	}
+	if strings.Contains(announced, "password") {
+		t.Errorf("a requested key must not be announced as added by the declaration: %q", announced)
 	}
 }

--- a/cmd/cluster_encrypt_declared_paths_test.go
+++ b/cmd/cluster_encrypt_declared_paths_test.go
@@ -3,8 +3,13 @@ package cmd
 import (
 	"bytes"
 	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+
+	"ankra/internal/client"
 )
 
 // PLA-830 (ankra-bfvfy): cluster-mode encrypt sealed only the --key paths.
@@ -195,5 +200,211 @@ func TestPathsToSealWithDeclared(t *testing.T) {
 	got = pathsToSealWithDeclared(out, []string{"password"}, nil)
 	if len(got) != 1 || got[0] != "password" || out.Len() != 0 {
 		t.Errorf("no declaration: got %v with output %q", got, out.String())
+	}
+}
+
+// File mode reaches the same shape by a different route: `ankra cluster
+// decrypt manifest -f` writes the plaintext document back to disk and
+// deliberately leaves encrypted_paths declared in the cluster.yaml, so the
+// documented decrypt-edit-encrypt loop leaves a plaintext file under a
+// multi-entry declaration. Sealing only --key there produces exactly the
+// document the platform's store-time guard refuses on the next `ankra apply`
+// - the PLA-830 verdict, one lane over.
+
+// writeDeclaredPathsFileModeFixture writes a cluster.yaml whose manifest and
+// addon already declare encrypted_paths, over a plaintext from_file - the
+// state `ankra cluster decrypt` leaves behind.
+func writeDeclaredPathsFileModeFixture(t *testing.T, manifestYAML, addonValuesYAML string) (clusterPath, manifestPath, addonPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	manifestPath = filepath.Join(dir, "manifests", "secret.yaml")
+	if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil {
+		t.Fatalf("create manifests dir: %v", err)
+	}
+	if err := os.WriteFile(manifestPath, []byte(manifestYAML), 0o644); err != nil {
+		t.Fatalf("write manifest fixture: %v", err)
+	}
+	addonPath = filepath.Join(dir, "values", "website.yaml")
+	if err := os.MkdirAll(filepath.Dir(addonPath), 0o755); err != nil {
+		t.Fatalf("create values dir: %v", err)
+	}
+	if err := os.WriteFile(addonPath, []byte(addonValuesYAML), 0o644); err != nil {
+		t.Fatalf("write addon fixture: %v", err)
+	}
+	clusterPath = filepath.Join(dir, "cluster.yaml")
+	clusterYAML := `apiVersion: v1
+kind: ImportCluster
+metadata:
+  name: file-mode-declared
+spec:
+  stacks:
+    - name: web
+      addons:
+        - name: website
+          chart_name: website
+          chart_version: 1.0.145
+          namespace: web
+          configuration:
+            from_file: values/website.yaml
+            encrypted_paths:
+              - smtpPassword
+      manifests:
+        - name: my-secret
+          from_file: manifests/secret.yaml
+          encrypted_paths:
+            - data.username
+            - stringData.OTHER_SECRET
+`
+	if err := os.WriteFile(clusterPath, []byte(clusterYAML), 0o644); err != nil {
+		t.Fatalf("write cluster fixture: %v", err)
+	}
+	return clusterPath, manifestPath, addonPath
+}
+
+func TestRunEncryptManifest_FileModeSealsTheDeclaredPathsWithTheKey(t *testing.T) {
+	clusterPath, _, _ := writeDeclaredPathsFileModeFixture(t, plainSecretManifestYAML, "adminPassword: hunter2\n")
+
+	mock := &upgradeMock{encryptResult: bothKeysEncryptedSecretManifestYAML}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "my-secret",
+		"--key", "password",
+		"-f", clusterPath,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+
+	if len(mock.encryptCalls) != 1 {
+		t.Fatalf("expected exactly one EncryptYAML call, got %d", len(mock.encryptCalls))
+	}
+	callPaths := mock.encryptCalls[0].EncryptedPaths
+	want := []string{"password", "data.username", "stringData.OTHER_SECRET"}
+	if strings.Join(callPaths, ",") != strings.Join(want, ",") {
+		t.Errorf("encrypted paths = %v, want the requested key first and every declared entry after it %v", callPaths, want)
+	}
+	if !strings.Contains(out.String(), "Also sealing the already-declared") {
+		t.Errorf("output does not say the declared paths are sealed too:\n%s", out.String())
+	}
+}
+
+func TestRunEncryptManifest_FileModeWithoutDeclaredPathsSealsOnlyTheKeys(t *testing.T) {
+	clusterPath, _ := writeEncryptFileModeFixture(t, plainSecretManifestYAML)
+
+	mock := &upgradeMock{encryptResult: encryptedSecretManifestYAML}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "my-secret",
+		"--key", "password",
+		"-f", clusterPath,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+
+	callPaths := mock.encryptCalls[0].EncryptedPaths
+	if len(callPaths) != 1 || callPaths[0] != "password" {
+		t.Errorf("encrypted paths = %v, want [password]", callPaths)
+	}
+	if strings.Contains(out.String(), "Also sealing") {
+		t.Errorf("nothing was declared, so nothing extra should be announced:\n%s", out.String())
+	}
+}
+
+func TestRunEncryptAddon_FileModeSealsTheDeclaredPathsWithTheKey(t *testing.T) {
+	clusterPath, _, _ := writeDeclaredPathsFileModeFixture(t, plainSecretManifestYAML,
+		"adminPassword: hunter2\nsmtpPassword: hunter3\n")
+
+	mock := &upgradeMock{encryptResult: "adminPassword: ENC[AES256_GCM,data:a]\nsmtpPassword: ENC[AES256_GCM,data:b]\n"}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "addon",
+		"--name", "website",
+		"--key", "adminPassword",
+		"-f", clusterPath,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+
+	callPaths := mock.encryptCalls[0].EncryptedPaths
+	want := []string{"adminPassword", "smtpPassword"}
+	if strings.Join(callPaths, ",") != strings.Join(want, ",") {
+		t.Errorf("encrypted paths = %v, want %v", callPaths, want)
+	}
+}
+
+// The other half of PLA-830: once cluster#2828 turned the store guard's
+// verdict into a 422, the CLI's blanket "git push failed:" prefix told the
+// customer their GitOps push had failed - for a save the platform refused
+// before it wrote anything, and right after they had confirmed no commit was
+// made. The refusal has to reach them as itself.
+func TestRunEncryptManifest_StoreGuardRefusalIsNotReportedAsAGitPushFailure(t *testing.T) {
+	const verdict = "Cannot persist values for 'runway-envs': the document carries SOPS metadata but " +
+		"declared encrypted paths [stringData.VOYAGE_API_KEY] are plaintext. " +
+		"Re-encrypt the document with sops (fresh MAC) before saving."
+
+	mock := &upgradeMock{
+		iac:           sampleIaCYAMLWithDeclaredPaths,
+		manifestB64:   base64.StdEncoding.EncodeToString([]byte(plainSecretManifestYAML)),
+		encryptResult: encryptedSecretManifestYAML,
+		patchErr: &client.PatchStackError{
+			StatusCode: 422,
+			Body:       []byte(`{"detail":` + strconv.Quote(verdict) + `}`),
+		},
+	}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "demo-namespace",
+		"--key", "password",
+		"--cluster", fakeClusterUUID,
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected the store-guard refusal to surface as an error")
+	}
+	if strings.Contains(err.Error(), "git push") {
+		t.Errorf("the refusal never reached git; it must not be reported as a push failure: %v", err)
+	}
+	if err.Error() != verdict {
+		t.Errorf("error = %q, want the platform's verdict verbatim %q", err.Error(), verdict)
+	}
+}
+
+func TestMapPatchError_OnlyAMarkedPushFailureIsCalledOne(t *testing.T) {
+	marked := &client.PatchStackError{StatusCode: 422,
+		Body: []byte(`{"detail":"GitHub authentication failed","error_code":"GIT_PUSH_FAILED"}`)}
+	if got := mapPatchError(marked).Error(); got != "git push failed: GitHub authentication failed" {
+		t.Errorf("marked push failure = %q, want the git-push prefix kept", got)
+	}
+
+	unmarked := &client.PatchStackError{StatusCode: 422,
+		Body: []byte(`{"detail":"Invalid encrypted_paths entry \"glob:\": the glob: prefix must be followed by a key-name pattern"}`)}
+	got := mapPatchError(unmarked).Error()
+	if strings.Contains(got, "git push") {
+		t.Errorf("unmarked refusal reported as a push failure: %q", got)
+	}
+	if !strings.HasPrefix(got, "Invalid encrypted_paths entry") {
+		t.Errorf("unmarked refusal = %q, want the platform detail verbatim", got)
 	}
 }

--- a/cmd/cluster_encrypt_declared_paths_test.go
+++ b/cmd/cluster_encrypt_declared_paths_test.go
@@ -1,0 +1,199 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+// PLA-830 (ankra-bfvfy): cluster-mode encrypt sealed only the --key paths.
+// A manifest or addon that already declared other encrypted_paths - values a
+// portal or API save stored as plaintext for the next GitOps push to seal -
+// came back as a SOPS document with plaintext under those declared paths,
+// which the platform's store-time guard refuses ("update stack failed:
+// status 500" on the CLI lane, with the verdict swallowed). The encrypt call
+// must carry the union of the requested keys and the declared paths.
+
+const sampleIaCYAMLWithDeclaredPaths = `apiVersion: v1
+kind: ImportCluster
+metadata:
+  name: website-demo
+spec:
+  stacks:
+    - name: demo-web-app
+      addons:
+        - name: website
+          chart_name: website
+          chart_version: 1.0.145
+          namespace: web
+          configuration:
+            encrypted_paths:
+              - smtpPassword
+      manifests:
+        - name: demo-namespace
+          namespace: web
+          encrypted_paths:
+            - stringData.OTHER_SECRET
+            - data.username
+`
+
+func TestRunEncryptManifest_ClusterModeSealsTheDeclaredPathsWithTheKey(t *testing.T) {
+	mock := &upgradeMock{
+		iac:           sampleIaCYAMLWithDeclaredPaths,
+		manifestB64:   base64.StdEncoding.EncodeToString([]byte(plainSecretManifestYAML)),
+		encryptResult: encryptedSecretManifestYAML,
+	}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "demo-namespace",
+		"--key", "password",
+		"--set", `data.password=bmV3LXZhbHVl`,
+		"--cluster", fakeClusterUUID,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+
+	if len(mock.encryptCalls) != 1 {
+		t.Fatalf("expected exactly one EncryptYAML call, got %d", len(mock.encryptCalls))
+	}
+	callPaths := mock.encryptCalls[0].EncryptedPaths
+	want := []string{"password", "stringData.OTHER_SECRET", "data.username"}
+	if strings.Join(callPaths, ",") != strings.Join(want, ",") {
+		t.Errorf("encrypted paths = %v, want the requested key first and every declared path after it %v", callPaths, want)
+	}
+	if !strings.Contains(out.String(), "Also sealing the already-declared") {
+		t.Errorf("output does not say the declared paths are sealed too:\n%s", out.String())
+	}
+
+	if len(mock.capturedRequests) != 1 {
+		t.Fatalf("expected one PATCH, got %d", len(mock.capturedRequests))
+	}
+	manifest := mock.capturedRequests[0].Body.Spec.Stacks[0].Manifests[0]
+	if !containsEncryptedPath(manifest.EncryptedPaths, "password") ||
+		!containsEncryptedPath(manifest.EncryptedPaths, "OTHER_SECRET") ||
+		!containsEncryptedPath(manifest.EncryptedPaths, "username") {
+		t.Errorf("manifest.encrypted_paths = %v, want the declared paths kept and password added", manifest.EncryptedPaths)
+	}
+}
+
+func TestRunEncryptManifest_ClusterModeDoesNotDuplicateAKeyAlreadyDeclared(t *testing.T) {
+	mock := &upgradeMock{
+		iac:           sampleIaCYAMLWithDeclaredPaths,
+		manifestB64:   base64.StdEncoding.EncodeToString([]byte(plainSecretManifestYAML)),
+		encryptResult: bothKeysEncryptedSecretManifestYAML,
+	}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "demo-namespace",
+		"--key", "username",
+		"--cluster", fakeClusterUUID,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+
+	callPaths := mock.encryptCalls[0].EncryptedPaths
+	want := []string{"username", "stringData.OTHER_SECRET"}
+	if strings.Join(callPaths, ",") != strings.Join(want, ",") {
+		t.Errorf("encrypted paths = %v, want %v (data.username and username are one key)", callPaths, want)
+	}
+	manifest := mock.capturedRequests[0].Body.Spec.Stacks[0].Manifests[0]
+	if len(manifest.EncryptedPaths) != 2 {
+		t.Errorf("manifest.encrypted_paths = %v, want the two declared entries unchanged", manifest.EncryptedPaths)
+	}
+}
+
+func TestRunEncryptManifest_ClusterModeWithoutDeclaredPathsSealsOnlyTheKeys(t *testing.T) {
+	mock := &upgradeMock{
+		iac:           sampleIaCYAMLForCmd,
+		manifestB64:   base64.StdEncoding.EncodeToString([]byte(plainSecretManifestYAML)),
+		encryptResult: encryptedSecretManifestYAML,
+	}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "manifest", "demo-namespace",
+		"--key", "password",
+		"--cluster", fakeClusterUUID,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+
+	callPaths := mock.encryptCalls[0].EncryptedPaths
+	if len(callPaths) != 1 || callPaths[0] != "password" {
+		t.Errorf("encrypted paths = %v, want [password]", callPaths)
+	}
+	if strings.Contains(out.String(), "Also sealing") {
+		t.Errorf("nothing was declared, so nothing extra should be announced:\n%s", out.String())
+	}
+}
+
+func TestRunEncryptAddon_ClusterModeSealsTheDeclaredPathsWithTheKey(t *testing.T) {
+	mock := &upgradeMock{
+		iac:           sampleIaCYAMLWithDeclaredPaths,
+		addonValues:   "adminPassword: hunter2\nsmtpPassword: hunter3\n",
+		encryptResult: "adminPassword: ENC[AES256_GCM,data:a]\nsmtpPassword: ENC[AES256_GCM,data:b]\n",
+	}
+	setMockClient(t, mock)
+	resetUpgradeCommandFlags(t)
+
+	cmd := rootCmd
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"cluster", "encrypt", "addon",
+		"--name", "website",
+		"--key", "adminPassword",
+		"--cluster", fakeClusterUUID,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\noutput: %s", err, out.String())
+	}
+
+	callPaths := mock.encryptCalls[0].EncryptedPaths
+	want := []string{"adminPassword", "smtpPassword"}
+	if strings.Join(callPaths, ",") != strings.Join(want, ",") {
+		t.Errorf("encrypted paths = %v, want %v", callPaths, want)
+	}
+	addon := mock.capturedRequests[0].Body.Spec.Stacks[0].Addons[0]
+	if addon.Configuration == nil {
+		t.Fatal("expected configuration in PATCH")
+	}
+	if strings.Join(addon.Configuration.EncryptedPaths, ",") != "smtpPassword,adminPassword" {
+		t.Errorf("addon.encrypted_paths = %v, want [smtpPassword adminPassword]", addon.Configuration.EncryptedPaths)
+	}
+}
+
+func TestPathsToSealWithDeclared(t *testing.T) {
+	out := new(bytes.Buffer)
+	got := pathsToSealWithDeclared(out, []string{"password"}, []string{"stringData.password", "glob:DB_*", "token"})
+	if strings.Join(got, ",") != "password,glob:DB_*,token" {
+		t.Errorf("union = %v, want the requested spelling kept and the rest appended in order", got)
+	}
+	if !strings.Contains(out.String(), "glob:DB_*") || !strings.Contains(out.String(), `"token"`) {
+		t.Errorf("announcement should name what was added: %q", out.String())
+	}
+
+	out.Reset()
+	got = pathsToSealWithDeclared(out, []string{"password"}, nil)
+	if len(got) != 1 || got[0] != "password" || out.Len() != 0 {
+		t.Errorf("no declaration: got %v with output %q", got, out.String())
+	}
+}

--- a/cmd/cluster_partial.go
+++ b/cmd/cluster_partial.go
@@ -371,8 +371,10 @@ func renderPatchResourceErrors(w io.Writer, resourceErrors []client.PatchStackRe
 //     via CLI preflight; print as-is so users see the underlying issue.
 //   - 403: sandbox cluster — cannot be modified through the CLI.
 //   - 409: stack pending deletion — orphaned resources marked for cleanup.
-//   - 422: git push failure (credential/auth or write issue), or a circular
-//     dependency rejection (surfaced verbatim).
+//   - 422: a git push failure when the platform marks it GIT_PUSH_FAILED;
+//     every other refusal on this status (SOPS store guard, spec
+//     validation, secret slots, circular dependency, rejected name) is
+//     surfaced verbatim, because it was refused before git was touched.
 //   - else: print status + body for debugging.
 func mapPatchError(perr *client.PatchStackError) error {
 	if perr == nil {
@@ -401,12 +403,26 @@ func mapPatchError(perr *client.PatchStackError) error {
 	case http.StatusConflict:
 		return fmt.Errorf("cluster is not available — stack may be pending deletion or cluster is deprovisioned: %s", detail)
 	case http.StatusUnprocessableEntity:
-		// 422 is overloaded: circular-dependency rejections carry a descriptive
-		// message that is not a git failure, so surface it as-is.
-		if strings.Contains(strings.ToLower(detail), "circular dependency") {
-			return errors.New(detail)
+		// 422 on the stack-write routes is seven different refusals, and only
+		// one of them is a git push failure: the store-time SOPS guards, the
+		// engine's spec validation, the secret-slot pre-flight, a circular
+		// dependency and a rejected name all refuse BEFORE the database write
+		// and before Git is touched at all. The platform marks the one real
+		// push failure with error_code GIT_PUSH_FAILED, so that is what
+		// decides - never the shape of the sentence.
+		//
+		// Labelling the rest "git push failed" sent the operator to look at
+		// GitOps credentials for a save that never reached git. It became the
+		// live failure mode when cluster#2828 turned the SOPS store guard's
+		// verdict into a 422: the customer whose encrypt was refused was told
+		// their git push had failed, having just confirmed no commit was made
+		// (PLA-830, ankra-bfvfy). Every one of these details is a complete,
+		// actionable sentence written for the person reading it, so the
+		// honest rendering of an unmarked refusal is the sentence itself.
+		if client.IsGitPushFailureResponse(perr.Body) {
+			return fmt.Errorf("git push failed: %s", detail)
 		}
-		return fmt.Errorf("git push failed: %s", detail)
+		return errors.New(detail)
 	case http.StatusUnauthorized:
 		// Wrap ErrUnauthorized (whose message is byte-for-byte identical to the
 		// historical text) so errors.Is matches and the exit code is exitAuth.

--- a/cmd/cluster_partial_test.go
+++ b/cmd/cluster_partial_test.go
@@ -436,7 +436,13 @@ func TestMapPatchError_StatusCodes(t *testing.T) {
 		{"400 validation", 400, `{"detail":"Exactly one stack must be provided"}`, "Exactly one stack"},
 		{"403 sandbox", 403, `{"detail":"sandbox mode is enabled"}`, "sandbox"},
 		{"409 pending", 409, `{"detail":"Stack is pending deletion"}`, "pending deletion"},
-		{"422 git push", 422, `{"detail":"permission denied"}`, "git push failed"},
+		// Only a 422 the platform marks GIT_PUSH_FAILED is a push failure.
+		// An unmarked 422 is one of the refusals that never reached git, and
+		// is surfaced as the platform wrote it (PLA-830, ankra-bfvfy).
+		{"422 git push", 422, `{"detail":"permission denied","error_code":"GIT_PUSH_FAILED"}`, "git push failed"},
+		{"422 sops store guard", 422,
+			`{"detail":"Cannot persist values for 'runway-envs': the document carries SOPS metadata but declared encrypted paths [stringData.VOYAGE_API_KEY] are plaintext."}`,
+			"Cannot persist values for 'runway-envs'"},
 		{"422 circular dep", 422, `{"detail":"Circular dependency detected: a -> b -> a"}`, "Circular dependency detected"},
 		{"401 unauth", 401, ``, "unauthorized"},
 		{"500 other", 500, `{"detail":"unexpected"}`, "status 500"},

--- a/cmd/upgrade_e2e_test.go
+++ b/cmd/upgrade_e2e_test.go
@@ -430,8 +430,9 @@ func TestRunAddonsUpgrade_DryRunJSONEnvelope(t *testing.T) {
 
 func TestRunAddonsUpgrade_BackendErrorMapping(t *testing.T) {
 	mock := &upgradeMock{
-		iac:      sampleIaCYAMLForCmd,
-		patchErr: &client.PatchStackError{StatusCode: 422, Body: []byte(`{"detail":"push failed"}`)},
+		iac: sampleIaCYAMLForCmd,
+		patchErr: &client.PatchStackError{StatusCode: 422,
+			Body: []byte(`{"detail":"push failed","error_code":"GIT_PUSH_FAILED"}`)},
 	}
 	setMockClient(t, mock)
 	resetUpgradeCommandFlags(t)

--- a/internal/client/gitpush.go
+++ b/internal/client/gitpush.go
@@ -15,7 +15,25 @@ import (
 // third answer, not the second: it keeps today's treat-as-error behavior.
 const (
 	gitPushErrorCodeDeferred = "GIT_PUSH_DEFERRED"
+	gitPushErrorCodeFailed   = "GIT_PUSH_FAILED"
 )
+
+// IsGitPushFailureResponse reports whether a 422 body is the platform's
+// genuine git-push failure (error_code GIT_PUSH_FAILED), as opposed to one
+// of the other refusals this status carries on the stack-write routes: the
+// store-time SOPS guards, spec validation, the secret-slot pre-flight, a
+// circular dependency, a rejected name. Those are refused BEFORE the
+// database write and before Git is touched at all, so a caller must not
+// describe them as a push failure (PLA-830).
+func IsGitPushFailureResponse(body []byte) bool {
+	var parsed struct {
+		ErrorCode string `json:"error_code"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return false
+	}
+	return parsed.ErrorCode == gitPushErrorCodeFailed
+}
 
 // GitPushDeferral reports a designed git-push refusal: the requested change
 // is saved and live on the cluster, and the platform will commit it back to


### PR DESCRIPTION
<!-- ankra-tech-agent:pr -->
Linear: https://linear.app/ankra/issue/PLA-830/1152-cluster-encrypt-manifest-cluster-mode-set-fails-update-stack-500
Bead: ankra-bfvfy

## What

Three fixes to the `ankra cluster encrypt` path, all one failure: a secret change the customer could not make, refused with a message that pointed at the wrong thing.

1. **Cluster mode seals the whole declaration.** `encrypt manifest` / `encrypt addon` send the platform's encrypt route the union of the `--key`s and every `encrypted_paths` entry the resource already declares (requested keys first, deduplicated by key name), and say so on stdout when the declaration added anything. Only the requested keys are verified afterwards, as before.
2. **File mode does the same.** It had the identical defect one lane over.
3. **A 422 is no longer blanket-labelled "git push failed".**

## Why

PLA-830 (Depict): `ankra cluster encrypt manifest runway-envs --cluster prod-multi-az --key EMBEDDING_VOYAGE_MERCHANT_IDS --set '...'` printed the in-memory `--set` and encrypt lines, then

```
Error: update stack failed: status 500, body: Internal Server Error
```

The escaped commas were fine and the stack was fine. Confirmed from the prod log for both runs (`ankra-cluster-api-go`, 10:02:39Z and 10:03:16Z, `PATCH /api/v1/org/clusters/imported/e781.../stacks/runway` 500):

```
Cannot persist values for 'runway-envs': the document carries SOPS metadata but declared
encrypted paths [stringData.METRICS_AUTH_TOKEN stringData.RUNWAY_TYPESENSE_ADMIN_KEY
 stringData.SEARCH_TOKEN_SIGNING_KEY stringData.TINYBIRD_EVENT_WRITING_KEY
 stringData.TRINITY_DB_PASSWORD stringData.TYPESENSE_SHOPIFY_AUTH_HEADER
 stringData.TYPESENSE_SHOPIFY_HOST stringData.TYPESENSE_SHOPIFY_PORT
 stringData.TYPESENSE_SHOPIFY_PROTOCOL stringData.TYPESENSE_SHOPIFY_WRITE_HOSTS
 stringData.VOYAGE_API_KEY] are plaintext. Re-encrypt the document with sops (fresh MAC) before saving.
```

The stored manifest content was plaintext under paths declared earlier (a portal or API save leaves a declared value plaintext until the next GitOps push seals it), and the CLI sealed only `EMBEDDING_VOYAGE_MERCHANT_IDS`. The result is a SOPS document with plaintext under the other eleven declared paths. The push lane passes a SOPS document through byte-for-byte rather than sealing it, so the store-time guard (cluster#2647) refuses that save — correctly: that shape is the one that leaked live S3 credentials to GitHub on 2026-07-07.

So the guard is right and the CLI was wrong. **`encrypt manifest --key X` in cluster mode could never succeed on a manifest that declared more than one encrypted path** — the declaration, not the document, is what the platform judges a save against, and the CLI only ever sealed one side of it. The platform's encrypt route unions in extra paths *only* when the input already carries sops metadata (`EncryptContent`), which a plaintext stored document does not.

**File mode (2)** reaches the same shape by a different route: `ankra cluster decrypt manifest -f` writes the plaintext document back to disk and deliberately leaves `encrypted_paths` declared, so the documented decrypt-edit-encrypt loop leaves a plaintext file under a multi-entry declaration. Sealing only `--key` there is refused on the next `ankra apply`.

**The 422 label (3)** is the "could the person act on it" half. cluster#2828 (same bead, merged 2026-09-08) stopped the guard's verdict reaching the CLI as a bare 500 and made it a 422 carrying the sentence — but `mapPatchError` prefixes every 422 with `git push failed:`. Seven different refusals answer 422 on the stack-write routes and only one is a push failure; the SOPS store guards, spec validation, the secret-slot pre-flight, a circular dependency and a rejected name are all refused *before* the database write and before git is touched. The customer would have been told their git push failed, in the same breath as confirming no commit was made — sending them to look at GitOps credentials for a refusal that never reached git. The platform already marks the real one with `error_code: GIT_PUSH_FAILED`, so that now decides; every other refusal is surfaced as the sentence the platform wrote.

A sealed stored document is unaffected: the encrypt route already merges the paths it observes as ciphertext, and the union is a superset.

## Tests

`cmd/cluster_encrypt_declared_paths_test.go`:
- manifest with declared `[stringData.OTHER_SECRET, data.username]` and `--key password --set ...` sends `[password stringData.OTHER_SECRET data.username]` and announces it; the PATCH keeps the declared entries and adds `password`
- a `--key` naming an already-declared key is not duplicated (`data.username` and `username` are one key)
- no declaration: only the requested keys are sent, nothing announced (existing behaviour, pinned)
- addon with declared `[smtpPassword]` and `--key adminPassword` sends `[adminPassword smtpPassword]`
- **file mode**: manifest and addon with declared paths seal the union; no declaration still seals only the keys
- **the store-guard refusal reaches the user as itself** — asserts the error carries no "git push" and equals the platform's verdict verbatim
- `mapPatchError`: a `GIT_PUSH_FAILED`-marked 422 keeps the git prefix, an unmarked one does not

`cmd/cluster_partial_test.go` / `cmd/upgrade_e2e_test.go`: the two cases that pinned the old blanket prefix now send the `error_code` the platform sends, plus a new case for the SOPS verdict.

Gates: the repo pre-commit hook ran the full suite and golangci-lint on the final commit — all packages ok, **0 lint issues**.

Not on the scary list: CLI behaviour in one command family. Ships with the next release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jU4skEXGw73M7eRSMYBPK
