### PR TITLE
feat(application): import a Claude Design export as an application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Ankra CLI Changelog
 
+## Unreleased
+
+- **A Claude Design export becomes a deployable application in one command.** `ankra application import claude-design <path>` takes what you exported from claude.ai/design - a directory of `<Name>.dc.html` artboards with `canvas.json` and images, a zip of it, one artboard, or a saved canvas page - and has Ankra convert it into a static site, create a GitHub repository under your GitHub credential (`--credential`, `--owner`), commit it with a Dockerfile and register the application, so the setup pull request, build and deploy follow as for any other application. `--repository`, `--visibility` and `--source-url` shape the repository; `--wait` follows the analysis to the setup pull request; `-o json` returns the pages and any warnings. Artboards that depend on the Claude Design runtime are kept as authored and reported, and re-running the same import registers the same repository without a second commit.
+
 ## v0.15.0 — 2026-09-08
 
 Promotes v0.15.0-rc0 through rc6. The headline is Ankra Pipelines from the

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -44,6 +44,7 @@ func newApplicationCommand() *cobra.Command {
 	}
 	applicationCommand.AddCommand(newApplicationAddCommand())
 	applicationCommand.AddCommand(newApplicationShipCommand())
+	applicationCommand.AddCommand(newApplicationImportCommand())
 	registerApplicationResourceCommands(applicationCommand)
 	return applicationCommand
 }

--- a/cmd/application_import.go
+++ b/cmd/application_import.go
@@ -66,7 +66,12 @@ sc-if, dc-import or a data-dc-script - are kept as authored and reported as
 warnings; they may not render as they did on the canvas.
 
 Running the same import again is safe: the repository keeps a provenance
-record, and an unchanged export registers without a second commit.`,
+record, and an unchanged export registers without a second commit.
+
+The lane ships behind the claude_design_import organisation feature flag,
+which is off by default while it rolls out: the platform answers 404 for
+organisations without it, and this command says so. Ask Ankra support to
+enable it for your organisation.`,
 		Example: `  ankra application import claude-design ./neighborly-export --name neighborly
   ankra application import claude-design neighborly.zip --credential github-acme --owner acme
   ankra application import claude-design Neighborly.html --source-url https://claude.ai/design/p/<id> --wait`,
