### PR TITLE
fix(helm): credentials get|update|delete accept the id that list prints (ankra-hloxg, PLA-825)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Fixed
+
+- **`ankra helm credentials get|update|delete` accept the id that `list`
+  prints.** The listing leads with an ID column, but the platform addresses a
+  credential by name, so the obvious next command - `helm credentials get
+  <id>` - answered a bare `404 Not Found` that read as "credentials are
+  write-only" (reported by Smartoptics, PLA-825). A canonical uuid is now
+  looked up in the listing and the credential's name is used; a name still
+  goes straight through. An id the listing does not hold exits 3 and points
+  at `ankra helm credentials list`, the same way a missing name does.
+
 ## v0.15.2 — 2026-09-10
 
 ### Added

--- a/cmd/helm.go
+++ b/cmd/helm.go
@@ -632,11 +632,16 @@ Example:
 }
 
 var helmCredentialsGetCmd = &cobra.Command{
-	Use:   "get <name>",
+	Use:   "get <name-or-id>",
 	Short: "Get details of a Helm registry credential",
-	Args:  cobra.ExactArgs(1),
+	Long: `Show a Helm registry credential by its name or by the id
+'ankra helm credentials list' prints. The password is never returned.`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		credentialName := args[0]
+		credentialName, err := resolveHelmCredentialName(apiClient, args[0])
+		if err != nil {
+			return err
+		}
 
 		response, err := apiClient.GetHelmRegistryCredential(credentialName)
 		if err != nil {
@@ -658,16 +663,20 @@ var helmCredentialsGetCmd = &cobra.Command{
 }
 
 var helmCredentialsUpdateCmd = &cobra.Command{
-	Use:   "update <name>",
+	Use:   "update <name-or-id>",
 	Short: "Update a Helm registry credential",
-	Long: `Update a Helm registry credential's username and password.
+	Long: `Update a Helm registry credential's username and password, addressed by
+its name or by the id 'ankra helm credentials list' prints.
 The password will be prompted interactively.
 
 Example:
   ankra helm credentials update my-cred --username user`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		credentialName := args[0]
+		credentialName, err := resolveHelmCredentialName(apiClient, args[0])
+		if err != nil {
+			return err
+		}
 		username, _ := cmd.Flags().GetString("username")
 
 		passwordPrompt := promptui.Prompt{
@@ -698,11 +707,16 @@ Example:
 }
 
 var helmCredentialsDeleteCmd = &cobra.Command{
-	Use:   "delete <name>",
+	Use:   "delete <name-or-id>",
 	Short: "Delete a Helm registry credential",
-	Args:  cobra.ExactArgs(1),
+	Long: `Delete a Helm registry credential, addressed by its name or by the id
+'ankra helm credentials list' prints.`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		credentialName := args[0]
+		credentialName, err := resolveHelmCredentialName(apiClient, args[0])
+		if err != nil {
+			return err
+		}
 		force, _ := cmd.Flags().GetBool("force")
 
 		if !force {

--- a/cmd/helm_credentials_resolve.go
+++ b/cmd/helm_credentials_resolve.go
@@ -40,6 +40,14 @@ func resolveHelmCredentialName(credentials APIClient, reference string) (string,
 			return credential.Name, nil
 		}
 	}
+	// A credential whose name happens to have the uuid shape is still
+	// addressable by that name: it is only treated as an id while no
+	// credential carries it as one.
+	for _, credential := range listing.Credentials {
+		if credential.Name == reference {
+			return reference, nil
+		}
+	}
 	if listing.TotalCount > len(listing.Credentials) {
 		// The listing is paged server-side and the client reads its first
 		// page only, so a miss on a partial read is not proof of absence.

--- a/cmd/helm_credentials_resolve.go
+++ b/cmd/helm_credentials_resolve.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// helmCredentialLookupFailure reports that an id could not be resolved
+// because the listing itself was unusable. The cause is wrapped so an
+// unauthorised or forbidden listing still classifies into its own exit code.
+func helmCredentialLookupFailure(reference string, cause error) error {
+	return fmt.Errorf("could not look up the Helm registry credential with id %q: %w - pass the "+
+		"credential name to skip the lookup, or run 'ankra helm credentials list' to find it", reference, cause)
+}
+
+// resolveHelmCredentialName accepts either a Helm registry credential name or
+// its id and returns the name the API addresses it by.
+//
+// The platform keys /api/v1/org/helm/credentials/{credential_name} by name,
+// while `helm credentials list` prints an ID column first, so the obvious next
+// command - `helm credentials get <id>` - reached the API with an id in the
+// name slot and came back as a bare 404 that read as "credentials are
+// write-only" (PLA-825). A canonical uuid is looked up in the listing instead;
+// anything else is already a name and goes through unchanged.
+func resolveHelmCredentialName(credentials APIClient, reference string) (string, error) {
+	reference = strings.TrimSpace(reference)
+	if reference == "" {
+		return "", withExitCode(exitUsage, errors.New("a Helm registry credential name or id is required"))
+	}
+	if !looksLikeUUID(reference) {
+		return reference, nil
+	}
+	listing, listError := credentials.ListHelmRegistryCredentials()
+	if listError != nil {
+		return "", helmCredentialLookupFailure(reference, listError)
+	}
+	for _, credential := range listing.Credentials {
+		if strings.EqualFold(credential.ID, reference) {
+			return credential.Name, nil
+		}
+	}
+	if listing.TotalCount > len(listing.Credentials) {
+		// The listing is paged server-side and the client reads its first
+		// page only, so a miss on a partial read is not proof of absence.
+		return "", helmCredentialLookupFailure(reference, fmt.Errorf(
+			"the listing holds %d credentials and only %d were read", listing.TotalCount, len(listing.Credentials)))
+	}
+	// exitNotFound keeps the id path and the name path telling scripts the
+	// same thing: a name that does not exist reaches the API and comes back
+	// 404, which exitCodeFor already maps to exitNotFound.
+	return "", withExitCode(exitNotFound, fmt.Errorf(
+		"no Helm registry credential with id %q - run 'ankra helm credentials list' to see the available credentials", reference))
+}

--- a/cmd/helm_credentials_resolve_test.go
+++ b/cmd/helm_credentials_resolve_test.go
@@ -1,0 +1,199 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+const (
+	resolveTestCredentialID   = "ebe7ee12-f294-4d80-956b-f107c30b2f3d"
+	resolveTestCredentialName = "ankra-harbor-app-dc62ed4f"
+)
+
+type helmCredentialResolveMock struct {
+	baseMock
+	credentials       []client.HelmCredentialListItem
+	totalCount        int
+	listError         error
+	listCalls         int
+	requestedName     string
+	deleteRequested   string
+	updateRequested   string
+	updateRequestBody client.UpdateHelmCredentialRequest
+}
+
+func (m *helmCredentialResolveMock) ListHelmRegistryCredentials() (*client.ListHelmCredentialsResponse, error) {
+	m.listCalls++
+	if m.listError != nil {
+		return nil, m.listError
+	}
+	totalCount := m.totalCount
+	if totalCount == 0 {
+		totalCount = len(m.credentials)
+	}
+	return &client.ListHelmCredentialsResponse{Credentials: m.credentials, TotalCount: totalCount}, nil
+}
+
+func (m *helmCredentialResolveMock) GetHelmRegistryCredential(credentialName string) (*client.GetHelmCredentialResponse, error) {
+	m.requestedName = credentialName
+	return &client.GetHelmCredentialResponse{
+		ID:       resolveTestCredentialID,
+		Name:     credentialName,
+		Username: "robot$org+app",
+		Provider: "helm",
+	}, nil
+}
+
+func (m *helmCredentialResolveMock) UpdateHelmRegistryCredential(credentialName string, request client.UpdateHelmCredentialRequest) error {
+	m.updateRequested = credentialName
+	m.updateRequestBody = request
+	return nil
+}
+
+func (m *helmCredentialResolveMock) DeleteHelmRegistryCredential(credentialName string) (*client.DeleteHelmCredentialResponse, error) {
+	m.deleteRequested = credentialName
+	return &client.DeleteHelmCredentialResponse{Success: true}, nil
+}
+
+func newHelmCredentialResolveMock() *helmCredentialResolveMock {
+	return &helmCredentialResolveMock{
+		credentials: []client.HelmCredentialListItem{
+			{ID: "4793065f-1278-4ae2-bc4e-b87467b2ba92", Name: "ankra-harbor-app-7da15f97"},
+			{ID: resolveTestCredentialID, Name: resolveTestCredentialName},
+		},
+	}
+}
+
+func TestResolveHelmCredentialNamePassesANameThroughWithoutListing(t *testing.T) {
+	mock := newHelmCredentialResolveMock()
+
+	resolved, resolveError := resolveHelmCredentialName(mock, "smartoptics-harbor-robot-admin")
+	if resolveError != nil {
+		t.Fatalf("unexpected error: %v", resolveError)
+	}
+	if resolved != "smartoptics-harbor-robot-admin" {
+		t.Errorf("expected the name to pass through unchanged, got %q", resolved)
+	}
+	if mock.listCalls != 0 {
+		t.Errorf("expected no listing for a name, got %d calls", mock.listCalls)
+	}
+}
+
+func TestResolveHelmCredentialNameResolvesAnIDToItsName(t *testing.T) {
+	mock := newHelmCredentialResolveMock()
+
+	resolved, resolveError := resolveHelmCredentialName(mock, strings.ToUpper(resolveTestCredentialID))
+	if resolveError != nil {
+		t.Fatalf("unexpected error: %v", resolveError)
+	}
+	if resolved != resolveTestCredentialName {
+		t.Errorf("expected %q, got %q", resolveTestCredentialName, resolved)
+	}
+}
+
+func TestResolveHelmCredentialNameUnknownIDExitsNotFound(t *testing.T) {
+	mock := newHelmCredentialResolveMock()
+
+	_, resolveError := resolveHelmCredentialName(mock, "00000000-0000-4000-8000-000000000000")
+	if resolveError == nil {
+		t.Fatal("expected an error for an id the listing does not hold")
+	}
+	if exitCodeFor(resolveError) != exitNotFound {
+		t.Errorf("expected exit %d, got %d (%v)", exitNotFound, exitCodeFor(resolveError), resolveError)
+	}
+	if !strings.Contains(resolveError.Error(), "ankra helm credentials list") {
+		t.Errorf("expected the error to point at the listing, got: %v", resolveError)
+	}
+}
+
+func TestResolveHelmCredentialNameRefusesToAnswerFromAPartialListing(t *testing.T) {
+	mock := newHelmCredentialResolveMock()
+	mock.totalCount = 250
+
+	_, resolveError := resolveHelmCredentialName(mock, "00000000-0000-4000-8000-000000000000")
+	if resolveError == nil {
+		t.Fatal("expected an error when the listing was only partly read")
+	}
+	if exitCodeFor(resolveError) == exitNotFound {
+		t.Errorf("a partial listing must not claim the credential is absent: %v", resolveError)
+	}
+	if !strings.Contains(resolveError.Error(), "only 2 were read") {
+		t.Errorf("expected the partial read to be named, got: %v", resolveError)
+	}
+}
+
+func TestResolveHelmCredentialNameSurfacesAListingFailure(t *testing.T) {
+	mock := newHelmCredentialResolveMock()
+	mock.listError = client.ErrUnauthorized
+
+	_, resolveError := resolveHelmCredentialName(mock, resolveTestCredentialID)
+	if !errors.Is(resolveError, client.ErrUnauthorized) {
+		t.Fatalf("expected the listing failure to be wrapped, got: %v", resolveError)
+	}
+	if exitCodeFor(resolveError) != exitAuth {
+		t.Errorf("expected exit %d, got %d", exitAuth, exitCodeFor(resolveError))
+	}
+}
+
+func TestResolveHelmCredentialNameEmptyReferenceIsAUsageError(t *testing.T) {
+	mock := newHelmCredentialResolveMock()
+
+	_, resolveError := resolveHelmCredentialName(mock, "  ")
+	if exitCodeFor(resolveError) != exitUsage {
+		t.Errorf("expected exit %d, got %d (%v)", exitUsage, exitCodeFor(resolveError), resolveError)
+	}
+}
+
+func TestHelmCredentialsGetAcceptsTheIDListPrints(t *testing.T) {
+	mock := newHelmCredentialResolveMock()
+	setMockClient(t, mock)
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("helm", "credentials", "get", resolveTestCredentialID)
+	})
+
+	if mock.requestedName != resolveTestCredentialName {
+		t.Errorf("expected the API to be asked for %q, got %q", resolveTestCredentialName, mock.requestedName)
+	}
+	if !strings.Contains(stdoutOutput, "Credential: "+resolveTestCredentialName) {
+		t.Errorf("expected the credential detail, got: %s", stdoutOutput)
+	}
+}
+
+func TestHelmCredentialsDeleteForceAcceptsTheID(t *testing.T) {
+	mock := newHelmCredentialResolveMock()
+	setMockClient(t, mock)
+	t.Cleanup(func() {
+		_ = helmCredentialsDeleteCmd.Flags().Set("force", "false")
+	})
+
+	stdoutOutput := captureStdout(t, func() {
+		_, _ = executeCommand("helm", "credentials", "delete", resolveTestCredentialID, "--force")
+	})
+
+	if mock.deleteRequested != resolveTestCredentialName {
+		t.Errorf("expected the API to delete %q, got %q", resolveTestCredentialName, mock.deleteRequested)
+	}
+	if !strings.Contains(stdoutOutput, "Credential '"+resolveTestCredentialName+"' deleted.") {
+		t.Errorf("expected the deletion to name the credential, got: %s", stdoutOutput)
+	}
+}
+
+func TestHelmCredentialsGetUnknownIDExitsNotFound(t *testing.T) {
+	mock := newHelmCredentialResolveMock()
+	setMockClient(t, mock)
+
+	_, commandError := executeCommand("helm", "credentials", "get", "00000000-0000-4000-8000-000000000000")
+	if commandError == nil {
+		t.Fatal("expected an error")
+	}
+	if exitCodeFor(commandError) != exitNotFound {
+		t.Errorf("expected exit %d, got %d (%v)", exitNotFound, exitCodeFor(commandError), commandError)
+	}
+	if mock.requestedName != "" {
+		t.Errorf("expected no API call for an unknown id, got a request for %q", mock.requestedName)
+	}
+}

--- a/cmd/helm_credentials_resolve_test.go
+++ b/cmd/helm_credentials_resolve_test.go
@@ -94,6 +94,22 @@ func TestResolveHelmCredentialNameResolvesAnIDToItsName(t *testing.T) {
 	}
 }
 
+func TestResolveHelmCredentialNameKeepsANameShapedLikeAUUID(t *testing.T) {
+	mock := newHelmCredentialResolveMock()
+	uuidShapedName := "11111111-2222-4333-8444-555555555555"
+	mock.credentials = append(mock.credentials, client.HelmCredentialListItem{
+		ID: "9f0c1e2d-3b4a-4c5d-8e6f-70a1b2c3d4e5", Name: uuidShapedName,
+	})
+
+	resolved, resolveError := resolveHelmCredentialName(mock, uuidShapedName)
+	if resolveError != nil {
+		t.Fatalf("unexpected error: %v", resolveError)
+	}
+	if resolved != uuidShapedName {
+		t.Errorf("expected the uuid-shaped name to be kept, got %q", resolved)
+	}
+}
+
 func TestResolveHelmCredentialNameUnknownIDExitsNotFound(t *testing.T) {
 	mock := newHelmCredentialResolveMock()
 


### PR DESCRIPTION
## What

`ankra helm credentials get|update|delete` now accept either the credential's name or the id that `ankra helm credentials list` prints.

## Why

The platform keys `/api/v1/org/helm/credentials/{credential_name}` by name, while the CLI listing leads with an ID column, so the obvious next command (`helm credentials get <id>`) answered a bare `404 Not Found`. The Smartoptics reporter on PLA-825 read that as "credentials are write-only". Item 5 of that ticket, bead `ankra-hloxg`.

## How

- New `resolveHelmCredentialName` in `cmd/helm_credentials_resolve.go`: a canonical uuid (`looksLikeUUID`) is looked up in the listing and the matching credential's name is used; anything else is a name and passes through untouched (no extra request).
- An id the listing does not hold exits 3 and points at `ankra helm credentials list`, matching what a missing name already does over the API.
- The listing is paged server-side (page_size max 100) and the client reads the first page only, so a miss on a partial read (`total_count > len(credentials)`) refuses to answer rather than claim absence.
- Wired into `get`, `update` and `delete`; `Use` strings and help updated. No client or interface change.

## Verification

- 10 new tests in `cmd/helm_credentials_resolve_test.go` (name pass-through without listing, id resolves case-insensitively, unknown id exits 3, partial listing refuses, listing failure keeps its exit code, empty reference is a usage error, `get`/`delete --force` end to end through the command, unknown id makes no API call).
- `go test ./cmd/ ./internal/client/` green; `golangci-lint run ./cmd/` 0 issues; pre-commit gate passed.
- Built binary against production, read-only, `--org Smartoptics`: the exact id from the ticket (`ebe7ee12-…`) returns the credential detail, a made-up id exits 3 with the pointer, and `get ankra-harbor-pull` by name is unchanged.

Bead: ankra-hloxg
Linear: PLA-825

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbYeTmx1EcZPMrU1pR2Fcw
