### PR TITLE
chore(release): v0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v0.15.2 — 2026-09-10
+
+### Added
+
 - **`ankra cluster operations list --include-internal` shows the platform's own
   maintenance executions.** The default listing hides them, so a commit in the
   cluster repository authored by the Ankra Reconciler ("Sync cluster state from
@@ -12,6 +16,21 @@
   the terminal. The default stays unchanged.
 
 - **A Claude Design export becomes a deployable application in one command.** `ankra application import claude-design <path>` takes what you exported from claude.ai/design - a directory of `<Name>.dc.html` artboards with `canvas.json` and images, a zip of it, one artboard, or a saved canvas page - and has Ankra convert it into a static site, create a GitHub repository under your GitHub credential (`--credential`, `--owner`), commit it with a Dockerfile and register the application, so the setup pull request, build and deploy follow as for any other application. `--repository`, `--visibility` and `--source-url` shape the repository; `--wait` follows the analysis to the setup pull request; `-o json` returns the pages and any warnings. Artboards that depend on the Claude Design runtime are kept as authored and reported, and re-running the same import registers the same repository without a second commit. The lane ships behind the `claude_design_import` organisation feature flag: while it is off the command explains that and exits 3, so ask Ankra support to enable it for your organisation.
+
+### Fixed
+
+- **`ankra support attach` no longer refuses a valid image with
+  "Unsupported attachment type".** Every upload was rejected whatever the
+  file held, a verified PNG included: the platform admits a support
+  attachment on the multipart part's own `Content-Type` header, checked
+  against an allowlist of PNG, JPEG, WebP and GIF, and the client built that
+  part with `CreateFormFile`, which the Go standard library hardcodes to
+  `application/octet-stream`. The answer was HTTP 415. The part now carries
+  the type read off the file's own bytes, so PNG, JPEG, GIF and WebP
+  attachments are accepted. A file whose bytes the sniffer cannot place is
+  still sent with whatever they suggest, so the platform's own 415 and its
+  allowlist message reach you unchanged rather than a client-side copy of
+  the rule.
 
 ## v0.15.1 — 2026-09-09
 


### PR DESCRIPTION
Linear: https://linear.app/ankra/issue/PLA-831

## What

Cuts `ankra-cli` v0.15.2. Promotes `## Unreleased` to `## v0.15.2 — 2026-09-10` with `### Added` / `### Fixed` subsections and leaves an empty `## Unreleased` above it.

## Why

Depict (PLA-831) needs `ankra cluster operations list --include-internal` (#281, ankra-o7z0p) in a released binary; it merged after v0.15.1 and is only on `master` today.

## What is in the release

**Added**

- `ankra cluster operations list --include-internal` surfaces the platform's own internal executions (#281, ankra-o7z0p, PLA-831).
- `ankra application import claude-design` turns a Claude Design export into a deployable application, behind the `claude_design_import` organisation flag (#278).

**Fixed**

- `ankra support attach` sends the file's real content type instead of `application/octet-stream`, so a valid PNG or JPEG is no longer refused with HTTP 415 (#279, ankra-tj0dr).

**#279 had merged with no changelog entry**, so this PR writes it. That is the failure mode the release notes cannot recover from: the release body is extracted from the matching CHANGELOG section, so an entry missing at tag time is missing from the release forever. `git log v0.15.1..origin/master` is three commits and #279 was the one without an entry.

## Verification

- Pre-commit gate ran in full on the commit: `go test ./...` all packages pass, `golangci-lint run ./...` reports 0 issues. Only `CHANGELOG.md` changed, so neither could have been affected; they are recorded as evidence the tree is clean.
- The release workflow's own extractor was run against the new heading before pushing:
  ```
  TAG=v0.15.2; VERSION="${TAG#v}"
  awk -v version="${VERSION}" '
    $0 ~ "^## v?"version"([[:space:]]|$)" {found=1; next}
    found && /^## / {exit}
    found {print}
  ' CHANGELOG.md
  ```
  It returns 29 lines, both Added entries and the new Fixed entry, and stops at `## v0.15.1 — 2026-09-09`. The empty `## Unreleased` above does not match, and no `v0.15.2-rc*` heading exists to be swallowed.
- No version constant to bump: the workflow stamps `-X main.version=${VERSION}` from the tag.

## Merge gate

Not on the scary list: one documentation file, no code, no schema, auth or CI surface. Squash-merge once CI is green, then the annotated tag `v0.15.2` on the merge commit drives `.github/workflows/release.yml` (six OS/arch binaries, checksums, install.sh, GitHub release, Homebrew formula).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
