### PR TITLE
release: cut v0.15.1 (PLA-834)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,26 @@
 # Ankra CLI Changelog
 
+## v0.15.1 — 2026-09-09
+
+### Fixed
+
+- **`ankra cluster apply` no longer drops a manifest's `force` and
+  `auto_remediate` flags.** The `manifests[]` entry on the wire said nothing
+  about either key: a file that set `force: true` on a CRD manifest applied
+  fine, then the platform stored false and exported `force: false` back into
+  the GitOps cluster file on the next sync, undoing a change that had been
+  made through Git minutes before. Both keys are now read and always sent,
+  following the same rule as the cluster file itself: apply is declarative,
+  so a key that is absent or null means false. A value that is not a boolean
+  (`force: "true"`) is refused with an error naming the key rather than
+  treated as off. Partial updates (`manifests update`, `manifests create`,
+  `cluster encrypt`) and `cluster clone` are unchanged and keep a stored flag
+  as it is.
+
 ## v0.16.0-rc0 — 2026-09-09
 
-### Added
-
-- **`ankra cluster apply` reads a manifest's `force` and `auto_remediate`
-  flags from the file and sends them, so a stack file can turn them on.** The
-  `manifests[]` entry on the wire said nothing about either flag: a file that
-  set `force: true` on a CRD manifest applied fine, then the platform stored
-  false and exported `force: false` back into the GitOps cluster file on the
-  next sync, undoing a change that had been made through Git minutes before.
-  Both keys are now read and always sent, following the same rule as the
-  cluster file itself: apply is declarative, so a key that is absent or null
-  means false. A value that is not a boolean (`force: "true"`) is refused
-  with an error naming the key rather than treated as off. Partial updates
-  (`manifests update`, `manifests create`, `cluster encrypt`) and
-  `cluster clone` are unchanged and keep a stored flag as it is.
+Pre-release cut before the change above was reclassified as a fix. Carries
+exactly the v0.15.1 fix and nothing else; stable users get it from v0.15.1.
 
 ## v0.15.0 — 2026-09-08
 


### PR DESCRIPTION
Cuts **v0.15.1** — a stable patch. Touches `CHANGELOG.md` only; the tag on the squash-merge commit publishes the release.

Linear: https://linear.app/ankra/issue/PLA-834

## Why a patch

The only code change since v0.15.0 is #274: `ankra cluster apply` was dropping the `force` and `auto_remediate` keys a manifest already declares, so the platform stored false and exported `force: false` back into the GitOps cluster file. No new command, flag or file key — an existing key now takes effect. That is a fix, and the customer on PLA-834 runs stable, so it needs a stable release: v0.16.0-rc0 (cut earlier today as a feature RC) is a pre-release and never reaches them.

## Changelog

New `## v0.15.1 — 2026-09-09` section with the entry under `### Fixed`. The `## v0.16.0-rc0` section shrinks to a pointer so the entry is not listed twice. Extractor dry-run returns the `### Fixed` block for `0.15.1`.

## After merge

`git tag -a v0.15.1 <merge-sha>` + push; verify the published darwin-arm64 binary (sha256, `--version`, the `force: "true"` refusal) before announcing. Also runs the Homebrew tap bump, since the tag has no hyphen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019biaDsvnLMyzkWVgQY72Bp
