### PR TITLE
fix(apply): read and send manifests[].force and auto_remediate from the file (ankra-cbktk, PLA-834)

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -742,7 +742,10 @@ func parseBoolField(m map[string]interface{}, key string) (bool, error) {
 	}
 	value, ok := raw.(bool)
 	if !ok {
-		return false, fmt.Errorf("'%s' must be true or false (got %v)", key, raw)
+		// Name the type as well as the value: force: "true" and force: true
+		// both print as true, and the quoted string is the case this guard
+		// exists for.
+		return false, fmt.Errorf("'%s' must be true or false (got %v of type %T)", key, raw, raw)
 	}
 	return value, nil
 }

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -729,6 +729,24 @@ func parseGroupField(m map[string]interface{}) (string, error) {
 	return group, nil
 }
 
+// parseBoolField extracts an optional boolean key such as a manifest's
+// 'force' or 'auto_remediate'. Absent (or explicitly null) is false, the
+// declarative reading the GitOps cluster file gets too. A non-boolean value
+// is an error rather than false: the platform types both as booleans and
+// would answer 422, and quietly reading "true" (a quoted string) as off is
+// the same silent drop that lost the flag in the first place (ankra-cbktk).
+func parseBoolField(m map[string]interface{}, key string) (bool, error) {
+	raw, present := m[key]
+	if !present || raw == nil {
+		return false, nil
+	}
+	value, ok := raw.(bool)
+	if !ok {
+		return false, fmt.Errorf("'%s' must be true or false (got %v)", key, raw)
+	}
+	return value, nil
+}
+
 func buildManifest(mm map[string]interface{}, baseDir string) (client.Manifest, error) {
 	name, _ := mm["name"].(string)
 	if name == "" {
@@ -801,12 +819,26 @@ func buildManifest(mm map[string]interface{}, baseDir string) (client.Manifest, 
 		return client.Manifest{}, err
 	}
 
+	// The apply flags. Dropped on the floor until ankra-cbktk: a file that
+	// said force: true applied without it, and the platform stored false over
+	// the flag the customer had set through a GitOps PR (PLA-834).
+	force, err := parseBoolField(mm, "force")
+	if err != nil {
+		return client.Manifest{}, err
+	}
+	autoRemediate, err := parseBoolField(mm, "auto_remediate")
+	if err != nil {
+		return client.Manifest{}, err
+	}
+
 	return client.Manifest{
 		Name:             name,
 		ManifestBase64:   encoded,
 		Namespace:        ns,
 		Parents:          parents,
 		EncryptedPaths:   encryptedPaths,
+		Force:            force,
+		AutoRemediate:    autoRemediate,
 		Group:            group,
 		AgentsMd:         agentsMd,
 		AgentsMdFromFile: agentsMdFromFile,

--- a/cmd/apply_flags_test.go
+++ b/cmd/apply_flags_test.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// ankra-cbktk (PLA-834): the manifests[] 'force' and 'auto_remediate' keys
+// were never read, so a file carrying force: true applied with no force key
+// in the payload and the platform stored false over the flag a GitOps PR
+// had just set. The flags are read as booleans and always sent, so the file
+// is authoritative either way.
+func TestBuildManifestApplyFlags(t *testing.T) {
+	t.Run("force and auto_remediate pass through and are sent", func(t *testing.T) {
+		mm := map[string]interface{}{
+			"name":           "strimzi-crd-kafkas",
+			"manifest":       "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition",
+			"force":          true,
+			"auto_remediate": true,
+		}
+		m, err := buildManifest(mm, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !m.Force || !m.AutoRemediate {
+			t.Fatalf("force = %v, auto_remediate = %v, want both true", m.Force, m.AutoRemediate)
+		}
+		payload, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		for _, want := range []string{`"force":true`, `"auto_remediate":true`} {
+			if !strings.Contains(string(payload), want) {
+				t.Errorf("payload %s lacks %s", payload, want)
+			}
+		}
+	})
+
+	t.Run("absent flags are false and still sent", func(t *testing.T) {
+		mm := map[string]interface{}{
+			"name":     "plain",
+			"manifest": "apiVersion: v1\nkind: Namespace",
+		}
+		m, err := buildManifest(mm, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m.Force || m.AutoRemediate {
+			t.Fatalf("force = %v, auto_remediate = %v, want both false for a file without the keys", m.Force, m.AutoRemediate)
+		}
+		payload, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		// Declarative: the key is on the wire as false, never omitted, so an
+		// apply of a file that dropped force: true clears it on the platform
+		// the way the GitOps cluster file would.
+		for _, want := range []string{`"force":false`, `"auto_remediate":false`} {
+			if !strings.Contains(string(payload), want) {
+				t.Errorf("payload %s lacks %s", payload, want)
+			}
+		}
+	})
+
+	t.Run("explicit null reads as false", func(t *testing.T) {
+		mm := map[string]interface{}{
+			"name":     "nulled",
+			"manifest": "apiVersion: v1\nkind: Namespace",
+			"force":    nil,
+		}
+		m, err := buildManifest(mm, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m.Force {
+			t.Fatal("force = true, want false for 'force:' with no value")
+		}
+	})
+
+	t.Run("a quoted force is rejected, not read as off", func(t *testing.T) {
+		mm := map[string]interface{}{
+			"name":     "quoted",
+			"manifest": "apiVersion: v1\nkind: Namespace",
+			"force":    "true",
+		}
+		_, err := buildManifest(mm, "")
+		if err == nil {
+			t.Fatal("expected an error for force: \"true\"")
+		}
+		if !strings.Contains(err.Error(), "'force'") {
+			t.Errorf("error %q does not name the 'force' key", err.Error())
+		}
+	})
+
+	t.Run("a non-boolean auto_remediate is rejected", func(t *testing.T) {
+		mm := map[string]interface{}{
+			"name":           "numeric",
+			"manifest":       "apiVersion: v1\nkind: Namespace",
+			"auto_remediate": 1,
+		}
+		_, err := buildManifest(mm, "")
+		if err == nil {
+			t.Fatal("expected an error for auto_remediate: 1")
+		}
+		if !strings.Contains(err.Error(), "'auto_remediate'") {
+			t.Errorf("error %q does not name the 'auto_remediate' key", err.Error())
+		}
+	})
+}

--- a/cmd/apply_flags_test.go
+++ b/cmd/apply_flags_test.go
@@ -91,6 +91,10 @@ func TestBuildManifestApplyFlags(t *testing.T) {
 		if !strings.Contains(err.Error(), "'force'") {
 			t.Errorf("error %q does not name the 'force' key", err.Error())
 		}
+		// "true" and true print alike; the message has to say it was a string.
+		if !strings.Contains(err.Error(), "of type string") {
+			t.Errorf("error %q does not say the value was a string", err.Error())
+		}
 	})
 
 	t.Run("a non-boolean auto_remediate is rejected", func(t *testing.T) {
@@ -105,6 +109,9 @@ func TestBuildManifestApplyFlags(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "'auto_remediate'") {
 			t.Errorf("error %q does not name the 'auto_remediate' key", err.Error())
+		}
+		if !strings.Contains(err.Error(), "of type int") {
+			t.Errorf("error %q does not say the value was an int", err.Error())
 		}
 	})
 }

--- a/internal/client/clusters.go
+++ b/internal/client/clusters.go
@@ -307,6 +307,15 @@ type Manifest struct {
 	Namespace      string   `json:"namespace,omitempty"`
 	Parents        []Parent `json:"parents"`
 	EncryptedPaths []string `json:"encrypted_paths,omitempty"`
+	// Force and AutoRemediate are the manifest's apply flags (force =
+	// server-side apply with --force-conflicts, the way a CRD hop takes a
+	// field another manager owns). Always sent, never omitted: apply is
+	// declarative, so a file without the key means false, the same rule the
+	// GitOps cluster file follows. Until ankra-cbktk neither key was read at
+	// all, so a file carrying force: true applied without it and the
+	// platform stored false over the flag a GitOps PR had just set (PLA-834).
+	Force         bool `json:"force"`
+	AutoRemediate bool `json:"auto_remediate"`
 	// Group: see the Addon field of the same name.
 	Group string `json:"group,omitempty"`
 	// AgentsMd / AgentsMdFromFile: see the Addon fields of the same name.


### PR DESCRIPTION
<!-- ankra-tech-agent:pr -->
Linear: https://linear.app/ankra/issue/PLA-834/1156-cli-cluster-apply-stores-forcefalse-on-manifests-regardless-of
Bead: ankra-cbktk

## Problem

`ankra cluster apply -f` dropped a manifest's `force` (and `auto_remediate`) flag. At v0.15.0 `client.Manifest` (`internal/client/clusters.go:304`) has no such field and `buildManifest` (`cmd/apply.go:732`) never reads the keys, so the `manifests[]` entry on the wire says nothing about force and the platform stores false.

On Smartoptics `so-development` (PLA-834, 2026-09-09) a GitOps PR set `force: true` on ten strimzi CRD manifests and the sync succeeded; five minutes later CI re-applied the unchanged stack file (which also carries `force: true`) with the CLI and the platform exported `force: false` back into the cluster file. Reproduced by the customer on v0.8.0 and v0.14.0; the code is the same at v0.15.0.

## Fix

- `client.Manifest` gains `Force` and `AutoRemediate`, always sent (no `omitempty`): apply is declarative, so a file without the key means false, the same rule the GitOps cluster file follows.
- `buildManifest` reads both through `parseBoolField`: absent or null is false, a non-boolean (`force: "true"`) is an error naming the key, like `parseGroupField`, rather than a silent off.

Left alone on purpose:

- `ManifestSpec` (partial patches behind `manifests update`, `manifests create`, `cluster encrypt`): those lanes patch one field of a manifest read back from the API, and the read shape has no force, so an always-sent field there would clear a stored flag. They rely on the platform's absent-means-keep rule from ankraio/cluster#2843 (bead ankra-tg8zb).
- `cluster clone`: it writes the parsed YAML node back, so keys its structs do not model already survive a copy.

## Behaviour note for the reviewer

With this CLI the file is authoritative in both directions: a file that carries `force: true` sets it, and a file that lacks the key clears it, exactly as the GitOps lane treats the cluster file. Before this PR the CLI could only ever clear. Older CLIs (through v0.15.0) keep clearing until cluster#2843 deploys, after which they leave the stored flag alone.

## Tests

`cmd/apply_flags_test.go`: both flags pass through and marshal as `"force":true`; absent flags are false and still on the wire; null reads as false; a quoted `force` and a numeric `auto_remediate` are rejected with the key named. The new test does not compile against the previous struct, which is the "fails before" for a dropped field.

## Gates run locally

`gofmt -l`, `go build -buildvcs=false ./...`, `go test -buildvcs=false -count=1 ./cmd/ ./internal/client/`, `go vet` on both packages. `golangci-lint` is not installed here; the full linter runs in CI.

## Merge notes

Not on the scary list: three files, under 100 lines, no auth, protocol, CI or deploy surface. Ships with the next CLI release; the customer's CI pins v0.8.0, so cluster#2843 is what protects them until they upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
