### PR TITLE
fix(support): attach sends the file's real Content-Type, not application/octet-stream (ankra-tj0dr)

### DIFF
--- a/internal/client/support.go
+++ b/internal/client/support.go
@@ -6,12 +6,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"mime"
 	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	neturl "net/url"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -245,6 +248,33 @@ func (c *Client) CommentSupportTicket(ctx context.Context, ticketID, comment str
 	return &out, nil
 }
 
+// attachmentContentType answers the media type the platform is told about an
+// attachment. The platform admits an upload on the multipart part's own
+// Content-Type header (image/png, image/jpeg, image/webp, image/gif) and
+// refuses anything else with 415, so the part must carry the file's real
+// type. multipart.Writer.CreateFormFile stamps every part
+// application/octet-stream, which is how a valid PNG used to be refused.
+// The type is read from the bytes, not the extension, because that is the
+// same evidence the platform's allowlist is meant to protect.
+func attachmentContentType(content []byte) string {
+	detected := http.DetectContentType(content)
+	if mediaType, _, parseError := mime.ParseMediaType(detected); parseError == nil {
+		return mediaType
+	}
+	return detected
+}
+
+// attachmentPartHeader is the multipart header CreateFormFile would write,
+// with the detected Content-Type in place of application/octet-stream.
+func attachmentPartHeader(filename string, contentType string) textproto.MIMEHeader {
+	quote := strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
+	header := make(textproto.MIMEHeader)
+	header.Set("Content-Disposition",
+		fmt.Sprintf(`form-data; name="file"; filename="%s"`, quote.Replace(filename)))
+	header.Set("Content-Type", contentType)
+	return header
+}
+
 func (c *Client) UploadSupportAttachment(ctx context.Context, ticketID, filePath string) (*SupportTicket, error) {
 	fileBytes, err := os.ReadFile(filePath)
 	if err != nil {
@@ -252,7 +282,7 @@ func (c *Client) UploadSupportAttachment(ctx context.Context, ticketID, filePath
 	}
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
-	part, err := writer.CreateFormFile("file", filepath.Base(filePath))
+	part, err := writer.CreatePart(attachmentPartHeader(filepath.Base(filePath), attachmentContentType(fileBytes)))
 	if err != nil {
 		return nil, fmt.Errorf("build form: %w", err)
 	}

--- a/internal/client/support_attach_test.go
+++ b/internal/client/support_attach_test.go
@@ -1,0 +1,129 @@
+package client
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The platform admits a support attachment on the multipart part's own
+// Content-Type header and answers 415 for anything outside its image
+// allowlist. These tests pin that the CLI sends the file's real type: on the
+// old CreateFormFile path every part read application/octet-stream and a
+// valid PNG was refused (PLA-836).
+func TestUploadSupportAttachmentSendsDetectedContentType(t *testing.T) {
+	// The signatures http.DetectContentType recognises for the four allowed
+	// types; the tail is arbitrary so only the magic bytes decide.
+	cases := []struct {
+		name     string
+		filename string
+		content  []byte
+		want     string
+	}{
+		{"png", "screenshot.png", append([]byte("\x89PNG\r\n\x1a\n"), make([]byte, 16)...), "image/png"},
+		{"jpeg", "photo.jpg", append([]byte("\xff\xd8\xff"), make([]byte, 16)...), "image/jpeg"},
+		{"gif", "anim.gif", append([]byte("GIF89a"), make([]byte, 16)...), "image/gif"},
+		{"webp", "pic.webp", append([]byte("RIFF\x00\x00\x00\x00WEBPVP"), make([]byte, 16)...), "image/webp"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPartType, gotFilename, gotField string
+			var gotBytes int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				file, header, err := r.FormFile("file")
+				if err != nil {
+					t.Errorf("FormFile(file) error = %v", err)
+					w.WriteHeader(http.StatusUnprocessableEntity)
+					return
+				}
+				defer file.Close()
+				content, _ := io.ReadAll(file)
+				gotBytes = len(content)
+				gotPartType = header.Header.Get("Content-Type")
+				gotFilename = header.Filename
+				gotField = "file"
+				jsonResponse(t, w, http.StatusOK, SupportTicket{ID: "ticket-1"})
+			}))
+			t.Cleanup(server.Close)
+
+			path := filepath.Join(t.TempDir(), tc.filename)
+			if err := os.WriteFile(path, tc.content, 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			c := New(testToken, server.URL)
+			ticket, err := c.UploadSupportAttachment(context.Background(), "ticket-1", path)
+			if err != nil {
+				t.Fatalf("UploadSupportAttachment() error = %v", err)
+			}
+			if ticket == nil || ticket.ID != "ticket-1" {
+				t.Fatalf("UploadSupportAttachment() ticket = %+v, want id ticket-1", ticket)
+			}
+			if gotField != "file" {
+				t.Errorf("multipart field = %q, want file", gotField)
+			}
+			if gotPartType != tc.want {
+				t.Errorf("part Content-Type = %q, want %q", gotPartType, tc.want)
+			}
+			if gotFilename != tc.filename {
+				t.Errorf("part filename = %q, want %q", gotFilename, tc.filename)
+			}
+			if gotBytes != len(tc.content) {
+				t.Errorf("part bytes = %d, want %d", gotBytes, len(tc.content))
+			}
+		})
+	}
+}
+
+// A file the sniffer cannot place is still sent, with whatever type the
+// bytes suggest, so the platform's own 415 and its allowlist message reach
+// the user unchanged rather than a client-side guess at the same rule.
+func TestUploadSupportAttachmentUnknownTypeReachesThePlatform(t *testing.T) {
+	var gotPartType string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, header, err := r.FormFile("file")
+		if err != nil {
+			t.Errorf("FormFile(file) error = %v", err)
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			return
+		}
+		gotPartType = header.Header.Get("Content-Type")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnsupportedMediaType)
+		_, _ = w.Write([]byte(`{"detail":"Unsupported attachment type. Allowed types: PNG, JPEG, WebP, GIF."}`))
+	}))
+	t.Cleanup(server.Close)
+
+	path := filepath.Join(t.TempDir(), "notes.txt")
+	if err := os.WriteFile(path, []byte("plain text, not an image\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c := New(testToken, server.URL)
+	_, err := c.UploadSupportAttachment(context.Background(), "ticket-1", path)
+	if err == nil {
+		t.Fatal("UploadSupportAttachment() error = nil, want the platform's 415")
+	}
+	if gotPartType != "text/plain" {
+		t.Errorf("part Content-Type = %q, want text/plain (parameters stripped)", gotPartType)
+	}
+}
+
+// attachmentPartHeader must write the same Content-Disposition
+// CreateFormFile does, so a filename with a quote or backslash still parses
+// on the platform side.
+func TestAttachmentPartHeaderEscapesFilename(t *testing.T) {
+	header := attachmentPartHeader(`we"ird\name.png`, "image/png")
+	got := header.Get("Content-Disposition")
+	want := `form-data; name="file"; filename="we\"ird\\name.png"`
+	if got != want {
+		t.Errorf("Content-Disposition = %q, want %q", got, want)
+	}
+	if header.Get("Content-Type") != "image/png" {
+		t.Errorf("Content-Type = %q, want image/png", header.Get("Content-Type"))
+	}
+}

--- a/internal/client/support_attach_test.go
+++ b/internal/client/support_attach_test.go
@@ -40,7 +40,7 @@ func TestUploadSupportAttachmentSendsDetectedContentType(t *testing.T) {
 					w.WriteHeader(http.StatusUnprocessableEntity)
 					return
 				}
-				defer file.Close()
+				defer func() { _ = file.Close() }()
 				content, _ := io.ReadAll(file)
 				gotBytes = len(content)
 				gotPartType = header.Header.Get("Content-Type")


### PR DESCRIPTION
<!-- ankra-tech-agent:pr -->
Linear: https://linear.app/ankra/issue/PLA-836/1158-upcloud-vs-digitalocean-what-if-pricing-looks-wrong-upcloud-eur
Bead: ankra-tj0dr

## What

`ankra support attach <ticket> <file>` answered HTTP 415 `Unsupported attachment type. Allowed types: PNG, JPEG, WebP, GIF.` for a valid PNG (verified magic bytes, 1999x977) and for a JPEG re-encode of it, reported on PLA-836.

## Why

The platform admits a support attachment on the multipart **part's** `Content-Type` header (`cluster` `go/internal/supportapi/handlers.go:456`, checked against the image allowlist in `go/internal/usecase/support/attachments.go:19-20`). `internal/client/support.go` built the part with `multipart.Writer.CreateFormFile`, which the Go standard library hardcodes to `Content-Type: application/octet-stream`. So every CLI upload was refused whatever the file held; the browser upload path sets the real type and works.

## Change

- `UploadSupportAttachment` writes the part with `CreatePart`, carrying the type `http.DetectContentType` reads off the file's bytes (png, jpeg, gif and webp are all recognised) and the same `Content-Disposition` `CreateFormFile` would have written (quotes and backslashes in the filename escaped identically).
- A file the sniffer cannot place is still sent with whatever the bytes suggest, so the platform's own 415 and its allowlist message reach the user unchanged rather than a client-side re-implementation of the rule.

## Verification

- `go test -count=1 ./internal/client/ -run 'UploadSupportAttachment|AttachmentPartHeader'`: 3 tests, 6 subtests, pass. The content-type test is **red on `master`** (part reads `application/octet-stream`), verified by checking out master's `support.go` against the new test.
- `go build ./...`, `go vet ./internal/client/ ./cmd/`, `gofmt -l` clean. `golangci-lint` is not installed locally; the full linter runs in CI.
- Not verified against the live platform (no outbound calls from a ticket session); the server-side contract is read at `cluster` `origin/main` `1891d51b8`.

## Merge gate

Not on the scary list: CLI client change, ~40 lines plus tests, no auth, protocol or CI surface. Auto-merge once CI is green and the AI review has nothing open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
