### PR TITLE
release: cut v0.16.0-rc0 (PLA-834)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Ankra CLI Changelog
 
+## v0.16.0-rc0 — 2026-09-09
+
+### Added
+
+- **`ankra cluster apply` reads a manifest's `force` and `auto_remediate`
+  flags from the file and sends them, so a stack file can turn them on.** The
+  `manifests[]` entry on the wire said nothing about either flag: a file that
+  set `force: true` on a CRD manifest applied fine, then the platform stored
+  false and exported `force: false` back into the GitOps cluster file on the
+  next sync, undoing a change that had been made through Git minutes before.
+  Both keys are now read and always sent, following the same rule as the
+  cluster file itself: apply is declarative, so a key that is absent or null
+  means false. A value that is not a boolean (`force: "true"`) is refused
+  with an error naming the key rather than treated as off. Partial updates
+  (`manifests update`, `manifests create`, `cluster encrypt`) and
+  `cluster clone` are unchanged and keep a stored flag as it is.
+
 ## v0.15.0 — 2026-09-08
 
 Promotes v0.15.0-rc0 through rc6. The headline is Ankra Pipelines from the


### PR DESCRIPTION
Cuts **v0.16.0-rc0** — the first pre-release on the v0.16.0 line. Touches `CHANGELOG.md` only; the tag on the squash-merge commit publishes the release.

Linear: https://linear.app/ankra/issue/PLA-834

## What is above v0.15.0

One commit, #274: `ankra cluster apply` now reads `manifests[].force` and `auto_remediate` from the file and always sends them (PLA-834). Two new wire fields on apply is new capability rather than a patch, so this opens the next minor line and starts with an RC per the repo's convention.

## Changelog

#274 merged without a changelog entry; the `### Added` entry under `## v0.16.0-rc0 — 2026-09-09` is written here at cut time. The release-notes extractor was dry-run against the heading and returns the section (starts at `### Added`, not the `--generate-notes` fallback).

## After merge

`git tag -a v0.16.0-rc0 <merge-sha>` + push; verify the published darwin-arm64 binary (sha256, `ankra version`, `cluster apply` help) before anyone promotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019biaDsvnLMyzkWVgQY72Bp
