### PR TITLE
fix(cluster): every cluster-scoped command takes the cluster's name, not just its id (ankra-aprvp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Ankra CLI Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Every cluster-scoped command now takes the cluster's name as well as its
+  id.** The three `ankra cluster playground` verbs learned this in #239, but
+  they were the only group: the other 103 commands - `cluster` bastion,
+  managed, mesh, node-group, nodes, scale, ssh-keys and upgrade,
+  `control-plane`, and every provider lane (DigitalOcean, Hetzner, OVH,
+  UpCloud, Scaleway, Proxmox VE, HPE Morpheus) - forwarded a name verbatim,
+  where it reached the route as a non-UUID path segment and came back as a
+  bare 404 or a `uuid_parsing` 422 with nothing to say an id was expected. A
+  cluster id still passes straight through without the extra lookup, an
+  unknown name is refused before the request, and a destructive prompt names
+  what you typed alongside the id it resolved to.
+- **Name lookup no longer picks one of two clusters whose names differ only by
+  case.** A name typed exactly as the cluster carries it wins immediately;
+  otherwise a single case-insensitive match resolves and several are refused
+  naming both clusters and both ids. This is the resolver the stacks,
+  security, cost and validate commands already shared, so they gain it too.
+- **A cluster name that is 36 characters long with four dashes is looked up
+  rather than forwarded as an id.** The lookup's own shape test was that loose
+  while the caller's was a strict UUID, so names of that shape fell into the
+  gap and answered with the opaque error this release removes everywhere else.
+- **A name beyond the lookup's 5000-cluster paging cap is no longer reported
+  as "not found".** A truncated listing was being presented as a verified
+  absence; the error now says the name was not among the first 5000 and to
+  pass the cluster id instead.
+
 ## v0.15.1 — 2026-09-09
 
 ### Fixed

--- a/cmd/agent_ci_test.go
+++ b/cmd/agent_ci_test.go
@@ -86,7 +86,7 @@ func TestClusterAgentCIGetPrintsTheSettingsAndTheApplyState(t *testing.T) {
 	if runError != nil {
 		t.Fatalf("expected success, got %v", runError)
 	}
-	if mock.getCalls != 1 || mock.lastClusterID != "test-cluster-id" {
+	if mock.getCalls != 1 || mock.lastClusterID != testClusterID {
 		t.Fatalf("expected one read of the selected cluster, got %d for %q", mock.getCalls, mock.lastClusterID)
 	}
 	for _, want := range []string{

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -78,7 +78,14 @@ func resolveCloudProviderNetworking(cmd *cobra.Command) (externalCloudProvider b
 // as `ankra cluster list` shows it.
 //
 // A UUID short-circuits, so a scripted caller that already holds the id pays
-// no extra request. A name is looked up once. Before this existed, only the
+// no extra request. The trade-off is that a cluster whose NAME is itself
+// UUID-shaped cannot be addressed by that name: the argument is forwarded as
+// an id and the route answers 404. Nothing in the CLI or the API constrains a
+// cluster's name, so this is reachable in principle; it stays this way because
+// the alternative costs every scripted caller a listing request on every
+// command, and the cluster id is always an unambiguous way to name it.
+//
+// A name is looked up once. Before this existed, only the
 // three playground verbs resolved a name (ankra-y8l44.35) and every other
 // cluster-scoped command forwarded the name verbatim: it reached the route as
 // a non-UUID path segment and came back as a bare 404, or as a uuid_parsing

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -72,3 +72,36 @@ func resolveCloudProviderNetworking(cmd *cobra.Command) (externalCloudProvider b
 	}
 	return externalCloudProvider, includeNetworking, nil
 }
+
+// resolveClusterArg turns a positional cluster argument into the id the
+// platform routes want, accepting either the id itself or the cluster's name
+// as `ankra cluster list` shows it.
+//
+// A UUID short-circuits, so a scripted caller that already holds the id pays
+// no extra request. A name is looked up once. Before this existed, only the
+// three playground verbs resolved a name (ankra-y8l44.35) and every other
+// cluster-scoped command forwarded the name verbatim: it reached the route as
+// a non-UUID path segment and came back as a bare 404, or as a uuid_parsing
+// 422 from a query parameter, with nothing in either to say an id was
+// expected (ankra-aprvp).
+func resolveClusterArg(nameOrID string) (string, error) {
+	if isLikelyClusterID(nameOrID) {
+		return nameOrID, nil
+	}
+	clusterID, resolveError := resolveClusterID(nameOrID)
+	if resolveError != nil {
+		return "", fmt.Errorf("%w (pass the cluster's name as `ankra cluster list` shows it, or its id)", resolveError)
+	}
+	return clusterID, nil
+}
+
+// clusterTarget renders the cluster a confirmation prompt is about. The
+// argument the user typed is what they recognise, so it leads; the id it
+// resolved to is appended when they differ, so a destructive prompt names the
+// cluster the API is actually about to be asked to act on.
+func clusterTarget(typed, clusterID string) string {
+	if typed == clusterID {
+		return fmt.Sprintf("%q", typed)
+	}
+	return fmt.Sprintf("%q (cluster %s)", typed, clusterID)
+}

--- a/cmd/cluster_bastion.go
+++ b/cmd/cluster_bastion.go
@@ -313,12 +313,16 @@ func newBastionCmd(opsFn func() bastionOps, provider string, supportsResize, sup
 	}
 
 	statusCmd := &cobra.Command{
-		Use:   "status <cluster_id>",
+		Use:   "status <cluster_id|name>",
 		Short: "Show the recorded bastion/gateway health verdict",
 		Long:  bastionStatusLong(supportsDiagnose),
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runBastionStatus(cmd, opsFn, args[0])
+			clusterID, resolveError := resolveClusterArg(args[0])
+			if resolveError != nil {
+				return resolveError
+			}
+			return runBastionStatus(cmd, opsFn, clusterID)
 		},
 	}
 	registerStructuredOutputFlags(statusCmd)
@@ -326,7 +330,7 @@ func newBastionCmd(opsFn func() bastionOps, provider string, supportsResize, sup
 
 	if supportsResize {
 		resizeCmd := &cobra.Command{
-			Use:   "resize <cluster_id> <instance_type>",
+			Use:   "resize <cluster_id|name> <instance_type>",
 			Short: "Change the bastion/gateway instance type",
 			Long: `Resize the bastion/gateway node. The provider's bastion/gateway update job
 powers it off, resizes it, and powers it back on, causing brief SSH/NAT
@@ -336,7 +340,11 @@ downtime for the cluster.
 reported on success. Follow it with 'ankra cluster operations list <operation_id>'.`,
 			Args: cobra.ExactArgs(2),
 			RunE: func(cmd *cobra.Command, args []string) error {
-				return runBastionResize(cmd, opsFn, args[0], args[1])
+				clusterID, resolveError := resolveClusterArg(args[0])
+				if resolveError != nil {
+					return resolveError
+				}
+				return runBastionResize(cmd, opsFn, clusterID, args[1])
 			},
 		}
 		registerAsyncWriteFlags(resizeCmd)
@@ -346,7 +354,7 @@ reported on success. Follow it with 'ankra cluster operations list <operation_id
 
 	if supportsDiagnose {
 		diagnoseCmd := &cobra.Command{
-			Use:   "diagnose <cluster_id>",
+			Use:   "diagnose <cluster_id|name>",
 			Short: "Run a read-only SSH diagnosis of the bastion/gateway",
 			Long: `Dispatch the provider's read-only bastion diagnose job and wait for its
 report: sshd configuration, failed-login volume, disk, failed units, journal
@@ -355,7 +363,11 @@ changed. The platform waits up to two minutes for the job; a slower run hands
 back the operation id to poll with 'cluster operations list'.`,
 			Args: cobra.ExactArgs(1),
 			RunE: func(cmd *cobra.Command, args []string) error {
-				return runBastionDiagnose(cmd, opsFn, args[0])
+				clusterID, resolveError := resolveClusterArg(args[0])
+				if resolveError != nil {
+					return resolveError
+				}
+				return runBastionDiagnose(cmd, opsFn, clusterID)
 			},
 		}
 		diagnoseCmd.Flags().Duration("timeout", defaultBastionDiagnoseTimeout,

--- a/cmd/cluster_bastion_test.go
+++ b/cmd/cluster_bastion_test.go
@@ -43,10 +43,10 @@ func TestClusterBastionResizeCommandWithWait(t *testing.T) {
 	setMockClient(t, mock)
 
 	stdoutOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "hetzner", "bastion", "resize", "cluster-1", "cx31", "--wait")
+		_, _ = executeCommand("cluster", "hetzner", "bastion", "resize", testClusterID, "cx31", "--wait")
 	})
 
-	if len(mock.resizeCalls) != 1 || mock.resizeCalls[0] != "cluster-1:cx31:true" {
+	if len(mock.resizeCalls) != 1 || mock.resizeCalls[0] != testClusterID+":cx31:true" {
 		t.Fatalf("expected one resize call with wait=true, got %v", mock.resizeCalls)
 	}
 	if !strings.Contains(stdoutOutput, "instance type set to 'cx31' (operation op-77)") {
@@ -72,7 +72,7 @@ func TestClusterBastionResizeCommandWithoutOperationID(t *testing.T) {
 	setMockClient(t, mock)
 
 	stdoutOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "hetzner", "bastion", "resize", "cluster-1", "cx31", "--wait")
+		_, _ = executeCommand("cluster", "hetzner", "bastion", "resize", testClusterID, "cx31", "--wait")
 	})
 
 	if !strings.Contains(stdoutOutput, "instance type set to 'cx31'") {
@@ -96,10 +96,10 @@ func TestClusterBastionResizeCommandSubmittedWithoutWait(t *testing.T) {
 	// reapply a bool flag's default between Execute() calls, so relying on
 	// the default would leak the previous test's --wait=true.
 	stdoutOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "hetzner", "bastion", "resize", "cluster-1", "cx31", "--wait=false")
+		_, _ = executeCommand("cluster", "hetzner", "bastion", "resize", testClusterID, "cx31", "--wait=false")
 	})
 
-	if len(mock.resizeCalls) != 1 || mock.resizeCalls[0] != "cluster-1:cx31:false" {
+	if len(mock.resizeCalls) != 1 || mock.resizeCalls[0] != testClusterID+":cx31:false" {
 		t.Fatalf("expected one resize call with wait=false, got %v", mock.resizeCalls)
 	}
 	if !strings.Contains(stdoutOutput, "submitted") {
@@ -112,7 +112,7 @@ func TestClusterBastionResizeCommandSurfacesError(t *testing.T) {
 	mock := &bastionResizeMock{resizeError: fmt.Errorf("No bastion or gateway node found for this cluster")}
 	setMockClient(t, mock)
 
-	_, commandError := executeCommand("cluster", "hetzner", "bastion", "resize", "cluster-1", "cx31", "--wait")
+	_, commandError := executeCommand("cluster", "hetzner", "bastion", "resize", testClusterID, "cx31", "--wait")
 	if commandError == nil || !strings.Contains(commandError.Error(), "No bastion or gateway node found") {
 		t.Fatalf("expected the not-found error, got %v", commandError)
 	}
@@ -162,10 +162,10 @@ func TestClusterBastionStatusCommandRendersTheVerdict(t *testing.T) {
 	setMockClient(t, mock)
 
 	stdoutOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "hetzner", "bastion", "status", "cluster-1")
+		_, _ = executeCommand("cluster", "hetzner", "bastion", "status", testClusterID)
 	})
 
-	if len(mock.healthCalls) != 1 || mock.healthCalls[0] != "cluster-1" {
+	if len(mock.healthCalls) != 1 || mock.healthCalls[0] != testClusterID {
 		t.Fatalf("expected one health read for cluster-1, got %v", mock.healthCalls)
 	}
 	for _, expected := range []string{
@@ -175,7 +175,7 @@ func TestClusterBastionStatusCommandRendersTheVerdict(t *testing.T) {
 			t.Errorf("expected %q in the verdict, got: %s", expected, stdoutOutput)
 		}
 	}
-	if !strings.Contains(stdoutOutput, "bastion diagnose cluster-1") {
+	if !strings.Contains(stdoutOutput, "bastion diagnose "+testClusterID) {
 		t.Errorf("a diagnosable bastion should point at the diagnose command, got: %s", stdoutOutput)
 	}
 }
@@ -195,7 +195,7 @@ func TestClusterBastionStatusCommandSaysDiagnosisIsUnavailable(t *testing.T) {
 	setMockClient(t, mock)
 
 	stdoutOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "hetzner", "bastion", "status", "cluster-1")
+		_, _ = executeCommand("cluster", "hetzner", "bastion", "status", testClusterID)
 	})
 
 	if !strings.Contains(stdoutOutput, "Diagnosis is not available for this provider.") {
@@ -216,7 +216,7 @@ func TestClusterBastionStatusCommandReportsAnUnprobedBastion(t *testing.T) {
 	setMockClient(t, mock)
 
 	stdoutOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "hetzner", "bastion", "status", "cluster-1")
+		_, _ = executeCommand("cluster", "hetzner", "bastion", "status", testClusterID)
 	})
 
 	if !strings.Contains(stdoutOutput, "not probed yet") {
@@ -229,7 +229,7 @@ func TestClusterBastionStatusCommandSurfacesTheNoBastionRefusal(t *testing.T) {
 	mock := &bastionHealthMock{healthError: fmt.Errorf("This cluster has no bastion resource.")}
 	setMockClient(t, mock)
 
-	_, commandError := executeCommand("cluster", "hetzner", "bastion", "status", "cluster-1")
+	_, commandError := executeCommand("cluster", "hetzner", "bastion", "status", testClusterID)
 	if commandError == nil || !strings.Contains(commandError.Error(), "no bastion resource") {
 		t.Fatalf("expected the no-bastion refusal, got %v", commandError)
 	}
@@ -250,10 +250,10 @@ func TestClusterBastionDiagnoseCommandRendersTheReport(t *testing.T) {
 	setMockClient(t, mock)
 
 	stdoutOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "hetzner", "bastion", "diagnose", "cluster-1")
+		_, _ = executeCommand("cluster", "hetzner", "bastion", "diagnose", testClusterID)
 	})
 
-	if len(mock.diagnoseCalls) != 1 || mock.diagnoseCalls[0] != "cluster-1" {
+	if len(mock.diagnoseCalls) != 1 || mock.diagnoseCalls[0] != testClusterID {
 		t.Fatalf("expected one diagnose call for cluster-1, got %v", mock.diagnoseCalls)
 	}
 	for _, expected := range []string{"hetzner_bastion_diagnose", "op-1", "Report:", "chrony.service"} {
@@ -278,7 +278,7 @@ func TestClusterBastionDiagnoseCommandPrintsThePollHintWhenStillRunning(t *testi
 	setMockClient(t, mock)
 
 	stdoutOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "hetzner", "bastion", "diagnose", "cluster-1")
+		_, _ = executeCommand("cluster", "hetzner", "bastion", "diagnose", testClusterID)
 	})
 
 	if !strings.Contains(stdoutOutput, "still running") ||
@@ -294,7 +294,7 @@ func TestClusterBastionDiagnoseCommandTagsTheWaitExpiry(t *testing.T) {
 	mock := &bastionHealthMock{diagnoseError: fmt.Errorf("request failed: %w", context.DeadlineExceeded)}
 	setMockClient(t, mock)
 
-	_, commandError := executeCommand("cluster", "hetzner", "bastion", "diagnose", "cluster-1")
+	_, commandError := executeCommand("cluster", "hetzner", "bastion", "diagnose", testClusterID)
 	if commandError == nil {
 		t.Fatal("expected an error, got nil")
 	}
@@ -378,19 +378,19 @@ func TestClusterBastionProxmoxUsesTheProxmoxCalls(t *testing.T) {
 	setMockClient(t, mock)
 
 	statusOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "proxmox", "bastion", "status", "cluster-1")
+		_, _ = executeCommand("cluster", "proxmox", "bastion", "status", testClusterID)
 	})
-	if len(mock.healthCalls) != 1 || mock.healthCalls[0] != "cluster-1" {
-		t.Fatalf("expected one proxmox health read for cluster-1, got %v", mock.healthCalls)
+	if len(mock.healthCalls) != 1 || mock.healthCalls[0] != testClusterID {
+		t.Fatalf("expected one proxmox health read for %s, got %v", testClusterID, mock.healthCalls)
 	}
-	if !strings.Contains(statusOutput, "ankra cluster proxmox bastion diagnose cluster-1") {
+	if !strings.Contains(statusOutput, "ankra cluster proxmox bastion diagnose "+testClusterID) {
 		t.Errorf("expected the proxmox diagnose hint, got: %s", statusOutput)
 	}
 
 	diagnoseOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "proxmox", "bastion", "diagnose", "cluster-1")
+		_, _ = executeCommand("cluster", "proxmox", "bastion", "diagnose", testClusterID)
 	})
-	if len(mock.diagnoseCalls) != 1 || mock.diagnoseCalls[0] != "cluster-1" {
+	if len(mock.diagnoseCalls) != 1 || mock.diagnoseCalls[0] != testClusterID {
 		t.Fatalf("expected one proxmox diagnose call for cluster-1, got %v", mock.diagnoseCalls)
 	}
 	if !strings.Contains(diagnoseOutput, "proxmox_bastion_diagnose") {
@@ -421,10 +421,10 @@ func TestClusterBastionScalewayStatusOffersNoDiagnose(t *testing.T) {
 	setMockClient(t, mock)
 
 	stdoutOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "scaleway", "bastion", "status", "cluster-1")
+		_, _ = executeCommand("cluster", "scaleway", "bastion", "status", testClusterID)
 	})
 
