### PR TITLE
feat(cluster): operations list --include-internal surfaces the platform's internal executions (ankra-o7z0p, PLA-831)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- **`ankra cluster operations list --include-internal` shows the platform's own
+  maintenance executions.** The default listing hides them, so a commit in the
+  cluster repository authored by the Ankra Reconciler ("Sync cluster state from
+  Ankra") had no execution the CLI could name. With the flag the GitOps
+  reconcile snapshot push and the other internal executions are listed
+  alongside your own, with the same columns and `-o json`/`yaml` output, so the
+  execution behind a repository commit or a re-encrypted file can be found from
+  the terminal. The default stays unchanged.
+
 - **A Claude Design export becomes a deployable application in one command.** `ankra application import claude-design <path>` takes what you exported from claude.ai/design - a directory of `<Name>.dc.html` artboards with `canvas.json` and images, a zip of it, one artboard, or a saved canvas page - and has Ankra convert it into a static site, create a GitHub repository under your GitHub credential (`--credential`, `--owner`), commit it with a Dockerfile and register the application, so the setup pull request, build and deploy follow as for any other application. `--repository`, `--visibility` and `--source-url` shape the repository; `--wait` follows the analysis to the setup pull request; `-o json` returns the pages and any warnings. Artboards that depend on the Claude Design runtime are kept as authored and reported, and re-running the same import registers the same repository without a second commit. The lane ships behind the `claude_design_import` organisation feature flag: while it is off the command explains that and exits 3, so ask Ankra support to enable it for your organisation.
 
 ## v0.15.1 — 2026-09-09

--- a/cmd/cluster_operation.go
+++ b/cmd/cluster_operation.go
@@ -79,6 +79,7 @@ var clusterOperationsListCmd = &cobra.Command{
 
 		statusFlag, _ := cmd.Flags().GetStringSlice("status")
 		failedOnly, _ := cmd.Flags().GetBool("failed")
+		includeInternal, _ := cmd.Flags().GetBool("include-internal")
 		limit, _ := cmd.Flags().GetInt("limit")
 		if limit <= 0 {
 			limit = defaultExecutionsPageSize
@@ -102,10 +103,11 @@ var clusterOperationsListCmd = &cobra.Command{
 			statusList = append(statusList, "failed", "critical")
 		}
 		options := client.ListExecutionsOptions{
-			ClusterID:  cluster.ID,
-			StatusList: statusList,
-			Page:       1,
-			PageSize:   limit,
+			ClusterID:                 cluster.ID,
+			StatusList:                statusList,
+			IncludeInternalExecutions: includeInternal,
+			Page:                      1,
+			PageSize:                  limit,
 		}
 
 		executionID := ""
@@ -567,6 +569,8 @@ func init() {
 	clusterOperationsListCmd.Flags().StringSlice("status", nil, "Filter by execution status (repeatable). Examples: failed, critical, running")
 	clusterOperationsListCmd.Flags().Bool("failed", false, "Shortcut for --status failed --status critical")
 	clusterOperationsListCmd.Flags().Int("limit", defaultExecutionsPageSize, "Maximum number of executions to return (max 100)")
+	clusterOperationsListCmd.Flags().Bool("include-internal", false,
+		"Also list the platform's internal maintenance executions, such as the GitOps reconcile snapshot push, which the default listing hides")
 	clusterOperationsListCmd.Flags().BoolP("watch", "w", false,
 		"Continuously poll and refresh until all executions reach a terminal state")
 	clusterOperationsListCmd.Flags().Duration("interval", defaultWatchInterval,

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -3179,11 +3179,37 @@ func TestClusterStacksListCommand(t *testing.T) {
 
 type clusterOperationsListMock struct {
 	baseMock
-	executions []client.ExecutionSummary
+	executions  []client.ExecutionSummary
+	lastOptions client.ListExecutionsOptions
 }
 
 func (m *clusterOperationsListMock) ListExecutions(opts client.ListExecutionsOptions) (client.ExecutionListResponse, error) {
+	m.lastOptions = opts
 	return client.ExecutionListResponse{Result: m.executions}, nil
+}
+
+// TestClusterOperationsListIncludeInternalFlag pins that --include-internal
+// reaches the client as IncludeInternalExecutions and that the default
+// listing leaves it off, so the platform's internal maintenance executions
+// stay hidden unless asked for.
+func TestClusterOperationsListIncludeInternalFlag(t *testing.T) {
+	writeSelectedClusterJSON(t)
+	mock := &clusterOperationsListMock{}
+	setMockClient(t, mock)
+
+	_ = captureStdout(t, func() {
+		_, _ = executeCommand("cluster", "operations", "list")
+	})
+	if mock.lastOptions.IncludeInternalExecutions {
+		t.Fatalf("default listing must not include internal executions, got options %+v", mock.lastOptions)
+	}
+
+	_ = captureStdout(t, func() {
+		_, _ = executeCommand("cluster", "operations", "list", "--include-internal")
+	})
+	if !mock.lastOptions.IncludeInternalExecutions {
+		t.Fatalf("--include-internal did not reach the client, got options %+v", mock.lastOptions)
+	}
 }
 
 func TestClusterOperationsListCommand(t *testing.T) {

--- a/internal/client/executions.go
+++ b/internal/client/executions.go
@@ -87,8 +87,14 @@ type ListExecutionsOptions struct {
 	StatusList         []string
 	TargetResourceKind string
 	TargetResourceID   string
-	Page               int
-	PageSize           int
+	// IncludeInternalExecutions also lists the platform's internal
+	// maintenance executions, which every default listing hides: the
+	// GitOps reconcile snapshot push that lands a "Sync cluster state from
+	// Ankra" commit and may re-encrypt sealed files. It is sent only when
+	// set, so the server default (hidden) is untouched otherwise.
+	IncludeInternalExecutions bool
+	Page                      int
+	PageSize                  int
 }
 
 type CancelExecutionResponse struct {
@@ -132,6 +138,9 @@ func (c *Client) ListExecutions(opts ListExecutionsOptions) (ExecutionListRespon
 	}
 	if opts.TargetResourceID != "" {
 		params.Set("target_resource_id", opts.TargetResourceID)
+	}
+	if opts.IncludeInternalExecutions {
+		params.Set("include_internal_executions", "true")
 	}
 	if opts.Page > 0 {
 		params.Set("page", fmt.Sprintf("%d", opts.Page))

--- a/internal/client/executions_test.go
+++ b/internal/client/executions_test.go
@@ -58,6 +58,35 @@ func TestListExecutionsBuildsQueryString(t *testing.T) {
 	}
 }
 
+// TestListExecutionsIncludeInternalIsSentOnlyWhenSet pins the wire contract
+// for --include-internal: the server hides internal executions by default and
+// reads include_internal_executions as an explicit opt-in, so the parameter
+// must be present (true) when asked for and absent otherwise - never sent as
+// "false", which some servers reject as a validation error.
+func TestListExecutionsIncludeInternalIsSentOnlyWhenSet(t *testing.T) {
+	var capturedQueries []string
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQueries = append(capturedQueries, r.URL.RawQuery)
+		jsonResponse(t, w, http.StatusOK, ExecutionListResponse{})
+	})
+
+	if _, err := testClient.ListExecutions(ListExecutionsOptions{ClusterID: "cluster-uuid"}); err != nil {
+		t.Fatalf("ListExecutions (default) error = %v", err)
+	}
+	if _, err := testClient.ListExecutions(ListExecutionsOptions{ClusterID: "cluster-uuid", IncludeInternalExecutions: true}); err != nil {
+		t.Fatalf("ListExecutions (include internal) error = %v", err)
+	}
+	if len(capturedQueries) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(capturedQueries))
+	}
+	if strings.Contains(capturedQueries[0], "include_internal_executions") {
+		t.Errorf("default listing must not send include_internal_executions, got: %s", capturedQueries[0])
+	}
+	if !strings.Contains(capturedQueries[1], "include_internal_executions=true") {
+		t.Errorf("expected include_internal_executions=true in query, got: %s", capturedQueries[1])
+	}
+}
+
 func TestGetExecutionReturnsDetail(t *testing.T) {
 	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if !strings.HasSuffix(r.URL.Path, "/exec-1") {


### PR DESCRIPTION
## What

`ankra cluster operations list --include-internal` (default off) sends `include_internal_executions=true` to the executions list endpoint, so the platform's internal maintenance executions - the GitOps reconcile snapshot push that lands a "Sync cluster state from Ankra" commit and may re-encrypt sealed files - are listed alongside the cluster's own. The parameter is omitted when the flag is off, so the server default (hidden) is untouched.

## Why

cluster#2856 gave the MCP tool and the chat lane this opt-in; the CLI was the missing half (Depict, support ticket #1153: a repository commit authored by the reconciler had no execution the CLI could name).

## Tests

- `internal/client`: the parameter is sent only when set, never as `false`.
- `cmd`: `--include-internal` reaches the client options; the default listing leaves it off.
- CHANGELOG Unreleased entry added.

Bead: ankra-o7z0p

🤖 Generated with [Claude Code](https://claude.com/claude-code)