@@ -302,6 +307,14 @@ func runApplicationImportClaudeDesign(command *cobra.Command, arguments []string
 func importClaudeDesign(requestContext context.Context, importRequest client.ImportClaudeDesignRequest) (applicationImportOutput, error) {
 	importResponse, importError := apiClient.ImportClaudeDesignApplication(requestContext, importRequest)
 	if importError != nil {
+		// The platform keeps the lane invisible while the organisation flag is
+		// off, so its 404 is the flag, not a missing route; name it.
+		var unexpected *client.UnexpectedResponseError
+		if errors.As(importError, &unexpected) && unexpected.StatusCode == 404 {
+			return applicationImportOutput{}, withExitCode(exitNotFound, errors.New(
+				"the Claude Design import is not enabled for this organisation (the claude_design_import feature flag is off; "+
+					"ask Ankra support to enable it) - check the selected organisation with `ankra org current`"))
+		}
 		return applicationImportOutput{}, fmt.Errorf("importing the design: %w", importError)
 	}
 	if importResponse == nil {

--- a/cmd/application_import.go
+++ b/cmd/application_import.go
@@ -136,8 +136,13 @@ func readClaudeDesignExport(path string) (claudeDesignExport, error) {
 		if readError != nil {
 			return claudeDesignExport{}, fmt.Errorf("reading %s: %w", filePath, readError)
 		}
-		isArchive := strings.HasSuffix(strings.ToLower(filePath), ".zip")
-		if len(content) > claudeDesignMaxFileBytes && !isArchive {
+		// A zip carries the entries and a saved canvas page carries the whole
+		// document, so both answer to the total cap only; the per-file cap is
+		// for the artboards and images the editor itself limits.
+		lowered := strings.ToLower(filePath)
+		isArchive := strings.HasSuffix(lowered, ".zip")
+		isSavedPage := strings.HasSuffix(lowered, ".html") && !strings.HasSuffix(lowered, ".dc.html")
+		if len(content) > claudeDesignMaxFileBytes && !isArchive && !isSavedPage {
 			return claudeDesignExport{}, withExitCode(exitUsage, fmt.Errorf(
 				"%s is %d bytes; the design editor caps a file at %d bytes, so this is not a file it exported",
 				filePath, len(content), claudeDesignMaxFileBytes))

--- a/cmd/application_import.go
+++ b/cmd/application_import.go
@@ -1,0 +1,336 @@
+package cmd
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"ankra/internal/client"
+)
+
+// The limits mirror the platform's, which mirror the design editor's own:
+// it drops any file over 2 MiB, and a saved canvas page caps at 16 MiB.
+const (
+	claudeDesignMaxFileBytes  = 2 << 20
+	claudeDesignMaxTotalBytes = 16 << 20
+)
+
+// applicationImportOutput is the structured result of an import.
+type applicationImportOutput struct {
+	ID               string                         `json:"id" yaml:"id"`
+	Name             string                         `json:"name" yaml:"name"`
+	Repository       string                         `json:"repository" yaml:"repository"`
+	RepositoryURL    string                         `json:"repository_url" yaml:"repository_url"`
+	Branch           string                         `json:"branch" yaml:"branch"`
+	CredentialName   string                         `json:"credential_name" yaml:"credential_name"`
+	CommitSHA        string                         `json:"commit_sha,omitempty" yaml:"commit_sha,omitempty"`
+	RepositoryReused bool                           `json:"repository_reused" yaml:"repository_reused"`
+	Pages            []client.ImportedDesignPage    `json:"pages" yaml:"pages"`
+	Warnings         []client.ImportedDesignWarning `json:"warnings" yaml:"warnings"`
+	Notes            []string                       `json:"notes,omitempty" yaml:"notes,omitempty"`
+}
+
+func newApplicationImportCommand() *cobra.Command {
+	importCommand := &cobra.Command{
+		Use:   "import",
+		Short: "Register an application from something that is not a repository yet",
+		Long: `Import an application from a source that has no Git repository of its own.
+Ankra converts what you give it, creates a GitHub repository for it, commits
+the result and registers the application, so the same setup pull request,
+build and deploy lane that follows every registration takes over.`,
+	}
+	importCommand.AddCommand(newApplicationImportClaudeDesignCommand())
+	return importCommand
+}
+
+func newApplicationImportClaudeDesignCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "claude-design <path>",
+		Short: "Turn a Claude Design export into a deployable application",
+		Long: `Turn a Claude Design export into a deployable application.
+
+<path> is what you exported from claude.ai/design: a directory holding the
+artboards (<Name>.dc.html), canvas.json and images, a zip of them, a single
+artboard, or a saved canvas page (.html). Ankra converts the artboards into a
+static site, creates a GitHub repository under the credential's account (or
+--owner), commits the site with a Dockerfile, and registers the application.
+
+Artboards that depend on the Claude Design runtime - template holes, sc-for,
+sc-if, dc-import or a data-dc-script - are kept as authored and reported as
+warnings; they may not render as they did on the canvas.
+
+Running the same import again is safe: the repository keeps a provenance
+record, and an unchanged export registers without a second commit.`,
+		Example: `  ankra application import claude-design ./neighborly-export --name neighborly
+  ankra application import claude-design neighborly.zip --credential github-acme --owner acme
+  ankra application import claude-design Neighborly.html --source-url https://claude.ai/design/p/<id> --wait`,
+		Args: cobra.ExactArgs(1),
+		RunE: runApplicationImportClaudeDesign,
+	}
+	command.Flags().String("name", "", "Application name (defaults to the export's directory or file name)")
+	command.Flags().String("credential", "", "GitHub credential name or ID (auto-detected when omitted)")
+	command.Flags().String("owner", "", "GitHub user or organisation to create the repository under (defaults to the credential's account)")
+	command.Flags().String("repository", "", "Repository name (defaults to a slug of the application name)")
+	command.Flags().String("visibility", "private", "Repository visibility: private or public")
+	command.Flags().String("source-url", "", "The claude.ai/design link the export came from, recorded in the repository")
+	command.Flags().Bool("wait", false,
+		"Wait for Ankra to finish analysing the repository, then print the setup pull request")
+	command.Flags().Duration("timeout", applicationAnalysisDefaultTimeout,
+		"How long --wait waits before giving up")
+	registerStructuredOutputFlags(command)
+	return command
+}
+
+// claudeDesignExport is what the command read from <path>.
+type claudeDesignExport struct {
+	files       []client.ImportClaudeDesignFile
+	defaultName string
+}
+
+// readClaudeDesignExport reads the export at path: every regular file of a
+// directory (dotfiles skipped), or the one file named. Names are sent as base
+// names; the platform decides what each one is.
+func readClaudeDesignExport(path string) (claudeDesignExport, error) {
+	information, statError := os.Stat(path)
+	if statError != nil {
+		return claudeDesignExport{}, withExitCode(exitUsage, fmt.Errorf("reading the export: %w", statError))
+	}
+	filePaths := []string{}
+	defaultName := ""
+	if information.IsDir() {
+		entries, readError := os.ReadDir(path)
+		if readError != nil {
+			return claudeDesignExport{}, fmt.Errorf("reading the export directory: %w", readError)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+				continue
+			}
+			filePaths = append(filePaths, filepath.Join(path, entry.Name()))
+		}
+		if len(filePaths) == 0 {
+			return claudeDesignExport{}, withExitCode(exitUsage,
+				fmt.Errorf("%s holds no files; export the design from claude.ai/design into it first", path))
+		}
+		defaultName = filepath.Base(filepath.Clean(path))
+	} else {
+		filePaths = append(filePaths, path)
+		defaultName = filepath.Base(path)
+		for _, suffix := range []string{".dc.html", ".html", ".zip"} {
+			if strings.HasSuffix(strings.ToLower(defaultName), suffix) {
+				defaultName = defaultName[:len(defaultName)-len(suffix)]
+				break
+			}
+		}
+	}
+	files := make([]client.ImportClaudeDesignFile, 0, len(filePaths))
+	total := 0
+	for _, filePath := range filePaths {
+		content, readError := os.ReadFile(filePath)
+		if readError != nil {
+			return claudeDesignExport{}, fmt.Errorf("reading %s: %w", filePath, readError)
+		}
+		isArchive := strings.HasSuffix(strings.ToLower(filePath), ".zip")
+		if len(content) > claudeDesignMaxFileBytes && !isArchive {
+			return claudeDesignExport{}, withExitCode(exitUsage, fmt.Errorf(
+				"%s is %d bytes; the design editor caps a file at %d bytes, so this is not a file it exported",
+				filePath, len(content), claudeDesignMaxFileBytes))
+		}
+		total += len(content)
+		if total > claudeDesignMaxTotalBytes {
+			return claudeDesignExport{}, withExitCode(exitUsage, fmt.Errorf(
+				"the export is over %d bytes; a Claude Design canvas saves under that, so check the directory holds only the export",
+				claudeDesignMaxTotalBytes))
+		}
+		files = append(files, client.ImportClaudeDesignFile{
+			Path:          filepath.Base(filePath),
+			ContentBase64: base64.StdEncoding.EncodeToString(content),
+		})
+	}
+	return claudeDesignExport{files: files, defaultName: applicationNameSlug(defaultName)}, nil
+}
+
+// applicationNameSlug lowercases a name and joins its words with hyphens,
+// the shape both an application name and a repository name accept.
+func applicationNameSlug(value string) string {
+	var builder strings.Builder
+	previousHyphen := false
+	for _, character := range strings.ToLower(value) {
+		isAlphanumeric := (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9')
+		switch {
+		case isAlphanumeric:
+			builder.WriteRune(character)
+			previousHyphen = false
+		case !previousHyphen && builder.Len() > 0:
+			builder.WriteByte('-')
+			previousHyphen = true
+		}
+	}
+	return strings.TrimSuffix(builder.String(), "-")
+}
+
+// resolveImportCredentialAndOwner picks the GitHub credential the way
+// `application add` does, then the owner: --owner when given, else the
+// credential's own account.
+func resolveImportCredentialAndOwner(command *cobra.Command) (client.Credential, string, error) {
+	requestedCredential, _ := command.Flags().GetString("credential")
+	requestedCredential = strings.TrimSpace(requestedCredential)
+	if command.Flags().Changed("credential") && requestedCredential == "" {
+		return client.Credential{}, "", withExitCode(exitUsage, errors.New("credential cannot be empty"))
+	}
+	owner, _ := command.Flags().GetString("owner")
+	owner = strings.TrimSpace(owner)
+	if command.Flags().Changed("owner") && owner == "" {
+		return client.Credential{}, "", withExitCode(exitUsage, errors.New("owner cannot be empty"))
+	}
+	githubProvider := "github"
+	credentials, credentialsError := apiClient.ListCredentials(&githubProvider)
+	if credentialsError != nil {
+		return client.Credential{}, "", fmt.Errorf("listing GitHub credentials: %w", credentialsError)
+	}
+	selectedCredential, selectionError := selectApplicationCredential(credentials, owner, requestedCredential)
+	if selectionError != nil {
+		return client.Credential{}, "", selectionError
+	}
+	if owner == "" {
+		if selectedCredential.AccountLogin == nil || strings.TrimSpace(*selectedCredential.AccountLogin) == "" {
+			return client.Credential{}, "", withExitCode(exitUsage, fmt.Errorf(
+				"credential %q names no GitHub account; pass --owner <user-or-organisation>", selectedCredential.Name))
+		}
+		owner = strings.TrimSpace(*selectedCredential.AccountLogin)
+	}
+	return selectedCredential, owner, nil
+}
+
+func runApplicationImportClaudeDesign(command *cobra.Command, arguments []string) error {
+	if _, outputError := structuredFormatFromFlags(command); outputError != nil {
+		return outputError
+	}
+	export, exportError := readClaudeDesignExport(arguments[0])
+	if exportError != nil {
+		return exportError
+	}
+	applicationName, _ := command.Flags().GetString("name")
+	applicationName = strings.TrimSpace(applicationName)
+	if applicationName == "" {
+		if command.Flags().Changed("name") {
+			return withExitCode(exitUsage, errors.New("application name cannot be empty"))
+		}
+		applicationName = export.defaultName
+	}
+	if applicationName == "" {
+		return withExitCode(exitUsage, errors.New("could not derive an application name from the path; pass --name"))
+	}
+	visibility, _ := command.Flags().GetString("visibility")
+	visibility = strings.ToLower(strings.TrimSpace(visibility))
+	if visibility != "private" && visibility != "public" {
+		return withExitCode(exitUsage, errors.New("visibility must be private or public"))
+	}
+	repositoryName, _ := command.Flags().GetString("repository")
+	sourceURL, _ := command.Flags().GetString("source-url")
+
+	selectedCredential, owner, resolveError := resolveImportCredentialAndOwner(command)
+	if resolveError != nil {
+		return resolveError
+	}
+
+	result, importError := importClaudeDesign(command.Context(), client.ImportClaudeDesignRequest{
+		Name:                     applicationName,
+		RepositoryCredentialName: selectedCredential.Name,
+		RepositoryOwner:          owner,
+		RepositoryName:           strings.TrimSpace(repositoryName),
+		Visibility:               visibility,
+		SourceURL:                strings.TrimSpace(sourceURL),
+		Files:                    export.files,
+	})
+	if importError != nil {
+		return importError
+	}
+	if rendered, renderError := renderStructured(command, result); rendered || renderError != nil {
+		if renderError != nil {
+			return renderError
+		}
+		return waitForApplicationAnalysis(command, result.ID)
+	}
+	output := command.OutOrStdout()
+	_, _ = fmt.Fprintln(output, "Application imported from Claude Design.")
+	_, _ = fmt.Fprintf(output, "  ID:         %s\n", result.ID)
+	_, _ = fmt.Fprintf(output, "  Name:       %s\n", result.Name)
+	_, _ = fmt.Fprintf(output, "  Repository: %s (%s)\n", result.Repository, result.RepositoryURL)
+	_, _ = fmt.Fprintf(output, "  Branch:     %s\n", result.Branch)
+	_, _ = fmt.Fprintf(output, "  Credential: %s\n", result.CredentialName)
+	switch {
+	case result.RepositoryReused:
+		_, _ = fmt.Fprintln(output, "  Commit:     none - the repository already held this export")
+	case result.CommitSHA != "":
+		_, _ = fmt.Fprintf(output, "  Commit:     %s\n", result.CommitSHA)
+	}
+	_, _ = fmt.Fprintf(output, "  Pages:      %d\n", len(result.Pages))
+	for _, page := range result.Pages {
+		suffix := ""
+		if page.Dynamic {
+			suffix = "  (uses template logic; served as authored)"
+		}
+		_, _ = fmt.Fprintf(output, "    %-28s site/%s%s\n", page.Title, page.Path, suffix)
+	}
+	if len(result.Warnings) > 0 {
+		_, _ = fmt.Fprintln(output, "Warnings:")
+		for _, warning := range result.Warnings {
+			_, _ = fmt.Fprintf(output, "  - %s\n", warning.Message)
+		}
+	}
+	for _, note := range result.Notes {
+		_, _ = fmt.Fprintf(output, "  Note: %s\n", note)
+	}
+	_, _ = fmt.Fprintln(output, "\nAnkra is now analyzing the repository.")
+	return waitForApplicationAnalysis(command, result.ID)
+}
+
+// importClaudeDesign calls the platform and turns its answer into the
+// command's result, or into the platform's refusal.
+func importClaudeDesign(requestContext context.Context, importRequest client.ImportClaudeDesignRequest) (applicationImportOutput, error) {
+	importResponse, importError := apiClient.ImportClaudeDesignApplication(requestContext, importRequest)
+	if importError != nil {
+		return applicationImportOutput{}, fmt.Errorf("importing the design: %w", importError)
+	}
+	if importResponse == nil {
+		return applicationImportOutput{}, errors.New("importing the design: platform returned an empty response")
+	}
+	if len(importResponse.Errors) > 0 {
+		return applicationImportOutput{}, applicationCreationError(importResponse.Errors)
+	}
+	if importResponse.ID == nil || strings.TrimSpace(*importResponse.ID) == "" {
+		return applicationImportOutput{}, errors.New("importing the design: platform response did not include an application ID")
+	}
+	if importResponse.Repository == nil {
+		return applicationImportOutput{}, errors.New("importing the design: platform response did not name the repository")
+	}
+	result := applicationImportOutput{
+		ID:               *importResponse.ID,
+		Name:             importRequest.Name,
+		Repository:       importResponse.Repository.Owner + "/" + importResponse.Repository.Name,
+		RepositoryURL:    importResponse.Repository.WebURL,
+		Branch:           importResponse.Repository.DefaultBranch,
+		CredentialName:   importRequest.RepositoryCredentialName,
+		RepositoryReused: importResponse.Repository.Reused,
+		Pages:            importResponse.Pages,
+		Warnings:         importResponse.Warnings,
+		Notes:            importResponse.Notes,
+	}
+	if importResponse.Repository.CommitSHA != nil {
+		result.CommitSHA = *importResponse.Repository.CommitSHA
+	}
+	if result.Pages == nil {
+		result.Pages = []client.ImportedDesignPage{}
+	}
+	if result.Warnings == nil {
+		result.Warnings = []client.ImportedDesignWarning{}
+	}
+	return result, nil
+}

--- a/cmd/application_import_test.go
+++ b/cmd/application_import_test.go
@@ -205,6 +205,30 @@ func TestApplicationImportClaudeDesignRefusesAnEmptyDirectory(t *testing.T) {
 	}
 }
 
+func TestApplicationImportClaudeDesignAcceptsASavedPageOverThePerFileCap(t *testing.T) {
+	resetApplicationImportFlags(t)
+	t.Cleanup(func() { resetApplicationImportFlags(t) })
+	importBody := serveClaudeDesignImport(t, importedNeighborly)
+	directory := t.TempDir()
+	savedPage := filepath.Join(directory, "Neighborly.html")
+	if writeError := os.WriteFile(savedPage, []byte(strings.Repeat("x", claudeDesignMaxFileBytes+1)), 0o644); writeError != nil {
+		t.Fatal(writeError)
+	}
+	if _, executeError := executeCommand("application", "import", "claude-design", savedPage); executeError != nil {
+		t.Fatalf("a saved canvas page over 2 MiB is a valid export: %v", executeError)
+	}
+	if files, _ := importBody()["files"].([]any); len(files) != 1 {
+		t.Fatalf("the saved page should be sent: %v", files)
+	}
+	oversizedArtboard := filepath.Join(directory, "Main.dc.html")
+	if writeError := os.WriteFile(oversizedArtboard, []byte(strings.Repeat("x", claudeDesignMaxFileBytes+1)), 0o644); writeError != nil {
+		t.Fatal(writeError)
+	}
+	if _, executeError := executeCommand("application", "import", "claude-design", oversizedArtboard); executeError == nil {
+		t.Fatal("an artboard over 2 MiB is still refused")
+	}
+}
+
 func TestApplicationNameSlug(t *testing.T) {
 	for input, expected := range map[string]string{
 		"Neighborly export": "neighborly-export",

--- a/cmd/application_import_test.go
+++ b/cmd/application_import_test.go
@@ -1,0 +1,218 @@
+package cmd
+
+// `application import claude-design`: the export on disk becomes the
+// platform's import request, and the platform's answer becomes the command's
+// report.
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func resetApplicationImportFlags(t *testing.T) {
+	t.Helper()
+	for _, applicationCommand := range rootCmd.Commands() {
+		if applicationCommand.Name() != "application" {
+			continue
+		}
+		for _, command := range applicationCommand.Commands() {
+			if command.Name() != "import" {
+				continue
+			}
+			for _, subcommand := range command.Commands() {
+				resetTreeFlags(t, subcommand)
+			}
+			return
+		}
+	}
+}
+
+func writeClaudeDesignExport(t *testing.T) string {
+	t.Helper()
+	directory := filepath.Join(t.TempDir(), "Neighborly export")
+	if mkdirError := os.MkdirAll(directory, 0o755); mkdirError != nil {
+		t.Fatal(mkdirError)
+	}
+	for name, content := range map[string]string{
+		"Main.dc.html": "<!doctype html><html><head><script src=\"./support.js\"></script></head><body><x-dc><h1>Hi</h1></x-dc></body></html>",
+		"canvas.json":  `{"artboards":[{"file":"Main.dc.html","w":1440,"h":900}]}`,
+		"logo.png":     "png-bytes",
+		".DS_Store":    "junk",
+	} {
+		if writeError := os.WriteFile(filepath.Join(directory, name), []byte(content), 0o644); writeError != nil {
+			t.Fatal(writeError)
+		}
+	}
+	return directory
+}
+
+// serveClaudeDesignImport answers the credential listing and the import
+// route, keeping the import body for the test to inspect.
+func serveClaudeDesignImport(t *testing.T, importResponse string) func() map[string]any {
+	t.Helper()
+	var mutex sync.Mutex
+	var importBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		responseWriter.Header().Set("Content-Type", "application/json")
+		if strings.Contains(request.URL.Path, "/credentials") {
+			_, _ = responseWriter.Write([]byte(`[{"id":"credential-acme","name":"github-acme","provider":"github",` +
+				`"available":true,"account_login":"acme","created_at":"2026-09-01T00:00:00Z"}]`))
+			return
+		}
+		if request.Method == http.MethodPost && strings.HasSuffix(request.URL.Path, "/applications/imports/claude-design") {
+			bodyBytes, _ := io.ReadAll(request.Body)
+			mutex.Lock()
+			_ = json.Unmarshal(bodyBytes, &importBody)
+			mutex.Unlock()
+			_, _ = responseWriter.Write([]byte(importResponse))
+			return
+		}
+		responseWriter.WriteHeader(http.StatusNotFound)
+	}))
+	useTestClient(t, server.URL)
+	t.Cleanup(server.Close)
+	return func() map[string]any {
+		mutex.Lock()
+		defer mutex.Unlock()
+		return importBody
+	}
+}
+
+const importedNeighborly = `{"id":"application-id","errors":[],` +
+	`"repository":{"owner":"acme","name":"neighborly-export","web_url":"https://github.com/acme/neighborly-export",` +
+	`"default_branch":"main","commit_sha":"abc123","reused":false},` +
+	`"pages":[{"artboard":"Main.dc.html","path":"index.html","title":"Home","dynamic":false},` +
+	`{"artboard":"Prices.dc.html","path":"prices.html","title":"Prices","dynamic":true}],` +
+	`"warnings":[{"artboard":"Prices.dc.html","kind":"dynamic_artboard","message":"Prices.dc.html uses template logic"}],` +
+	`"notes":[]}`
+
+func TestApplicationImportClaudeDesignSendsTheExportAndReportsTheResult(t *testing.T) {
+	directory := writeClaudeDesignExport(t)
+	resetApplicationImportFlags(t)
+	t.Cleanup(func() { resetApplicationImportFlags(t) })
+	importBody := serveClaudeDesignImport(t, importedNeighborly)
+
+	output, executeError := executeCommand("application", "import", "claude-design", directory,
+		"--source-url", "https://claude.ai/design/p/abc")
+	if executeError != nil {
+		t.Fatalf("application import claude-design = %v\n%s", executeError, output)
+	}
+
+	body := importBody()
+	if body["name"] != "neighborly-export" {
+		t.Errorf("name should derive from the directory: %v", body["name"])
+	}
+	if body["app_repo_credential_name"] != "github-acme" || body["app_repo_owner"] != "acme" {
+		t.Errorf("credential and owner should come from the single GitHub credential: %v", body)
+	}
+	if body["visibility"] != "private" || body["source_url"] != "https://claude.ai/design/p/abc" {
+		t.Errorf("visibility/source_url = %v / %v", body["visibility"], body["source_url"])
+	}
+	files, _ := body["files"].([]any)
+	if len(files) != 3 {
+		t.Fatalf("expected the three export files (dotfiles skipped), got %v", files)
+	}
+	for _, rawFile := range files {
+		file, _ := rawFile.(map[string]any)
+		if file["path"] == "logo.png" {
+			decoded, _ := base64.StdEncoding.DecodeString(file["content_base64"].(string))
+			if string(decoded) != "png-bytes" {
+				t.Errorf("logo.png content = %q", decoded)
+			}
+		}
+		if strings.Contains(file["path"].(string), "/") {
+			t.Errorf("files are sent by base name: %v", file["path"])
+		}
+	}
+
+	for _, expected := range []string{
+		"Application imported from Claude Design.",
+		"ID:         application-id",
+		"Repository: acme/neighborly-export (https://github.com/acme/neighborly-export)",
+		"Commit:     abc123",
+		"Pages:      2",
+		"site/prices.html  (uses template logic; served as authored)",
+		"Warnings:",
+		"Prices.dc.html uses template logic",
+		"Ankra is now analyzing the repository.",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("output missing %q:\n%s", expected, output)
+		}
+	}
+}
+
+func TestApplicationImportClaudeDesignHonoursNameOwnerAndRepositoryFlags(t *testing.T) {
+	directory := writeClaudeDesignExport(t)
+	resetApplicationImportFlags(t)
+	t.Cleanup(func() { resetApplicationImportFlags(t) })
+	importBody := serveClaudeDesignImport(t, importedNeighborly)
+
+	output, executeError := executeCommand("application", "import", "claude-design", filepath.Join(directory, "Main.dc.html"),
+		"--name", "neighborly", "--owner", "acme", "--repository", "neighborly-site", "--visibility", "public", "-o", "json")
+	if executeError != nil {
+		t.Fatalf("application import claude-design = %v\n%s", executeError, output)
+	}
+	body := importBody()
+	if body["name"] != "neighborly" || body["app_repo_name"] != "neighborly-site" || body["visibility"] != "public" {
+		t.Errorf("flags not carried: %v", body)
+	}
+	if files, _ := body["files"].([]any); len(files) != 1 {
+		t.Errorf("a single file path sends one file: %v", files)
+	}
+	var structured map[string]any
+	if unmarshalError := json.Unmarshal([]byte(stripANSICodes(output)), &structured); unmarshalError != nil {
+		t.Fatalf("-o json output does not parse: %v\n%s", unmarshalError, output)
+	}
+	if structured["id"] != "application-id" || structured["repository_url"] != "https://github.com/acme/neighborly-export" {
+		t.Errorf("structured output = %v", structured)
+	}
+}
+
+func TestApplicationImportClaudeDesignReportsThePlatformRefusal(t *testing.T) {
+	directory := writeClaudeDesignExport(t)
+	resetApplicationImportFlags(t)
+	t.Cleanup(func() { resetApplicationImportFlags(t) })
+	serveClaudeDesignImport(t, `{"id":null,"errors":[{"name":"neighborly-export","kind":"ApplicationResource",`+
+		`"errors":[{"key":"app_repo_name","message":"A repository named 'neighborly-export' already exists under acme and holds other content; choose another repository name."}]}],`+
+		`"repository":null,"pages":[],"warnings":[],"notes":[]}`)
+
+	_, executeError := executeCommand("application", "import", "claude-design", directory)
+	if executeError == nil {
+		t.Fatal("a platform refusal must fail the command")
+	}
+	if !strings.Contains(executeError.Error(), "already exists under acme") {
+		t.Errorf("error does not carry the platform's reason: %v", executeError)
+	}
+}
+
+func TestApplicationImportClaudeDesignRefusesAnEmptyDirectory(t *testing.T) {
+	resetApplicationImportFlags(t)
+	t.Cleanup(func() { resetApplicationImportFlags(t) })
+	serveClaudeDesignImport(t, importedNeighborly)
+
+	_, executeError := executeCommand("application", "import", "claude-design", t.TempDir())
+	if executeError == nil || !strings.Contains(executeError.Error(), "holds no files") {
+		t.Fatalf("an empty directory must be refused before any request: %v", executeError)
+	}
+}
+
+func TestApplicationNameSlug(t *testing.T) {
+	for input, expected := range map[string]string{
+		"Neighborly export": "neighborly-export",
+		"Neighborly":        "neighborly",
+		"my__site v2":       "my-site-v2",
+	} {
+		if slug := applicationNameSlug(input); slug != expected {
+			t.Errorf("applicationNameSlug(%q) = %q, want %q", input, slug, expected)
+		}
+	}
+}

