### PR TITLE
feat(operations): show the derived attention state and filter with --attention (PLA-840)

### DIFF
--- a/cmd/cluster_operation.go
+++ b/cmd/cluster_operation.go
@@ -79,6 +79,11 @@ var clusterOperationsListCmd = &cobra.Command{
 
 		statusFlag, _ := cmd.Flags().GetStringSlice("status")
 		failedOnly, _ := cmd.Flags().GetBool("failed")
+		attentionFlag, _ := cmd.Flags().GetString("attention")
+		attentionState, err := normaliseAttentionFlag(attentionFlag)
+		if err != nil {
+			return err
+		}
 		includeInternal, _ := cmd.Flags().GetBool("include-internal")
 		limit, _ := cmd.Flags().GetInt("limit")
 		if limit <= 0 {
@@ -106,6 +111,7 @@ var clusterOperationsListCmd = &cobra.Command{
 			ClusterID:                 cluster.ID,
 			StatusList:                statusList,
 			IncludeInternalExecutions: includeInternal,
+			AttentionState:            attentionState,
 			Page:                      1,
 			PageSize:                  limit,
 		}
@@ -439,19 +445,49 @@ func printExecutionStepResults(detail client.ExecutionDetail, resultsByStep map[
 	}
 }
 
+// normaliseAttentionFlag validates --attention: "open" keeps the failures
+// that still need a person, "resolved" the ones a later run or the
+// resource's own recovery already cleared; empty lists everything.
+func normaliseAttentionFlag(value string) (string, error) {
+	normalised := strings.ToLower(strings.TrimSpace(value))
+	switch normalised {
+	case "", "open", "resolved":
+		return normalised, nil
+	}
+	return "", fmt.Errorf("--attention must be 'open' or 'resolved', got %q", value)
+}
+
+// renderAttention renders the derived attention state beside the status:
+// nothing for an execution that did not fail (or a platform predating the
+// field), "open" while a failure still needs a person, and "resolved"
+// naming the later execution that cleared it when there is one.
+func renderAttention(execution client.ExecutionSummary) string {
+	switch execution.AttentionState {
+	case "open":
+		return text.FgYellow.Sprint("open")
+	case "resolved":
+		if execution.ResolvedByExecutionID != nil && *execution.ResolvedByExecutionID != "" {
+			return text.FgGreen.Sprintf("resolved by %s", *execution.ResolvedByExecutionID)
+		}
+		return text.FgGreen.Sprint("resolved")
+	}
+	return ""
+}
+
 func renderExecutionsTable(executions []client.ExecutionSummary) {
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
 	t.SetStyle(table.StyleRounded)
-	t.AppendHeader(table.Row{"ID", "Name", "Status", "Steps (✓/✗/⟳)", "Error", "Created At", "Updated At"})
+	t.AppendHeader(table.Row{"ID", "Name", "Status", "Attention", "Steps (✓/✗/⟳)", "Error", "Created At", "Updated At"})
 	t.SetColumnConfigs([]table.ColumnConfig{
 		{Number: 1, WidthMin: 30},
 		{Number: 2, WidthMin: 30},
 		{Number: 3, WidthMin: 12},
-		{Number: 4, WidthMin: 16},
-		{Number: 5, WidthMin: 30, WidthMax: 60},
-		{Number: 6, WidthMin: 20},
+		{Number: 4, WidthMin: 10},
+		{Number: 5, WidthMin: 16},
+		{Number: 6, WidthMin: 30, WidthMax: 60},
 		{Number: 7, WidthMin: 20},
+		{Number: 8, WidthMin: 20},
 	})
 
 	for _, execution := range executions {
@@ -468,6 +504,7 @@ func renderExecutionsTable(executions []client.ExecutionSummary) {
 			execution.ID,
 			execution.DisplayName,
 			renderColouredStatus(execution.Status),
+			renderAttention(execution),
 			summary,
 			errExcerpt,
 			formatOptionalTime(execution.CreatedAt),
@@ -524,6 +561,9 @@ func printExecutionDetail(detail client.ExecutionDetail) {
 	fmt.Printf("  Type: %s\n", detail.Execution.Type)
 	fmt.Printf("  Scope: %s\n", detail.Execution.Scope)
 	fmt.Printf("  Status: %s\n", renderColouredStatus(detail.Execution.Status))
+	if attention := renderAttention(detail.Execution); attention != "" {
+		fmt.Printf("  Attention: %s\n", attention)
+	}
 	if detail.Execution.ErrorExcerpt != nil && *detail.Execution.ErrorExcerpt != "" {
 		fmt.Printf("  Error: %s\n", *detail.Execution.ErrorExcerpt)
 	}
@@ -568,6 +608,7 @@ func truncateString(value string, maxLen int) string {
 func init() {
 	clusterOperationsListCmd.Flags().StringSlice("status", nil, "Filter by execution status (repeatable). Examples: failed, critical, running")
 	clusterOperationsListCmd.Flags().Bool("failed", false, "Shortcut for --status failed --status critical")
+	clusterOperationsListCmd.Flags().String("attention", "", "Keep only executions in this attention state: 'open' (a failure that still needs you) or 'resolved' (a later run or the resource's own recovery cleared it)")
 	clusterOperationsListCmd.Flags().Int("limit", defaultExecutionsPageSize, "Maximum number of executions to return (max 100)")
 	clusterOperationsListCmd.Flags().Bool("include-internal", false,
 		"Also list the platform's internal maintenance executions, such as the GitOps reconcile snapshot push, which the default listing hides")

--- a/cmd/cluster_operation_test.go
+++ b/cmd/cluster_operation_test.go
@@ -5,6 +5,10 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jedib0t/go-pretty/v6/text"
+
+	"ankra/internal/client"
 )
 
 func TestIsTerminalExecutionStatus(t *testing.T) {
@@ -28,6 +32,35 @@ func TestIsTerminalExecutionStatus(t *testing.T) {
 	for _, tc := range cases {
 		if got := isTerminalExecutionStatus(tc.status); got != tc.wantTerminal {
 			t.Errorf("isTerminalExecutionStatus(%q) = %v, want %v", tc.status, got, tc.wantTerminal)
+		}
+	}
+}
+
+func TestNormaliseAttentionFlag(t *testing.T) {
+	for _, value := range []string{"", "open", "Resolved", " open "} {
+		if _, err := normaliseAttentionFlag(value); err != nil {
+			t.Errorf("normaliseAttentionFlag(%q) = %v, want nil", value, err)
+		}
+	}
+	if _, err := normaliseAttentionFlag("dismissed"); err == nil {
+		t.Error("normaliseAttentionFlag(\"dismissed\") = nil, want an error")
+	}
+}
+
+func TestRenderAttention(t *testing.T) {
+	resolvedBy := "1471b248-b9e1-4106-aafd-d127fbad9e0b"
+	cases := []struct {
+		summary client.ExecutionSummary
+		want    string
+	}{
+		{client.ExecutionSummary{Status: "success"}, ""},
+		{client.ExecutionSummary{Status: "failed", AttentionState: "open"}, "open"},
+		{client.ExecutionSummary{Status: "failed", AttentionState: "resolved"}, "resolved"},
+		{client.ExecutionSummary{Status: "failed", AttentionState: "resolved", ResolvedByExecutionID: &resolvedBy}, "resolved by " + resolvedBy},
+	}
+	for _, testCase := range cases {
+		if got := text.StripEscape(renderAttention(testCase.summary)); got != testCase.want {
+			t.Errorf("renderAttention(%+v) = %q, want %q", testCase.summary, got, testCase.want)
 		}
 	}
 }

--- a/internal/client/executions.go
+++ b/internal/client/executions.go
@@ -32,6 +32,15 @@ type ExecutionSummary struct {
 	StepSummary    StepSummary `json:"step_summary"`
 	CreatedAt      *string     `json:"created_at"`
 	UpdatedAt      *string     `json:"updated_at"`
+	// AttentionState is derived by the platform on every read: "none"
+	// unless the execution ended failed, critical or cancelled; "resolved"
+	// once every resource its failed steps targeted has recovered (a later
+	// write execution on the same resource succeeded, the resource is up,
+	// or it is gone); "open" otherwise. Empty on platforms that predate it.
+	AttentionState string `json:"attention_state,omitempty"`
+	// ResolvedByExecutionID names the later execution that cleared the
+	// attention; nil when the resource itself recovered or nothing did.
+	ResolvedByExecutionID *string `json:"resolved_by_execution_id,omitempty"`
 }
 
 type ExecutionStep struct {
@@ -93,8 +102,12 @@ type ListExecutionsOptions struct {
 	// Ankra" commit and may re-encrypt sealed files. It is sent only when
 	// set, so the server default (hidden) is untouched otherwise.
 	IncludeInternalExecutions bool
-	Page                      int
-	PageSize                  int
+	// AttentionState keeps only executions in that derived attention state
+	// ("open" for the needs-attention view, "resolved" for failures a later
+	// run already cleared); empty lists every execution.
+	AttentionState string
+	Page           int
+	PageSize       int
 }
 
 type CancelExecutionResponse struct {
@@ -141,6 +154,9 @@ func (c *Client) ListExecutions(opts ListExecutionsOptions) (ExecutionListRespon
 	}
 	if opts.IncludeInternalExecutions {
 		params.Set("include_internal_executions", "true")
+	}
+	if opts.AttentionState != "" {
+		params.Set("attention_state", opts.AttentionState)
 	}
 	if opts.Page > 0 {
 		params.Set("page", fmt.Sprintf("%d", opts.Page))

--- a/internal/client/executions_test.go
+++ b/internal/client/executions_test.go
@@ -63,6 +63,37 @@ func TestListExecutionsBuildsQueryString(t *testing.T) {
 // reads include_internal_executions as an explicit opt-in, so the parameter
 // must be present (true) when asked for and absent otherwise - never sent as
 // "false", which some servers reject as a validation error.
+func TestListExecutionsAttentionStateIsSentOnlyWhenSet(t *testing.T) {
+	var capturedQueries []string
+	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQueries = append(capturedQueries, r.URL.RawQuery)
+		resolvedBy := "exec-2"
+		jsonResponse(t, w, http.StatusOK, ExecutionListResponse{
+			Result: []ExecutionSummary{{
+				ID: "exec-1", Status: "failed", AttentionState: "resolved", ResolvedByExecutionID: &resolvedBy,
+			}},
+		})
+	})
+
+	resp, err := testClient.ListExecutions(ListExecutionsOptions{ClusterID: "cluster-uuid", AttentionState: "open"})
+	if err != nil {
+		t.Fatalf("ListExecutions error = %v", err)
+	}
+	if _, err := testClient.ListExecutions(ListExecutionsOptions{ClusterID: "cluster-uuid"}); err != nil {
+		t.Fatalf("ListExecutions error = %v", err)
+	}
+	if !strings.Contains(capturedQueries[0], "attention_state=open") {
+		t.Errorf("expected attention_state in query, got: %s", capturedQueries[0])
+	}
+	if strings.Contains(capturedQueries[1], "attention_state") {
+		t.Errorf("attention_state must be omitted when unset, got: %s", capturedQueries[1])
+	}
+	if resp.Result[0].AttentionState != "resolved" || resp.Result[0].ResolvedByExecutionID == nil ||
+		*resp.Result[0].ResolvedByExecutionID != "exec-2" {
+		t.Errorf("attention fields not decoded: %+v", resp.Result[0])
+	}
+}
+
 func TestListExecutionsIncludeInternalIsSentOnlyWhenSet(t *testing.T) {
 	var capturedQueries []string
 	testClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Linear: https://linear.app/ankra/issue/PLA-840/1162-activity-feed-failed-executions-stay-needs-attention-forever-no
Depends on: https://github.com/ankraio/cluster/pull/2916

## Why

`ankra cluster operations list --failed` listed every failed execution as if it still needed someone, with no way to tell a failure that a retry (or the resource's own recovery) already cleared from one that is still broken. cluster#2916 derives `attention_state` and `resolved_by_execution_id` on every execution read.

## What changes

- `client.ExecutionSummary` decodes `attention_state` and `resolved_by_execution_id`; `ListExecutionsOptions.AttentionState` sends the server-side filter, only when set.
- `ankra cluster operations list` gains an **Attention** column beside Status: empty for a run that did not fail (or a platform predating the field), `open` while it still needs you, `resolved by <execution id>` when a later run cleared it, `resolved` when the resource recovered on its own. The detail view prints the same line.
- `--attention open|resolved` filters server-side, so a needs-attention listing and its count exclude the resolved rows. Any other value is rejected before the request.

## Verification

- `TestListExecutionsAttentionStateIsSentOnlyWhenSet`, `TestNormaliseAttentionFlag`, `TestRenderAttention` (new); `go test ./cmd/ ./internal/client/` and `golangci-lint` clean (pre-commit ran both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