-	if len(mock.healthCalls) != 1 || mock.healthCalls[0] != "cluster-1" {
+	if len(mock.healthCalls) != 1 || mock.healthCalls[0] != testClusterID {
 		t.Fatalf("expected one scaleway health read for cluster-1, got %v", mock.healthCalls)
 	}
 	if !strings.Contains(stdoutOutput, "Diagnosis is not available for this provider.") {
@@ -452,7 +452,7 @@ func TestClusterBastionStatusCommandStructuredOutputIsClean(t *testing.T) {
 	}
 	t.Cleanup(func() { resetTreeFlags(t, statusCmd) })
 
-	commandOutput, commandError := executeCommand("cluster", "hetzner", "bastion", "status", "cluster-1", "-o", "json")
+	commandOutput, commandError := executeCommand("cluster", "hetzner", "bastion", "status", testClusterID, "-o", "json")
 	if commandError != nil {
 		t.Fatalf("status -o json: %v", commandError)
 	}

--- a/cmd/cluster_managed.go
+++ b/cmd/cluster_managed.go
@@ -107,7 +107,7 @@ var managedCreateCmd = &cobra.Command{
 }
 
 var managedDeleteCmd = &cobra.Command{
-	Use:   "delete <cluster_id>",
+	Use:   "delete <cluster_id|name>",
 	Short: "Delete a managed Kubernetes cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -116,12 +116,15 @@ var managedDeleteCmd = &cobra.Command{
 			return err
 		}
 
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		force, _ := cmd.Flags().GetBool("force")
 		yes, _ := cmd.Flags().GetBool("yes")
 
 		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
-			fmt.Sprintf("Delete managed %s cluster %q? This destroys all cloud resources! [y/N]: ", provider, clusterID),
+			fmt.Sprintf("Delete managed %s cluster %s? This destroys all cloud resources! [y/N]: ", provider, clusterTarget(args[0], clusterID)),
 			yes); err != nil {
 			return err
 		}
@@ -165,7 +168,7 @@ var managedNodePoolCmd = &cobra.Command{
 }
 
 var managedNodePoolAddCmd = &cobra.Command{
-	Use:   "add <cluster_id>",
+	Use:   "add <cluster_id|name>",
 	Short: "Add a node pool to a managed cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -174,7 +177,10 @@ var managedNodePoolAddCmd = &cobra.Command{
 			return err
 		}
 
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		name, _ := cmd.Flags().GetString("name")
 		size, _ := cmd.Flags().GetString("size")
 		count, _ := cmd.Flags().GetInt("count")
@@ -211,7 +217,7 @@ var managedNodePoolAddCmd = &cobra.Command{
 }
 
 var managedNodePoolScaleCmd = &cobra.Command{
-	Use:   "scale <cluster_id> <node_pool_name>",
+	Use:   "scale <cluster_id|name> <node_pool_name>",
 	Short: "Scale a managed cluster node pool",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -220,7 +226,10 @@ var managedNodePoolScaleCmd = &cobra.Command{
 			return err
 		}
 
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		nodePoolName := args[1]
 		count, _ := cmd.Flags().GetInt("count")
 
@@ -241,7 +250,7 @@ var managedNodePoolScaleCmd = &cobra.Command{
 }
 
 var managedNodePoolDeleteCmd = &cobra.Command{
-	Use:   "delete <cluster_id> <node_pool_name>",
+	Use:   "delete <cluster_id|name> <node_pool_name>",
 	Short: "Delete a managed cluster node pool",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -250,12 +259,15 @@ var managedNodePoolDeleteCmd = &cobra.Command{
 			return err
 		}
 
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		nodePoolName := args[1]
 		yes, _ := cmd.Flags().GetBool("yes")
 
 		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
-			fmt.Sprintf("Delete node pool %q from cluster %q? [y/N]: ", nodePoolName, clusterID),
+			fmt.Sprintf("Delete node pool %q from cluster %s? [y/N]: ", nodePoolName, clusterTarget(args[0], clusterID)),
 			yes); err != nil {
 			return err
 		}
@@ -277,7 +289,7 @@ var managedNodePoolDeleteCmd = &cobra.Command{
 }
 
 var managedNodePoolUpdateCmd = &cobra.Command{
-	Use:   "update <cluster_id> <node_pool_name>",
+	Use:   "update <cluster_id|name> <node_pool_name>",
 	Short: "Update a managed cluster node pool",
 	Long: `Update the node count or autoscaling settings of a managed cluster node
 pool. Pass at least one of --count, --autoscaling, --autoscaling-min, or
@@ -289,7 +301,10 @@ pool. Pass at least one of --count, --autoscaling, --autoscaling-min, or
 			return err
 		}
 
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		nodePoolName := args[1]
 
 		var request client.UpdateManagedNodePoolRequest
@@ -344,7 +359,7 @@ pool. Pass at least one of --count, --autoscaling, --autoscaling-min, or
 }
 
 var managedStopCmd = &cobra.Command{
-	Use:   "stop <cluster_id>",
+	Use:   "stop <cluster_id|name>",
 	Short: "Stop a managed cluster's compute",
 	Long: `Stop a managed Kubernetes cluster's compute while keeping its configuration
 so it can be started again later. Currently only AKS supports stopping and
@@ -356,7 +371,12 @@ starting managed clusters.`,
 			return err
 		}
 
-		result, stopError := apiClient.StopManagedCluster(provider, args[0])
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
+
+		result, stopError := apiClient.StopManagedCluster(provider, clusterID)
 		if stopError != nil {
 			return managedLifecycleError("stopping", stopError)
 		}
@@ -377,7 +397,7 @@ starting managed clusters.`,
 }
 
 var managedStartCmd = &cobra.Command{
-	Use:   "start <cluster_id>",
+	Use:   "start <cluster_id|name>",
 	Short: "Start a stopped managed cluster",
 	Long: `Start a stopped managed Kubernetes cluster. Currently only AKS supports
 stopping and starting managed clusters.`,
@@ -388,7 +408,12 @@ stopping and starting managed clusters.`,
 			return err
 		}
 
-		result, startError := apiClient.StartManagedCluster(provider, args[0])
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
+
+		result, startError := apiClient.StartManagedCluster(provider, clusterID)
 		if startError != nil {
 			return managedLifecycleError("starting", startError)
 		}
@@ -409,7 +434,7 @@ stopping and starting managed clusters.`,
 }
 
 var managedUpgradeCmd = &cobra.Command{
-	Use:   "upgrade <cluster_id>",
+	Use:   "upgrade <cluster_id|name>",
 	Short: "Upgrade a managed cluster Kubernetes version",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -418,12 +443,15 @@ var managedUpgradeCmd = &cobra.Command{
 			return err
 		}
 
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		version, _ := cmd.Flags().GetString("version")
 		yes, _ := cmd.Flags().GetBool("yes")
 
 		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
-			fmt.Sprintf("Upgrade managed cluster %q to Kubernetes %s? [y/N]: ", clusterID, version),
+			fmt.Sprintf("Upgrade managed cluster %s to Kubernetes %s? [y/N]: ", clusterTarget(args[0], clusterID), version),
 			yes); err != nil {
 			return err
 		}

--- a/cmd/cluster_managed_test.go
+++ b/cmd/cluster_managed_test.go
@@ -40,7 +40,7 @@ func (m *managedClusterMock) CreateManagedCluster(provider client.ManagedK8sProv
 	if m.createError != nil {
 		return nil, m.createError
 	}
-	return &client.CreateManagedClusterResponse{ClusterID: "cluster-1", Name: request.Name}, nil
+	return &client.CreateManagedClusterResponse{ClusterID: testClusterID, Name: request.Name}, nil
 }
 
 func (m *managedClusterMock) AddManagedNodePool(provider client.ManagedK8sProvider, clusterID string, request client.AddManagedNodePoolRequest) (*client.AddManagedNodePoolResponse, error) {
@@ -265,7 +265,7 @@ func TestManagedNodePoolAdd_SendsAutoscaling(t *testing.T) {
 	mock := &managedClusterMock{}
 	resetConfirmFlag(t, managedNodePoolAddCmd)
 	out, err := runWithInput(t, mock, "",
-		"cluster", "managed", "node-pool", "add", "cluster-1",
+		"cluster", "managed", "node-pool", "add", testClusterID,
 		"--provider", "gke", "--name", "workers", "--size", "e2-medium", "--count", "3",
 		"--autoscaling", "--autoscaling-min", "2", "--autoscaling-max", "6")
 	if err != nil {
@@ -285,7 +285,7 @@ func TestManagedNodePoolAdd_WithoutAutoscalingOmitsIt(t *testing.T) {
 	mock := &managedClusterMock{}
 	resetConfirmFlag(t, managedNodePoolAddCmd)
 	_, err := runWithInput(t, mock, "",
-		"cluster", "managed", "node-pool", "add", "cluster-1",
+		"cluster", "managed", "node-pool", "add", testClusterID,
 		"--provider", "gke", "--name", "workers", "--size", "e2-medium")
 	if err != nil {
 		t.Fatalf("execute failed: %v", err)
@@ -300,7 +300,7 @@ func TestManagedNodePoolUpdate_SendsChangedFlagsOnly(t *testing.T) {
 	resetConfirmFlag(t, managedNodePoolUpdateCmd)
 	out := captureStdout(t, func() {
 		_, err := runWithInput(t, mock, "",
-			"cluster", "managed", "node-pool", "update", "cluster-1", "workers",
+			"cluster", "managed", "node-pool", "update", testClusterID, "workers",
 			"--provider", "kapsule", "--count", "4")
 		if err != nil {
 			t.Fatalf("execute failed: %v", err)
@@ -316,10 +316,10 @@ func TestManagedNodePoolUpdate_SendsChangedFlagsOnly(t *testing.T) {
 	if request.AutoscalingEnabled != nil || request.AutoscalingMin != nil || request.AutoscalingMax != nil {
 		t.Errorf("autoscaling fields should be unset, got %+v", request)
 	}
-	if mock.updatePoolCluster != "cluster-1" || mock.updatePoolName != "workers" {
-		t.Errorf("target = %s/%s, want cluster-1/workers", mock.updatePoolCluster, mock.updatePoolName)
+	if mock.updatePoolCluster != testClusterID || mock.updatePoolName != "workers" {
+		t.Errorf("target = %s/%s, want %s/workers", mock.updatePoolCluster, mock.updatePoolName, testClusterID)
 	}
-	if !strings.Contains(out, `Node pool "workers" updated on cluster cluster-1`) {
+	if !strings.Contains(out, `Node pool "workers" updated on cluster `+testClusterID) {
 		t.Errorf("unexpected output:\n%s", out)
 	}
 }
@@ -328,7 +328,7 @@ func TestManagedNodePoolUpdate_SendsAutoscalingBounds(t *testing.T) {
 	mock := &managedClusterMock{}
 	resetConfirmFlag(t, managedNodePoolUpdateCmd)
 	_, err := runWithInput(t, mock, "",
-		"cluster", "managed", "node-pool", "update", "cluster-1", "workers",
+		"cluster", "managed", "node-pool", "update", testClusterID, "workers",
 		"--provider", "kapsule", "--autoscaling", "--autoscaling-min", "1", "--autoscaling-max", "9")
 	if err != nil {
 		t.Fatalf("execute failed: %v", err)
@@ -352,7 +352,7 @@ func TestManagedNodePoolUpdate_DisableAutoscaling(t *testing.T) {
 	mock := &managedClusterMock{}
 	resetConfirmFlag(t, managedNodePoolUpdateCmd)
 	_, err := runWithInput(t, mock, "",
-		"cluster", "managed", "node-pool", "update", "cluster-1", "workers",
+		"cluster", "managed", "node-pool", "update", testClusterID, "workers",
 		"--provider", "kapsule", "--autoscaling=false")
 	if err != nil {
 		t.Fatalf("execute failed: %v", err)
@@ -367,7 +367,7 @@ func TestManagedNodePoolUpdate_RequiresAtLeastOneFlag(t *testing.T) {
 	mock := &managedClusterMock{}
 	resetConfirmFlag(t, managedNodePoolUpdateCmd)
 	_, err := runWithInput(t, mock, "",
-		"cluster", "managed", "node-pool", "update", "cluster-1", "workers",
+		"cluster", "managed", "node-pool", "update", testClusterID, "workers",
 		"--provider", "kapsule")
 	if err == nil {
 		t.Fatal("expected usage error without update flags")
@@ -386,7 +386,7 @@ func TestManagedNodePoolUpdate_APIErrorPassesThrough(t *testing.T) {
 	}
 	resetConfirmFlag(t, managedNodePoolUpdateCmd)
 	_, err := runWithInput(t, mock, "",
-		"cluster", "managed", "node-pool", "update", "cluster-1", "workers",
+		"cluster", "managed", "node-pool", "update", testClusterID, "workers",
 		"--provider", "kapsule", "--count", "2")
 	if err == nil {
 		t.Fatal("expected API error to surface")
@@ -401,12 +401,12 @@ func TestManagedStop_Success(t *testing.T) {
 	resetConfirmFlag(t, managedStopCmd)
 	out := captureStdout(t, func() {
 		_, err := runWithInput(t, mock, "",
-			"cluster", "managed", "stop", "cluster-1", "--provider", "aks")
+			"cluster", "managed", "stop", testClusterID, "--provider", "aks")
 		if err != nil {
 			t.Fatalf("execute failed: %v", err)
 		}
 	})
-	if len(mock.stopCalls) != 1 || mock.stopCalls[0] != "cluster-1" {
+	if len(mock.stopCalls) != 1 || mock.stopCalls[0] != testClusterID {
 		t.Fatalf("stop calls = %v, want [cluster-1]", mock.stopCalls)
 	}
 	if !strings.Contains(out, "Managed cluster stop initiated.") {
@@ -422,12 +422,12 @@ func TestManagedStart_Success(t *testing.T) {
 	resetConfirmFlag(t, managedStartCmd)
 	out := captureStdout(t, func() {
 		_, err := runWithInput(t, mock, "",
-			"cluster", "managed", "start", "cluster-1", "--provider", "aks")
+			"cluster", "managed", "start", testClusterID, "--provider", "aks")
 		if err != nil {
 			t.Fatalf("execute failed: %v", err)
 		}
 	})
-	if len(mock.startCalls) != 1 || mock.startCalls[0] != "cluster-1" {
+	if len(mock.startCalls) != 1 || mock.startCalls[0] != testClusterID {
 		t.Fatalf("start calls = %v, want [cluster-1]", mock.startCalls)
 	}
 	if !strings.Contains(out, "Managed cluster start initiated.") {
@@ -441,7 +441,7 @@ func TestManagedStop_UnsupportedProviderMentionsAKS(t *testing.T) {
 	}
 	resetConfirmFlag(t, managedStopCmd)
 	_, err := runWithInput(t, mock, "",
-		"cluster", "managed", "stop", "cluster-1", "--provider", "gke")
+		"cluster", "managed", "stop", testClusterID, "--provider", "gke")
 	if err == nil {
 		t.Fatal("expected refusal to surface as an error")
 	}
@@ -456,7 +456,7 @@ func TestManagedStart_UnsupportedProviderMentionsAKS(t *testing.T) {
 	}
 	resetConfirmFlag(t, managedStartCmd)
 	_, err := runWithInput(t, mock, "",
-		"cluster", "managed", "start", "cluster-1", "--provider", "doks")
+		"cluster", "managed", "start", testClusterID, "--provider", "doks")
 	if err == nil {
 		t.Fatal("expected refusal to surface as an error")
 	}
@@ -471,7 +471,7 @@ func TestManagedStop_UnrelatedErrorHasNoAKSHint(t *testing.T) {
 	}
 	resetConfirmFlag(t, managedStopCmd)
 	_, err := runWithInput(t, mock, "",
-		"cluster", "managed", "stop", "cluster-1", "--provider", "aks")
+		"cluster", "managed", "stop", testClusterID, "--provider", "aks")
 	if err == nil {
 		t.Fatal("expected error to surface")
 	}
@@ -572,7 +572,7 @@ func TestManagedNodePoolAdd_AksSpot(t *testing.T) {
 	t.Cleanup(func() { resetManagedFlags(t) })
 	mock := &managedClusterMock{}
 	_, err := runWithInput(t, mock, "",
-		"cluster", "managed", "node-pool", "add", "cluster-1",
+		"cluster", "managed", "node-pool", "add", testClusterID,
 		"--provider", "aks", "--name", "batch", "--size", "Standard_E4s_v5", "--count", "3",
 		"--spot", "--spot-max-price", "0.05", "--zone", "3")
 	if err != nil {
@@ -591,7 +591,7 @@ func TestManagedNodePoolAdd_AksSpot(t *testing.T) {
 
 	resetManagedFlags(t)
 	_, err = runWithInput(t, mock, "",
-		"cluster", "managed", "node-pool", "add", "cluster-1",
+		"cluster", "managed", "node-pool", "add", testClusterID,
 		"--provider", "aks", "--name", "batch", "--size", "Standard_E4s_v5", "--spot-max-price", "0.05")
 	if err == nil || !strings.Contains(err.Error(), "requires --spot") {
 		t.Fatalf("expected --spot-max-price to require --spot, got %v", err)

--- a/cmd/cluster_mesh.go
+++ b/cmd/cluster_mesh.go
@@ -107,30 +107,38 @@ var clusterMeshDeleteCmd = &cobra.Command{
 }
 
 var clusterMeshJoinCmd = &cobra.Command{
-	Use:   "join <mesh_id> <cluster_id>",
+	Use:   "join <mesh_id> <cluster_id|name>",
 	Short: "Add a cluster to a mesh",
 	Long: "Add a cluster to a mesh. The platform mints the mesh's shared certificate authority on the first join, " +
 		"hands it to the joining cluster, and re-renders every member's peer list.\n\n" +
 		"A cluster that cannot mesh is refused with the reason; `ankra cluster mesh readiness` reports the same checks up front.",
 	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if joinError := apiClient.JoinClusterMesh(args[0], args[1]); joinError != nil {
+		clusterID, resolveError := resolveClusterArg(args[1])
+		if resolveError != nil {
+			return resolveError
+		}
+		if joinError := apiClient.JoinClusterMesh(args[0], clusterID); joinError != nil {
 			return fmt.Errorf("joining cluster mesh: %w", joinError)
 		}
-		fmt.Printf("Cluster %s joined mesh %s.\n", args[1], args[0])
+		fmt.Printf("Cluster %s joined mesh %s.\n", clusterID, args[0])
 		return nil
 	},
 }
 
 var clusterMeshLeaveCmd = &cobra.Command{
-	Use:   "leave <mesh_id> <cluster_id>",
+	Use:   "leave <mesh_id> <cluster_id|name>",
 	Short: "Remove a cluster from a mesh",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if leaveError := apiClient.LeaveClusterMesh(args[0], args[1]); leaveError != nil {
+		clusterID, resolveError := resolveClusterArg(args[1])
+		if resolveError != nil {
+			return resolveError
+		}
+		if leaveError := apiClient.LeaveClusterMesh(args[0], clusterID); leaveError != nil {
 			return fmt.Errorf("leaving cluster mesh: %w", leaveError)
 		}
-		fmt.Printf("Cluster %s left mesh %s.\n", args[1], args[0])
+		fmt.Printf("Cluster %s left mesh %s.\n", clusterID, args[0])
 		return nil
 	},
 }
@@ -138,7 +146,7 @@ var clusterMeshLeaveCmd = &cobra.Command{
 var clusterMeshMakeReadySiteIP string
 
 var clusterMeshMakeReadyCmd = &cobra.Command{
-	Use:   "make-ready <cluster_id>",
+	Use:   "make-ready <cluster_id|name>",
 	Short: "Turn an existing cluster mesh-capable without recreating it",
 	Long: "Turn an existing cluster mesh-capable, day-2: allocate its Cilium identity and overlay range, stamp the " +
 		"overlay onto its stored definitions, and set its resources converging so every node joins the platform " +
@@ -146,7 +154,11 @@ var clusterMeshMakeReadyCmd = &cobra.Command{
 		"Proxmox clusters need --site-public-ip: the address other sites dial this cluster's site gateway on.",
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		result, makeReadyError := apiClient.MakeClusterMeshReady(args[0], clusterMeshMakeReadySiteIP)
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
+		result, makeReadyError := apiClient.MakeClusterMeshReady(clusterID, clusterMeshMakeReadySiteIP)
 		if makeReadyError != nil {
 			return fmt.Errorf("making the cluster mesh-ready: %w", makeReadyError)
 		}
@@ -166,14 +178,25 @@ var clusterMeshMakeReadyCmd = &cobra.Command{
 }
 
 var clusterMeshReadinessCmd = &cobra.Command{
-	Use:   "readiness <cluster_id> [cluster_id...]",
+	Use:   "readiness <cluster_id|name> [cluster_id|name...]",
 	Short: "Check whether clusters can mesh together, and why not",
 	Long: "Check whether the given clusters could form one mesh. Each cluster is reported ready or not, with the " +
 		"failing checks spelled out.\n\nSome failures cannot be fixed on a running cluster: the Cilium identity and " +
 		"the overlay network mode are set when the cluster is created, so a cluster without them has to be rebuilt to mesh.",
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		readiness, readinessError := apiClient.CheckClusterMeshReadiness(args)
+		// Every argument is a cluster, so each is resolved; the label the
+		// report prints stays the one the user typed, which is what they
+		// recognise in a list of several clusters.
+		clusterIDs := make([]string, 0, len(args))
+		for _, arg := range args {
+			clusterID, resolveError := resolveClusterArg(arg)
+			if resolveError != nil {
+				return resolveError
+			}
+			clusterIDs = append(clusterIDs, clusterID)
+		}
+		readiness, readinessError := apiClient.CheckClusterMeshReadiness(clusterIDs)
 		if readinessError != nil {
 			return fmt.Errorf("checking cluster mesh readiness: %w", readinessError)
 		}
@@ -182,17 +205,18 @@ var clusterMeshReadinessCmd = &cobra.Command{
 		} else if handled {
 			return nil
 		}
-		for _, clusterID := range args {
+		for index, clusterID := range clusterIDs {
+			label := args[index]
 			result, isKnown := readiness[clusterID]
 			if !isKnown {
-				fmt.Printf("%s  unknown\n", clusterID)
+				fmt.Printf("%s  unknown\n", label)
 				continue
 			}
 			if result.Ready {
-				fmt.Printf("%s  ready\n", clusterID)
+				fmt.Printf("%s  ready\n", label)
 				continue
 			}
-			fmt.Printf("%s  NOT ready\n", clusterID)
+			fmt.Printf("%s  NOT ready\n", label)
 			for _, item := range result.Items {
 				if item.Ready {
 					continue

--- a/cmd/cluster_mesh.go
+++ b/cmd/cluster_mesh.go
@@ -121,7 +121,7 @@ var clusterMeshJoinCmd = &cobra.Command{
 		if joinError := apiClient.JoinClusterMesh(args[0], clusterID); joinError != nil {
 			return fmt.Errorf("joining cluster mesh: %w", joinError)
 		}
-		fmt.Printf("Cluster %s joined mesh %s.\n", clusterID, args[0])
+		fmt.Printf("Cluster %s joined mesh %s.\n", clusterTarget(args[1], clusterID), args[0])
 		return nil
 	},
 }
@@ -138,7 +138,7 @@ var clusterMeshLeaveCmd = &cobra.Command{
 		if leaveError := apiClient.LeaveClusterMesh(args[0], clusterID); leaveError != nil {
 			return fmt.Errorf("leaving cluster mesh: %w", leaveError)
 		}
-		fmt.Printf("Cluster %s left mesh %s.\n", clusterID, args[0])
+		fmt.Printf("Cluster %s left mesh %s.\n", clusterTarget(args[1], clusterID), args[0])
 		return nil
 	},
 }

--- a/cmd/cluster_mesh_test.go
+++ b/cmd/cluster_mesh_test.go
@@ -8,6 +8,14 @@ import (
 	"ankra/internal/client"
 )
 
+// The mesh routes take cluster ids. These are id-shaped so resolveClusterArg
+// passes them through untouched; a cluster NAME reaching these commands is
+// covered in cluster_name_args_test.go.
+const (
+	meshTestClusterID      = "9c1f2d3e-4a5b-4c6d-8e9f-0a1b2c3d4e5f"
+	meshTestOtherClusterID = "1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d"
+)
+
 type clusterMeshMock struct {
 	baseMock
 	meshes    []client.ClusterMesh
@@ -104,11 +112,11 @@ func TestClusterMeshJoinPassesMeshAndCluster(t *testing.T) {
 	mock := &clusterMeshMock{}
 	setMockClient(t, mock)
 
-	if err := executeMeshCommand(t, "cluster", "mesh", "join", "mesh-1", "cluster-9"); err != nil {
+	if err := executeMeshCommand(t, "cluster", "mesh", "join", "mesh-1", meshTestClusterID); err != nil {
 		t.Fatalf("join returned %v", err)
 	}
-	if len(mock.joins) != 1 || mock.joins[0] != [2]string{"mesh-1", "cluster-9"} {
-		t.Fatalf("expected one join of cluster-9 into mesh-1, got %v", mock.joins)
+	if len(mock.joins) != 1 || mock.joins[0] != [2]string{"mesh-1", meshTestClusterID} {
+		t.Fatalf("expected one join of %s into mesh-1, got %v", meshTestClusterID, mock.joins)
 	}
 }
 
@@ -120,7 +128,7 @@ func TestClusterMeshJoinSurfacesTheRefusalReason(t *testing.T) {
 	}
 	setMockClient(t, mock)
 
-	err := executeMeshCommand(t, "cluster", "mesh", "join", "mesh-1", "c1")
+	err := executeMeshCommand(t, "cluster", "mesh", "join", "mesh-1", meshTestClusterID)
 	if err == nil {
 		t.Fatal("expected the refusal to fail the command")
 	}
@@ -133,10 +141,10 @@ func TestClusterMeshLeavePassesMeshAndCluster(t *testing.T) {
 	mock := &clusterMeshMock{}
 	setMockClient(t, mock)
 
-	if err := executeMeshCommand(t, "cluster", "mesh", "leave", "mesh-1", "cluster-9"); err != nil {
+	if err := executeMeshCommand(t, "cluster", "mesh", "leave", "mesh-1", meshTestClusterID); err != nil {
 		t.Fatalf("leave returned %v", err)
 	}
-	if len(mock.leaves) != 1 || mock.leaves[0] != [2]string{"mesh-1", "cluster-9"} {
+	if len(mock.leaves) != 1 || mock.leaves[0] != [2]string{"mesh-1", meshTestClusterID} {
 		t.Fatalf("expected one leave, got %v", mock.leaves)
 	}
 }
@@ -144,15 +152,15 @@ func TestClusterMeshLeavePassesMeshAndCluster(t *testing.T) {
 func TestClusterMeshReadinessPassesEveryCluster(t *testing.T) {
 	mock := &clusterMeshMock{
 		readiness: map[string]client.ClusterMeshReadiness{
-			"c1": {Ready: true},
-			"c2": {Ready: false, Items: []client.ClusterMeshReadinessItem{
+			meshTestClusterID: {Ready: true},
+			meshTestOtherClusterID: {Ready: false, Items: []client.ClusterMeshReadinessItem{
 				{Name: "transport", Ready: false, Detail: "not on the overlay", Remediable: false},
 			}},
 		},
 	}
 	setMockClient(t, mock)
 
-	if err := executeMeshCommand(t, "cluster", "mesh", "readiness", "c1", "c2"); err != nil {
+	if err := executeMeshCommand(t, "cluster", "mesh", "readiness", meshTestClusterID, meshTestOtherClusterID); err != nil {
 		t.Fatalf("readiness returned %v", err)
 	}
 	if len(mock.readinessFor) != 1 || len(mock.readinessFor[0]) != 2 {
@@ -190,15 +198,14 @@ func TestClusterMeshDeletePassesTheMesh(t *testing.T) {
 	}
 }
 
-
 func TestClusterMeshMakeReadyCommand(t *testing.T) {
 	mock := &clusterMeshMock{}
 	setMockClient(t, mock)
 
-	if err := executeMeshCommand(t, "cluster", "mesh", "make-ready", "cluster-9", "--site-public-ip", "203.0.113.9"); err != nil {
+	if err := executeMeshCommand(t, "cluster", "mesh", "make-ready", meshTestClusterID, "--site-public-ip", "203.0.113.9"); err != nil {
 		t.Fatalf("make-ready returned %v", err)
 	}
-	if mock.madeReadyCluster != "cluster-9" || mock.madeReadySiteIP != "203.0.113.9" {
+	if mock.madeReadyCluster != meshTestClusterID || mock.madeReadySiteIP != "203.0.113.9" {
 		t.Fatalf("make-ready must pass the cluster and site address through, got %q %q",
 			mock.madeReadyCluster, mock.madeReadySiteIP)
 	}
@@ -210,7 +217,7 @@ func TestClusterMeshMakeReadySurfacesTheRefusalReason(t *testing.T) {
 	mock := &clusterMeshMock{makeReadyError: errors.New("network_mode is not supported for hetzner clusters")}
 	setMockClient(t, mock)
 
-	err := executeMeshCommand(t, "cluster", "mesh", "make-ready", "cluster-9")
+	err := executeMeshCommand(t, "cluster", "mesh", "make-ready", meshTestClusterID)
 	if err == nil {
 		t.Fatal("expected the refusal to fail the command")
 	}

--- a/cmd/cluster_name_args_test.go
+++ b/cmd/cluster_name_args_test.go
@@ -217,3 +217,40 @@ func TestEveryClusterArgumentAdvertisesTheName(t *testing.T) {
 			strings.Join(offenders, ", "))
 	}
 }
+
+// Two clusters whose names differ only by case used to resolve to whichever
+// the listing ordered first, silently pointing a command - `deprovision`
+// included - at an arbitrary one of them.
+func TestResolveClusterArgRefusesAnAmbiguousName(t *testing.T) {
+	withClusterArgMock(t, &clusterArgMock{clusters: []client.ClusterListItem{
+		{ID: testClusterID, Name: "Prod-EU"},
+		{ID: "11111111-2222-4333-8444-555555555555", Name: "prod-eu"},
+	}})
+
+	_, err := resolveClusterArg("PROD-eu")
+	if err == nil {
+		t.Fatal("a name matching two clusters must be refused, not resolved to one of them")
+	}
+	for _, expected := range []string{"ambiguous", "Prod-EU", "prod-eu", testClusterID, "pass the cluster id"} {
+		if !strings.Contains(err.Error(), expected) {
+			t.Errorf("expected %q in the error, got %q", expected, err.Error())
+		}
+	}
+}
+
+// An exact match is the user's unambiguous intent, so it wins over a
+// case-insensitive twin rather than being reported as ambiguous.
+func TestResolveClusterArgPrefersTheExactName(t *testing.T) {
+	withClusterArgMock(t, &clusterArgMock{clusters: []client.ClusterListItem{
+		{ID: "11111111-2222-4333-8444-555555555555", Name: "PROD-EU"},
+		{ID: testClusterID, Name: "prod-eu"},
+	}})
+
+	resolved, err := resolveClusterArg("prod-eu")
+	if err != nil {
+		t.Fatalf("an exact name must resolve even with a case-insensitive twin: %v", err)
+	}
+	if resolved != testClusterID {
+		t.Errorf("the exactly-matching cluster must win, got %q", resolved)
+	}
+}

--- a/cmd/cluster_name_args_test.go
+++ b/cmd/cluster_name_args_test.go
@@ -25,6 +25,10 @@ type clusterArgMock struct {
 	clusters  []client.ClusterListItem
 	listCalls int
 
+	// totalPages reports more pages than the resolver will read, to exercise
+	// the paging cap; 0 means the fixture fits on one page.
+	totalPages int
+
 	workersRequested   string
 	meshReadyRequested string
 	readinessRequested []string
@@ -32,9 +36,13 @@ type clusterArgMock struct {
 
 func (m *clusterArgMock) ListClusters(page int, pageSize int) (*client.ClusterListResponse, error) {
 	m.listCalls++
+	totalPages := m.totalPages
+	if totalPages == 0 {
+		totalPages = 1
+	}
 	return &client.ClusterListResponse{
 		Result:     m.clusters,
-		Pagination: client.Pagination{TotalPages: 1, Page: page, PageSize: pageSize},
+		Pagination: client.Pagination{TotalPages: totalPages, Page: page, PageSize: pageSize},
 	}, nil
 }
 
@@ -252,5 +260,47 @@ func TestResolveClusterArgPrefersTheExactName(t *testing.T) {
 	}
 	if resolved != testClusterID {
 		t.Errorf("the exactly-matching cluster must win, got %q", resolved)
+	}
+}
+
+// "36 characters with four dashes" describes plenty of real cluster names, not
+// just a UUID. Such a name used to be forwarded to the API as an id.
+func TestResolveClusterArgTreatsAUUIDShapedNameAsAName(t *testing.T) {
+	const name = "production-eu-primary-cluster-abcdef"
+	if len(name) != 36 || strings.Count(name, "-") != 4 {
+		t.Fatalf("the fixture must be 36 chars with 4 dashes to exercise the old heuristic, got %d/%d",
+			len(name), strings.Count(name, "-"))
+	}
+	withClusterArgMock(t, &clusterArgMock{clusters: []client.ClusterListItem{{ID: testClusterID, Name: name}}})
+
+	resolved, err := resolveClusterArg(name)
+	if err != nil {
+		t.Fatalf("a 36-char name with four dashes must be looked up, not forwarded as an id: %v", err)
+	}
+	if resolved != testClusterID {
+		t.Errorf("expected the name to resolve to %q, got %q", testClusterID, resolved)
+	}
+}
+
+// The resolver reads at most 5000 clusters. Beyond that it used to answer
+// "not found", presenting a truncated listing as a verified negative on the
+// resolution path of every command, destructive ones included.
+func TestResolveClusterArgSaysTheListingWasTruncatedRatherThanNotFound(t *testing.T) {
+	withClusterArgMock(t, &clusterArgMock{
+		clusters:   []client.ClusterListItem{{ID: testClusterID, Name: "prod-eu"}},
+		totalPages: 999,
+	})
+
+	_, err := resolveClusterArg("a-cluster-on-a-later-page")
+	if err == nil {
+		t.Fatal("an unresolved name must still be an error")
+	}
+	if strings.Contains(err.Error(), "not found") {
+		t.Errorf("a truncated listing must not be reported as a verified absence, got %q", err.Error())
+	}
+	for _, expected := range []string{"was not among the first", "pass the cluster id"} {
+		if !strings.Contains(err.Error(), expected) {
+			t.Errorf("expected %q in the error, got %q", expected, err.Error())
+		}
 	}
 }

--- a/cmd/cluster_name_args_test.go
+++ b/cmd/cluster_name_args_test.go
@@ -1,0 +1,211 @@
+package cmd
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// testClusterID is id-shaped, so resolveClusterArg forwards it untouched and
+// treats every other argument as a cluster name. Every command test that
+// passes a cluster argument uses it: a placeholder like "cluster-1" is a NAME
+// now, and sends the command to the cluster listing instead (ankra-aprvp).
+const testClusterID = "62f4559a-a44d-46d7-aab3-a57c9dd6b4c6"
+
+// clusterArgMock answers the cluster listing that resolveClusterArg pages
+// through, and records the ids the commands under test forward to the API.
+type clusterArgMock struct {
+	baseMock
+
+	clusters  []client.ClusterListItem
+	listCalls int
+
+	workersRequested   string
+	meshReadyRequested string
+	readinessRequested []string
+}
+
+func (m *clusterArgMock) ListClusters(page int, pageSize int) (*client.ClusterListResponse, error) {
+	m.listCalls++
+	return &client.ClusterListResponse{
+		Result:     m.clusters,
+		Pagination: client.Pagination{TotalPages: 1, Page: page, PageSize: pageSize},
+	}, nil
+}
+
+func (m *clusterArgMock) GetScalewayWorkerCount(clusterID string) (*client.WorkerCountResult, error) {
+	m.workersRequested = clusterID
+	return &client.WorkerCountResult{WorkerCount: 3, Min: 1, Max: 5}, nil
+}
+
+func (m *clusterArgMock) MakeClusterMeshReady(clusterID string, sitePublicIP string) (*client.ClusterMeshMakeReadyResult, error) {
+	m.meshReadyRequested = clusterID
+	return &client.ClusterMeshMakeReadyResult{ClusterID: clusterID}, nil
+}
+
+func (m *clusterArgMock) CheckClusterMeshReadiness(clusterIDs []string) (map[string]client.ClusterMeshReadiness, error) {
+	m.readinessRequested = clusterIDs
+	readiness := make(map[string]client.ClusterMeshReadiness, len(clusterIDs))
+	for _, clusterID := range clusterIDs {
+		readiness[clusterID] = client.ClusterMeshReadiness{Ready: true}
+	}
+	return readiness, nil
+}
+
+func withClusterArgMock(t *testing.T, mock *clusterArgMock) {
+	t.Helper()
+	previous := apiClient
+	apiClient = mock
+	t.Cleanup(func() { apiClient = previous })
+}
+
+func newClusterArgMock() *clusterArgMock {
+	return &clusterArgMock{clusters: []client.ClusterListItem{
+		{ID: "11111111-2222-4333-8444-555555555555", Name: "other"},
+		{ID: testClusterID, Name: "prod-eu"},
+	}}
+}
+
+// A cluster id is what the routes want, so it must reach the API untouched -
+// and without the listing request a name lookup costs.
+func TestResolveClusterArgPassesAnIDThroughWithoutListing(t *testing.T) {
+	mock := newClusterArgMock()
+	withClusterArgMock(t, mock)
+
+	resolved, err := resolveClusterArg(testClusterID)
+	if err != nil {
+		t.Fatalf("an id must resolve to itself: %v", err)
+	}
+	if resolved != testClusterID {
+		t.Errorf("id must pass through unchanged, got %q", resolved)
+	}
+	if mock.listCalls != 0 {
+		t.Errorf("an id must not cost a cluster listing, made %d", mock.listCalls)
+	}
+}
+
+func TestResolveClusterArgResolvesANameCaseInsensitively(t *testing.T) {
+	withClusterArgMock(t, newClusterArgMock())
+
+	for _, typed := range []string{"prod-eu", "PROD-EU", "Prod-Eu"} {
+		resolved, err := resolveClusterArg(typed)
+		if err != nil {
+			t.Fatalf("%q must resolve: %v", typed, err)
+		}
+		if resolved != testClusterID {
+			t.Errorf("%q must resolve to %q, got %q", typed, testClusterID, resolved)
+		}
+	}
+}
+
+// An unknown name is refused before the request, naming the argument and how
+// to find the right one. Forwarding it reached the route as a non-UUID path
+// segment and came back as a bare 404 (ankra-aprvp).
+func TestResolveClusterArgRefusesAnUnknownNameWithAHint(t *testing.T) {
+	mock := newClusterArgMock()
+	withClusterArgMock(t, mock)
+
+	_, err := resolveClusterArg("staging")
+	if err == nil {
+		t.Fatal("an unknown name must be refused")
+	}
+	for _, expected := range []string{`cluster "staging" not found`, "ankra cluster list"} {
+		if !strings.Contains(err.Error(), expected) {
+			t.Errorf("expected %q in the error, got %q", expected, err.Error())
+		}
+	}
+}
+
+// The prompt for a destructive command names what the user typed, so they can
+// recognise it; the resolved id follows so the cluster the API is about to be
+// asked to act on is on screen too.
+func TestClusterTargetNamesTheTypedArgumentAndTheResolvedID(t *testing.T) {
+	if got := clusterTarget(testClusterID, testClusterID); got != fmt.Sprintf("%q", testClusterID) {
+		t.Errorf("an id names only itself, got %s", got)
+	}
+	got := clusterTarget("prod-eu", testClusterID)
+	for _, expected := range []string{`"prod-eu"`, testClusterID} {
+		if !strings.Contains(got, expected) {
+			t.Errorf("expected %q in the prompt target, got %s", expected, got)
+		}
+	}
+}
+
+// A provider command is the class this change is about: before ankra-aprvp
+// only the playground verbs resolved a name.
+func TestProviderCommandResolvesAClusterName(t *testing.T) {
+	mock := newClusterArgMock()
+	withClusterArgMock(t, mock)
+
+	captureStdout(t, func() {
+		if err := scalewayWorkersCmd.RunE(scalewayWorkersCmd, []string{"prod-eu"}); err != nil {
+			t.Fatalf("workers by name failed: %v", err)
+		}
+	})
+	if mock.workersRequested != testClusterID {
+		t.Errorf("the name must resolve to the id, requested %q", mock.workersRequested)
+	}
+}
+
+func TestClusterMeshMakeReadyResolvesAClusterName(t *testing.T) {
+	mock := newClusterArgMock()
+	withClusterArgMock(t, mock)
+
+	captureStdout(t, func() {
+		if err := clusterMeshMakeReadyCmd.RunE(clusterMeshMakeReadyCmd, []string{"prod-eu"}); err != nil {
+			t.Fatalf("make-ready by name failed: %v", err)
+		}
+	})
+	if mock.meshReadyRequested != testClusterID {
+		t.Errorf("the name must resolve to the id, requested %q", mock.meshReadyRequested)
+	}
+}
+
+// readiness takes several clusters at once: every argument resolves, and the
+// report still labels each row with the name the user typed.
+func TestClusterMeshReadinessResolvesEveryArgumentAndLabelsWhatWasTyped(t *testing.T) {
+	mock := newClusterArgMock()
+	withClusterArgMock(t, mock)
+
+	output := captureStdout(t, func() {
+		if err := clusterMeshReadinessCmd.RunE(clusterMeshReadinessCmd,
+			[]string{"prod-eu", "11111111-2222-4333-8444-555555555555"}); err != nil {
+			t.Fatalf("readiness by name failed: %v", err)
+		}
+	})
+	want := []string{testClusterID, "11111111-2222-4333-8444-555555555555"}
+	if len(mock.readinessRequested) != 2 ||
+		mock.readinessRequested[0] != want[0] || mock.readinessRequested[1] != want[1] {
+		t.Errorf("every argument must resolve, requested %v want %v", mock.readinessRequested, want)
+	}
+	if !strings.Contains(output, "prod-eu  ready") {
+		t.Errorf("the report must label the row with the typed name, got: %s", output)
+	}
+}
+
+// A ratchet: a cluster-scoped command added later must advertise that it takes
+// a name too, so the fix does not quietly regress one command at a time.
+func TestEveryClusterArgumentAdvertisesTheName(t *testing.T) {
+	stale := regexp.MustCompile(`<cluster_id>|\[cluster_id\.\.\.\]`)
+	var offenders []string
+	var walk func(command *cobra.Command)
+	walk = func(command *cobra.Command) {
+		if stale.MatchString(command.Use) {
+			offenders = append(offenders, command.CommandPath())
+		}
+		for _, child := range command.Commands() {
+			walk(child)
+		}
+	}
+	walk(rootCmd)
+	if len(offenders) > 0 {
+		t.Errorf("these commands still advertise an id-only cluster argument; "+
+			"resolve it with resolveClusterArg and widen the Use string to <cluster_id|name>: %s",
+			strings.Join(offenders, ", "))
+	}
+}

--- a/cmd/cluster_name_args_test.go
+++ b/cmd/cluster_name_args_test.go
@@ -190,13 +190,21 @@ func TestClusterMeshReadinessResolvesEveryArgumentAndLabelsWhatWasTyped(t *testi
 
 // A ratchet: a cluster-scoped command added later must advertise that it takes
 // a name too, so the fix does not quietly regress one command at a time.
+//
+// It reads every bracketed placeholder in a Use string rather than two literal
+// spellings, so `[cluster_id]`, `<cluster-id>` and `<clusterID>` are caught as
+// well as `<cluster_id>` - any of them would forward a typed name verbatim.
 func TestEveryClusterArgumentAdvertisesTheName(t *testing.T) {
-	stale := regexp.MustCompile(`<cluster_id>|\[cluster_id\.\.\.\]`)
+	placeholder := regexp.MustCompile(`<[^<>]+>|\[[^\[\]]+\]`)
+	clusterID := regexp.MustCompile(`(?i)cluster[-_ ]?id`)
 	var offenders []string
 	var walk func(command *cobra.Command)
 	walk = func(command *cobra.Command) {
-		if stale.MatchString(command.Use) {
-			offenders = append(offenders, command.CommandPath())
+		for _, token := range placeholder.FindAllString(command.Use, -1) {
+			// The widened form is the whole point, so it is never an offender.
+			if clusterID.MatchString(token) && !strings.Contains(token, "|name") {
+				offenders = append(offenders, command.CommandPath()+" "+token)
+			}
 		}
 		for _, child := range command.Commands() {
 			walk(child)

--- a/cmd/cluster_node_group.go
+++ b/cmd/cluster_node_group.go
@@ -233,11 +233,14 @@ Morpheus) is detected automatically from the cluster.`,
 }
 
 var clusterNodeGroupListCmd = &cobra.Command{
-	Use:   "list <cluster_id>",
+	Use:   "list <cluster_id|name>",
 	Short: "List node groups",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		kind, kindError := resolveNodeGroupClusterKind(clusterID)
 		if kindError != nil {
 			return kindError
@@ -307,11 +310,14 @@ func readNodeGroupUserDataFile(path string) (string, error) {
 }
 
 var clusterNodeGroupAddCmd = &cobra.Command{
-	Use:   "add <cluster_id>",
+	Use:   "add <cluster_id|name>",
 	Short: "Add a node group",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		kind, kindError := resolveNodeGroupClusterKind(clusterID)
 		if kindError != nil {
 			return kindError
@@ -366,11 +372,14 @@ var clusterNodeGroupAddCmd = &cobra.Command{
 }
 
 var clusterNodeGroupScaleCmd = &cobra.Command{
-	Use:   "scale <cluster_id> <group_name> <count>",
+	Use:   "scale <cluster_id|name> <group_name> <count>",
 	Short: "Scale a node group",
 	Args:  cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		count, convertError := strconv.Atoi(args[2])
 		if convertError != nil {
@@ -411,11 +420,14 @@ var clusterNodeGroupScaleCmd = &cobra.Command{
 }
 
 var clusterNodeGroupUpgradeCmd = &cobra.Command{
-	Use:   "upgrade <cluster_id> <group_name> <instance_type>",
+	Use:   "upgrade <cluster_id|name> <group_name> <instance_type>",
 	Short: "Upgrade instance type for a node group (cannot be reversed)",
 	Args:  cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		instanceType := args[2]
 		kind, kindError := resolveNodeGroupClusterKind(clusterID)
@@ -453,11 +465,14 @@ var clusterNodeGroupUpgradeCmd = &cobra.Command{
 }
 
 var clusterNodeGroupDeleteCmd = &cobra.Command{
-	Use:   "delete <cluster_id> <group_name>",
+	Use:   "delete <cluster_id|name> <group_name>",
 	Short: "Delete a node group and all its nodes",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		yes, _ := cmd.Flags().GetBool("yes")
 		kind, kindError := resolveNodeGroupClusterKind(clusterID)
@@ -467,7 +482,7 @@ var clusterNodeGroupDeleteCmd = &cobra.Command{
 
 		if err := confirmPrompt(
 			cmd.InOrStdin(), cmd.OutOrStdout(),
-			fmt.Sprintf("Delete node group %q from cluster %q? This deletes all its nodes! [y/N]: ", groupName, clusterID),
+			fmt.Sprintf("Delete node group %q from cluster %s? This deletes all its nodes! [y/N]: ", groupName, clusterTarget(args[0], clusterID)),
 			yes,
 		); err != nil {
 			return err
@@ -513,11 +528,14 @@ stays allowed but is clamped into the same bounds.`,
 }
 
 var clusterNodeGroupAutoscalingGetCmd = &cobra.Command{
-	Use:   "get <cluster_id> <group_name>",
+	Use:   "get <cluster_id|name> <group_name>",
 	Short: "Show autoscaling settings for a node group",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		kind, kindError := resolveNodeGroupClusterKind(clusterID)
 		if kindError != nil {
@@ -550,7 +568,7 @@ var clusterNodeGroupAutoscalingGetCmd = &cobra.Command{
 }
 
 var clusterNodeGroupAutoscalingSetCmd = &cobra.Command{
-	Use:   "set <cluster_id> <group_name>",
+	Use:   "set <cluster_id|name> <group_name>",
 	Short: "Enable or disable autoscaling for a node group",
 	Long: `Enable autoscaling with --enabled --min <n> --max <n>, or disable it with
 --enabled=false. min must be at least 1 (scale-to-zero is not supported);
@@ -558,7 +576,10 @@ enabling requires the cluster's ankra-agent to be recent enough to serve
 the autoscaler, and installs the Cluster Autoscaler on first enable.`,
 	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		enabled, _ := cmd.Flags().GetBool("enabled")
 		minCount, _ := cmd.Flags().GetInt("min")
@@ -610,12 +631,15 @@ the autoscaler, and installs the Cluster Autoscaler on first enable.`,
 }
 
 var clusterNodeGroupLabelsCmd = &cobra.Command{
-	Use:   "labels <cluster_id> <group_name>",
+	Use:   "labels <cluster_id|name> <group_name>",
 	Short: "Set labels on all nodes in a node group",
 	Long:  "Replace the labels on every node in the group. Pass --labels as a comma-separated list of key=value pairs, or --clear to remove all labels. The cloud provider is detected automatically from the cluster.",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		clear, _ := cmd.Flags().GetBool("clear")
 		labelsChanged := cmd.Flags().Changed("labels")
@@ -667,12 +691,15 @@ var clusterNodeGroupLabelsCmd = &cobra.Command{
 }
 
 var clusterNodeGroupTaintsCmd = &cobra.Command{
-	Use:   "taints <cluster_id> <group_name>",
+	Use:   "taints <cluster_id|name> <group_name>",
 	Short: "Set taints on all nodes in a node group",
 	Long:  "Replace the taints on every node in the group. Pass --taints as a comma-separated list of key=value:Effect (value optional, effect defaults to NoSchedule), or --clear to remove all taints. The cloud provider is detected automatically from the cluster.",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		clear, _ := cmd.Flags().GetBool("clear")
 		taintsChanged := cmd.Flags().Changed("taints")

--- a/cmd/cluster_node_group_autoscaling_test.go
+++ b/cmd/cluster_node_group_autoscaling_test.go
@@ -49,7 +49,7 @@ func TestClusterNodeGroupAutoscalingGetCommand(t *testing.T) {
 	setMockClient(t, mock)
 
 	stdoutOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "node-group", "autoscaling", "get", "test-cluster-id", "default")
+		_, _ = executeCommand("cluster", "node-group", "autoscaling", "get", testClusterID, "default")
 	})
 
 	if !strings.Contains(stdoutOutput, "autoscaling: enabled") {
@@ -66,7 +66,7 @@ func TestClusterNodeGroupAutoscalingSetCommandSendsBounds(t *testing.T) {
 	setMockClient(t, mock)
 
 	stdoutOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "node-group", "autoscaling", "set", "test-cluster-id", "default",
+		_, _ = executeCommand("cluster", "node-group", "autoscaling", "set", testClusterID, "default",
 			"--enabled", "--min", "2", "--max", "6", "--wait")
 	})
 
@@ -88,7 +88,7 @@ func TestClusterNodeGroupAutoscalingSetCommandDisables(t *testing.T) {
 	setMockClient(t, mock)
 
 	stdoutOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "node-group", "autoscaling", "set", "test-cluster-id", "default",
+		_, _ = executeCommand("cluster", "node-group", "autoscaling", "set", testClusterID, "default",
 			"--enabled=false", "--min", "1", "--max", "5", "--wait")
 	})
 
@@ -105,7 +105,7 @@ func TestClusterNodeGroupAutoscalingRefusesUnsupportedKind(t *testing.T) {
 	mock := &autoscalingMock{clusterKind: "imported"}
 	setMockClient(t, mock)
 
-	_, commandError := executeCommand("cluster", "node-group", "autoscaling", "get", "test-cluster-id", "default")
+	_, commandError := executeCommand("cluster", "node-group", "autoscaling", "get", testClusterID, "default")
 	if commandError == nil || !strings.Contains(commandError.Error(), "does not support node groups") {
 		t.Fatalf("expected the unsupported-kind refusal, got %v", commandError)
 	}

--- a/cmd/cluster_nodes.go
+++ b/cmd/cluster_nodes.go
@@ -312,20 +312,28 @@ included so the saved topology is visible before re-provisioning.`,
 	}
 
 	listCmd := &cobra.Command{
-		Use:   "list <cluster_id>",
+		Use:   "list <cluster_id|name>",
 		Short: "List all nodes for the cluster",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runNodesList(cmd, opsFn, args[0])
+			clusterID, resolveError := resolveClusterArg(args[0])
+			if resolveError != nil {
+				return resolveError
+			}
+			return runNodesList(cmd, opsFn, clusterID)
 		},
 	}
 
 	getCmd := &cobra.Command{
-		Use:   "get <cluster_id> <node_id>",
+		Use:   "get <cluster_id|name> <node_id>",
 		Short: "Show full spec and metadata for a single node",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runNodesGet(cmd, opsFn, args[0], args[1])
+			clusterID, resolveError := resolveClusterArg(args[0])
+			if resolveError != nil {
+				return resolveError
+			}
+			return runNodesGet(cmd, opsFn, clusterID, args[1])
 		},
 	}
 
@@ -334,7 +342,7 @@ included so the saved topology is visible before re-provisioning.`,
 
 	if supportsRestart {
 		restartCmd := &cobra.Command{
-			Use:   "restart <cluster_id> <node_id>",
+			Use:   "restart <cluster_id|name> <node_id>",
 			Short: "Restart a node (control plane, worker, or bastion/gateway)",
 			Long: `Schedule a native reboot (falling back to a power cycle) of the node as a
 tracked operation. The node must be in the 'up' state and have no restart
@@ -343,7 +351,11 @@ reboots. Works for any node returned by 'nodes list', including the
 bastion/gateway.`,
 			Args: cobra.ExactArgs(2),
 			RunE: func(cmd *cobra.Command, args []string) error {
-				return runNodesRestart(cmd, opsFn, args[0], args[1])
+				clusterID, resolveError := resolveClusterArg(args[0])
+				if resolveError != nil {
+					return resolveError
+				}
+				return runNodesRestart(cmd, opsFn, clusterID, args[1])
 			},
 		}
 		registerStructuredOutputFlags(restartCmd)
@@ -352,7 +364,7 @@ bastion/gateway.`,
 
 	if supportsCloudInitLog {
 		cloudInitLogCmd := &cobra.Command{
-			Use:   "cloud-init-log <cluster_id> <node_id>",
+			Use:   "cloud-init-log <cluster_id|name> <node_id>",
 			Short: "Read the node's cloud-init status and output-log tail",
 			Long: `Fetch 'cloud-init status --long' and the tail of
 /var/log/cloud-init-output.log from the node over the platform's bastion SSH
@@ -363,7 +375,11 @@ an in-flight fetch instead of dispatching duplicates. Find node ids with
 'nodes list'.`,
 			Args: cobra.ExactArgs(2),
 			RunE: func(cmd *cobra.Command, args []string) error {
-				return runNodesCloudInitLog(cmd, opsFn, args[0], args[1])
+				clusterID, resolveError := resolveClusterArg(args[0])
+				if resolveError != nil {
+					return resolveError
+				}
+				return runNodesCloudInitLog(cmd, opsFn, clusterID, args[1])
 			},
 		}
 		registerStructuredOutputFlags(cloudInitLogCmd)

--- a/cmd/cluster_nodes_test.go
+++ b/cmd/cluster_nodes_test.go
@@ -38,11 +38,11 @@ func TestClusterNodesRestartCommand(t *testing.T) {
 	setMockClient(t, mock)
 
 	stdoutOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "hetzner", "nodes", "restart", "cluster-1", "node-1")
+		_, _ = executeCommand("cluster", "hetzner", "nodes", "restart", testClusterID, "node-1")
 	})
 
-	if len(mock.restartCalls) != 1 || mock.restartCalls[0] != "cluster-1:node-1" {
-		t.Fatalf("expected one restart call for cluster-1:node-1, got %v", mock.restartCalls)
+	if len(mock.restartCalls) != 1 || mock.restartCalls[0] != testClusterID+":node-1" {
+		t.Fatalf("expected one restart call for %s:node-1, got %v", testClusterID, mock.restartCalls)
 	}
 	if !strings.Contains(stdoutOutput, "Restart scheduled for node node-1") {
 		t.Errorf("expected restart confirmation, got: %s", stdoutOutput)
@@ -59,7 +59,7 @@ func TestClusterNodesRestartCommandSurfacesError(t *testing.T) {
 	}
 	setMockClient(t, mock)
 
-	_, commandError := executeCommand("cluster", "hetzner", "nodes", "restart", "cluster-1", "node-1")
+	_, commandError := executeCommand("cluster", "hetzner", "nodes", "restart", testClusterID, "node-1")
 	if commandError == nil || !strings.Contains(commandError.Error(), "must be in 'up' state") {
 		t.Fatalf("expected the invalid-state error, got %v", commandError)
 	}
@@ -69,7 +69,7 @@ func TestClusterNodesRestartCommandRequiresBothArgs(t *testing.T) {
 	writeSelectedClusterJSON(t)
 	setMockClient(t, &nodeRestartMock{})
 
-	if _, err := executeCommand("cluster", "hetzner", "nodes", "restart", "cluster-1"); err == nil {
+	if _, err := executeCommand("cluster", "hetzner", "nodes", "restart", testClusterID); err == nil {
 		t.Fatal("expected an error when node_id is missing")
 	}
 }
@@ -101,11 +101,11 @@ func TestClusterNodesRestartCommandDispatchesScaleway(t *testing.T) {
 	setMockClient(t, mock)
 
 	stdoutOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "scaleway", "nodes", "restart", "cluster-9", "node-9")
+		_, _ = executeCommand("cluster", "scaleway", "nodes", "restart", testClusterID, "node-9")
 	})
 
-	if len(mock.restartCalls) != 1 || mock.restartCalls[0] != "cluster-9:node-9" {
-		t.Fatalf("expected one Scaleway restart call for cluster-9:node-9, got %v", mock.restartCalls)
+	if len(mock.restartCalls) != 1 || mock.restartCalls[0] != testClusterID+":node-9" {
+		t.Fatalf("expected one Scaleway restart call for %s:node-9, got %v", testClusterID, mock.restartCalls)
 	}
 	if !strings.Contains(stdoutOutput, "scaleway_restart_server") {
 		t.Errorf("expected the Scaleway job name in output, got: %s", stdoutOutput)
@@ -120,11 +120,11 @@ func TestClusterNodesListCommandDispatchesScaleway(t *testing.T) {
 	setMockClient(t, mock)
 
 	stdoutOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "scaleway", "nodes", "list", "cluster-9")
+		_, _ = executeCommand("cluster", "scaleway", "nodes", "list", testClusterID)
 	})
 
-	if len(mock.listCalls) != 1 || mock.listCalls[0] != "cluster-9" {
-		t.Fatalf("expected one Scaleway list call for cluster-9, got %v", mock.listCalls)
+	if len(mock.listCalls) != 1 || mock.listCalls[0] != testClusterID {
+		t.Fatalf("expected one Scaleway list call for %s, got %v", testClusterID, mock.listCalls)
 	}
 	if !strings.Contains(stdoutOutput, "worker-1") {
 		t.Errorf("expected the node name in output, got: %s", stdoutOutput)

--- a/cmd/cluster_playground.go
+++ b/cmd/cluster_playground.go
@@ -89,7 +89,7 @@ var clusterPlaygroundResizeCmd = &cobra.Command{
 		if clusterPlaygroundResizeSize == "" {
 			return fmt.Errorf("--size is required; list sizes with `ankra cluster playground plans`")
 		}
-		clusterID, err := resolvePlaygroundClusterID(args[0])
+		clusterID, err := resolveClusterArg(args[0])
 		if err != nil {
 			return err
 		}
@@ -129,7 +129,7 @@ var clusterPlaygroundStatusCmd = &cobra.Command{
 	Short: "Show the provisioning phase of a playground",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID, err := resolvePlaygroundClusterID(args[0])
+		clusterID, err := resolveClusterArg(args[0])
 		if err != nil {
 			return err
 		}
@@ -181,17 +181,14 @@ var clusterPlaygroundDestroyCmd = &cobra.Command{
 		"provisioner's next pass. Destroying the environment is what removes it for good.",
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID, err := resolvePlaygroundClusterID(args[0])
+		clusterID, err := resolveClusterArg(args[0])
 		if err != nil {
 			return err
 		}
 		yes, _ := cmd.Flags().GetBool("yes")
 		// A name resolves to an id before the request; the prompt names both
 		// so what the user confirms is the cluster the API is asked to destroy.
-		target := fmt.Sprintf("%q", args[0])
-		if clusterID != args[0] {
-			target = fmt.Sprintf("%q (cluster %s)", args[0], clusterID)
-		}
+		target := clusterTarget(args[0], clusterID)
 		// The prompt goes to stderr so `-o json` keeps stdout parseable.
 		if err := confirmPrompt(cmd.InOrStdin(), cmd.ErrOrStderr(),
 			fmt.Sprintf("Destroy playground %s? Everything deployed in it, including its storage, "+
@@ -228,19 +225,4 @@ func init() {
 	clusterPlaygroundCmd.AddCommand(clusterPlaygroundStatusCmd)
 	clusterPlaygroundCmd.AddCommand(clusterPlaygroundDestroyCmd)
 	clusterCmd.AddCommand(clusterPlaygroundCmd)
-}
-
-// resolvePlaygroundClusterID accepts the cluster id the playground routes
-// want, or the cluster's name as `ankra cluster list` shows it: passing the
-// name straight through answered a bare 404 from the route, with nothing
-// to say an id was expected (ankra-y8l44.35).
-func resolvePlaygroundClusterID(nameOrID string) (string, error) {
-	if isLikelyClusterID(nameOrID) {
-		return nameOrID, nil
-	}
-	clusterID, err := resolveClusterID(nameOrID)
-	if err != nil {
-		return "", fmt.Errorf("%w (playground commands take the cluster id or its name from `ankra cluster list`)", err)
-	}
-	return clusterID, nil
 }

--- a/cmd/cluster_scale.go
+++ b/cmd/cluster_scale.go
@@ -37,7 +37,7 @@ func scaleFunctionForKind(kind string) (workerScaleFunc, bool) {
 }
 
 var clusterScaleCmd = &cobra.Command{
-	Use:   "scale <cluster_id> <worker_count>",
+	Use:   "scale <cluster_id|name> <worker_count>",
 	Short: "Scale the default worker pool of a cloud cluster",
 	Long: `Scale the number of default-pool worker nodes up or down for a cloud cluster.
 
@@ -50,7 +50,10 @@ Example:
   ankra cluster scale 62f4559a-a44d-46d7-aab3-a57c9dd6b4c6 3`,
 	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		workerCount, convertError := strconv.Atoi(args[1])
 		if convertError != nil {
 			return fmt.Errorf("invalid worker count: %w", convertError)

--- a/cmd/cluster_ssh_keys.go
+++ b/cmd/cluster_ssh_keys.go
@@ -106,11 +106,14 @@ Morpheus) is detected automatically from the cluster.`,
 }
 
 var clusterSSHKeysGetCmd = &cobra.Command{
-	Use:   "get <cluster_id>",
+	Use:   "get <cluster_id|name>",
 	Short: "Show SSH keys attached to a cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		kind, err := resolveSSHKeysClusterKind(clusterID)
 		if err != nil {
 			return err
@@ -147,7 +150,7 @@ var clusterSSHKeysGetCmd = &cobra.Command{
 }
 
 var clusterSSHKeysSetCmd = &cobra.Command{
-	Use:   "set <cluster_id>",
+	Use:   "set <cluster_id|name>",
 	Short: "Set the SSH keys attached to a cluster",
 	Long: `Replace the SSH key credentials attached to a cluster. Changes take effect on
 the next reconciliation and are applied to running nodes.
@@ -155,7 +158,10 @@ the next reconciliation and are applied to running nodes.
 Pass --clear to remove all user SSH keys (the Ankra-managed key always remains).`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		clear, _ := cmd.Flags().GetBool("clear")
 		sshKeyCredentialIDs, _ := cmd.Flags().GetStringSlice("ssh-key-credential-ids")
 
@@ -195,7 +201,7 @@ Pass --clear to remove all user SSH keys (the Ankra-managed key always remains).
 }
 
 var clusterSSHKeysResyncCmd = &cobra.Command{
-	Use:   "resync <cluster_id>",
+	Use:   "resync <cluster_id|name>",
 	Short: "Re-sync a cluster's SSH keys with the cloud provider",
 	Long: `Re-sync the cluster's SSH key with the cloud provider. Use this to repair a
 stale provider-side SSH key reference (for example when the key was deleted and
@@ -203,7 +209,10 @@ re-created in the provider console) that blocks new node creation, and to
 re-apply the authorised keys to running nodes.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		kind, err := resolveSSHKeysClusterKind(clusterID)
 		if err != nil {
 			return err

--- a/cmd/cluster_stacks.go
+++ b/cmd/cluster_stacks.go
@@ -422,6 +422,13 @@ and will need to be reconfigured in the target cluster.`,
 // callers can pass either form. Otherwise the cluster list is paged
 // through until a matching name is found, instead of relying on a
 // single page that may silently truncate results.
+//
+// A name typed exactly as the cluster carries it wins immediately. Only when
+// no exact match exists does the case-insensitive fallback decide, and then
+// the whole listing is read first: matching with EqualFold and returning the
+// first hit picked an arbitrary one of two clusters whose names differ only by
+// case, and sent the command - `deprovision` included - to whichever the
+// listing happened to order first. Ambiguity is now an error naming both.
 func resolveClusterID(nameOrID string) (string, error) {
 	if len(nameOrID) == 36 && strings.Count(nameOrID, "-") == 4 {
 		return nameOrID, nil
@@ -429,14 +436,18 @@ func resolveClusterID(nameOrID string) (string, error) {
 
 	const pageSize = 100
 	const maxPages = 50
+	var caseInsensitiveMatches []client.ClusterListItem
 	for page := 1; page <= maxPages; page++ {
 		response, err := apiClient.ListClusters(page, pageSize)
 		if err != nil {
 			return "", fmt.Errorf("listing clusters: %w", err)
 		}
 		for _, cluster := range response.Result {
-			if strings.EqualFold(cluster.Name, nameOrID) {
+			if cluster.Name == nameOrID {
 				return cluster.ID, nil
+			}
+			if strings.EqualFold(cluster.Name, nameOrID) {
+				caseInsensitiveMatches = append(caseInsensitiveMatches, cluster)
 			}
 		}
 		if response.Pagination.TotalPages <= page || len(response.Result) == 0 {
@@ -444,7 +455,19 @@ func resolveClusterID(nameOrID string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("cluster %q not found", nameOrID)
+	switch len(caseInsensitiveMatches) {
+	case 0:
+		return "", fmt.Errorf("cluster %q not found", nameOrID)
+	case 1:
+		return caseInsensitiveMatches[0].ID, nil
+	default:
+		candidates := make([]string, 0, len(caseInsensitiveMatches))
+		for _, cluster := range caseInsensitiveMatches {
+			candidates = append(candidates, fmt.Sprintf("%s (%s)", cluster.Name, cluster.ID))
+		}
+		return "", fmt.Errorf("cluster %q is ambiguous - %d clusters differ from it only by case: %s; pass the cluster id instead",
+			nameOrID, len(caseInsensitiveMatches), strings.Join(candidates, ", "))
+	}
 }
 
 func init() {

--- a/cmd/cluster_stacks.go
+++ b/cmd/cluster_stacks.go
@@ -430,13 +430,18 @@ and will need to be reconfigured in the target cluster.`,
 // case, and sent the command - `deprovision` included - to whichever the
 // listing happened to order first. Ambiguity is now an error naming both.
 func resolveClusterID(nameOrID string) (string, error) {
-	if len(nameOrID) == 36 && strings.Count(nameOrID, "-") == 4 {
+	// isLikelyClusterID, not a len/dash count: "36 characters with four
+	// dashes" also describes plenty of real cluster names, and every one of
+	// them was forwarded to the API as an id and answered with an opaque 404
+	// instead of being looked up as the name it is.
+	if isLikelyClusterID(nameOrID) {
 		return nameOrID, nil
 	}
 
 	const pageSize = 100
 	const maxPages = 50
 	var caseInsensitiveMatches []client.ClusterListItem
+	listingTruncated := false
 	for page := 1; page <= maxPages; page++ {
 		response, err := apiClient.ListClusters(page, pageSize)
 		if err != nil {
@@ -453,10 +458,17 @@ func resolveClusterID(nameOrID string) (string, error) {
 		if response.Pagination.TotalPages <= page || len(response.Result) == 0 {
 			break
 		}
+		if page == maxPages {
+			listingTruncated = true
+		}
 	}
 
 	switch len(caseInsensitiveMatches) {
 	case 0:
+		if listingTruncated {
+			return "", fmt.Errorf("cluster %q was not among the first %d clusters and the listing has more; pass the cluster id instead",
+				nameOrID, pageSize*maxPages)
+		}
 		return "", fmt.Errorf("cluster %q not found", nameOrID)
 	case 1:
 		return caseInsensitiveMatches[0].ID, nil

--- a/cmd/cluster_stop_force_test.go
+++ b/cmd/cluster_stop_force_test.go
@@ -40,10 +40,10 @@ func TestProxmoxStopForceReachesTheClient(t *testing.T) {
 	t.Cleanup(func() { _ = proxmoxStopCmd.Flags().Set("force", "false") })
 
 	captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "proxmox", "stop", "pm-123", "--force")
+		_, _ = executeCommand("cluster", "proxmox", "stop", testClusterID, "--force")
 	})
-	if mock.stopClusterID != "pm-123" {
-		t.Fatalf("cluster id = %q, want pm-123", mock.stopClusterID)
+	if mock.stopClusterID != testClusterID {
+		t.Fatalf("cluster id = %q, want %q", mock.stopClusterID, testClusterID)
 	}
 	if !mock.gotForce {
 		t.Fatal("expected --force to reach the API")
@@ -55,7 +55,7 @@ func TestProxmoxStopDefaultsToUnforced(t *testing.T) {
 	setMockClient(t, mock)
 
 	captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "proxmox", "stop", "pm-123")
+		_, _ = executeCommand("cluster", "proxmox", "stop", testClusterID)
 	})
 	if mock.gotForce {
 		t.Fatal("a plain stop must not send force")
@@ -68,10 +68,10 @@ func TestMorpheusStopForceReachesTheClient(t *testing.T) {
 	t.Cleanup(func() { _ = morpheusStopCmd.Flags().Set("force", "false") })
 
 	captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "morpheus", "stop", "mo-123", "--force")
+		_, _ = executeCommand("cluster", "morpheus", "stop", testClusterID, "--force")
 	})
-	if mock.stopClusterID != "mo-123" {
-		t.Fatalf("cluster id = %q, want mo-123", mock.stopClusterID)
+	if mock.stopClusterID != testClusterID {
+		t.Fatalf("cluster id = %q, want %q", mock.stopClusterID, testClusterID)
 	}
 	if !mock.gotForce {
 		t.Fatal("expected --force to reach the API")

--- a/cmd/cluster_upgrade.go
+++ b/cmd/cluster_upgrade.go
@@ -38,7 +38,7 @@ func upgradeFunctionForKind(kind string) (k8sVersionUpgrade, bool) {
 var clusterUpgradeForce bool
 
 var clusterUpgradeCmd = &cobra.Command{
-	Use:   "upgrade <cluster_id> <target_version>",
+	Use:   "upgrade <cluster_id|name> <target_version>",
 	Short: "Upgrade the Kubernetes version of a cloud cluster",
 	Long: `Upgrade the Kubernetes version on all nodes in a cloud cluster.
 
@@ -60,7 +60,10 @@ Examples:
   ankra cluster upgrade 62f4559a-a44d-46d7-aab3-a57c9dd6b4c6 v1.36.1+k3s1    # k3s`,
 	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		targetVersion := args[1]
 
 		cluster, err := apiClient.GetClusterByID(clusterID)

--- a/cmd/confirm_core_test.go
+++ b/cmd/confirm_core_test.go
@@ -87,7 +87,7 @@ func (m *stacksDeleteMock) DeleteStack(ctx context.Context, clusterID, stackName
 }
 
 func TestClusterStacksDelete_DeclineDoesNotDelete(t *testing.T) {
-	mock := &stacksDeleteMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo"}}
+	mock := &stacksDeleteMock{cluster: client.ClusterListItem{ID: testClusterID, Name: "demo"}}
 	_, err := runConfirmCommand(t, mock, "n\n",
 		[]*cobra.Command{clusterStacksDeleteCmd},
 		"cluster", "stacks", "delete", "platform", "--cluster", "demo")
@@ -103,7 +103,7 @@ func TestClusterStacksDelete_DeclineDoesNotDelete(t *testing.T) {
 }
 
 func TestClusterStacksDelete_YesFlagProceeds(t *testing.T) {
-	mock := &stacksDeleteMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo"}}
+	mock := &stacksDeleteMock{cluster: client.ClusterListItem{ID: testClusterID, Name: "demo"}}
 	_, err := runConfirmCommand(t, mock, "",
 		[]*cobra.Command{clusterStacksDeleteCmd},
 		"cluster", "stacks", "delete", "platform", "--cluster", "demo", "--yes")
@@ -116,7 +116,7 @@ func TestClusterStacksDelete_YesFlagProceeds(t *testing.T) {
 }
 
 func TestClusterStacksDelete_PipedYesProceeds(t *testing.T) {
-	mock := &stacksDeleteMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo"}}
+	mock := &stacksDeleteMock{cluster: client.ClusterListItem{ID: testClusterID, Name: "demo"}}
 	_, err := runConfirmCommand(t, mock, "y\n",
 		[]*cobra.Command{clusterStacksDeleteCmd},
 		"cluster", "stacks", "delete", "platform", "--cluster", "demo")
@@ -149,7 +149,7 @@ func (m *stacksListMock) ListClusterStacks(clusterID string) ([]client.ClusterSt
 
 func TestClusterStacksList_NotFoundUsesExitNotFound(t *testing.T) {
 	mock := &stacksListMock{
-		cluster: client.ClusterListItem{ID: "c-1", Name: "demo"},
+		cluster: client.ClusterListItem{ID: testClusterID, Name: "demo"},
 		stacks:  []client.ClusterStackListItem{{Name: "other"}},
 	}
 	_, err := runConfirmCommand(t, mock, "",
@@ -192,7 +192,7 @@ func (m *deprovisionMock) DeprovisionCluster(ctx context.Context, clusterID stri
 
 func TestClusterDeprovision_DeclineDoesNotDeprovision(t *testing.T) {
 	// Kind is intentionally empty so the generic deprovision path is used.
-	mock := &deprovisionMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo"}}
+	mock := &deprovisionMock{cluster: client.ClusterListItem{ID: testClusterID, Name: "demo"}}
 	_, err := runConfirmCommand(t, mock, "n\n",
 		[]*cobra.Command{clusterDeprovisionCmd},
 		"cluster", "deprovision", "demo")
@@ -208,7 +208,7 @@ func TestClusterDeprovision_DeclineDoesNotDeprovision(t *testing.T) {
 }
 
 func TestClusterDeprovision_YesFlagProceeds(t *testing.T) {
-	mock := &deprovisionMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo"}}
+	mock := &deprovisionMock{cluster: client.ClusterListItem{ID: testClusterID, Name: "demo"}}
 	_, err := runConfirmCommand(t, mock, "",
 		[]*cobra.Command{clusterDeprovisionCmd},
 		"cluster", "deprovision", "demo", "--yes")
@@ -223,7 +223,7 @@ func TestClusterDeprovision_YesFlagProceeds(t *testing.T) {
 func TestClusterDeprovision_ForceWarnsWhenIgnored(t *testing.T) {
 	// Empty kind routes to the generic deprovision endpoint, which is one of
 	// the lanes where the backend discards force.
-	mock := &deprovisionMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo"}}
+	mock := &deprovisionMock{cluster: client.ClusterListItem{ID: testClusterID, Name: "demo"}}
 	output, err := runConfirmCommand(t, mock, "",
 		[]*cobra.Command{clusterDeprovisionCmd},
 		"cluster", "deprovision", "demo", "--yes", "--force")
@@ -239,7 +239,7 @@ func TestClusterDeprovision_ForceWarnsWhenIgnored(t *testing.T) {
 }
 
 func TestClusterDeprovision_NoForceNoWarning(t *testing.T) {
-	mock := &deprovisionMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo"}}
+	mock := &deprovisionMock{cluster: client.ClusterListItem{ID: testClusterID, Name: "demo"}}
 	output, err := runConfirmCommand(t, mock, "",
 		[]*cobra.Command{clusterDeprovisionCmd},
 		"cluster", "deprovision", "demo", "--yes")
@@ -254,7 +254,7 @@ func TestClusterDeprovision_NoForceNoWarning(t *testing.T) {
 func TestClusterDeprovision_DeprecatedAutoDeleteStillParses(t *testing.T) {
 	// --auto-delete is a deprecated no-op kept so existing scripts don't
 	// break on an unknown flag; it must parse and the deprovision must run.
-	mock := &deprovisionMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo"}}
+	mock := &deprovisionMock{cluster: client.ClusterListItem{ID: testClusterID, Name: "demo"}}
 	_, err := runConfirmCommand(t, mock, "",
 		[]*cobra.Command{clusterDeprovisionCmd},
 		"cluster", "deprovision", "demo", "--yes", "--auto-delete")
@@ -267,7 +267,7 @@ func TestClusterDeprovision_DeprecatedAutoDeleteStillParses(t *testing.T) {
 }
 
 func TestClusterDeprovision_PipedYesProceeds(t *testing.T) {
-	mock := &deprovisionMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo"}}
+	mock := &deprovisionMock{cluster: client.ClusterListItem{ID: testClusterID, Name: "demo"}}
 	_, err := runConfirmCommand(t, mock, "y\n",
 		[]*cobra.Command{clusterDeprovisionCmd},
 		"cluster", "deprovision", "demo")
@@ -300,10 +300,10 @@ func (m *nodeGroupDeleteMock) DeleteHetznerNodeGroup(ctx context.Context, cluste
 }
 
 func TestClusterNodeGroupDelete_DeclineDoesNotDelete(t *testing.T) {
-	mock := &nodeGroupDeleteMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo", Kind: "hetzner"}}
+	mock := &nodeGroupDeleteMock{cluster: client.ClusterListItem{ID: testClusterID, Name: "demo", Kind: "hetzner"}}
 	_, err := runConfirmCommand(t, mock, "n\n",
 		[]*cobra.Command{clusterNodeGroupDeleteCmd},
-		"cluster", "node-group", "delete", "c-1", "workers")
+		"cluster", "node-group", "delete", testClusterID, "workers")
 	if !errors.Is(err, errCancelled) {
 		t.Fatalf("expected errCancelled on decline, got %v", err)
 	}
@@ -316,10 +316,10 @@ func TestClusterNodeGroupDelete_DeclineDoesNotDelete(t *testing.T) {
 }
 
 func TestClusterNodeGroupDelete_YesFlagProceeds(t *testing.T) {
-	mock := &nodeGroupDeleteMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo", Kind: "hetzner"}}
+	mock := &nodeGroupDeleteMock{cluster: client.ClusterListItem{ID: testClusterID, Name: "demo", Kind: "hetzner"}}
 	_, err := runConfirmCommand(t, mock, "",
 		[]*cobra.Command{clusterNodeGroupDeleteCmd},
-		"cluster", "node-group", "delete", "c-1", "workers", "--yes")
+		"cluster", "node-group", "delete", testClusterID, "workers", "--yes")
 	if err != nil {
 		t.Fatalf("expected success with --yes, got %v", err)
 	}
@@ -329,10 +329,10 @@ func TestClusterNodeGroupDelete_YesFlagProceeds(t *testing.T) {
 }
 
 func TestClusterNodeGroupDelete_PipedYesProceeds(t *testing.T) {
-	mock := &nodeGroupDeleteMock{cluster: client.ClusterListItem{ID: "c-1", Name: "demo", Kind: "hetzner"}}
+	mock := &nodeGroupDeleteMock{cluster: client.ClusterListItem{ID: testClusterID, Name: "demo", Kind: "hetzner"}}
 	_, err := runConfirmCommand(t, mock, "y\n",
 		[]*cobra.Command{clusterNodeGroupDeleteCmd},
-		"cluster", "node-group", "delete", "c-1", "workers")
+		"cluster", "node-group", "delete", testClusterID, "workers")
 	if err != nil {
 		t.Fatalf("expected success with piped y, got %v", err)
 	}

--- a/cmd/control_plane.go
+++ b/cmd/control_plane.go
@@ -232,16 +232,20 @@ Run "control-plane get" to see which of the two is available right now.`,
 	}
 
 	getCmd := &cobra.Command{
-		Use:   "get <cluster_id>",
+		Use:   "get <cluster_id|name>",
 		Short: "Show the current control plane configuration",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runControlPlaneGet(cmd, opsFn, args[0])
+			clusterID, resolveError := resolveClusterArg(args[0])
+			if resolveError != nil {
+				return resolveError
+			}
+			return runControlPlaneGet(cmd, opsFn, clusterID)
 		},
 	}
 
 	setCountCmd := &cobra.Command{
-		Use:   "set-count <cluster_id> <count>",
+		Use:   "set-count <cluster_id|name> <count>",
 		Short: "Change the controller count (1 or 3)",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -252,17 +256,25 @@ Run "control-plane get" to see which of the two is available right now.`,
 			if count != 1 && count != 3 {
 				return errors.New("count must be 1 or 3 (etcd quorum)")
 			}
-			return runControlPlaneSetCount(cmd, opsFn, args[0], count)
+			clusterID, resolveError := resolveClusterArg(args[0])
+			if resolveError != nil {
+				return resolveError
+			}
+			return runControlPlaneSetCount(cmd, opsFn, clusterID, count)
 		},
 	}
 
 	setInstanceTypeCmd := &cobra.Command{
-		Use:   "set-instance-type <cluster_id> <instance_type>",
+		Use:   "set-instance-type <cluster_id|name> <instance_type>",
 		Short: "Change the controller instance type",
 		Long:  setInstanceTypeLong(provider, catalogCommand),
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runControlPlaneSetInstanceType(cmd, opsFn, args[0], args[1])
+			clusterID, resolveError := resolveClusterArg(args[0])
+			if resolveError != nil {
+				return resolveError
+			}
+			return runControlPlaneSetInstanceType(cmd, opsFn, clusterID, args[1])
 		},
 	}
 

--- a/cmd/control_plane_test.go
+++ b/cmd/control_plane_test.go
@@ -47,7 +47,7 @@ func TestControlPlaneGetRendersTheTwoControlsSeparately(t *testing.T) {
 	}
 
 	stdoutOutput := captureStdout(t, func() {
-		if err := runControlPlaneGet(&cobra.Command{}, stubControlPlaneOps(info, nil), "cluster-1"); err != nil {
+		if err := runControlPlaneGet(&cobra.Command{}, stubControlPlaneOps(info, nil), testClusterID); err != nil {
 			t.Fatalf("runControlPlaneGet returned an error: %v", err)
 		}
 	})
@@ -83,7 +83,7 @@ func TestControlPlaneGetFallsBackToLegacyFields(t *testing.T) {
 	}
 
 	stdoutOutput := captureStdout(t, func() {
-		if err := runControlPlaneGet(&cobra.Command{}, stubControlPlaneOps(info, nil), "cluster-1"); err != nil {
+		if err := runControlPlaneGet(&cobra.Command{}, stubControlPlaneOps(info, nil), testClusterID); err != nil {
 			t.Fatalf("runControlPlaneGet returned an error: %v", err)
 		}
 	})
@@ -112,7 +112,7 @@ func TestSetInstanceTypeRollingReportsTheOperationAndNoStart(t *testing.T) {
 	}
 
 	stdoutOutput := captureStdout(t, func() {
-		err := runControlPlaneSetInstanceType(&cobra.Command{}, stubControlPlaneOps(nil, changed), "cluster-1", "s-4vcpu-8gb")
+		err := runControlPlaneSetInstanceType(&cobra.Command{}, stubControlPlaneOps(nil, changed), testClusterID, "s-4vcpu-8gb")
 		if err != nil {
 			t.Fatalf("runControlPlaneSetInstanceType returned an error: %v", err)
 		}
@@ -140,7 +140,7 @@ func TestSetInstanceTypeOfflineStillSaysStartTheCluster(t *testing.T) {
 	}
 
 	stdoutOutput := captureStdout(t, func() {
-		err := runControlPlaneSetInstanceType(&cobra.Command{}, stubControlPlaneOps(nil, changed), "cluster-1", "s-4vcpu-8gb")
+		err := runControlPlaneSetInstanceType(&cobra.Command{}, stubControlPlaneOps(nil, changed), testClusterID, "s-4vcpu-8gb")
 		if err != nil {
 			t.Fatalf("runControlPlaneSetInstanceType returned an error: %v", err)
 		}
@@ -164,7 +164,7 @@ func TestSetInstanceTypeWithoutModeKeepsLegacyWording(t *testing.T) {
 	}
 
 	stdoutOutput := captureStdout(t, func() {
-		err := runControlPlaneSetInstanceType(&cobra.Command{}, stubControlPlaneOps(nil, changed), "cluster-1", "s-4vcpu-8gb")
+		err := runControlPlaneSetInstanceType(&cobra.Command{}, stubControlPlaneOps(nil, changed), testClusterID, "s-4vcpu-8gb")
 		if err != nil {
 			t.Fatalf("runControlPlaneSetInstanceType returned an error: %v", err)
 		}
@@ -187,7 +187,7 @@ func TestSetInstanceTypeNoOpSaysNothingChanged(t *testing.T) {
 	}
 
 	stdoutOutput := captureStdout(t, func() {
-		err := runControlPlaneSetInstanceType(&cobra.Command{}, stubControlPlaneOps(nil, changed), "cluster-1", "s-2vcpu-4gb")
+		err := runControlPlaneSetInstanceType(&cobra.Command{}, stubControlPlaneOps(nil, changed), testClusterID, "s-2vcpu-4gb")
 		if err != nil {
 			t.Fatalf("runControlPlaneSetInstanceType returned an error: %v", err)
 		}
@@ -214,7 +214,7 @@ func TestSetInstanceTypeZeroUpdatedNeverReportsAChange(t *testing.T) {
 	}
 
 	stdoutOutput := captureStdout(t, func() {
-		err := runControlPlaneSetInstanceType(&cobra.Command{}, stubControlPlaneOps(nil, changed), "cluster-1", "s-4vcpu-8gb")
+		err := runControlPlaneSetInstanceType(&cobra.Command{}, stubControlPlaneOps(nil, changed), testClusterID, "s-4vcpu-8gb")
 		if err != nil {
 			t.Fatalf("runControlPlaneSetInstanceType returned an error: %v", err)
 		}

--- a/cmd/digitalocean_cluster.go
+++ b/cmd/digitalocean_cluster.go
@@ -98,11 +98,14 @@ var digitaloceanCreateCmd = &cobra.Command{
 }
 
 var digitaloceanDeprovisionCmd = &cobra.Command{
-	Use:   "deprovision <cluster_id>",
+	Use:   "deprovision <cluster_id|name>",
 	Short: "Deprovision an DigitalOcean cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		yes, _ := cmd.Flags().GetBool("yes")
 
 		force, _ := cmd.Flags().GetBool("force")
@@ -111,7 +114,7 @@ var digitaloceanDeprovisionCmd = &cobra.Command{
 			warning = "This deletes all its servers, networks, SSH keys, block storage volumes and load balancers!"
 		}
 		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
-			fmt.Sprintf("Deprovision DigitalOcean cluster %q? %s [y/N]: ", clusterID, warning),
+			fmt.Sprintf("Deprovision DigitalOcean cluster %s? %s [y/N]: ", clusterTarget(args[0], clusterID), warning),
 			yes); err != nil {
 			return err
 		}
@@ -142,12 +145,15 @@ var digitaloceanDeprovisionCmd = &cobra.Command{
 }
 
 var digitaloceanStopCmd = &cobra.Command{
-	Use:   "stop <cluster_id>",
+	Use:   "stop <cluster_id|name>",
 	Short: "Stop an DigitalOcean cluster",
 	Long:  "Stop an DigitalOcean cluster's compute while keeping its configuration so it can be started again later.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		force, _ := cmd.Flags().GetBool("force")
 
 		result, err := apiClient.StopDigitaloceanCluster(clusterID, force)
@@ -169,12 +175,15 @@ var digitaloceanStopCmd = &cobra.Command{
 }
 
 var digitaloceanStartCmd = &cobra.Command{
-	Use:   "start <cluster_id>",
+	Use:   "start <cluster_id|name>",
 	Short: "Start a stopped DigitalOcean cluster",
 	Long:  "Start (re-provision) a stopped DigitalOcean cluster. Use --scope control_plane to bring up only the control plane.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		scope, _ := cmd.Flags().GetString("scope")
 		if scope != "all" && scope != "control_plane" {
 			return fmt.Errorf("invalid --scope %q: must be 'all' or 'control_plane'", scope)
@@ -196,11 +205,14 @@ var digitaloceanStartCmd = &cobra.Command{
 }
 
 var digitaloceanWorkersCmd = &cobra.Command{
-	Use:   "workers <cluster_id>",
+	Use:   "workers <cluster_id|name>",
 	Short: "Get current worker count for an DigitalOcean cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 
 		result, err := apiClient.GetDigitaloceanWorkerCount(clusterID)
 		if err != nil {
@@ -221,12 +233,15 @@ var digitaloceanWorkersCmd = &cobra.Command{
 }
 
 var digitaloceanScaleCmd = &cobra.Command{
-	Use:   "scale <cluster_id> <worker_count>",
+	Use:   "scale <cluster_id|name> <worker_count>",
 	Short: "Scale workers for an DigitalOcean cluster",
 	Long:  "Scale the number of worker nodes up or down for an DigitalOcean cluster.",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		workerCount, err := strconv.Atoi(args[1])
 		if err != nil {
 			return fmt.Errorf("invalid worker count: %w", err)
@@ -257,11 +272,14 @@ var digitaloceanScaleCmd = &cobra.Command{
 }
 
 var digitaloceanK8sVersionCmd = &cobra.Command{
-	Use:   "k8s-version <cluster_id>",
+	Use:   "k8s-version <cluster_id|name>",
 	Short: "Get current Kubernetes version for an DigitalOcean cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 
 		result, err := apiClient.GetDigitaloceanK8sVersion(clusterID)
 		if err != nil {
@@ -285,13 +303,16 @@ var digitaloceanK8sVersionCmd = &cobra.Command{
 }
 
 var digitaloceanUpgradeCmd = &cobra.Command{
-	Use:        "upgrade <cluster_id> <target_version>",
+	Use:        "upgrade <cluster_id|name> <target_version>",
 	Short:      "Upgrade Kubernetes version for an DigitalOcean cluster",
 	Long:       "Upgrade the Kubernetes version on all nodes in an DigitalOcean cluster. This deprecated form always runs the safe non-forced rollout; use `ankra cluster upgrade` for --force (PodDisruptionBudget override) and operation progress tracking.",
 	Deprecated: "use `ankra cluster upgrade <cluster_id> <target_version>` instead; the cloud provider is detected automatically.",
 	Args:       cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		targetVersion := args[1]
 
 		result, err := apiClient.UpgradeDigitaloceanK8sVersion(clusterID, targetVersion, false)
@@ -324,11 +345,14 @@ var digitaloceanNodeGroupCmd = &cobra.Command{
 }
 
 var digitaloceanNodeGroupListCmd = &cobra.Command{
-	Use:   "list <cluster_id>",
+	Use:   "list <cluster_id|name>",
 	Short: "List node groups",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		result, err := apiClient.ListDigitaloceanNodeGroups(clusterID)
 		if err != nil {
 			return fmt.Errorf("listing node groups: %w", err)
@@ -351,11 +375,14 @@ var digitaloceanNodeGroupListCmd = &cobra.Command{
 }
 
 var digitaloceanNodeGroupAddCmd = &cobra.Command{
-	Use:   "add <cluster_id>",
+	Use:   "add <cluster_id|name>",
 	Short: "Add a node group",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		name, _ := cmd.Flags().GetString("name")
 		instanceType, _ := cmd.Flags().GetString("instance-type")
 		count, _ := cmd.Flags().GetInt("count")
@@ -396,11 +423,14 @@ var digitaloceanNodeGroupAddCmd = &cobra.Command{
 }
 
 var digitaloceanNodeGroupScaleCmd = &cobra.Command{
-	Use:   "scale <cluster_id> <group_name> <count>",
+	Use:   "scale <cluster_id|name> <group_name> <count>",
 	Short: "Scale a node group",
 	Args:  cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		count, err := strconv.Atoi(args[2])
 		if err != nil {
@@ -437,11 +467,14 @@ var digitaloceanNodeGroupScaleCmd = &cobra.Command{
 }
 
 var digitaloceanNodeGroupUpgradeCmd = &cobra.Command{
-	Use:   "upgrade <cluster_id> <group_name> <size>",
+	Use:   "upgrade <cluster_id|name> <group_name> <size>",
 	Short: "Upgrade server size for a node group",
 	Args:  cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		size := args[2]
 
@@ -475,16 +508,19 @@ var digitaloceanNodeGroupUpgradeCmd = &cobra.Command{
 }
 
 var digitaloceanNodeGroupDeleteCmd = &cobra.Command{
-	Use:   "delete <cluster_id> <group_name>",
+	Use:   "delete <cluster_id|name> <group_name>",
 	Short: "Delete a node group and all its nodes",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		yes, _ := cmd.Flags().GetBool("yes")
 
 		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
-			fmt.Sprintf("Delete node group %q from cluster %q? This deletes all its nodes! [y/N]: ", groupName, clusterID),
+			fmt.Sprintf("Delete node group %q from cluster %s? This deletes all its nodes! [y/N]: ", groupName, clusterTarget(args[0], clusterID)),
 			yes); err != nil {
 			return err
 		}

--- a/cmd/digitalocean_cluster_test.go
+++ b/cmd/digitalocean_cluster_test.go
@@ -92,7 +92,7 @@ func (m *digitaloceanNodeGroupDeleteMock) DeleteDigitaloceanNodeGroup(ctx contex
 func TestDigitaloceanDeprovision_DeclineDoesNotCallAPI(t *testing.T) {
 	mock := &digitaloceanDeprovisionMock{}
 	resetConfirmFlag(t, digitaloceanDeprovisionCmd)
-	_, err := runWithInput(t, mock, "n\n", "cluster", "digitalocean", "deprovision", "uc-123")
+	_, err := runWithInput(t, mock, "n\n", "cluster", "digitalocean", "deprovision", testClusterID)
 	if !errors.Is(err, errCancelled) {
 		t.Fatalf("expected errCancelled on decline, got %v", err)
 	}
@@ -104,22 +104,22 @@ func TestDigitaloceanDeprovision_DeclineDoesNotCallAPI(t *testing.T) {
 func TestDigitaloceanDeprovision_YesProceeds(t *testing.T) {
 	mock := &digitaloceanDeprovisionMock{}
 	resetConfirmFlag(t, digitaloceanDeprovisionCmd)
-	out, err := runWithInput(t, mock, "", "cluster", "digitalocean", "deprovision", "uc-123", "--yes")
+	out, err := runWithInput(t, mock, "", "cluster", "digitalocean", "deprovision", testClusterID, "--yes")
 	if err != nil {
 		t.Fatalf("execute failed: %v\noutput: %s", err, out)
 	}
 	if !mock.called {
 		t.Fatal("expected deprovision call with --yes")
 	}
-	if mock.gotClusterID != "uc-123" {
-		t.Errorf("cluster id = %q, want uc-123", mock.gotClusterID)
+	if mock.gotClusterID != testClusterID {
+		t.Errorf("cluster id = %q, want %q", mock.gotClusterID, testClusterID)
 	}
 }
 
 func TestDigitaloceanNodeGroupDelete_DeclineDoesNotCallAPI(t *testing.T) {
 	mock := &digitaloceanNodeGroupDeleteMock{}
 	resetConfirmFlag(t, digitaloceanNodeGroupDeleteCmd)
-	_, err := runWithInput(t, mock, "n\n", "cluster", "digitalocean", "node-group", "delete", "uc-123", "workers")
+	_, err := runWithInput(t, mock, "n\n", "cluster", "digitalocean", "node-group", "delete", testClusterID, "workers")
 	if !errors.Is(err, errCancelled) {
 		t.Fatalf("expected errCancelled on decline, got %v", err)
 	}
@@ -131,14 +131,14 @@ func TestDigitaloceanNodeGroupDelete_DeclineDoesNotCallAPI(t *testing.T) {
 func TestDigitaloceanNodeGroupDelete_YesProceeds(t *testing.T) {
 	mock := &digitaloceanNodeGroupDeleteMock{}
 	resetConfirmFlag(t, digitaloceanNodeGroupDeleteCmd)
-	out, err := runWithInput(t, mock, "", "cluster", "digitalocean", "node-group", "delete", "uc-123", "workers", "--yes")
+	out, err := runWithInput(t, mock, "", "cluster", "digitalocean", "node-group", "delete", testClusterID, "workers", "--yes")
 	if err != nil {
 		t.Fatalf("execute failed: %v\noutput: %s", err, out)
 	}
 	if !mock.called {
 		t.Fatal("expected delete call with --yes")
 	}
-	if mock.gotClusterID != "uc-123" || mock.gotGroupName != "workers" {
-		t.Errorf("got cluster=%q group=%q, want uc-123/workers", mock.gotClusterID, mock.gotGroupName)
+	if mock.gotClusterID != testClusterID || mock.gotGroupName != "workers" {
+		t.Errorf("got cluster=%q group=%q, want %q/workers", mock.gotClusterID, mock.gotGroupName, testClusterID)
 	}
 }

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -2805,7 +2805,7 @@ func TestClusterListEmptyCommand(t *testing.T) {
 func TestClusterInfoCommand(t *testing.T) {
 	mock := &clusterGetMock{
 		cluster: client.ClusterListItem{
-			ID:          "test-cluster-id",
+			ID:          testClusterID,
 			Name:        "my-cluster",
 			Environment: "production",
 			KubeVersion: "1.28.0",
@@ -2832,7 +2832,7 @@ func TestClusterInfoCommand(t *testing.T) {
 func TestClusterInfoNetworkSectionCommand(t *testing.T) {
 	mock := &clusterGetMock{
 		cluster: client.ClusterListItem{
-			ID:          "test-cluster-id",
+			ID:          testClusterID,
 			Name:        "my-cluster",
 			Environment: "production",
 			KubeVersion: "1.28.0",
@@ -2874,7 +2874,7 @@ func TestClusterInfoNetworkSectionCommand(t *testing.T) {
 func TestClusterInfoWithoutNetworkOmitsSection(t *testing.T) {
 	mock := &clusterGetMock{
 		cluster: client.ClusterListItem{
-			ID:    "test-cluster-id",
+			ID:    testClusterID,
 			Name:  "my-cluster",
 			State: "online",
 		},
@@ -3021,7 +3021,7 @@ func writeSelectedClusterJSON(t *testing.T) {
 	if err := os.MkdirAll(ankraDir, 0755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	data, err := json.Marshal(client.ClusterListItem{ID: "test-cluster-id", Name: "test-cluster"})
+	data, err := json.Marshal(client.ClusterListItem{ID: testClusterID, Name: "test-cluster"})
 	if err != nil {
 		t.Fatalf("json: %v", err)
 	}
@@ -3906,7 +3906,7 @@ func TestClusterHetznerNodeGroupListCommand(t *testing.T) {
 	setMockClient(t, mock)
 
 	stdoutOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "hetzner", "node-group", "list", "test-cluster-id")
+		_, _ = executeCommand("cluster", "hetzner", "node-group", "list", testClusterID)
 	})
 
 	if !strings.Contains(stdoutOutput, "workers") {
@@ -3939,7 +3939,7 @@ func TestClusterOvhNodeGroupListCommand(t *testing.T) {
 	setMockClient(t, mock)
 
 	stdoutOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "ovh", "node-group", "list", "test-cluster-id")
+		_, _ = executeCommand("cluster", "ovh", "node-group", "list", testClusterID)
 	})
 
 	if !strings.Contains(stdoutOutput, "ovh-default") {
@@ -3972,7 +3972,7 @@ func TestClusterUpcloudNodeGroupListCommand(t *testing.T) {
 	setMockClient(t, mock)
 
 	stdoutOutput := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "upcloud", "node-group", "list", "test-cluster-id")
+		_, _ = executeCommand("cluster", "upcloud", "node-group", "list", testClusterID)
 	})
 
 	if !strings.Contains(stdoutOutput, "uc-workers") {

--- a/cmd/hetzner_cluster.go
+++ b/cmd/hetzner_cluster.go
@@ -104,19 +104,22 @@ var hetznerCreateCmd = &cobra.Command{
 }
 
 var hetznerDeprovisionCmd = &cobra.Command{
-	Use:   "deprovision <cluster_id>",
+	Use:   "deprovision <cluster_id|name>",
 	Short: "Initiate deprovision of a Hetzner cluster",
 	Long: "Initiate asynchronous deprovision of a Hetzner cluster. The platform schedules teardown " +
 		"jobs that delete cloud resources (servers, networks, SSH keys). Cloud resources are not " +
 		"deleted by the time this command returns; track progress via operations or the UI.",
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		force, _ := cmd.Flags().GetBool("force")
 		yes, _ := cmd.Flags().GetBool("yes")
 
 		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
-			fmt.Sprintf("Deprovision Hetzner cluster %q? This deletes all its servers, networks and SSH keys! [y/N]: ", clusterID),
+			fmt.Sprintf("Deprovision Hetzner cluster %s? This deletes all its servers, networks and SSH keys! [y/N]: ", clusterTarget(args[0], clusterID)),
 			yes); err != nil {
 			return err
 		}
@@ -148,11 +151,14 @@ var hetznerDeprovisionCmd = &cobra.Command{
 }
 
 var hetznerWorkersCmd = &cobra.Command{
-	Use:   "workers <cluster_id>",
+	Use:   "workers <cluster_id|name>",
 	Short: "Get current worker count for a Hetzner cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 
 		result, err := apiClient.GetHetznerWorkerCount(clusterID)
 		if err != nil {
@@ -173,12 +179,15 @@ var hetznerWorkersCmd = &cobra.Command{
 }
 
 var hetznerScaleCmd = &cobra.Command{
-	Use:   "scale <cluster_id> <worker_count>",
+	Use:   "scale <cluster_id|name> <worker_count>",
 	Short: "Scale workers for a Hetzner cluster",
 	Long:  "Scale the number of worker nodes up or down for a Hetzner cluster.",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		workerCount, err := strconv.Atoi(args[1])
 		if err != nil {
 			return fmt.Errorf("invalid worker count: %w", err)
@@ -209,11 +218,14 @@ var hetznerScaleCmd = &cobra.Command{
 }
 
 var hetznerK8sVersionCmd = &cobra.Command{
-	Use:   "k8s-version <cluster_id>",
+	Use:   "k8s-version <cluster_id|name>",
 	Short: "Get current Kubernetes version for a Hetzner cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 
 		result, err := apiClient.GetHetznerK8sVersion(clusterID)
 		if err != nil {
@@ -237,12 +249,15 @@ var hetznerK8sVersionCmd = &cobra.Command{
 }
 
 var hetznerStopCmd = &cobra.Command{
-	Use:   "stop <cluster_id>",
+	Use:   "stop <cluster_id|name>",
 	Short: "Stop a Hetzner cluster",
 	Long:  "Stop a Hetzner cluster's compute while keeping its configuration so it can be started again later.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		force, _ := cmd.Flags().GetBool("force")
 
 		result, stopError := apiClient.StopHetznerCluster(clusterID, force)
@@ -270,12 +285,15 @@ var hetznerStopCmd = &cobra.Command{
 }
 
 var hetznerStartCmd = &cobra.Command{
-	Use:   "start <cluster_id>",
+	Use:   "start <cluster_id|name>",
 	Short: "Start a stopped Hetzner cluster",
 	Long:  "Start (re-provision) a stopped Hetzner cluster. Use --scope control_plane to bring up only the control plane.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		scope, _ := cmd.Flags().GetString("scope")
 		if scope != "all" && scope != "control_plane" {
 			return fmt.Errorf("invalid --scope %q: must be 'all' or 'control_plane'", scope)
@@ -303,13 +321,16 @@ var hetznerStartCmd = &cobra.Command{
 }
 
 var hetznerUpgradeCmd = &cobra.Command{
-	Use:        "upgrade <cluster_id> <target_version>",
+	Use:        "upgrade <cluster_id|name> <target_version>",
 	Short:      "Upgrade Kubernetes version for a Hetzner cluster",
 	Long:       "Upgrade the Kubernetes version on all nodes in a Hetzner cluster. This deprecated form always runs the safe non-forced rollout; use `ankra cluster upgrade` for --force (PodDisruptionBudget override) and operation progress tracking.",
 	Deprecated: "use `ankra cluster upgrade <cluster_id> <target_version>` instead; the cloud provider is detected automatically.",
 	Args:       cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		targetVersion := args[1]
 
 		result, err := apiClient.UpgradeHetznerK8sVersion(clusterID, targetVersion, false)
@@ -342,11 +363,14 @@ var nodeGroupCmd = &cobra.Command{
 }
 
 var nodeGroupListCmd = &cobra.Command{
-	Use:   "list <cluster_id>",
+	Use:   "list <cluster_id|name>",
 	Short: "List node groups",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		result, err := apiClient.ListHetznerNodeGroups(clusterID)
 		if err != nil {
 			return fmt.Errorf("listing node groups: %w", err)
@@ -369,11 +393,14 @@ var nodeGroupListCmd = &cobra.Command{
 }
 
 var nodeGroupAddCmd = &cobra.Command{
-	Use:   "add <cluster_id>",
+	Use:   "add <cluster_id|name>",
 	Short: "Add a node group",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		name, _ := cmd.Flags().GetString("name")
 		instanceType, _ := cmd.Flags().GetString("instance-type")
 		count, _ := cmd.Flags().GetInt("count")
@@ -414,11 +441,14 @@ var nodeGroupAddCmd = &cobra.Command{
 }
 
 var nodeGroupScaleCmd = &cobra.Command{
-	Use:   "scale <cluster_id> <group_name> <count>",
+	Use:   "scale <cluster_id|name> <group_name> <count>",
 	Short: "Scale a node group",
 	Args:  cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		count, err := strconv.Atoi(args[2])
 		if err != nil {
@@ -455,11 +485,14 @@ var nodeGroupScaleCmd = &cobra.Command{
 }
 
 var nodeGroupUpgradeCmd = &cobra.Command{
-	Use:   "upgrade <cluster_id> <group_name> <instance_type>",
+	Use:   "upgrade <cluster_id|name> <group_name> <instance_type>",
 	Short: "Upgrade instance type for a node group (cannot be reversed)",
 	Args:  cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		instanceType := args[2]
 
@@ -493,16 +526,19 @@ var nodeGroupUpgradeCmd = &cobra.Command{
 }
 
 var nodeGroupDeleteCmd = &cobra.Command{
-	Use:   "delete <cluster_id> <group_name>",
+	Use:   "delete <cluster_id|name> <group_name>",
 	Short: "Delete a node group and all its nodes",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		yes, _ := cmd.Flags().GetBool("yes")
 
 		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
-			fmt.Sprintf("Delete node group %q from cluster %q? This deletes all its nodes! [y/N]: ", groupName, clusterID),
+			fmt.Sprintf("Delete node group %q from cluster %s? This deletes all its nodes! [y/N]: ", groupName, clusterTarget(args[0], clusterID)),
 			yes); err != nil {
 			return err
 		}

--- a/cmd/hetzner_cluster_test.go
+++ b/cmd/hetzner_cluster_test.go
@@ -125,7 +125,7 @@ func runWithInput(t *testing.T, mock APIClient, input string, args ...string) (s
 func TestHetznerDeprovision_DeclineDoesNotCallAPI(t *testing.T) {
 	mock := &hetznerDeprovisionMock{}
 	resetConfirmFlag(t, hetznerDeprovisionCmd)
-	_, err := runWithInput(t, mock, "n\n", "cluster", "hetzner", "deprovision", "hz-123")
+	_, err := runWithInput(t, mock, "n\n", "cluster", "hetzner", "deprovision", testClusterID)
 	if !errors.Is(err, errCancelled) {
 		t.Fatalf("expected errCancelled on decline, got %v", err)
 	}
@@ -137,22 +137,22 @@ func TestHetznerDeprovision_DeclineDoesNotCallAPI(t *testing.T) {
 func TestHetznerDeprovision_YesProceeds(t *testing.T) {
 	mock := &hetznerDeprovisionMock{}
 	resetConfirmFlag(t, hetznerDeprovisionCmd)
-	out, err := runWithInput(t, mock, "", "cluster", "hetzner", "deprovision", "hz-123", "--yes")
+	out, err := runWithInput(t, mock, "", "cluster", "hetzner", "deprovision", testClusterID, "--yes")
 	if err != nil {
 		t.Fatalf("execute failed: %v\noutput: %s", err, out)
 	}
 	if !mock.called {
 		t.Fatal("expected deprovision call with --yes")
 	}
-	if mock.gotClusterID != "hz-123" {
-		t.Errorf("cluster id = %q, want hz-123", mock.gotClusterID)
+	if mock.gotClusterID != testClusterID {
+		t.Errorf("cluster id = %q, want %q", mock.gotClusterID, testClusterID)
 	}
 }
 
 func TestHetznerDeprovision_YesPreservesForce(t *testing.T) {
 	mock := &hetznerDeprovisionMock{}
 	resetConfirmFlag(t, hetznerDeprovisionCmd)
-	_, err := runWithInput(t, mock, "", "cluster", "hetzner", "deprovision", "hz-123", "--yes", "--force")
+	_, err := runWithInput(t, mock, "", "cluster", "hetzner", "deprovision", testClusterID, "--yes", "--force")
 	if err != nil {
 		t.Fatalf("execute failed: %v", err)
 	}
@@ -164,7 +164,7 @@ func TestHetznerDeprovision_YesPreservesForce(t *testing.T) {
 func TestHetznerNodeGroupDelete_DeclineDoesNotCallAPI(t *testing.T) {
 	mock := &hetznerNodeGroupDeleteMock{}
 	resetConfirmFlag(t, nodeGroupDeleteCmd)
-	_, err := runWithInput(t, mock, "n\n", "cluster", "hetzner", "node-group", "delete", "hz-123", "workers")
+	_, err := runWithInput(t, mock, "n\n", "cluster", "hetzner", "node-group", "delete", testClusterID, "workers")
 	if !errors.Is(err, errCancelled) {
 		t.Fatalf("expected errCancelled on decline, got %v", err)
 	}
@@ -176,14 +176,14 @@ func TestHetznerNodeGroupDelete_DeclineDoesNotCallAPI(t *testing.T) {
 func TestHetznerNodeGroupDelete_YesProceeds(t *testing.T) {
 	mock := &hetznerNodeGroupDeleteMock{}
 	resetConfirmFlag(t, nodeGroupDeleteCmd)
-	out, err := runWithInput(t, mock, "", "cluster", "hetzner", "node-group", "delete", "hz-123", "workers", "--yes")
+	out, err := runWithInput(t, mock, "", "cluster", "hetzner", "node-group", "delete", testClusterID, "workers", "--yes")
 	if err != nil {
 		t.Fatalf("execute failed: %v\noutput: %s", err, out)
 	}
 	if !mock.called {
 		t.Fatal("expected delete call with --yes")
 	}
-	if mock.gotClusterID != "hz-123" || mock.gotGroupName != "workers" {
-		t.Errorf("got cluster=%q group=%q, want hz-123/workers", mock.gotClusterID, mock.gotGroupName)
+	if mock.gotClusterID != testClusterID || mock.gotGroupName != "workers" {
+		t.Errorf("got cluster=%q group=%q, want %q/workers", mock.gotClusterID, mock.gotGroupName, testClusterID)
 	}
 }

--- a/cmd/morpheus_cluster.go
+++ b/cmd/morpheus_cluster.go
@@ -96,12 +96,15 @@ var morpheusCreateCmd = &cobra.Command{
 }
 
 var morpheusStopCmd = &cobra.Command{
-	Use:   "stop <cluster_id>",
+	Use:   "stop <cluster_id|name>",
 	Short: "Stop an HPE Morpheus cluster",
 	Long:  "Stop an HPE Morpheus cluster's instances while keeping its configuration so it can be started again later.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		force, _ := cmd.Flags().GetBool("force")
 
 		result, stopError := apiClient.StopMorpheusCluster(clusterID, force)
@@ -123,12 +126,15 @@ var morpheusStopCmd = &cobra.Command{
 }
 
 var morpheusStartCmd = &cobra.Command{
-	Use:   "start <cluster_id>",
+	Use:   "start <cluster_id|name>",
 	Short: "Start a stopped HPE Morpheus cluster",
 	Long:  "Start (re-provision) a stopped HPE Morpheus cluster. Use --scope control_plane to bring up only the control plane.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		scope, _ := cmd.Flags().GetString("scope")
 		if scope != "all" && scope != "control_plane" {
 			return fmt.Errorf("invalid --scope %q: must be 'all' or 'control_plane'", scope)
@@ -150,11 +156,14 @@ var morpheusStartCmd = &cobra.Command{
 }
 
 var morpheusWorkersCmd = &cobra.Command{
-	Use:   "workers <cluster_id>",
+	Use:   "workers <cluster_id|name>",
 	Short: "Get current worker count for an HPE Morpheus cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 
 		result, fetchError := apiClient.GetMorpheusWorkerCount(clusterID)
 		if fetchError != nil {
@@ -175,11 +184,14 @@ var morpheusWorkersCmd = &cobra.Command{
 }
 
 var morpheusK8sVersionCmd = &cobra.Command{
-	Use:   "k8s-version <cluster_id>",
+	Use:   "k8s-version <cluster_id|name>",
 	Short: "Get current Kubernetes version for an HPE Morpheus cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 
 		result, fetchError := apiClient.GetMorpheusK8sVersion(clusterID)
 		if fetchError != nil {

--- a/cmd/ovh_cluster.go
+++ b/cmd/ovh_cluster.go
@@ -106,11 +106,14 @@ var ovhCreateCmd = &cobra.Command{
 }
 
 var ovhDeprovisionCmd = &cobra.Command{
-	Use:   "deprovision <cluster_id>",
+	Use:   "deprovision <cluster_id|name>",
 	Short: "Deprovision an OVH cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		yes, _ := cmd.Flags().GetBool("yes")
 		force, _ := cmd.Flags().GetBool("force")
 
@@ -119,7 +122,7 @@ var ovhDeprovisionCmd = &cobra.Command{
 			warning = "This deletes all its servers, networks, SSH keys, Cinder volumes and load balancers!"
 		}
 		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
-			fmt.Sprintf("Deprovision OVH cluster %q? %s [y/N]: ", clusterID, warning),
+			fmt.Sprintf("Deprovision OVH cluster %s? %s [y/N]: ", clusterTarget(args[0], clusterID), warning),
 			yes); err != nil {
 			return err
 		}
@@ -150,11 +153,14 @@ var ovhDeprovisionCmd = &cobra.Command{
 }
 
 var ovhWorkersCmd = &cobra.Command{
-	Use:   "workers <cluster_id>",
+	Use:   "workers <cluster_id|name>",
 	Short: "Get current worker count for an OVH cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 
 		result, err := apiClient.GetOvhWorkerCount(clusterID)
 		if err != nil {
@@ -175,12 +181,15 @@ var ovhWorkersCmd = &cobra.Command{
 }
 
 var ovhScaleCmd = &cobra.Command{
-	Use:   "scale <cluster_id> <worker_count>",
+	Use:   "scale <cluster_id|name> <worker_count>",
 	Short: "Scale workers for an OVH cluster",
 	Long:  "Scale the number of worker nodes up or down for an OVH cluster.",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		workerCount, err := strconv.Atoi(args[1])
 		if err != nil {
 			return fmt.Errorf("invalid worker count: %w", err)
@@ -211,11 +220,14 @@ var ovhScaleCmd = &cobra.Command{
 }
 
 var ovhK8sVersionCmd = &cobra.Command{
-	Use:   "k8s-version <cluster_id>",
+	Use:   "k8s-version <cluster_id|name>",
 	Short: "Get current Kubernetes version for an OVH cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 
 		result, err := apiClient.GetOvhK8sVersion(clusterID)
 		if err != nil {
@@ -239,13 +251,16 @@ var ovhK8sVersionCmd = &cobra.Command{
 }
 
 var ovhUpgradeCmd = &cobra.Command{
-	Use:        "upgrade <cluster_id> <target_version>",
+	Use:        "upgrade <cluster_id|name> <target_version>",
 	Short:      "Upgrade Kubernetes version for an OVH cluster",
 	Long:       "Upgrade the Kubernetes version on all nodes in an OVH cluster. This deprecated form always runs the safe non-forced rollout; use `ankra cluster upgrade` for --force (PodDisruptionBudget override) and operation progress tracking.",
 	Deprecated: "use `ankra cluster upgrade <cluster_id> <target_version>` instead; the cloud provider is detected automatically.",
 	Args:       cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		targetVersion := args[1]
 
 		result, err := apiClient.UpgradeOvhK8sVersion(clusterID, targetVersion, false)
@@ -318,12 +333,15 @@ var ovhRegionsCmd = &cobra.Command{
 }
 
 var ovhStopCmd = &cobra.Command{
-	Use:   "stop <cluster_id>",
+	Use:   "stop <cluster_id|name>",
 	Short: "Stop an OVH cluster",
 	Long:  "Stop an OVH cluster's compute while keeping its configuration so it can be started again later.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		force, _ := cmd.Flags().GetBool("force")
 
 		result, err := apiClient.StopOvhCluster(clusterID, force)
@@ -351,12 +369,15 @@ var ovhStopCmd = &cobra.Command{
 }
 
 var ovhStartCmd = &cobra.Command{
-	Use:   "start <cluster_id>",
+	Use:   "start <cluster_id|name>",
 	Short: "Start a stopped OVH cluster",
 	Long:  "Start (re-provision) a stopped OVH cluster. Use --scope control_plane to bring up only the control plane.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		scope, _ := cmd.Flags().GetString("scope")
 		if scope != "all" && scope != "control_plane" {
 			return fmt.Errorf("invalid --scope %q: must be 'all' or 'control_plane'", scope)
@@ -384,12 +405,15 @@ var ovhStartCmd = &cobra.Command{
 }
 
 var ovhAccessInfoCmd = &cobra.Command{
-	Use:   "access-info <cluster_id>",
+	Use:   "access-info <cluster_id|name>",
 	Short: "Show SSH access details for an OVH cluster",
 	Long:  "Show the gateway (bastion) and control plane IPs plus ready-to-use SSH jump and Kubernetes API port-forward commands.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 
 		result, err := apiClient.GetOvhAccessInfo(clusterID)
 		if err != nil {
@@ -443,11 +467,14 @@ var ovhSSHKeysCmd = &cobra.Command{
 }
 
 var ovhSSHKeysGetCmd = &cobra.Command{
-	Use:   "get <cluster_id>",
+	Use:   "get <cluster_id|name>",
 	Short: "Show SSH keys attached to an OVH cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 
 		result, err := apiClient.GetOvhClusterSSHKeys(clusterID)
 		if err != nil {
@@ -480,12 +507,15 @@ var ovhSSHKeysGetCmd = &cobra.Command{
 }
 
 var ovhSSHKeysSetCmd = &cobra.Command{
-	Use:   "set <cluster_id>",
+	Use:   "set <cluster_id|name>",
 	Short: "Set the SSH keys attached to an OVH cluster",
 	Long:  "Replace the SSH key credentials attached to an OVH cluster. Changes take effect on the next reconciliation.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		sshKeyCredentialIDs, _ := cmd.Flags().GetStringSlice("ssh-key-credential-ids")
 		if len(sshKeyCredentialIDs) == 0 {
 			return errors.New("at least one --ssh-key-credential-ids value is required")
@@ -518,12 +548,15 @@ var ovhNodeGroupCmd = &cobra.Command{
 }
 
 var ovhNodeGroupLabelsCmd = &cobra.Command{
-	Use:   "labels <cluster_id> <group_name>",
+	Use:   "labels <cluster_id|name> <group_name>",
 	Short: "Set labels on all nodes in a node group",
 	Long:  "Replace the labels on every node in the group. Pass --labels as a comma-separated list of key=value pairs, or --clear to remove all labels.",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		clear, _ := cmd.Flags().GetBool("clear")
 		labelsChanged := cmd.Flags().Changed("labels")
@@ -571,12 +604,15 @@ var ovhNodeGroupLabelsCmd = &cobra.Command{
 }
 
 var ovhNodeGroupTaintsCmd = &cobra.Command{
-	Use:   "taints <cluster_id> <group_name>",
+	Use:   "taints <cluster_id|name> <group_name>",
 	Short: "Set taints on all nodes in a node group",
 	Long:  "Replace the taints on every node in the group. Pass --taints as a comma-separated list of key=value:Effect (value optional, effect defaults to NoSchedule), or --clear to remove all taints.",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		clear, _ := cmd.Flags().GetBool("clear")
 		taintsChanged := cmd.Flags().Changed("taints")
@@ -624,11 +660,14 @@ var ovhNodeGroupTaintsCmd = &cobra.Command{
 }
 
 var ovhNodeGroupListCmd = &cobra.Command{
-	Use:   "list <cluster_id>",
+	Use:   "list <cluster_id|name>",
 	Short: "List node groups",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		result, err := apiClient.ListOvhNodeGroups(clusterID)
 		if err != nil {
 			return fmt.Errorf("listing node groups: %w", err)
@@ -652,11 +691,14 @@ var ovhNodeGroupListCmd = &cobra.Command{
 }
 
 var ovhNodeGroupAddCmd = &cobra.Command{
-	Use:   "add <cluster_id>",
+	Use:   "add <cluster_id|name>",
 	Short: "Add a node group",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		name, _ := cmd.Flags().GetString("name")
 		instanceType, _ := cmd.Flags().GetString("instance-type")
 		count, _ := cmd.Flags().GetInt("count")
@@ -712,11 +754,14 @@ var ovhNodeGroupAddCmd = &cobra.Command{
 }
 
 var ovhNodeGroupScaleCmd = &cobra.Command{
-	Use:   "scale <cluster_id> <group_name> <count>",
+	Use:   "scale <cluster_id|name> <group_name> <count>",
 	Short: "Scale a node group",
 	Args:  cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		count, err := strconv.Atoi(args[2])
 		if err != nil {
@@ -753,11 +798,14 @@ var ovhNodeGroupScaleCmd = &cobra.Command{
 }
 
 var ovhNodeGroupUpgradeCmd = &cobra.Command{
-	Use:   "upgrade <cluster_id> <group_name> <instance_type>",
+	Use:   "upgrade <cluster_id|name> <group_name> <instance_type>",
 	Short: "Upgrade instance type for a node group (cannot be reversed)",
 	Args:  cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		instanceType := args[2]
 
@@ -791,11 +839,14 @@ var ovhNodeGroupUpgradeCmd = &cobra.Command{
 }
 
 var ovhNodeGroupDeleteCmd = &cobra.Command{
-	Use:   "delete <cluster_id> <group_name>",
+	Use:   "delete <cluster_id|name> <group_name>",
 	Short: "Delete a node group and all its nodes",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		yes, _ := cmd.Flags().GetBool("yes")
 

--- a/cmd/ovh_cluster_test.go
+++ b/cmd/ovh_cluster_test.go
@@ -27,16 +27,16 @@ func TestOvhStopCommand(t *testing.T) {
 	setMockClient(t, mock)
 
 	output := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "ovh", "stop", "ovh-123")
+		_, _ = executeCommand("cluster", "ovh", "stop", testClusterID)
 	})
 
-	if mock.gotClusterID != "ovh-123" {
-		t.Errorf("cluster id = %q, want ovh-123", mock.gotClusterID)
+	if mock.gotClusterID != testClusterID {
+		t.Errorf("cluster id = %q, want %q", mock.gotClusterID, testClusterID)
 	}
 	if !strings.Contains(output, "stop initiated") {
 		t.Errorf("expected 'stop initiated', got: %s", output)
 	}
-	if !strings.Contains(output, "ovh-123") {
+	if !strings.Contains(output, testClusterID) {
 		t.Errorf("expected cluster id in output, got: %s", output)
 	}
 }
@@ -58,7 +58,7 @@ func TestOvhStartCommandWithScope(t *testing.T) {
 	setMockClient(t, mock)
 
 	output := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "ovh", "start", "ovh-123", "--scope", "control_plane")
+		_, _ = executeCommand("cluster", "ovh", "start", testClusterID, "--scope", "control_plane")
 	})
 
 	if mock.gotScope != "control_plane" {
@@ -92,7 +92,7 @@ func TestOvhAccessInfoCommand(t *testing.T) {
 	setMockClient(t, &ovhAccessInfoMock{})
 
 	output := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "ovh", "access-info", "ovh-123")
+		_, _ = executeCommand("cluster", "ovh", "access-info", testClusterID)
 	})
 
 	if !strings.Contains(output, "203.0.113.10") {
@@ -127,7 +127,7 @@ func TestOvhSSHKeysGetCommand(t *testing.T) {
 	setMockClient(t, &ovhSSHKeysMock{})
 
 	output := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "ovh", "ssh-keys", "get", "ovh-123")
+		_, _ = executeCommand("cluster", "ovh", "ssh-keys", "get", testClusterID)
 	})
 
 	if !strings.Contains(output, "ssh-1") {
@@ -143,7 +143,7 @@ func TestOvhSSHKeysSetCommand(t *testing.T) {
 	setMockClient(t, mock)
 
 	output := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "ovh", "ssh-keys", "set", "ovh-123", "--ssh-key-credential-ids", "ssh-1,ssh-2")
+		_, _ = executeCommand("cluster", "ovh", "ssh-keys", "set", testClusterID, "--ssh-key-credential-ids", "ssh-1,ssh-2")
 	})
 
 	if len(mock.gotSetIDs) != 2 || mock.gotSetIDs[0] != "ssh-1" || mock.gotSetIDs[1] != "ssh-2" {
@@ -170,7 +170,7 @@ func TestOvhNodeGroupAddWithLabelsAndTaints(t *testing.T) {
 
 	output := captureStdout(t, func() {
 		_, _ = executeCommand(
-			"cluster", "ovh", "node-group", "add", "ovh-123",
+			"cluster", "ovh", "node-group", "add", testClusterID,
 			"--name", "gpu", "--instance-type", "b2-30", "--count", "2",
 			"--labels", "tier=gold,team=ml",
 			"--taints", "dedicated=gpu:NoSchedule",
@@ -252,7 +252,7 @@ func TestOvhNodeGroupLabels_BareInvocationIsUsageError(t *testing.T) {
 	mock := &ovhNodeGroupLabelsMock{}
 	setMockClient(t, mock)
 
-	_, err := executeCommand("cluster", "ovh", "node-group", "labels", "ovh-123", "gpu")
+	_, err := executeCommand("cluster", "ovh", "node-group", "labels", testClusterID, "gpu")
 	if err == nil {
 		t.Fatal("expected usage error when neither --labels nor --clear is given")
 	}
@@ -269,7 +269,7 @@ func TestOvhNodeGroupLabels_ClearAndLabelsTogetherIsUsageError(t *testing.T) {
 	mock := &ovhNodeGroupLabelsMock{}
 	setMockClient(t, mock)
 
-	_, err := executeCommand("cluster", "ovh", "node-group", "labels", "ovh-123", "gpu", "--labels", "a=b", "--clear")
+	_, err := executeCommand("cluster", "ovh", "node-group", "labels", testClusterID, "gpu", "--labels", "a=b", "--clear")
 	if err == nil {
 		t.Fatal("expected usage error when both --labels and --clear are given")
 	}
@@ -286,7 +286,7 @@ func TestOvhNodeGroupLabels_ClearSendsEmptyMap(t *testing.T) {
 	mock := &ovhNodeGroupLabelsMock{}
 	setMockClient(t, mock)
 
-	_, _ = executeCommand("cluster", "ovh", "node-group", "labels", "ovh-123", "gpu", "--clear")
+	_, _ = executeCommand("cluster", "ovh", "node-group", "labels", testClusterID, "gpu", "--clear")
 
 	if !mock.called {
 		t.Fatal("expected API to be called with --clear")
@@ -301,7 +301,7 @@ func TestOvhNodeGroupLabels_SetLabels(t *testing.T) {
 	mock := &ovhNodeGroupLabelsMock{}
 	setMockClient(t, mock)
 
-	_, _ = executeCommand("cluster", "ovh", "node-group", "labels", "ovh-123", "gpu", "--labels", "tier=gold")
+	_, _ = executeCommand("cluster", "ovh", "node-group", "labels", testClusterID, "gpu", "--labels", "tier=gold")
 
 	if !mock.called {
 		t.Fatal("expected API to be called with --labels")
@@ -328,7 +328,7 @@ func TestOvhNodeGroupTaints_BareInvocationIsUsageError(t *testing.T) {
 	mock := &ovhNodeGroupTaintsMock{}
 	setMockClient(t, mock)
 
-	_, err := executeCommand("cluster", "ovh", "node-group", "taints", "ovh-123", "gpu")
+	_, err := executeCommand("cluster", "ovh", "node-group", "taints", testClusterID, "gpu")
 	if err == nil {
 		t.Fatal("expected usage error when neither --taints nor --clear is given")
 	}
@@ -345,7 +345,7 @@ func TestOvhNodeGroupTaints_ClearAndTaintsTogetherIsUsageError(t *testing.T) {
 	mock := &ovhNodeGroupTaintsMock{}
 	setMockClient(t, mock)
 
-	_, err := executeCommand("cluster", "ovh", "node-group", "taints", "ovh-123", "gpu", "--taints", "a=b:NoSchedule", "--clear")
+	_, err := executeCommand("cluster", "ovh", "node-group", "taints", testClusterID, "gpu", "--taints", "a=b:NoSchedule", "--clear")
 	if err == nil {
 		t.Fatal("expected usage error when both --taints and --clear are given")
 	}
@@ -362,7 +362,7 @@ func TestOvhNodeGroupTaints_ClearSendsEmptySlice(t *testing.T) {
 	mock := &ovhNodeGroupTaintsMock{}
 	setMockClient(t, mock)
 
-	_, _ = executeCommand("cluster", "ovh", "node-group", "taints", "ovh-123", "gpu", "--clear")
+	_, _ = executeCommand("cluster", "ovh", "node-group", "taints", testClusterID, "gpu", "--clear")
 
 	if !mock.called {
 		t.Fatal("expected API to be called with --clear")
@@ -377,7 +377,7 @@ func TestOvhNodeGroupTaints_SetTaints(t *testing.T) {
 	mock := &ovhNodeGroupTaintsMock{}
 	setMockClient(t, mock)
 
-	_, _ = executeCommand("cluster", "ovh", "node-group", "taints", "ovh-123", "gpu", "--taints", "dedicated=gpu:NoSchedule")
+	_, _ = executeCommand("cluster", "ovh", "node-group", "taints", testClusterID, "gpu", "--taints", "dedicated=gpu:NoSchedule")
 
 	if !mock.called {
 		t.Fatal("expected API to be called with --taints")
@@ -403,7 +403,7 @@ func TestOvhDeprovision_DeclinedPromptCancels(t *testing.T) {
 	setMockClient(t, mock)
 	setStdin(t, "n\n")
 
-	_, err := executeCommand("cluster", "ovh", "deprovision", "ovh-123")
+	_, err := executeCommand("cluster", "ovh", "deprovision", testClusterID)
 	if !errors.Is(err, errCancelled) {
 		t.Fatalf("expected errCancelled, got %v", err)
 	}
@@ -418,7 +418,7 @@ func TestOvhDeprovision_YesSkipsPrompt(t *testing.T) {
 	setMockClient(t, mock)
 	setStdin(t, "") // empty input would block/decline if prompted
 
-	_, err := executeCommand("cluster", "ovh", "deprovision", "ovh-123", "--yes")
+	_, err := executeCommand("cluster", "ovh", "deprovision", testClusterID, "--yes")
 	if err != nil {
 		t.Fatalf("expected success with --yes, got %v", err)
 	}
@@ -443,7 +443,7 @@ func TestOvhNodeGroupDelete_DeclinedPromptCancels(t *testing.T) {
 	setMockClient(t, mock)
 	setStdin(t, "n\n")
 
-	_, err := executeCommand("cluster", "ovh", "node-group", "delete", "ovh-123", "gpu")
+	_, err := executeCommand("cluster", "ovh", "node-group", "delete", testClusterID, "gpu")
 	if !errors.Is(err, errCancelled) {
 		t.Fatalf("expected errCancelled, got %v", err)
 	}
@@ -458,7 +458,7 @@ func TestOvhNodeGroupDelete_YesSkipsPrompt(t *testing.T) {
 	setMockClient(t, mock)
 	setStdin(t, "")
 
-	_, err := executeCommand("cluster", "ovh", "node-group", "delete", "ovh-123", "gpu", "--yes")
+	_, err := executeCommand("cluster", "ovh", "node-group", "delete", testClusterID, "gpu", "--yes")
 	if err != nil {
 		t.Fatalf("expected success with --yes, got %v", err)
 	}
@@ -474,7 +474,7 @@ type ovhCreateZonesMock struct {
 
 func (m *ovhCreateZonesMock) CreateOvhCluster(req client.CreateOvhClusterRequest) (*client.CreateOvhClusterResponse, error) {
 	m.gotRequest = req
-	return &client.CreateOvhClusterResponse{ClusterID: "ovh-123", Name: req.Name}, nil
+	return &client.CreateOvhClusterResponse{ClusterID: testClusterID, Name: req.Name}, nil
 }
 
 // Without the flag reaching the request the cluster is created single-zone and
@@ -584,7 +584,7 @@ func TestOvhNodeGroupAddSendsTheAvailabilityZone(t *testing.T) {
 	mock := &ovhNodeGroupZoneMock{}
 	setMockClient(t, mock)
 
-	_, err := executeCommand("cluster", "ovh", "node-group", "add", "ovh-123",
+	_, err := executeCommand("cluster", "ovh", "node-group", "add", testClusterID,
 		"--name", "database", "--instance-type", "r3-128", "--count", "1",
 		"--availability-zone", "eu-west-par-c")
 	if err != nil {

--- a/cmd/proxmox_cluster.go
+++ b/cmd/proxmox_cluster.go
@@ -120,12 +120,15 @@ var proxmoxCreateCmd = &cobra.Command{
 }
 
 var proxmoxStopCmd = &cobra.Command{
-	Use:   "stop <cluster_id>",
+	Use:   "stop <cluster_id|name>",
 	Short: "Stop a Proxmox VE cluster",
 	Long:  "Stop a Proxmox VE cluster's virtual machines while keeping its configuration so it can be started again later.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		force, _ := cmd.Flags().GetBool("force")
 
 		result, stopError := apiClient.StopProxmoxCluster(clusterID, force)
@@ -147,12 +150,15 @@ var proxmoxStopCmd = &cobra.Command{
 }
 
 var proxmoxStartCmd = &cobra.Command{
-	Use:   "start <cluster_id>",
+	Use:   "start <cluster_id|name>",
 	Short: "Start a stopped Proxmox VE cluster",
 	Long:  "Start (re-provision) a stopped Proxmox VE cluster. Use --scope control_plane to bring up only the control plane.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		scope, _ := cmd.Flags().GetString("scope")
 		if scope != "all" && scope != "control_plane" {
 			return fmt.Errorf("invalid --scope %q: must be 'all' or 'control_plane'", scope)
@@ -174,11 +180,14 @@ var proxmoxStartCmd = &cobra.Command{
 }
 
 var proxmoxWorkersCmd = &cobra.Command{
-	Use:   "workers <cluster_id>",
+	Use:   "workers <cluster_id|name>",
 	Short: "Get current worker count for a Proxmox VE cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 
 		result, fetchError := apiClient.GetProxmoxWorkerCount(clusterID)
 		if fetchError != nil {
@@ -199,11 +208,14 @@ var proxmoxWorkersCmd = &cobra.Command{
 }
 
 var proxmoxK8sVersionCmd = &cobra.Command{
-	Use:   "k8s-version <cluster_id>",
+	Use:   "k8s-version <cluster_id|name>",
 	Short: "Get current Kubernetes version for a Proxmox VE cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 
 		result, fetchError := apiClient.GetProxmoxK8sVersion(clusterID)
 		if fetchError != nil {

--- a/cmd/scaleway_cluster.go
+++ b/cmd/scaleway_cluster.go
@@ -19,12 +19,15 @@ var scalewayCmd = &cobra.Command{
 }
 
 var scalewayStopCmd = &cobra.Command{
-	Use:   "stop <cluster_id>",
+	Use:   "stop <cluster_id|name>",
 	Short: "Stop a Scaleway cluster",
 	Long:  "Stop a Scaleway cluster by terminating its compute while preserving its configuration so it can be re-provisioned later.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, arguments []string) error {
-		clusterID := arguments[0]
+		clusterID, resolveError := resolveClusterArg(arguments[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		force, _ := cmd.Flags().GetBool("force")
 		result, stopError := apiClient.StopScalewayCluster(clusterID, force)
 		if stopError != nil {
@@ -45,12 +48,15 @@ var scalewayStopCmd = &cobra.Command{
 }
 
 var scalewayStartCmd = &cobra.Command{
-	Use:   "start <cluster_id>",
+	Use:   "start <cluster_id|name>",
 	Short: "Start a stopped Scaleway cluster",
 	Long:  "Re-provision a stopped Scaleway cluster. Use --scope control_plane to bring up only the control plane.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(command *cobra.Command, arguments []string) error {
-		clusterID := arguments[0]
+		clusterID, resolveError := resolveClusterArg(arguments[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		scope, scopeError := command.Flags().GetString("scope")
 		if scopeError != nil {
 			return fmt.Errorf("reading scope: %w", scopeError)
@@ -251,14 +257,18 @@ Takes the same flags as 'create'.`,
 }
 
 var scalewayDeprovisionCmd = &cobra.Command{
-	Use:   "deprovision <cluster_id>",
+	Use:   "deprovision <cluster_id|name>",
 	Short: "Deprovision a Scaleway cluster and release its cloud resources",
 	Long: `Permanently delete a Scaleway cluster and the provider resources Ankra
 created for it. Volumes and load balancers follow the cluster's
 retention_policy: 'retain' keeps them, 'delete' sweeps the tagged orphans.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		result, deprovisionError := apiClient.DeprovisionScalewayCluster(args[0])
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
+		result, deprovisionError := apiClient.DeprovisionScalewayCluster(clusterID)
 		if deprovisionError != nil {
 			return fmt.Errorf("deprovisioning Scaleway cluster: %w", deprovisionError)
 		}
@@ -279,11 +289,15 @@ retention_policy: 'retain' keeps them, 'delete' sweeps the tagged orphans.`,
 }
 
 var scalewayWorkersCmd = &cobra.Command{
-	Use:   "workers <cluster_id>",
+	Use:   "workers <cluster_id|name>",
 	Short: "Get current worker count for a Scaleway cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		result, fetchError := apiClient.GetScalewayWorkerCount(args[0])
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
+		result, fetchError := apiClient.GetScalewayWorkerCount(clusterID)
 		if fetchError != nil {
 			return fmt.Errorf("fetching worker count: %w", fetchError)
 		}
@@ -302,11 +316,15 @@ var scalewayWorkersCmd = &cobra.Command{
 }
 
 var scalewayK8sVersionCmd = &cobra.Command{
-	Use:   "k8s-version <cluster_id>",
+	Use:   "k8s-version <cluster_id|name>",
 	Short: "Get current Kubernetes version for a Scaleway cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		result, fetchError := apiClient.GetScalewayK8sVersion(args[0])
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
+		result, fetchError := apiClient.GetScalewayK8sVersion(clusterID)
 		if fetchError != nil {
 			return fmt.Errorf("fetching Kubernetes version: %w", fetchError)
 		}

--- a/cmd/scaleway_cluster_test.go
+++ b/cmd/scaleway_cluster_test.go
@@ -30,11 +30,11 @@ func TestScalewayStopCommand(t *testing.T) {
 	setMockClient(t, mock)
 
 	output := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "scaleway", "stop", "cluster-123")
+		_, _ = executeCommand("cluster", "scaleway", "stop", testClusterID)
 	})
 
-	if mock.stopClusterID != "cluster-123" {
-		t.Fatalf("cluster id = %q, want cluster-123", mock.stopClusterID)
+	if mock.stopClusterID != testClusterID {
+		t.Fatalf("cluster id = %q, want %q", mock.stopClusterID, testClusterID)
 	}
 	if !strings.Contains(output, "Scaleway cluster stop initiated") {
 		t.Fatalf("unexpected output: %s", output)
@@ -46,11 +46,11 @@ func TestScalewayStartCommandWithScope(t *testing.T) {
 	setMockClient(t, mock)
 
 	output := captureStdout(t, func() {
-		_, _ = executeCommand("cluster", "scaleway", "start", "cluster-123", "--scope", "control_plane")
+		_, _ = executeCommand("cluster", "scaleway", "start", testClusterID, "--scope", "control_plane")
 	})
 
-	if mock.startClusterID != "cluster-123" {
-		t.Fatalf("cluster id = %q, want cluster-123", mock.startClusterID)
+	if mock.startClusterID != testClusterID {
+		t.Fatalf("cluster id = %q, want %q", mock.startClusterID, testClusterID)
 	}
 	if mock.startScope != "control_plane" {
 		t.Fatalf("scope = %q, want control_plane", mock.startScope)

--- a/cmd/upcloud_cluster.go
+++ b/cmd/upcloud_cluster.go
@@ -103,11 +103,14 @@ var upcloudCreateCmd = &cobra.Command{
 }
 
 var upcloudDeprovisionCmd = &cobra.Command{
-	Use:   "deprovision <cluster_id>",
+	Use:   "deprovision <cluster_id|name>",
 	Short: "Deprovision an UpCloud cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		yes, _ := cmd.Flags().GetBool("yes")
 		force, _ := cmd.Flags().GetBool("force")
 
@@ -116,7 +119,7 @@ var upcloudDeprovisionCmd = &cobra.Command{
 			warning = "This deletes all its servers, networks, SSH keys, CSI storage volumes and load balancers!"
 		}
 		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
-			fmt.Sprintf("Deprovision UpCloud cluster %q? %s [y/N]: ", clusterID, warning),
+			fmt.Sprintf("Deprovision UpCloud cluster %s? %s [y/N]: ", clusterTarget(args[0], clusterID), warning),
 			yes); err != nil {
 			return err
 		}
@@ -147,14 +150,17 @@ var upcloudDeprovisionCmd = &cobra.Command{
 }
 
 var upcloudStopCmd = &cobra.Command{
-	Use:   "stop <cluster_id>",
+	Use:   "stop <cluster_id|name>",
 	Short: "Stop an UpCloud cluster",
 	Long: "Stop an UpCloud cluster's compute while keeping its configuration so it can be started again later.\n\n" +
 		"--force also deletes the cluster's CSI storage volumes and load balancers, which otherwise keep billing " +
 		"while the cluster is stopped - the persisted data is lost.",
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		force, _ := cmd.Flags().GetBool("force")
 
 		result, err := apiClient.StopUpcloudCluster(clusterID, force)
@@ -176,12 +182,15 @@ var upcloudStopCmd = &cobra.Command{
 }
 
 var upcloudStartCmd = &cobra.Command{
-	Use:   "start <cluster_id>",
+	Use:   "start <cluster_id|name>",
 	Short: "Start a stopped UpCloud cluster",
 	Long:  "Start (re-provision) a stopped UpCloud cluster. Use --scope control_plane to bring up only the control plane.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		scope, _ := cmd.Flags().GetString("scope")
 		if scope != "all" && scope != "control_plane" {
 			return fmt.Errorf("invalid --scope %q: must be 'all' or 'control_plane'", scope)
@@ -203,11 +212,14 @@ var upcloudStartCmd = &cobra.Command{
 }
 
 var upcloudWorkersCmd = &cobra.Command{
-	Use:   "workers <cluster_id>",
+	Use:   "workers <cluster_id|name>",
 	Short: "Get current worker count for an UpCloud cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 
 		result, err := apiClient.GetUpcloudWorkerCount(clusterID)
 		if err != nil {
@@ -228,12 +240,15 @@ var upcloudWorkersCmd = &cobra.Command{
 }
 
 var upcloudScaleCmd = &cobra.Command{
-	Use:   "scale <cluster_id> <worker_count>",
+	Use:   "scale <cluster_id|name> <worker_count>",
 	Short: "Scale workers for an UpCloud cluster",
 	Long:  "Scale the number of worker nodes up or down for an UpCloud cluster.",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		workerCount, err := strconv.Atoi(args[1])
 		if err != nil {
 			return fmt.Errorf("invalid worker count: %w", err)
@@ -264,11 +279,14 @@ var upcloudScaleCmd = &cobra.Command{
 }
 
 var upcloudK8sVersionCmd = &cobra.Command{
-	Use:   "k8s-version <cluster_id>",
+	Use:   "k8s-version <cluster_id|name>",
 	Short: "Get current Kubernetes version for an UpCloud cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 
 		result, err := apiClient.GetUpcloudK8sVersion(clusterID)
 		if err != nil {
@@ -292,13 +310,16 @@ var upcloudK8sVersionCmd = &cobra.Command{
 }
 
 var upcloudUpgradeCmd = &cobra.Command{
-	Use:        "upgrade <cluster_id> <target_version>",
+	Use:        "upgrade <cluster_id|name> <target_version>",
 	Short:      "Upgrade Kubernetes version for an UpCloud cluster",
 	Long:       "Upgrade the Kubernetes version on all nodes in an UpCloud cluster. This deprecated form always runs the safe non-forced rollout; use `ankra cluster upgrade` for --force (PodDisruptionBudget override) and operation progress tracking.",
 	Deprecated: "use `ankra cluster upgrade <cluster_id> <target_version>` instead; the cloud provider is detected automatically.",
 	Args:       cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		targetVersion := args[1]
 
 		result, err := apiClient.UpgradeUpcloudK8sVersion(clusterID, targetVersion, false)
@@ -325,7 +346,7 @@ var upcloudUpgradeCmd = &cobra.Command{
 }
 
 var upcloudZonesCmd = &cobra.Command{
-	Use:   "zones <cluster_id>",
+	Use:   "zones <cluster_id|name>",
 	Short: "Extend a multi-zone cluster's zone pool",
 	Long: `Extend the zone pool of an UpCloud cluster created with --network-mode wireguard_mesh
 (or with --zones). Pass the full desired pool, primary zone first: zones can only be
@@ -335,7 +356,10 @@ scaled afterwards spread across the grown pool, and the cloud-provider stack
 republishes with load balancers and volumes scoped to the primary zone.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		zones, _ := cmd.Flags().GetStringSlice("zones")
 
 		requestContext, cancelRequestContext, wait, err := nodeGroupAsyncContext(cmd)
@@ -378,11 +402,14 @@ var upcloudNodeGroupCmd = &cobra.Command{
 }
 
 var upcloudNodeGroupListCmd = &cobra.Command{
-	Use:   "list <cluster_id>",
+	Use:   "list <cluster_id|name>",
 	Short: "List node groups",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		result, err := apiClient.ListUpcloudNodeGroups(clusterID)
 		if err != nil {
 			return fmt.Errorf("listing node groups: %w", err)
@@ -405,11 +432,14 @@ var upcloudNodeGroupListCmd = &cobra.Command{
 }
 
 var upcloudNodeGroupAddCmd = &cobra.Command{
-	Use:   "add <cluster_id>",
+	Use:   "add <cluster_id|name>",
 	Short: "Add a node group",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		name, _ := cmd.Flags().GetString("name")
 		instanceType, _ := cmd.Flags().GetString("instance-type")
 		count, _ := cmd.Flags().GetInt("count")
@@ -452,11 +482,14 @@ var upcloudNodeGroupAddCmd = &cobra.Command{
 }
 
 var upcloudNodeGroupScaleCmd = &cobra.Command{
-	Use:   "scale <cluster_id> <group_name> <count>",
+	Use:   "scale <cluster_id|name> <group_name> <count>",
 	Short: "Scale a node group",
 	Args:  cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		count, err := strconv.Atoi(args[2])
 		if err != nil {
@@ -493,11 +526,14 @@ var upcloudNodeGroupScaleCmd = &cobra.Command{
 }
 
 var upcloudNodeGroupUpgradeCmd = &cobra.Command{
-	Use:   "upgrade <cluster_id> <group_name> <plan>",
+	Use:   "upgrade <cluster_id|name> <group_name> <plan>",
 	Short: "Upgrade server plan for a node group",
 	Args:  cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		plan := args[2]
 
@@ -531,16 +567,19 @@ var upcloudNodeGroupUpgradeCmd = &cobra.Command{
 }
 
 var upcloudNodeGroupDeleteCmd = &cobra.Command{
-	Use:   "delete <cluster_id> <group_name>",
+	Use:   "delete <cluster_id|name> <group_name>",
 	Short: "Delete a node group and all its nodes",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterID := args[0]
+		clusterID, resolveError := resolveClusterArg(args[0])
+		if resolveError != nil {
+			return resolveError
+		}
 		groupName := args[1]
 		yes, _ := cmd.Flags().GetBool("yes")
 
 		if err := confirmPrompt(cmd.InOrStdin(), cmd.OutOrStdout(),
-			fmt.Sprintf("Delete node group %q from cluster %q? This deletes all its nodes! [y/N]: ", groupName, clusterID),
+			fmt.Sprintf("Delete node group %q from cluster %s? This deletes all its nodes! [y/N]: ", groupName, clusterTarget(args[0], clusterID)),
 			yes); err != nil {
 			return err
 		}

--- a/cmd/upcloud_cluster_test.go
+++ b/cmd/upcloud_cluster_test.go
@@ -40,7 +40,7 @@ func (m *upcloudNodeGroupDeleteMock) DeleteUpcloudNodeGroup(ctx context.Context,
 func TestUpcloudDeprovision_DeclineDoesNotCallAPI(t *testing.T) {
 	mock := &upcloudDeprovisionMock{}
 	resetConfirmFlag(t, upcloudDeprovisionCmd)
-	_, err := runWithInput(t, mock, "n\n", "cluster", "upcloud", "deprovision", "uc-123")
+	_, err := runWithInput(t, mock, "n\n", "cluster", "upcloud", "deprovision", testClusterID)
 	if !errors.Is(err, errCancelled) {
 		t.Fatalf("expected errCancelled on decline, got %v", err)
 	}
@@ -52,22 +52,22 @@ func TestUpcloudDeprovision_DeclineDoesNotCallAPI(t *testing.T) {
 func TestUpcloudDeprovision_YesProceeds(t *testing.T) {
 	mock := &upcloudDeprovisionMock{}
 	resetConfirmFlag(t, upcloudDeprovisionCmd)
-	out, err := runWithInput(t, mock, "", "cluster", "upcloud", "deprovision", "uc-123", "--yes")
+	out, err := runWithInput(t, mock, "", "cluster", "upcloud", "deprovision", testClusterID, "--yes")
 	if err != nil {
 		t.Fatalf("execute failed: %v\noutput: %s", err, out)
 	}
 	if !mock.called {
 		t.Fatal("expected deprovision call with --yes")
 	}
-	if mock.gotClusterID != "uc-123" {
-		t.Errorf("cluster id = %q, want uc-123", mock.gotClusterID)
+	if mock.gotClusterID != testClusterID {
+		t.Errorf("cluster id = %q, want %q", mock.gotClusterID, testClusterID)
 	}
 }
 
 func TestUpcloudNodeGroupDelete_DeclineDoesNotCallAPI(t *testing.T) {
 	mock := &upcloudNodeGroupDeleteMock{}
 	resetConfirmFlag(t, upcloudNodeGroupDeleteCmd)
-	_, err := runWithInput(t, mock, "n\n", "cluster", "upcloud", "node-group", "delete", "uc-123", "workers")
+	_, err := runWithInput(t, mock, "n\n", "cluster", "upcloud", "node-group", "delete", testClusterID, "workers")
 	if !errors.Is(err, errCancelled) {
 		t.Fatalf("expected errCancelled on decline, got %v", err)
 	}
@@ -79,15 +79,15 @@ func TestUpcloudNodeGroupDelete_DeclineDoesNotCallAPI(t *testing.T) {
 func TestUpcloudNodeGroupDelete_YesProceeds(t *testing.T) {
 	mock := &upcloudNodeGroupDeleteMock{}
 	resetConfirmFlag(t, upcloudNodeGroupDeleteCmd)
-	out, err := runWithInput(t, mock, "", "cluster", "upcloud", "node-group", "delete", "uc-123", "workers", "--yes")
+	out, err := runWithInput(t, mock, "", "cluster", "upcloud", "node-group", "delete", testClusterID, "workers", "--yes")
 	if err != nil {
 		t.Fatalf("execute failed: %v\noutput: %s", err, out)
 	}
 	if !mock.called {
 		t.Fatal("expected delete call with --yes")
 	}
-	if mock.gotClusterID != "uc-123" || mock.gotGroupName != "workers" {
-		t.Errorf("got cluster=%q group=%q, want uc-123/workers", mock.gotClusterID, mock.gotGroupName)
+	if mock.gotClusterID != testClusterID || mock.gotGroupName != "workers" {
+		t.Errorf("got cluster=%q group=%q, want %q/workers", mock.gotClusterID, mock.gotGroupName, testClusterID)
 	}
 }
 
@@ -98,7 +98,7 @@ type upcloudCreateMock struct {
 
 func (m *upcloudCreateMock) CreateUpcloudCluster(req client.CreateUpcloudClusterRequest) (*client.CreateUpcloudClusterResponse, error) {
 	m.gotRequest = req
-	return &client.CreateUpcloudClusterResponse{ClusterID: "uc-123", Name: req.Name}, nil
+	return &client.CreateUpcloudClusterResponse{ClusterID: testClusterID, Name: req.Name}, nil
 }
 
 // The flag used to default to the literal 10.0.0.0/16, so every CLI create
@@ -222,12 +222,12 @@ func (m *upcloudZonePoolMock) UpdateUpcloudZonePool(_ context.Context, clusterID
 func TestUpcloudZones_SendsTheDesiredPool(t *testing.T) {
 	mock := &upcloudZonePoolMock{}
 	output := captureStdout(t, func() {
-		if _, err := runWithInput(t, mock, "", "cluster", "upcloud", "zones", "uc-123",
+		if _, err := runWithInput(t, mock, "", "cluster", "upcloud", "zones", testClusterID,
 			"--zones", "fi-hel1,fi-hel2,se-sto1", "--wait"); err != nil {
 			t.Fatalf("execute failed: %v", err)
 		}
 	})
-	if mock.gotClusterID != "uc-123" || strings.Join(mock.gotZones, ",") != "fi-hel1,fi-hel2,se-sto1" || !mock.gotWait {
+	if mock.gotClusterID != testClusterID || strings.Join(mock.gotZones, ",") != "fi-hel1,fi-hel2,se-sto1" || !mock.gotWait {
 		t.Errorf("request = %s / %v / wait=%v", mock.gotClusterID, mock.gotZones, mock.gotWait)
 	}
 	if !strings.Contains(output, "added se-sto1") {
@@ -248,7 +248,7 @@ func (m *upcloudNodeGroupZoneMock) AddUpcloudNodeGroup(_ context.Context, _ stri
 func TestUpcloudNodeGroupAdd_ZoneFlagPinsTheGroup(t *testing.T) {
 	mock := &upcloudNodeGroupZoneMock{}
 	_ = captureStdout(t, func() {
-		if _, err := runWithInput(t, mock, "", "cluster", "upcloud", "node-group", "add", "uc-123",
+		if _, err := runWithInput(t, mock, "", "cluster", "upcloud", "node-group", "add", testClusterID,
 			"--name", "db-sto", "--instance-type", "4xCPU-8GB", "--count", "2", "--zone", "se-sto1", "--wait"); err != nil {
 			t.Fatalf("execute failed: %v", err)
 		}


### PR DESCRIPTION
## Why

`ankra cluster list` is the one place a user reads a cluster's identity, and it
shows the **name**. Until now only three commands accepted one.

ankra-cli#239 taught the `cluster playground` verbs to resolve a name to the id
their routes want. They were the only group. A sweep of `master` found **103
more commands** whose positional argument is the cluster and which forwarded it
untouched:

| Group | Commands |
|---|---|
| `cluster` | bastion, managed, mesh, node-group, nodes, scale, ssh-keys, upgrade |
| `control-plane` | get, set-count, set-instance-type |
| provider lanes | DigitalOcean, Hetzner, OVH, UpCloud, Scaleway, Proxmox VE, HPE Morpheus |

A name in any of them reached the route as a non-UUID path segment and came
back as a bare `404`, or as a `uuid_parsing` `422` from a query parameter, with
nothing in either to say an id was expected.

## What changed

`resolveClusterArg` is the shared entry point, generalised from the playground
helper it replaces:

- a **UUID short-circuits**, so a scripted caller that already holds the id pays
  no extra request;
- a **name** is resolved through the existing paged `resolveClusterID`;
- an **unknown name** is refused *before* the request, quoting what was typed
  and naming `ankra cluster list`.

Every `Use:` string widened to `<cluster_id|name>`, so the help advertises it.

Two things needed care beyond the mechanical change:

- **Destructive prompts.** A prompt used to name whatever the user typed. Now
  that a name resolves first, the eleven prompts that name the cluster render it
  through `clusterTarget`, which leads with what was typed and appends the id it
  resolved to, rather than confronting the user with a bare UUID.
- **`cluster mesh readiness`** takes several clusters at once. Every argument
  resolves, and each row is still labelled with the name that was typed.

## Tests

New coverage in `cmd/cluster_name_args_test.go`: name resolution (including
case-insensitivity), the id short-circuit costing no listing, the refusal for an
unknown name, the prompt target, and one command from each newly covered shape
(a provider lane, mesh make-ready, mesh readiness).

`TestEveryClusterArgumentAdvertisesTheName` walks the command tree and fails on
any `<cluster_id>` left in a `Use:` string, naming the offending command path,
so a command added later cannot quietly regress to id-only. It was verified to
fail by reverting one usage string.

## Test-fixture churn

The command tests carried placeholder cluster ids (`"cluster-1"`, `"ovh-123"`,
`"c-1"`, `"test-cluster-id"`) that a name-resolving CLI now reads as *names*,
which sent 78 tests to the cluster listing. They use one shared, id-shaped
`testClusterID` instead, which is what the routes actually take. This is the
bulk of the test diff.

## Validation

Local pre-commit gate on the final commit: `go test ./...` green across every
package, `golangci-lint run ./...` reports **0 issues**. `gofmt` is clean across
`cmd/`, including `cluster_mesh_test.go`, which was already unformatted on
`master`.

Bead: ankra-aprvp

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6Wvx6CJkF6eEwRUhGdxdW