--- a/cmd/application_import_test.go
+++ b/cmd/application_import_test.go
@@ -229,6 +229,35 @@ func TestApplicationImportClaudeDesignAcceptsASavedPageOverThePerFileCap(t *test
 	}
 }
 
+func TestApplicationImportClaudeDesignExplainsTheDarkFlag(t *testing.T) {
+	directory := writeClaudeDesignExport(t)
+	resetApplicationImportFlags(t)
+	t.Cleanup(func() { resetApplicationImportFlags(t) })
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		responseWriter.Header().Set("Content-Type", "application/json")
+		if strings.Contains(request.URL.Path, "/credentials") {
+			_, _ = responseWriter.Write([]byte(`[{"id":"credential-acme","name":"github-acme","provider":"github",` +
+				`"available":true,"account_login":"acme","created_at":"2026-09-01T00:00:00Z"}]`))
+			return
+		}
+		responseWriter.WriteHeader(http.StatusNotFound)
+		_, _ = responseWriter.Write([]byte(`{"detail":"Not Found"}`))
+	}))
+	useTestClient(t, server.URL)
+	t.Cleanup(server.Close)
+
+	_, executeError := executeCommand("application", "import", "claude-design", directory)
+	if executeError == nil {
+		t.Fatal("a dark flag must fail the command")
+	}
+	if !strings.Contains(executeError.Error(), "claude_design_import feature flag is off") {
+		t.Fatalf("the 404 should be explained as the flag, got: %v", executeError)
+	}
+	if code := exitCodeFor(executeError); code != exitNotFound {
+		t.Fatalf("exit code = %d, want %d", code, exitNotFound)
+	}
+}
+
 func TestApplicationNameSlug(t *testing.T) {
 	for input, expected := range map[string]string{
 		"Neighborly export": "neighborly-export",

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -361,6 +361,10 @@ func (m baseMock) CreateApplication(requestContext context.Context, applicationR
 	return nil, errors.New("not implemented")
 }
 
+func (m baseMock) ImportClaudeDesignApplication(context.Context, client.ImportClaudeDesignRequest) (*client.ImportClaudeDesignResponse, error) {
+	return nil, nil
+}
+
 func (m baseMock) ListApplicationsRaw(requestContext context.Context, page int, pageSize int, search string) (json.RawMessage, error) {
 	return nil, errors.New("not implemented")
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -231,6 +231,7 @@ type APIClient interface {
 	DeleteStackProfileLogo(requestContext context.Context, profileID string) (json.RawMessage, error)
 
 	CreateApplication(requestContext context.Context, applicationRequest client.CreateApplicationRequest) (*client.CreateApplicationResponse, error)
+	ImportClaudeDesignApplication(requestContext context.Context, importRequest client.ImportClaudeDesignRequest) (*client.ImportClaudeDesignResponse, error)
 	ListApplicationsRaw(requestContext context.Context, page int, pageSize int, search string) (json.RawMessage, error)
 	GetApplicationRaw(requestContext context.Context, applicationID string) (json.RawMessage, error)
 	GetApplicationJobs(requestContext context.Context, applicationID string, page int, pageSize int) (json.RawMessage, error)

--- a/internal/client/applications_import.go
+++ b/internal/client/applications_import.go
@@ -1,0 +1,117 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// ImportClaudeDesignFile is one export file on the wire, base64.
+type ImportClaudeDesignFile struct {
+	Path          string `json:"path"`
+	ContentBase64 string `json:"content_base64"`
+}
+
+// ImportClaudeDesignRequest mirrors the platform import body: the create
+// route's repository fields plus the export files. The repository name,
+// visibility and source URL are omitted when empty so the platform applies
+// its defaults.
+type ImportClaudeDesignRequest struct {
+	Name                     string                   `json:"name"`
+	RepositoryCredentialName string                   `json:"app_repo_credential_name"`
+	RepositoryOwner          string                   `json:"app_repo_owner"`
+	RepositoryName           string                   `json:"app_repo_name,omitempty"`
+	Visibility               string                   `json:"visibility,omitempty"`
+	SourceURL                string                   `json:"source_url,omitempty"`
+	Files                    []ImportClaudeDesignFile `json:"files"`
+}
+
+// ImportedRepository is the repository the import landed in.
+type ImportedRepository struct {
+	Owner         string  `json:"owner"`
+	Name          string  `json:"name"`
+	WebURL        string  `json:"web_url"`
+	DefaultBranch string  `json:"default_branch"`
+	CommitSHA     *string `json:"commit_sha"`
+	Reused        bool    `json:"reused"`
+}
+
+// ImportedDesignPage is one converted artboard.
+type ImportedDesignPage struct {
+	Artboard string `json:"artboard"`
+	Path     string `json:"path"`
+	Title    string `json:"title"`
+	Dynamic  bool   `json:"dynamic"`
+	PageID   string `json:"page_id,omitempty"`
+}
+
+// ImportedDesignWarning is a non-fatal finding about one artboard.
+type ImportedDesignWarning struct {
+	Artboard string `json:"artboard"`
+	Kind     string `json:"kind"`
+	Message  string `json:"message"`
+}
+
+// ImportClaudeDesignResponse carries the registration outcome in the create
+// route's shape plus what the conversion produced.
+type ImportClaudeDesignResponse struct {
+	ID         *string                    `json:"id"`
+	Errors     []ApplicationResourceError `json:"errors"`
+	Repository *ImportedRepository        `json:"repository"`
+	Pages      []ImportedDesignPage       `json:"pages"`
+	Warnings   []ImportedDesignWarning    `json:"warnings"`
+	Notes      []string                   `json:"notes"`
+}
+
+// ImportClaudeDesignApplication turns a Claude Design export into a
+// registered application on a repository the platform creates.
+func (client *Client) ImportClaudeDesignApplication(requestContext context.Context, importRequest ImportClaudeDesignRequest) (*ImportClaudeDesignResponse, error) {
+	requestBody, marshalError := json.Marshal(importRequest)
+	if marshalError != nil {
+		return nil, fmt.Errorf("marshal request: %w", marshalError)
+	}
+
+	request, requestError := http.NewRequestWithContext(
+		requestContext,
+		http.MethodPost,
+		client.BaseURL+"/api/v1/org/applications/imports/claude-design",
+		bytes.NewReader(requestBody),
+	)
+	if requestError != nil {
+		return nil, fmt.Errorf("create request: %w", requestError)
+	}
+	request.Header.Set("Authorization", "Bearer "+client.Token)
+	request.Header.Set("Content-Type", "application/json")
+
+	response, sendError := client.HTTP.Do(request)
+	if sendError != nil {
+		return nil, fmt.Errorf("request failed: %w", sendError)
+	}
+	defer closeBody(response)
+
+	responseBody, readError := readResponseBody(response)
+	if readError != nil {
+		return nil, fmt.Errorf("read response: %w", readError)
+	}
+	if response.StatusCode == http.StatusUnauthorized {
+		return nil, ErrUnauthorized
+	}
+	if response.StatusCode != http.StatusOK {
+		if permissionDenied := PermissionDeniedFromResponse(response.StatusCode, responseBody); permissionDenied != nil {
+			return nil, permissionDenied
+		}
+		return nil, newUnexpectedResponseError(
+			"import claude design application failed",
+			response.StatusCode,
+			redactedBodyForError(responseBody, 500),
+		)
+	}
+
+	var importResponse ImportClaudeDesignResponse
+	if unmarshalError := json.Unmarshal(responseBody, &importResponse); unmarshalError != nil {
+		return nil, fmt.Errorf("parse response: %w", unmarshalError)
+	}
+	return &importResponse, nil
+}

--- a/internal/skills/embedded/skills/ankra-applications/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-applications/SKILL.md
@@ -55,6 +55,30 @@ Related flags: `--registry-api-url`, `--registry-username-secret`, `--registry-p
 to let Ankra write the named credential into those secrets for you. See
 [reference.md](reference.md) for the registry matrix (Harbor, ECR, GAR, ACR, GHCR, Docker Hub).
 
+## 1b. From a Claude Design export (no repository yet)
+
+A canvas exported from [Claude Design](https://claude.ai/design) can be registered without a
+repository of its own: Ankra converts the artboards into a static site, creates the GitHub
+repository under the credential's account, commits the site with a busybox `httpd` Dockerfile,
+and registers the application - the same setup PR, build and deploy lane follows.
+
+```bash
+ankra application import claude-design ./neighborly-export --name neighborly
+ankra application import claude-design neighborly.zip --credential github-acme --owner acme \
+  --repository neighborly-site --source-url https://claude.ai/design/p/<id> --wait
+```
+
+`<path>` is a directory of the export (`<Name>.dc.html` artboards, `canvas.json`, images), a zip
+of it, one artboard, or a saved canvas page (`.html`). `Main.dc.html` becomes `site/index.html`,
+the other artboards `site/<name>.html`, and a multi-artboard canvas gets a `site/canvas.html`
+index. Artboards that use template logic (`{{ }}` holes, `sc-for`/`sc-if`, `dc-import`, a
+`data-dc-script`) are kept as authored and reported as warnings: they need the Claude Design
+runtime and may not render as on the canvas - replace the logic with markup and import again, or
+edit the page under `site/`. Re-running the same import registers the same repository without a
+second commit (`.ankra/design-import.json` records the inputs); a changed export is refused -
+use a new `--repository` name. The GitHub App cannot create repositories in a personal
+account: use an organisation owner, or create the repository first and use `application add`.
+
 ## 2. Review what Ankra generated
 
 Ankra opens a **setup pull request** carrying the Dockerfile, the Helm chart, and the build


### PR DESCRIPTION
## What

`ankra application import claude-design <path>` turns a Claude Design export into a deployable application.

`<path>` is a directory holding the export (`<Name>.dc.html` artboards, `canvas.json`, images), a zip of it, one artboard, or a saved canvas page. The command reads the files, picks the GitHub credential the way `application add` does (`--credential`, and `--owner` defaults to the credential's account), and calls the platform's import route (ankraio/cluster: "import a Claude Design export as an application"), which converts the artboards into a static site, creates the repository, commits it with a Dockerfile and registers the application. It reports the repository, the commit, every page, and any artboard that depends on the design runtime; `--wait` follows the analysis to the setup pull request; `-o json` keeps stdout parseable.

- `cmd/application_import.go` - the `import` family and its `claude-design` subcommand; export reading with the editor's own size limits; name derived from the directory or file when `--name` is omitted.
- `internal/client/applications_import.go` - the typed call; `APIClient` and `baseMock` extended per the repo rule.
- Embedded `ankra-applications` skill documents the lane beside `application add` (the split-repo embedded copy is canonical here).
- `CHANGELOG.md` Unreleased entry.

## Feature flag

**`claude_design_import`**, an organisation feature flag registered dark (toggle per organisation in the admin portal). The platform answers 404 while the organisation flag is off; the command explains that ("the claude_design_import feature flag is off; ask Ankra support"), exits 3, and says so in its help and the changelog.

## Verification

`go build`, `go test ./cmd/` (four new command tests against an httptest platform: request body, flags, refusal, empty directory), `go vet`, `golangci-lint` clean; the pre-commit hook's full test + lint gate passed.

Tracker: the beads tracker was partitioned when this was built, so no bead id is cited yet; one will be filed and linked as soon as it heals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017b5dUUVmPSe2tQ2ZLxet7s

Bead: ankra-ac1i1
