### PR TITLE
feat(stack-profiles): fleet verbs - multi-cluster apply, deployments table, content diff, rollout (ankra-edvu9)

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -194,7 +194,13 @@ func buildImportRequest(path string) (client.CreateImportClusterRequest, error) 
 	if err != nil {
 		return client.CreateImportClusterRequest{}, fmt.Errorf("could not read the file: %w", err)
 	}
+	return buildImportRequestFromBytes(data, filepath.Dir(path))
+}
 
+// buildImportRequestFromBytes parses an ImportCluster document that is
+// already in memory (an exported profile version, for instance). from_file
+// references inside it resolve against baseDirectory.
+func buildImportRequestFromBytes(data []byte, baseDirectory string) (client.CreateImportClusterRequest, error) {
 	var raw map[string]interface{}
 	if err := yaml.Unmarshal(data, &raw); err != nil {
 		return client.CreateImportClusterRequest{}, fmt.Errorf("the file is not valid YAML: %w", err)
@@ -252,7 +258,6 @@ func buildImportRequest(path string) (client.CreateImportClusterRequest, error) 
 		}
 	}
 
-	baseDirectory := filepath.Dir(path)
 	rawStackItems, _ := spec["stacks"].([]interface{})
 	stacks := make([]client.Stack, 0, len(rawStackItems))
 	for index, rawStack := range rawStackItems {

--- a/cmd/stack_profile_fleet.go
+++ b/cmd/stack_profile_fleet.go
@@ -52,11 +52,17 @@ func loadStackProfileDeployments(requestContext context.Context, profileID strin
 	return payload, &deployments, nil
 }
 
+// stackProfileDeploymentStatus reads the platform's own outdated flag; the
+// current version is quoted only when the payload carried one, so an older
+// platform that omits it never shows a defaulted "v0" as if measured.
 func stackProfileDeploymentStatus(deployment stackProfileDeployment, currentVersion int) string {
-	if deployment.Outdated {
-		return fmt.Sprintf("update available (v%d)", currentVersion)
+	if !deployment.Outdated {
+		return "up to date"
 	}
-	return "up to date"
+	if currentVersion <= 0 {
+		return "update available"
+	}
+	return fmt.Sprintf("update available (v%d)", currentVersion)
 }
 
 // renderStackProfileDeployments prints the fleet table: one row per stack
@@ -87,10 +93,17 @@ func renderStackProfileDeployments(out io.Writer, deployments *stackProfileDeplo
 	}
 	drift := "all up to date"
 	if behind > 0 {
-		drift = fmt.Sprintf("%d behind v%d", behind, deployments.CurrentVersion)
+		drift = fmt.Sprintf("%d behind", behind)
+		if deployments.CurrentVersion > 0 {
+			drift = fmt.Sprintf("%d behind v%d", behind, deployments.CurrentVersion)
+		}
 	}
-	_, _ = fmt.Fprintf(out, "Current version v%d  ·  %d %s across %d %s  ·  %s\n",
-		deployments.CurrentVersion,
+	currentVersion := "Current version unknown"
+	if deployments.CurrentVersion > 0 {
+		currentVersion = fmt.Sprintf("Current version v%d", deployments.CurrentVersion)
+	}
+	_, _ = fmt.Fprintf(out, "%s  ·  %d %s across %d %s  ·  %s\n",
+		currentVersion,
 		len(deployments.Result), pluralise(len(deployments.Result), "deployment", "deployments"),
 		len(clusters), pluralise(len(clusters), "cluster", "clusters"),
 		drift)

--- a/cmd/stack_profile_fleet.go
+++ b/cmd/stack_profile_fleet.go
@@ -218,14 +218,15 @@ func rolloutTargets(deployments *stackProfileDeployments, clusterFlags []string,
 }
 
 // rolloutRequest is the exported version, re-addressed to one target: the
-// document's metadata.name becomes the cluster, and its single stack takes
-// the name the deployment already uses so the platform updates that stack
-// in place instead of creating a second one.
+// document's metadata.name becomes the cluster, and its stack takes the
+// name the deployment already uses so the platform updates that stack in
+// place instead of creating a second one. The caller has already checked
+// the export holds exactly one stack.
 func rolloutRequest(base client.CreateImportClusterRequest, target rolloutTarget) client.CreateImportClusterRequest {
 	request := base
 	request.Name = target.ClusterName
 	stacks := append([]client.Stack(nil), base.Spec.Stacks...)
-	if len(stacks) == 1 && target.StackName != "" {
+	if target.StackName != "" {
 		stacks[0].Name = target.StackName
 	}
 	request.Spec.Stacks = stacks
@@ -304,6 +305,10 @@ manifest and add-on deploys run in the background. Watch them with
 			if format != outputDefault {
 				return encodeStructured(cmd.OutOrStdout(), format, map[string]any{"profile": detail.Profile.Name, "version": version, "targets": []rolloutOutcome{}})
 			}
+			if len(deployments.Result) == 0 {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Nothing to roll out: no stack has been deployed from '%s' yet. Deploy one with 'ankra stack-profiles apply %s --cluster <name> --deploy'.\n", detail.Profile.Name, detail.Profile.Name)
+				return nil
+			}
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Nothing to roll out: every deployment of '%s' already runs v%d.\n", detail.Profile.Name, version)
 			return nil
 		}
@@ -333,6 +338,9 @@ manifest and add-on deploys run in the background. Watch them with
 		base, buildError := buildImportRequestFromBytes(document, ".")
 		if buildError != nil {
 			return fmt.Errorf("invalid ImportCluster in the exported profile version: %w", buildError)
+		}
+		if len(base.Spec.Stacks) != 1 {
+			return fmt.Errorf("profile '%s' v%d exports %d stacks; rollout updates one deployed stack per cluster, so it needs a single-stack profile version (apply it with 'ankra cluster apply' after renaming the stacks yourself)", detail.Profile.Name, version, len(base.Spec.Stacks))
 		}
 
 		wait, waitError := asyncWriteWaitFlag(cmd)
@@ -383,7 +391,13 @@ manifest and add-on deploys run in the background. Watch them with
 		}
 
 		if format != outputDefault {
-			return encodeStructured(cmd.OutOrStdout(), format, map[string]any{"profile": detail.Profile.Name, "version": version, "targets": outcomes})
+			if encodeError := encodeStructured(cmd.OutOrStdout(), format, map[string]any{"profile": detail.Profile.Name, "version": version, "targets": outcomes}); encodeError != nil {
+				return encodeError
+			}
+			if failed > 0 {
+				return fmt.Errorf("%d of %d %s failed to apply", failed, len(targets), pluralise(len(targets), "rollout", "rollouts"))
+			}
+			return nil
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout())
 		renderRolloutOutcomes(cmd.OutOrStdout(), outcomes)

--- a/cmd/stack_profile_fleet.go
+++ b/cmd/stack_profile_fleet.go
@@ -1,0 +1,437 @@
+package cmd
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+
+	"ankra/internal/client"
+)
+
+// The fleet side of stack profiles: reading where a profile is deployed and
+// rolling a published version out to those clusters. Both used to need a
+// shell loop, jq and yq around export-iac and cluster apply.
+
+// stackProfileDeployment is one row of GET /stack-profiles/{id}/instantiations.
+type stackProfileDeployment struct {
+	ID              string `json:"id"`
+	TargetClusterID string `json:"target_cluster_id"`
+	ClusterName     string `json:"cluster_name"`
+	StackName       string `json:"stack_name"`
+	StackState      string `json:"stack_state"`
+	Version         int    `json:"version"`
+	Outdated        bool   `json:"outdated"`
+	CreatedAt       string `json:"created_at"`
+}
+
+type stackProfileDeployments struct {
+	Result         []stackProfileDeployment `json:"result"`
+	CurrentVersion int                      `json:"current_version"`
+}
+
+func loadStackProfileDeployments(requestContext context.Context, profileID string) (json.RawMessage, *stackProfileDeployments, error) {
+	payload, listError := apiClient.ListStackProfileInstantiations(requestContext, profileID)
+	if listError != nil {
+		return nil, nil, fmt.Errorf("listing stack profile deployments: %w", listError)
+	}
+	var deployments stackProfileDeployments
+	if len(payload) > 0 {
+		if unmarshalError := json.Unmarshal(payload, &deployments); unmarshalError != nil {
+			return nil, nil, fmt.Errorf("parsing stack profile deployments: %w", unmarshalError)
+		}
+	}
+	return payload, &deployments, nil
+}
+
+func stackProfileDeploymentStatus(deployment stackProfileDeployment, currentVersion int) string {
+	if deployment.Outdated {
+		return fmt.Sprintf("update available (v%d)", currentVersion)
+	}
+	return "up to date"
+}
+
+// renderStackProfileDeployments prints the fleet table: one row per stack
+// deployed from the profile, with whether it is behind the current version.
+func renderStackProfileDeployments(out io.Writer, deployments *stackProfileDeployments, onlyOutdated bool) {
+	rows := deployments.Result
+	if onlyOutdated {
+		rows = []stackProfileDeployment{}
+		for _, deployment := range deployments.Result {
+			if deployment.Outdated {
+				rows = append(rows, deployment)
+			}
+		}
+	}
+	sort.SliceStable(rows, func(left int, right int) bool {
+		if rows[left].ClusterName != rows[right].ClusterName {
+			return rows[left].ClusterName < rows[right].ClusterName
+		}
+		return rows[left].StackName < rows[right].StackName
+	})
+	clusters := map[string]bool{}
+	behind := 0
+	for _, deployment := range deployments.Result {
+		clusters[deployment.TargetClusterID] = true
+		if deployment.Outdated {
+			behind++
+		}
+	}
+	drift := "all up to date"
+	if behind > 0 {
+		drift = fmt.Sprintf("%d behind v%d", behind, deployments.CurrentVersion)
+	}
+	_, _ = fmt.Fprintf(out, "Current version v%d  ·  %d %s across %d %s  ·  %s\n",
+		deployments.CurrentVersion,
+		len(deployments.Result), pluralise(len(deployments.Result), "deployment", "deployments"),
+		len(clusters), pluralise(len(clusters), "cluster", "clusters"),
+		drift)
+	if len(rows) == 0 {
+		if onlyOutdated {
+			_, _ = fmt.Fprintln(out, "No deployment is behind the current version.")
+		} else {
+			_, _ = fmt.Fprintln(out, "No stack has been deployed from this profile yet. Deploy one with 'ankra stack-profiles apply <profile> --cluster <name> --deploy'.")
+		}
+		return
+	}
+	fleetTable := table.NewWriter()
+	fleetTable.SetOutputMirror(out)
+	fleetTable.SetStyle(table.StyleRounded)
+	fleetTable.AppendHeader(table.Row{"CLUSTER", "STACK", "STATE", "VERSION", "STATUS", "DEPLOYED"})
+	for _, deployment := range rows {
+		fleetTable.AppendRow(table.Row{
+			deployment.ClusterName,
+			deployment.StackName,
+			deployment.StackState,
+			fmt.Sprintf("v%d", deployment.Version),
+			stackProfileDeploymentStatus(deployment, deployments.CurrentVersion),
+			formatDeploymentTimestamp(deployment.CreatedAt),
+		})
+	}
+	fleetTable.Render()
+	if behind > 0 && !onlyOutdated {
+		_, _ = fmt.Fprintf(out, "\nRoll the current version out with 'ankra stack-profiles rollout <profile> --all --outdated'.\n")
+	}
+}
+
+func formatDeploymentTimestamp(raw string) string {
+	if len(raw) >= 16 && strings.Contains(raw, "T") {
+		return strings.Replace(raw[:16], "T", " ", 1)
+	}
+	if raw == "" {
+		return "-"
+	}
+	return raw
+}
+
+// rolloutTarget is one (cluster, stack) pair a rollout writes to.
+type rolloutTarget struct {
+	ClusterID   string `json:"cluster_id"`
+	ClusterName string `json:"cluster_name"`
+	StackName   string `json:"stack_name"`
+	FromVersion int    `json:"from_version"`
+}
+
+type rolloutOutcome struct {
+	rolloutTarget
+	ToVersion int    `json:"to_version"`
+	Status    string `json:"status"`
+	Message   string `json:"message,omitempty"`
+}
+
+// resolveClusterReference turns a cluster name or ID into both, paging the
+// cluster list the way resolveClusterID does.
+func resolveClusterReference(nameOrID string) (string, string, error) {
+	const pageSize = 100
+	const maxPages = 50
+	isID := len(nameOrID) == 36 && strings.Count(nameOrID, "-") == 4
+	for page := 1; page <= maxPages; page++ {
+		response, listError := apiClient.ListClusters(page, pageSize)
+		if listError != nil {
+			return "", "", fmt.Errorf("listing clusters: %w", listError)
+		}
+		for _, cluster := range response.Result {
+			if (isID && cluster.ID == nameOrID) || strings.EqualFold(cluster.Name, nameOrID) {
+				return cluster.ID, cluster.Name, nil
+			}
+		}
+		if response.Pagination.TotalPages <= page || len(response.Result) == 0 {
+			break
+		}
+	}
+	return "", "", fmt.Errorf("cluster %q not found", nameOrID)
+}
+
+// rolloutTargets picks the deployments a rollout writes to: every
+// deployment of the profile with --all, otherwise the ones on the named
+// clusters. A cluster that does not run the profile is refused rather than
+// silently given a first deployment; that is what apply is for.
+func rolloutTargets(deployments *stackProfileDeployments, clusterFlags []string, all bool, onlyOutdated bool) ([]rolloutTarget, error) {
+	targets := []rolloutTarget{}
+	seen := map[string]bool{}
+	add := func(deployment stackProfileDeployment) {
+		key := deployment.TargetClusterID + "/" + deployment.StackName
+		if seen[key] {
+			return
+		}
+		if onlyOutdated && !deployment.Outdated {
+			return
+		}
+		seen[key] = true
+		targets = append(targets, rolloutTarget{
+			ClusterID:   deployment.TargetClusterID,
+			ClusterName: deployment.ClusterName,
+			StackName:   deployment.StackName,
+			FromVersion: deployment.Version,
+		})
+	}
+	if all {
+		for _, deployment := range deployments.Result {
+			add(deployment)
+		}
+		return targets, nil
+	}
+	for _, clusterFlag := range clusterFlags {
+		clusterID, clusterName, resolveError := resolveClusterReference(clusterFlag)
+		if resolveError != nil {
+			return nil, resolveError
+		}
+		matched := false
+		for _, deployment := range deployments.Result {
+			if deployment.TargetClusterID == clusterID {
+				add(deployment)
+				matched = true
+			}
+		}
+		if !matched {
+			return nil, fmt.Errorf("cluster %q has no stack deployed from this profile; deploy one first with 'ankra stack-profiles apply <profile> --cluster %s --deploy'", clusterName, clusterName)
+		}
+	}
+	return targets, nil
+}
+
+// rolloutRequest is the exported version, re-addressed to one target: the
+// document's metadata.name becomes the cluster, and its single stack takes
+// the name the deployment already uses so the platform updates that stack
+// in place instead of creating a second one.
+func rolloutRequest(base client.CreateImportClusterRequest, target rolloutTarget) client.CreateImportClusterRequest {
+	request := base
+	request.Name = target.ClusterName
+	stacks := append([]client.Stack(nil), base.Spec.Stacks...)
+	if len(stacks) == 1 && target.StackName != "" {
+		stacks[0].Name = target.StackName
+	}
+	request.Spec.Stacks = stacks
+	return request
+}
+
+var stackProfilesRolloutCmd = &cobra.Command{
+	Use:   "rollout [profile-id|profile-name]",
+	Short: "Roll a published profile version out to the clusters already running it",
+	Long: `Update the stacks deployed from a profile to a published version, in place.
+
+For every target the profile version is exported as ClusterInfrastructureAsCode,
+addressed to that cluster and the stack it already runs, and applied the way
+'ankra cluster apply' applies a file: the same stack is updated, so Kubernetes
+performs a rolling update of the workloads and nothing is created twice.
+
+Pick targets with --cluster (repeatable) or --all for every deployment of the
+profile; add --outdated to touch only the ones behind the chosen version.
+Without --version the profile's current version is rolled out.
+
+The configuration write returns as soon as the platform has accepted it; the
+manifest and add-on deploys run in the background. Watch them with
+'ankra cluster operations list --cluster <name>'.`,
+	Example: `  ankra stack-profiles rollout hello-fleet --all --outdated
+  ankra stack-profiles rollout hello-fleet --cluster prod-eu --cluster prod-us --version 2
+  ankra stack-profiles rollout hello-fleet --all --dry-run`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		format, formatError := structuredFormatFromFlags(cmd)
+		if formatError != nil {
+			return formatError
+		}
+		clusterFlags, _ := cmd.Flags().GetStringArray("cluster")
+		all, _ := cmd.Flags().GetBool("all")
+		onlyOutdated, _ := cmd.Flags().GetBool("outdated")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		versionRaw, _ := cmd.Flags().GetString("version")
+		if all == (len(clusterFlags) > 0) {
+			return withExitCode(exitUsage, errors.New("pick the targets with --cluster (repeatable) or --all, not both"))
+		}
+		versionFlag, versionError := parseProfileVersionFlag(versionRaw)
+		if versionError != nil {
+			return versionError
+		}
+
+		profileID, resolveError := resolveStackProfileID(apiClient, args[0])
+		if resolveError != nil {
+			return resolveError
+		}
+		detail, detailError := apiClient.GetStackProfile(profileID)
+		if detailError != nil {
+			return fmt.Errorf("reading stack profile: %w", detailError)
+		}
+		version := versionFlag
+		if version <= 0 {
+			version = detail.Profile.CurrentVersion
+		}
+		if version <= 0 {
+			return fmt.Errorf("profile %s has no published version to roll out", detail.Profile.Name)
+		}
+
+		_, deployments, deploymentsError := loadStackProfileDeployments(cmd.Context(), profileID)
+		if deploymentsError != nil {
+			return deploymentsError
+		}
+		if onlyOutdated {
+			for index := range deployments.Result {
+				deployments.Result[index].Outdated = deployments.Result[index].Version < version
+			}
+		}
+		targets, targetsError := rolloutTargets(deployments, clusterFlags, all, onlyOutdated)
+		if targetsError != nil {
+			return targetsError
+		}
+		if len(targets) == 0 {
+			if format != outputDefault {
+				return encodeStructured(cmd.OutOrStdout(), format, map[string]any{"profile": detail.Profile.Name, "version": version, "targets": []rolloutOutcome{}})
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Nothing to roll out: every deployment of '%s' already runs v%d.\n", detail.Profile.Name, version)
+			return nil
+		}
+
+		if dryRun {
+			outcomes := make([]rolloutOutcome, 0, len(targets))
+			for _, target := range targets {
+				outcomes = append(outcomes, rolloutOutcome{rolloutTarget: target, ToVersion: version, Status: "planned"})
+			}
+			if format != outputDefault {
+				return encodeStructured(cmd.OutOrStdout(), format, map[string]any{"profile": detail.Profile.Name, "version": version, "dry_run": true, "targets": outcomes})
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Dry run: '%s' v%d would be rolled out to %d %s (nothing written):\n",
+				detail.Profile.Name, version, len(targets), pluralise(len(targets), "stack", "stacks"))
+			renderRolloutOutcomes(cmd.OutOrStdout(), outcomes)
+			return nil
+		}
+
+		export, exportError := apiClient.ExportStackProfileIac(profileID, version)
+		if exportError != nil {
+			return fmt.Errorf("exporting profile version: %w", exportError)
+		}
+		document, decodeError := base64.StdEncoding.DecodeString(export.ContentBase64)
+		if decodeError != nil {
+			return fmt.Errorf("decoding export: %w", decodeError)
+		}
+		base, buildError := buildImportRequestFromBytes(document, ".")
+		if buildError != nil {
+			return fmt.Errorf("invalid ImportCluster in the exported profile version: %w", buildError)
+		}
+
+		wait, waitError := asyncWriteWaitFlag(cmd)
+		if waitError != nil {
+			return waitError
+		}
+		requestContext, cancelRequestContext, contextError := asyncWriteRequestContext(cmd)
+		if contextError != nil {
+			return contextError
+		}
+		defer cancelRequestContext()
+
+		if format == outputDefault {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Rolling out '%s' v%d to %d %s...\n",
+				detail.Profile.Name, version, len(targets), pluralise(len(targets), "stack", "stacks"))
+		}
+		outcomes := make([]rolloutOutcome, 0, len(targets))
+		failed := 0
+		for _, target := range targets {
+			outcome := rolloutOutcome{rolloutTarget: target, ToVersion: version}
+			request := rolloutRequest(base, target)
+			response, submitted, applyError := apiClient.ApplyCluster(requestContext, request, wait)
+			switch {
+			case applyError != nil:
+				outcome.Status = "failed"
+				outcome.Message = applyError.Error()
+				failed++
+			case submitted:
+				outcome.Status = "submitted"
+			case response != nil && len(response.Errors) > 0:
+				outcome.Status = "failed"
+				outcome.Message = describeImportErrors(response.Errors)
+				failed++
+			case response != nil && response.GitPushDeferred:
+				outcome.Status = "applied"
+				outcome.Message = response.GitPushMessage
+			default:
+				outcome.Status = "applied"
+			}
+			if format == outputDefault {
+				line := fmt.Sprintf("  %s / %s: v%d -> v%d %s", target.ClusterName, target.StackName, target.FromVersion, version, outcome.Status)
+				if outcome.Message != "" {
+					line += " (" + outcome.Message + ")"
+				}
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), line)
+			}
+			outcomes = append(outcomes, outcome)
+		}
+
+		if format != outputDefault {
+			return encodeStructured(cmd.OutOrStdout(), format, map[string]any{"profile": detail.Profile.Name, "version": version, "targets": outcomes})
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout())
+		renderRolloutOutcomes(cmd.OutOrStdout(), outcomes)
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nManifest and add-on deploys run in the background from here.")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Watch them with 'ankra cluster operations list --cluster <name>'.")
+		if failed > 0 {
+			return fmt.Errorf("%d of %d %s failed to apply", failed, len(targets), pluralise(len(targets), "rollout", "rollouts"))
+		}
+		return nil
+	},
+}
+
+func describeImportErrors(resourceErrors []client.ImportResponseResourceError) string {
+	parts := []string{}
+	for _, resourceError := range resourceErrors {
+		for _, detail := range resourceError.Errors {
+			parts = append(parts, fmt.Sprintf("%s %q: %s", resourceError.Kind, resourceError.Name, detail.Message))
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
+func renderRolloutOutcomes(out io.Writer, outcomes []rolloutOutcome) {
+	rolloutTable := table.NewWriter()
+	rolloutTable.SetOutputMirror(out)
+	rolloutTable.SetStyle(table.StyleRounded)
+	rolloutTable.AppendHeader(table.Row{"CLUSTER", "STACK", "FROM", "TO", "STATUS"})
+	for _, outcome := range outcomes {
+		rolloutTable.AppendRow(table.Row{
+			outcome.ClusterName, outcome.StackName,
+			fmt.Sprintf("v%d", outcome.FromVersion), fmt.Sprintf("v%d", outcome.ToVersion),
+			outcome.Status,
+		})
+	}
+	rolloutTable.Render()
+}
+
+func init() {
+	stackProfilesRolloutCmd.Flags().StringArray("cluster", nil, "Target cluster name or ID (repeatable)")
+	stackProfilesRolloutCmd.Flags().Bool("all", false, "Every cluster that runs a stack deployed from this profile")
+	stackProfilesRolloutCmd.Flags().Bool("outdated", false, "Only the deployments behind the version being rolled out")
+	stackProfilesRolloutCmd.Flags().String("version", "", "Profile version to roll out, as 2 or v2 (defaults to the profile's current version)")
+	stackProfilesRolloutCmd.Flags().Bool("dry-run", false, "List the stacks that would be updated without writing anything")
+	registerAsyncWriteFlags(stackProfilesRolloutCmd)
+	if waitFlag := stackProfilesRolloutCmd.Flags().Lookup("wait"); waitFlag != nil {
+		waitFlag.Usage = "Wait for each configuration write to be applied before moving to the next cluster. " +
+			"Manifest and add-on deploys are dispatched afterwards and are NOT covered by this flag"
+	}
+	registerStructuredOutputFlags(stackProfilesRolloutCmd)
+	stackProfilesCmd.AddCommand(stackProfilesRolloutCmd)
+}

--- a/cmd/stack_profile_fleet.go
+++ b/cmd/stack_profile_fleet.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
 
@@ -151,6 +152,10 @@ type rolloutOutcome struct {
 func resolveClusterReference(nameOrID string) (string, string, error) {
 	const pageSize = 100
 	const maxPages = 50
+	// The same shape test resolveClusterID uses: a 36-character, four-dash
+	// value is tried as an id (exact match) and, failing that, still as a
+	// name, so a cluster whose name happens to look like a uuid stays
+	// reachable by name.
 	isID := len(nameOrID) == 36 && strings.Count(nameOrID, "-") == 4
 	for page := 1; page <= maxPages; page++ {
 		response, listError := apiClient.ListClusters(page, pageSize)
@@ -335,7 +340,16 @@ manifest and add-on deploys run in the background. Watch them with
 		if decodeError != nil {
 			return fmt.Errorf("decoding export: %w", decodeError)
 		}
-		base, buildError := buildImportRequestFromBytes(document, ".")
+		// An export embeds every manifest and values file, so it never
+		// references a file; parsing it against an empty directory turns a
+		// from_file that somehow appears into a loud failure instead of a
+		// read of whatever happens to sit in the operator's working directory.
+		emptyDirectory, temporaryError := os.MkdirTemp("", "ankra-rollout-")
+		if temporaryError != nil {
+			return fmt.Errorf("creating a scratch directory: %w", temporaryError)
+		}
+		defer func() { _ = os.RemoveAll(emptyDirectory) }()
+		base, buildError := buildImportRequestFromBytes(document, emptyDirectory)
 		if buildError != nil {
 			return fmt.Errorf("invalid ImportCluster in the exported profile version: %w", buildError)
 		}

--- a/cmd/stack_profile_fleet_test.go
+++ b/cmd/stack_profile_fleet_test.go
@@ -27,11 +27,12 @@ spec:
 
 type rolloutMock struct {
 	baseMock
-	deployments   string
-	exportVersion int
-	applied       []client.CreateImportClusterRequest
-	failCluster   string
-	clusters      []client.ClusterListItem
+	deployments    string
+	exportDocument string
+	exportVersion  int
+	applied        []client.CreateImportClusterRequest
+	failCluster    string
+	clusters       []client.ClusterListItem
 }
 
 func (mock *rolloutMock) GetStackProfile(profileID string) (*client.StackProfileDetail, error) {
@@ -44,8 +45,12 @@ func (mock *rolloutMock) ListStackProfileInstantiations(requestContext context.C
 
 func (mock *rolloutMock) ExportStackProfileIac(profileID string, version int) (*client.StackProfileIacExport, error) {
 	mock.exportVersion = version
+	document := mock.exportDocument
+	if document == "" {
+		document = rolloutExportDocument
+	}
 	return &client.StackProfileIacExport{ProfileID: profileID, Version: version,
-		ContentBase64: base64.StdEncoding.EncodeToString([]byte(rolloutExportDocument))}, nil
+		ContentBase64: base64.StdEncoding.EncodeToString([]byte(document))}, nil
 }
 
 func (mock *rolloutMock) ApplyCluster(ctx context.Context, request client.CreateImportClusterRequest, wait bool) (*client.ImportResponse, bool, error) {
@@ -194,5 +199,55 @@ func TestUnifiedDiff(t *testing.T) {
 	}
 	if got := unifiedDiff("/dev/null", "to", "", "x\n"); got != "--- /dev/null\n+++ to\n@@ -0,0 +1 @@\n+x\n" {
 		t.Errorf("all-added diff = %q", got)
+	}
+}
+
+func TestStackProfilesRolloutStructuredOutputStillFailsOnPartialFailure(t *testing.T) {
+	resetStackProfileCommandFlags(t, stackProfilesRolloutCmd)
+	mock := newRolloutMock()
+	mock.failCluster = "prod-eu"
+	output, executeError := runStackProfilesCommand(t, mock, "", "rollout", "hello-fleet", "--all", "-o", "json")
+	if executeError == nil {
+		t.Fatal("-o json must still exit non-zero when a target failed")
+	}
+	if !strings.Contains(output, `"status": "failed"`) || !strings.Contains(output, `"status": "applied"`) {
+		t.Errorf("the JSON payload should still be emitted before the error:\n%s", output)
+	}
+}
+
+func TestStackProfilesRolloutRefusesMultiStackExport(t *testing.T) {
+	resetStackProfileCommandFlags(t, stackProfilesRolloutCmd)
+	mock := newRolloutMock()
+	mock.exportDocument = rolloutExportDocument + `  - name: second
+    manifests: []
+    addons: []
+`
+	_, executeError := runStackProfilesCommand(t, mock, "", "rollout", "hello-fleet", "--all")
+	if executeError == nil || !strings.Contains(executeError.Error(), "exports 2 stacks") {
+		t.Fatalf("expected a refusal for a multi-stack export, got %v", executeError)
+	}
+	if len(mock.applied) != 0 {
+		t.Errorf("nothing should be applied: %+v", mock.applied)
+	}
+}
+
+func TestStackProfilesRolloutSaysWhenNothingIsDeployed(t *testing.T) {
+	resetStackProfileCommandFlags(t, stackProfilesRolloutCmd)
+	mock := newRolloutMock()
+	mock.deployments = `{"current_version": 2, "result": []}`
+	output, executeError := runStackProfilesCommand(t, mock, "", "rollout", "hello-fleet", "--all")
+	if executeError != nil {
+		t.Fatalf("rollout failed: %v", executeError)
+	}
+	if !strings.Contains(output, "no stack has been deployed from 'hello-fleet' yet") {
+		t.Errorf("output = %q", output)
+	}
+	resetStackProfileCommandFlags(t, stackProfilesRolloutCmd)
+	output, executeError = runStackProfilesCommand(t, mock, "", "rollout", "hello-fleet", "--all", "--outdated")
+	if executeError != nil {
+		t.Fatalf("rollout failed: %v", executeError)
+	}
+	if !strings.Contains(output, "no stack has been deployed") {
+		t.Errorf("output = %q", output)
 	}
 }

--- a/cmd/stack_profile_fleet_test.go
+++ b/cmd/stack_profile_fleet_test.go
@@ -1,0 +1,198 @@
+package cmd
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+const rolloutExportDocument = `apiVersion: v1
+kind: ImportCluster
+metadata:
+  name: hello-fleet
+spec:
+  stacks:
+  - name: hello-fleet
+    manifests:
+    - name: hello-namespace
+      manifest_base64: YXBpVmVyc2lvbjogdjEKa2luZDogTmFtZXNwYWNlCm1ldGFkYXRhOgogIG5hbWU6IGhlbGxvCg==
+      parents: []
+    addons: []
+`
+
+type rolloutMock struct {
+	baseMock
+	deployments   string
+	exportVersion int
+	applied       []client.CreateImportClusterRequest
+	failCluster   string
+	clusters      []client.ClusterListItem
+}
+
+func (mock *rolloutMock) GetStackProfile(profileID string) (*client.StackProfileDetail, error) {
+	return &client.StackProfileDetail{Profile: client.StackProfileSummary{ID: profileID, Name: "hello-fleet", CurrentVersion: 2}}, nil
+}
+
+func (mock *rolloutMock) ListStackProfileInstantiations(requestContext context.Context, profileID string) (json.RawMessage, error) {
+	return json.RawMessage(mock.deployments), nil
+}
+
+func (mock *rolloutMock) ExportStackProfileIac(profileID string, version int) (*client.StackProfileIacExport, error) {
+	mock.exportVersion = version
+	return &client.StackProfileIacExport{ProfileID: profileID, Version: version,
+		ContentBase64: base64.StdEncoding.EncodeToString([]byte(rolloutExportDocument))}, nil
+}
+
+func (mock *rolloutMock) ApplyCluster(ctx context.Context, request client.CreateImportClusterRequest, wait bool) (*client.ImportResponse, bool, error) {
+	mock.applied = append(mock.applied, request)
+	if request.Name == mock.failCluster {
+		return nil, false, errors.New("cluster is offline")
+	}
+	return &client.ImportResponse{Name: request.Name, ClusterId: "cluster-id"}, false, nil
+}
+
+func (mock *rolloutMock) ListClusters(page int, pageSize int) (*client.ClusterListResponse, error) {
+	return &client.ClusterListResponse{Result: mock.clusters, Pagination: client.Pagination{TotalPages: 1}}, nil
+}
+
+func newRolloutMock() *rolloutMock {
+	return &rolloutMock{
+		deployments: fleetDeploymentsPayload,
+		clusters: []client.ClusterListItem{
+			{ID: "11111111-1111-1111-1111-111111111111", Name: "prod-eu"},
+			{ID: "22222222-2222-2222-2222-222222222222", Name: "prod-us"},
+			{ID: "33333333-3333-3333-3333-333333333333", Name: "staging"},
+		},
+	}
+}
+
+func TestStackProfilesRolloutAllOutdated(t *testing.T) {
+	resetStackProfileCommandFlags(t, stackProfilesRolloutCmd)
+	mock := newRolloutMock()
+	output, executeError := runStackProfilesCommand(t, mock, "", "rollout", "hello-fleet", "--all", "--outdated")
+	if executeError != nil {
+		t.Fatalf("rollout failed: %v\n%s", executeError, output)
+	}
+	if mock.exportVersion != 2 {
+		t.Errorf("exported version = %d, want the current version 2", mock.exportVersion)
+	}
+	if len(mock.applied) != 1 {
+		t.Fatalf("applied %d clusters, want only the outdated one: %+v", len(mock.applied), mock.applied)
+	}
+	request := mock.applied[0]
+	if request.Name != "prod-eu" {
+		t.Errorf("metadata.name = %q, want the target cluster prod-eu", request.Name)
+	}
+	if len(request.Spec.Stacks) != 1 || request.Spec.Stacks[0].Name != "hello-fleet" {
+		t.Errorf("stack = %+v", request.Spec.Stacks)
+	}
+	for _, want := range []string{"Rolling out 'hello-fleet' v2 to 1 stack", "prod-eu / hello-fleet: v1 -> v2 applied", "operations list"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("output lacks %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestStackProfilesRolloutRenamesStackToTheDeployedName(t *testing.T) {
+	resetStackProfileCommandFlags(t, stackProfilesRolloutCmd)
+	mock := newRolloutMock()
+	mock.deployments = `{"current_version": 2, "result": [
+	  {"id": "i-1", "target_cluster_id": "11111111-1111-1111-1111-111111111111", "cluster_name": "prod-eu", "stack_name": "web-blue", "stack_state": "up", "version": 1, "outdated": true}
+	]}`
+	if _, executeError := runStackProfilesCommand(t, mock, "", "rollout", "hello-fleet", "--cluster", "prod-eu"); executeError != nil {
+		t.Fatalf("rollout failed: %v", executeError)
+	}
+	if len(mock.applied) != 1 || mock.applied[0].Spec.Stacks[0].Name != "web-blue" {
+		t.Fatalf("the exported stack should take the deployed stack's name: %+v", mock.applied)
+	}
+}
+
+func TestStackProfilesRolloutByClusterRollsEveryVersion(t *testing.T) {
+	resetStackProfileCommandFlags(t, stackProfilesRolloutCmd)
+	mock := newRolloutMock()
+	output, executeError := runStackProfilesCommand(t, mock, "", "rollout", "hello-fleet",
+		"--cluster", "prod-eu", "--cluster", "22222222-2222-2222-2222-222222222222", "--version", "v2")
+	if executeError != nil {
+		t.Fatalf("rollout failed: %v\n%s", executeError, output)
+	}
+	if len(mock.applied) != 2 || mock.applied[0].Name != "prod-eu" || mock.applied[1].Name != "prod-us" {
+		t.Fatalf("applied = %+v", mock.applied)
+	}
+}
+
+func TestStackProfilesRolloutRefusesClusterWithoutDeployment(t *testing.T) {
+	resetStackProfileCommandFlags(t, stackProfilesRolloutCmd)
+	mock := newRolloutMock()
+	_, executeError := runStackProfilesCommand(t, mock, "", "rollout", "hello-fleet", "--cluster", "staging")
+	if executeError == nil || !strings.Contains(executeError.Error(), "no stack deployed from this profile") {
+		t.Fatalf("expected a refusal for a cluster without a deployment, got %v", executeError)
+	}
+	if len(mock.applied) != 0 {
+		t.Errorf("nothing should be applied: %+v", mock.applied)
+	}
+}
+
+func TestStackProfilesRolloutDryRunWritesNothing(t *testing.T) {
+	resetStackProfileCommandFlags(t, stackProfilesRolloutCmd)
+	mock := newRolloutMock()
+	output, executeError := runStackProfilesCommand(t, mock, "", "rollout", "hello-fleet", "--all", "--dry-run")
+	if executeError != nil {
+		t.Fatalf("dry run failed: %v", executeError)
+	}
+	if len(mock.applied) != 0 || mock.exportVersion != 0 {
+		t.Errorf("dry run must not export or apply: applied=%d export=%d", len(mock.applied), mock.exportVersion)
+	}
+	for _, want := range []string{"Dry run", "prod-eu", "prod-us", "planned"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("output lacks %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestStackProfilesRolloutKeepsGoingPastAFailure(t *testing.T) {
+	resetStackProfileCommandFlags(t, stackProfilesRolloutCmd)
+	mock := newRolloutMock()
+	mock.failCluster = "prod-eu"
+	output, executeError := runStackProfilesCommand(t, mock, "", "rollout", "hello-fleet", "--all")
+	if executeError == nil {
+		t.Fatal("expected the failed cluster to be reported")
+	}
+	if len(mock.applied) != 2 {
+		t.Fatalf("the second cluster should still be rolled after the first failed: %+v", mock.applied)
+	}
+	if !strings.Contains(output, "failed (cluster is offline)") || !strings.Contains(output, "prod-us / hello-fleet: v2 -> v2 applied") {
+		t.Errorf("output = %s", output)
+	}
+}
+
+func TestStackProfilesRolloutNeedsTargets(t *testing.T) {
+	resetStackProfileCommandFlags(t, stackProfilesRolloutCmd)
+	mock := newRolloutMock()
+	if _, executeError := runStackProfilesCommand(t, mock, "", "rollout", "hello-fleet"); executeError == nil {
+		t.Fatal("expected an error without --cluster or --all")
+	}
+	resetStackProfileCommandFlags(t, stackProfilesRolloutCmd)
+	if _, executeError := runStackProfilesCommand(t, mock, "", "rollout", "hello-fleet", "--all", "--cluster", "prod-eu"); executeError == nil {
+		t.Fatal("expected an error with both --cluster and --all")
+	}
+}
+
+func TestUnifiedDiff(t *testing.T) {
+	from := "a\nb\nc\nd\ne\nf\ng\nh\n"
+	to := "a\nb\nc\nD\ne\nf\ng\nh\n"
+	want := "--- from\n+++ to\n@@ -1,7 +1,7 @@\n a\n b\n c\n-d\n+D\n e\n f\n g\n"
+	if got := unifiedDiff("from", "to", from, to); got != want {
+		t.Errorf("unifiedDiff =\n%s\nwant\n%s", got, want)
+	}
+	if got := unifiedDiff("from", "to", from, from); got != "" {
+		t.Errorf("identical inputs should produce no diff, got %q", got)
+	}
+	if got := unifiedDiff("/dev/null", "to", "", "x\n"); got != "--- /dev/null\n+++ to\n@@ -0,0 +1 @@\n+x\n" {
+		t.Errorf("all-added diff = %q", got)
+	}
+}

--- a/cmd/stack_profile_fleet_test.go
+++ b/cmd/stack_profile_fleet_test.go
@@ -275,3 +275,33 @@ spec:
 		t.Errorf("nothing should be applied: %+v", mock.applied)
 	}
 }
+
+func TestUnifiedDiffShowsATrailingNewlineOnlyChange(t *testing.T) {
+	got := unifiedDiff("from", "to", "a\nb", "a\nb\n")
+	want := "--- from\n+++ to\n@@ -1,2 +1,2 @@\n a\n-b\n\\ No newline at end of file\n+b\n"
+	if got != want {
+		t.Errorf("unifiedDiff =\n%s\nwant\n%s", got, want)
+	}
+	if got := unifiedDiff("from", "to", "a\nb", "a\nb"); got != "" {
+		t.Errorf("identical inputs without a trailing newline should produce no diff, got %q", got)
+	}
+}
+
+func TestStackProfilesDeploymentsWithoutCurrentVersion(t *testing.T) {
+	resetStackProfileCommandFlags(t, stackProfilesDeploymentsCmd)
+	mock := &stackProfileManageMock{payload: json.RawMessage(`{"result": [
+	  {"id": "i-1", "target_cluster_id": "11111111-1111-1111-1111-111111111111", "cluster_name": "prod-eu", "stack_name": "hello-fleet", "stack_state": "up", "version": 1, "outdated": true}
+	]}`)}
+	output, executeError := runStackProfilesCommand(t, mock, "", "deployments", "profile-1")
+	if executeError != nil {
+		t.Fatalf("deployments failed: %v", executeError)
+	}
+	if strings.Contains(output, "v0") {
+		t.Errorf("a missing current_version must not be shown as v0:\n%s", output)
+	}
+	for _, want := range []string{"Current version unknown", "1 behind", "update available"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("output lacks %q:\n%s", want, output)
+		}
+	}
+}

--- a/cmd/stack_profile_fleet_test.go
+++ b/cmd/stack_profile_fleet_test.go
@@ -251,3 +251,27 @@ func TestStackProfilesRolloutSaysWhenNothingIsDeployed(t *testing.T) {
 		t.Errorf("output = %q", output)
 	}
 }
+
+func TestStackProfilesRolloutRefusesAFileReferenceInTheExport(t *testing.T) {
+	resetStackProfileCommandFlags(t, stackProfilesRolloutCmd)
+	mock := newRolloutMock()
+	mock.exportDocument = `apiVersion: v1
+kind: ImportCluster
+metadata:
+  name: hello-fleet
+spec:
+  stacks:
+  - name: hello-fleet
+    manifests:
+    - name: hello-namespace
+      from_file: namespace.yaml
+    addons: []
+`
+	_, executeError := runStackProfilesCommand(t, mock, "", "rollout", "hello-fleet", "--all")
+	if executeError == nil || !strings.Contains(executeError.Error(), "invalid ImportCluster in the exported profile version") {
+		t.Fatalf("a from_file in an export must fail loudly, got %v", executeError)
+	}
+	if len(mock.applied) != 0 {
+		t.Errorf("nothing should be applied: %+v", mock.applied)
+	}
+}

--- a/cmd/stack_profile_manage.go
+++ b/cmd/stack_profile_manage.go
@@ -325,8 +325,11 @@ func renderProfileVersionContentDiff(cmd *cobra.Command, profileID string, fromV
 		return toError
 	}
 	var diffPayload profileVersionDiffPayload
-	if len(payload) > 0 {
-		_ = json.Unmarshal(payload, &diffPayload)
+	diffPayloadKnown := len(payload) > 0
+	if diffPayloadKnown {
+		if unmarshalError := json.Unmarshal(payload, &diffPayload); unmarshalError != nil {
+			diffPayloadKnown = false
+		}
 	}
 	out := cmd.OutOrStdout()
 	fromKeys := map[string]profileResource{}
@@ -379,7 +382,10 @@ func renderProfileVersionContentDiff(cmd *cobra.Command, profileID string, fromV
 	}
 	if changed == 0 {
 		_, _ = fmt.Fprintf(out, "No manifest or add-on values differ between v%d and v%d", fromVersion, toVersion)
-		if stackChanges > 0 {
+		switch {
+		case !diffPayloadKnown:
+			_, _ = fmt.Fprint(out, " (the platform's change list could not be read, so whether the stack's own settings changed is unknown; see 'ankra stack-profiles diff -o json')")
+		case stackChanges > 0:
 			_, _ = fmt.Fprint(out, " (the stack's own settings changed; compare them with 'ankra stack-profiles version')")
 		}
 		_, _ = fmt.Fprintln(out, ".")

--- a/cmd/stack_profile_manage.go
+++ b/cmd/stack_profile_manage.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -292,8 +293,112 @@ var stackProfilesDiffCmd = &cobra.Command{
 		if diffError != nil {
 			return fmt.Errorf("diffing stack profile versions: %w", diffError)
 		}
-		return renderApplicationPayload(cmd, payload)
+		format, _ := structuredFormatFromFlags(cmd)
+		if format != outputDefault {
+			return renderApplicationPayload(cmd, payload)
+		}
+		return renderProfileVersionContentDiff(cmd, profileID, fromVersion, toVersion, payload)
 	},
+}
+
+// profileVersionDiffPayload is the slice of the platform's version diff the
+// human output needs: which resources changed. The content itself is not in
+// the payload (it carries hashes), so it is read from both versions.
+type profileVersionDiffPayload struct {
+	Changes []struct {
+		Key        string `json:"key"`
+		ChangeType string `json:"change_type"`
+	} `json:"changes"`
+}
+
+// renderProfileVersionContentDiff prints a unified diff of every manifest
+// and add-on values file that differs between two versions, decoded, the
+// way `diff -u` would show it. Resources only one version has are printed
+// whole, as all-added or all-removed.
+func renderProfileVersionContentDiff(cmd *cobra.Command, profileID string, fromVersion int, toVersion int, payload json.RawMessage) error {
+	fromResources, fromError := loadProfileVersionResources(cmd, profileID, fromVersion)
+	if fromError != nil {
+		return fromError
+	}
+	toResources, toError := loadProfileVersionResources(cmd, profileID, toVersion)
+	if toError != nil {
+		return toError
+	}
+	var diffPayload profileVersionDiffPayload
+	if len(payload) > 0 {
+		_ = json.Unmarshal(payload, &diffPayload)
+	}
+	out := cmd.OutOrStdout()
+	fromKeys := map[string]profileResource{}
+	for _, resource := range fromResources {
+		fromKeys[resource.Kind+":"+resource.Name] = resource
+	}
+	toKeys := map[string]profileResource{}
+	for _, resource := range toResources {
+		toKeys[resource.Kind+":"+resource.Name] = resource
+	}
+	keys := []string{}
+	seen := map[string]bool{}
+	for _, resource := range append(append([]profileResource{}, fromResources...), toResources...) {
+		key := resource.Kind + ":" + resource.Name
+		if !seen[key] {
+			seen[key] = true
+			keys = append(keys, key)
+		}
+	}
+	changed, unchanged := 0, 0
+	for _, key := range keys {
+		fromResource, inFrom := fromKeys[key]
+		toResource, inTo := toKeys[key]
+		fromLabel := fmt.Sprintf("%s (v%d)", key, fromVersion)
+		toLabel := fmt.Sprintf("%s (v%d)", key, toVersion)
+		var rendered string
+		switch {
+		case inFrom && inTo:
+			rendered = unifiedDiff(fromLabel, toLabel, fromResource.Content, toResource.Content)
+		case inFrom:
+			rendered = unifiedDiff(fromLabel, "/dev/null", fromResource.Content, "")
+		default:
+			rendered = unifiedDiff("/dev/null", toLabel, "", toResource.Content)
+		}
+		if rendered == "" {
+			unchanged++
+			continue
+		}
+		changed++
+		if changed > 1 {
+			_, _ = fmt.Fprintln(out)
+		}
+		_, _ = fmt.Fprint(out, rendered)
+	}
+	stackChanges := 0
+	for _, change := range diffPayload.Changes {
+		if !strings.Contains(change.Key, "/") {
+			stackChanges++
+		}
+	}
+	if changed == 0 {
+		_, _ = fmt.Fprintf(out, "No manifest or add-on values differ between v%d and v%d", fromVersion, toVersion)
+		if stackChanges > 0 {
+			_, _ = fmt.Fprint(out, " (the stack's own settings changed; compare them with 'ankra stack-profiles version')")
+		}
+		_, _ = fmt.Fprintln(out, ".")
+		return nil
+	}
+	_, _ = fmt.Fprintf(out, "\n%d %s changed, %d unchanged, v%d -> v%d.\n", changed, pluralise(changed, "resource", "resources"), unchanged, fromVersion, toVersion)
+	return nil
+}
+
+func loadProfileVersionResources(cmd *cobra.Command, profileID string, version int) ([]profileResource, error) {
+	payload, getError := apiClient.GetStackProfileVersion(cmd.Context(), profileID, version)
+	if getError != nil {
+		return nil, fmt.Errorf("getting stack profile version v%d: %w", version, getError)
+	}
+	var versionPayload profileVersionPayload
+	if unmarshalError := json.Unmarshal(payload, &versionPayload); unmarshalError != nil {
+		return nil, fmt.Errorf("parsing stack profile version v%d: %w", version, unmarshalError)
+	}
+	return profileVersionResources(&versionPayload)
 }
 
 var stackProfilesDeploymentsCmd = &cobra.Command{
@@ -301,7 +406,11 @@ var stackProfilesDeploymentsCmd = &cobra.Command{
 	Short: "List the stacks deployed from a profile across the fleet",
 	Long: `List every stack your organisation deployed from this profile: the target
 cluster, the stack, the profile version it runs, and whether a newer
-version is available.`,
+version is available. --outdated keeps only the ones behind the current
+version; -o json returns the raw records.`,
+	Example: `  ankra stack-profiles deployments hello-fleet
+  ankra stack-profiles deployments hello-fleet --outdated
+  ankra stack-profiles deployments hello-fleet -o json`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if _, formatError := structuredFormatFromFlags(cmd); formatError != nil {
@@ -311,11 +420,17 @@ version is available.`,
 		if resolveError != nil {
 			return resolveError
 		}
-		payload, listError := apiClient.ListStackProfileInstantiations(cmd.Context(), profileID)
+		payload, deployments, listError := loadStackProfileDeployments(cmd.Context(), profileID)
 		if listError != nil {
-			return fmt.Errorf("listing stack profile deployments: %w", listError)
+			return listError
 		}
-		return renderApplicationPayload(cmd, payload)
+		format, _ := structuredFormatFromFlags(cmd)
+		if format != outputDefault {
+			return renderApplicationPayload(cmd, payload)
+		}
+		onlyOutdated, _ := cmd.Flags().GetBool("outdated")
+		renderStackProfileDeployments(cmd.OutOrStdout(), deployments, onlyOutdated)
+		return nil
 	},
 }
 
@@ -357,6 +472,7 @@ func init() {
 	stackProfilesDiffCmd.Flags().String("to", "", "Version to compare to, as 1 or v1 (required)")
 	registerStructuredOutputFlags(stackProfilesDiffCmd)
 
+	stackProfilesDeploymentsCmd.Flags().Bool("outdated", false, "Only the deployments behind the current version")
 	registerStructuredOutputFlags(stackProfilesDeploymentsCmd)
 
 	stackProfilesCmd.AddCommand(

--- a/cmd/stack_profile_manage_test.go
+++ b/cmd/stack_profile_manage_test.go
@@ -3,9 +3,11 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -19,7 +21,8 @@ import (
 // make and answers each with a fixed payload.
 type stackProfileManageMock struct {
 	baseMock
-	payload json.RawMessage
+	payload  json.RawMessage
+	versions map[int]json.RawMessage
 
 	createRequest      *client.CreateStackProfileFromStackRequest
 	updateProfileID    string
@@ -82,6 +85,9 @@ func (mock *stackProfileManageMock) SetStackProfileCurrentVersion(requestContext
 
 func (mock *stackProfileManageMock) GetStackProfileVersion(requestContext context.Context, profileID string, version int) (json.RawMessage, error) {
 	mock.versionRequested = version
+	if payload, ok := mock.versions[version]; ok {
+		return payload, nil
+	}
 	return mock.answer()
 }
 
@@ -359,7 +365,7 @@ func TestStackProfilesDiffRequiresRange(t *testing.T) {
 func TestStackProfilesDeploymentsCallsInstantiations(t *testing.T) {
 	resetStackProfileCommandFlags(t, stackProfilesDeploymentsCmd)
 	mock := &stackProfileManageMock{payload: json.RawMessage(`{"result":[]}`)}
-	output, executeError := runStackProfilesCommand(t, mock, "", "deployments", "profile-1")
+	output, executeError := runStackProfilesCommand(t, mock, "", "deployments", "profile-1", "-o", "json")
 	if executeError != nil {
 		t.Fatalf("deployments failed: %v", executeError)
 	}
@@ -368,6 +374,119 @@ func TestStackProfilesDeploymentsCallsInstantiations(t *testing.T) {
 	}
 	if !strings.Contains(output, `"result"`) {
 		t.Errorf("output = %q", output)
+	}
+}
+
+const fleetDeploymentsPayload = `{"current_version": 2, "result": [
+  {"id": "i-1", "target_cluster_id": "11111111-1111-1111-1111-111111111111", "cluster_name": "prod-eu", "stack_name": "hello-fleet", "stack_state": "up", "version": 1, "outdated": true, "created_at": "2026-09-10T19:49:37Z"},
+  {"id": "i-2", "target_cluster_id": "22222222-2222-2222-2222-222222222222", "cluster_name": "prod-us", "stack_name": "hello-fleet", "stack_state": "up", "version": 2, "outdated": false, "created_at": "2026-09-10T20:03:41Z"}
+]}`
+
+func TestStackProfilesDeploymentsRendersFleetTable(t *testing.T) {
+	resetStackProfileCommandFlags(t, stackProfilesDeploymentsCmd)
+	mock := &stackProfileManageMock{payload: json.RawMessage(fleetDeploymentsPayload)}
+	output, executeError := runStackProfilesCommand(t, mock, "", "deployments", "profile-1")
+	if executeError != nil {
+		t.Fatalf("deployments failed: %v", executeError)
+	}
+	for _, want := range []string{
+		"Current version v2",
+		"2 deployments across 2 clusters",
+		"1 behind v2",
+		"prod-eu", "update available (v2)",
+		"prod-us", "up to date",
+		"rollout <profile> --all --outdated",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("output lacks %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, `"result"`) {
+		t.Errorf("default output should be a table, got JSON:\n%s", output)
+	}
+
+	resetStackProfileCommandFlags(t, stackProfilesDeploymentsCmd)
+	output, executeError = runStackProfilesCommand(t, mock, "", "deployments", "profile-1", "--outdated")
+	if executeError != nil {
+		t.Fatalf("deployments --outdated failed: %v", executeError)
+	}
+	if !strings.Contains(output, "prod-eu") || strings.Contains(output, "prod-us") {
+		t.Errorf("--outdated should keep only the outdated row:\n%s", output)
+	}
+}
+
+func TestStackProfilesDeploymentsEmptyFleet(t *testing.T) {
+	resetStackProfileCommandFlags(t, stackProfilesDeploymentsCmd)
+	mock := &stackProfileManageMock{payload: json.RawMessage(`{"current_version": 1, "result": []}`)}
+	output, executeError := runStackProfilesCommand(t, mock, "", "deployments", "profile-1")
+	if executeError != nil {
+		t.Fatalf("deployments failed: %v", executeError)
+	}
+	if !strings.Contains(output, "No stack has been deployed from this profile yet") {
+		t.Errorf("output = %q", output)
+	}
+}
+
+func encodedProfileVersion(t *testing.T, version int, manifestName string, content string) json.RawMessage {
+	t.Helper()
+	encoded := base64.StdEncoding.EncodeToString([]byte(content))
+	return json.RawMessage(`{"version": ` + strconv.Itoa(version) + `, "channel": "stable", "spec": {"stacks": [{"name": "web", "manifests": [{"name": "` + manifestName + `", "manifest_base64": "` + encoded + `"}], "addons": []}]}}`)
+}
+
+func TestStackProfilesDiffRendersContentDiff(t *testing.T) {
+	resetStackProfileCommandFlags(t, stackProfilesDiffCmd)
+	mock := &stackProfileManageMock{
+		payload: json.RawMessage(`{"changes": [{"key": "stack:web/manifest:web-deployment", "change_type": "modified"}]}`),
+		versions: map[int]json.RawMessage{
+			1: encodedProfileVersion(t, 1, "web-deployment", "kind: Deployment\nspec:\n  replicas: 2\n  image: nginx:1.27\n"),
+			2: encodedProfileVersion(t, 2, "web-deployment", "kind: Deployment\nspec:\n  replicas: 2\n  image: nginx:1.29\n"),
+		},
+	}
+	output, executeError := runStackProfilesCommand(t, mock, "", "diff", "profile-1", "--from", "1", "--to", "2")
+	if executeError != nil {
+		t.Fatalf("diff failed: %v", executeError)
+	}
+	for _, want := range []string{
+		"--- manifest:web-deployment (v1)",
+		"+++ manifest:web-deployment (v2)",
+		"-  image: nginx:1.27",
+		"+  image: nginx:1.29",
+		"1 resource changed, 0 unchanged, v1 -> v2.",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("output lacks %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "content_hash") {
+		t.Errorf("default output should be a content diff, not the hash payload:\n%s", output)
+	}
+
+	resetStackProfileCommandFlags(t, stackProfilesDiffCmd)
+	output, executeError = runStackProfilesCommand(t, mock, "", "diff", "profile-1", "--from", "1", "--to", "2", "-o", "json")
+	if executeError != nil {
+		t.Fatalf("diff -o json failed: %v", executeError)
+	}
+	if !strings.Contains(output, `"change_type"`) {
+		t.Errorf("-o json should return the platform payload:\n%s", output)
+	}
+}
+
+func TestStackProfilesDiffReportsAddedAndRemovedResources(t *testing.T) {
+	resetStackProfileCommandFlags(t, stackProfilesDiffCmd)
+	mock := &stackProfileManageMock{
+		versions: map[int]json.RawMessage{
+			1: encodedProfileVersion(t, 1, "old-config", "kind: ConfigMap\n"),
+			2: encodedProfileVersion(t, 2, "new-config", "kind: Secret\n"),
+		},
+	}
+	output, executeError := runStackProfilesCommand(t, mock, "", "diff", "profile-1", "--from", "1", "--to", "2")
+	if executeError != nil {
+		t.Fatalf("diff failed: %v", executeError)
+	}
+	for _, want := range []string{"+++ /dev/null", "-kind: ConfigMap", "--- /dev/null", "+kind: Secret", "2 resources changed"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("output lacks %q:\n%s", want, output)
+		}
 	}
 }
 

--- a/cmd/stack_profiles.go
+++ b/cmd/stack_profiles.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"sort"
@@ -507,7 +508,7 @@ which parameters a profile expects.`,
 			return encodeStructured(cmd.OutOrStdout(), format, result)
 		}
 
-		printApplyResult(result)
+		printApplyResult(os.Stdout, result)
 		return nil
 	},
 }
@@ -522,28 +523,28 @@ func instantiateProfileOnCluster(clusterID string, request client.InstantiateSta
 	return result, nil
 }
 
-func printApplyResult(result *client.InstantiateStackProfileResult) {
-	fmt.Printf("\nStack profile applied successfully!\n")
-	fmt.Printf("  Draft ID:    %s\n", result.DraftID)
-	fmt.Printf("  Stack Name:  %s\n", result.StackName)
-	fmt.Printf("  Version:     v%d\n", result.ProfileVersion)
-	fmt.Printf("  Addons:      %d\n", result.AddonsCount)
-	fmt.Printf("  Manifests:   %d\n", result.ManifestsCount)
+func printApplyResult(out io.Writer, result *client.InstantiateStackProfileResult) {
+	_, _ = fmt.Fprintf(out, "\nStack profile applied successfully!\n")
+	_, _ = fmt.Fprintf(out, "  Draft ID:    %s\n", result.DraftID)
+	_, _ = fmt.Fprintf(out, "  Stack Name:  %s\n", result.StackName)
+	_, _ = fmt.Fprintf(out, "  Version:     v%d\n", result.ProfileVersion)
+	_, _ = fmt.Fprintf(out, "  Addons:      %d\n", result.AddonsCount)
+	_, _ = fmt.Fprintf(out, "  Manifests:   %d\n", result.ManifestsCount)
 
 	if len(result.Warnings) > 0 {
-		fmt.Println("\nWarnings:")
+		_, _ = fmt.Fprintln(out, "\nWarnings:")
 		for _, warning := range result.Warnings {
-			fmt.Printf("  - %s\n", warning)
+			_, _ = fmt.Fprintf(out, "  - %s\n", warning)
 		}
 	}
 
 	if result.Deployed {
-		fmt.Printf("\nThe stack has been deployed. %d job(s) scheduled.\n", result.JobCount)
+		_, _ = fmt.Fprintf(out, "\nThe stack has been deployed. %d job(s) scheduled.\n", result.JobCount)
 		if result.OperationID != nil {
-			fmt.Printf("  Operation ID: %s\n", *result.OperationID)
+			_, _ = fmt.Fprintf(out, "  Operation ID: %s\n", *result.OperationID)
 		}
 	} else {
-		fmt.Printf("\nThe stack was created as a draft. Review and deploy it in the Ankra dashboard, or re-run with --deploy.\n")
+		_, _ = fmt.Fprintf(out, "\nThe stack was created as a draft. Review and deploy it in the Ankra dashboard, or re-run with --deploy.\n")
 	}
 }
 
@@ -561,6 +562,7 @@ type multiClusterApplyOutcome struct {
 // so one bad cluster does not stop the rest of the fleet. The exit status
 // reports any failure.
 func applyProfileToClusters(cmd *cobra.Command, format outputFormat, clusterFlags []string, request client.InstantiateStackProfileRequest) error {
+	out := cmd.OutOrStdout()
 	outcomes := make([]multiClusterApplyOutcome, 0, len(clusterFlags))
 	failed := 0
 	for _, clusterFlag := range clusterFlags {
@@ -570,7 +572,7 @@ func applyProfileToClusters(cmd *cobra.Command, format outputFormat, clusterFlag
 			outcome.Status, outcome.Error = "failed", resolveError.Error()
 		} else {
 			if format == outputDefault {
-				fmt.Printf("== %s\n", clusterFlag)
+				_, _ = fmt.Fprintf(out, "== %s\n", clusterFlag)
 			}
 			result, applyError := instantiateProfileOnCluster(clusterID, request)
 			switch {
@@ -582,14 +584,14 @@ func applyProfileToClusters(cmd *cobra.Command, format outputFormat, clusterFlag
 				outcome.Status, outcome.Result = "draft", result
 			}
 			if format == outputDefault && result != nil {
-				printApplyResult(result)
-				fmt.Println()
+				printApplyResult(out, result)
+				_, _ = fmt.Fprintln(out)
 			}
 		}
 		if outcome.Status == "failed" {
 			failed++
 			if format == outputDefault {
-				fmt.Printf("== %s\n  failed: %s\n\n", clusterFlag, outcome.Error)
+				_, _ = fmt.Fprintf(out, "== %s\n  failed: %s\n\n", clusterFlag, outcome.Error)
 			}
 		}
 		outcomes = append(outcomes, outcome)
@@ -604,7 +606,7 @@ func applyProfileToClusters(cmd *cobra.Command, format outputFormat, clusterFlag
 		return nil
 	}
 	summary := table.NewWriter()
-	summary.SetOutputMirror(os.Stdout)
+	summary.SetOutputMirror(out)
 	summary.SetStyle(table.StyleRounded)
 	summary.AppendHeader(table.Row{"CLUSTER", "STACK", "VERSION", "STATUS"})
 	for _, outcome := range outcomes {

--- a/cmd/stack_profiles.go
+++ b/cmd/stack_profiles.go
@@ -595,7 +595,13 @@ func applyProfileToClusters(cmd *cobra.Command, format outputFormat, clusterFlag
 		outcomes = append(outcomes, outcome)
 	}
 	if format != outputDefault {
-		return encodeStructured(cmd.OutOrStdout(), format, outcomes)
+		if encodeError := encodeStructured(cmd.OutOrStdout(), format, outcomes); encodeError != nil {
+			return encodeError
+		}
+		if failed > 0 {
+			return fmt.Errorf("%d of %d clusters failed", failed, len(clusterFlags))
+		}
+		return nil
 	}
 	summary := table.NewWriter()
 	summary.SetOutputMirror(os.Stdout)

--- a/cmd/stack_profiles.go
+++ b/cmd/stack_profiles.go
@@ -431,6 +431,9 @@ var stackProfilesApplyCmd = &cobra.Command{
 By default this creates a reviewable stack DRAFT on the target cluster - nothing is
 deployed until you review it in the Ankra dashboard or pass --deploy.
 
+Repeat --cluster to apply the same version and bindings to several clusters in
+one command; a summary table reports each cluster at the end.
+
 Bind profile parameters with --set name=value. For secret parameters prefer
 --set-file name=path or --set-env name=ENV_VAR so the value never appears in your
 shell history or process list. Use 'ankra stack-profiles get <profile-id>' to see
@@ -441,7 +444,7 @@ which parameters a profile expects.`,
 		if resolveError != nil {
 			return resolveError
 		}
-		clusterFlag, _ := cmd.Flags().GetString("cluster")
+		clusterFlags, _ := cmd.Flags().GetStringArray("cluster")
 		stackName, _ := cmd.Flags().GetString("stack-name")
 		versionRaw, _ := cmd.Flags().GetString("version")
 		versionFlag, versionError := parseProfileVersionFlag(versionRaw)
@@ -463,11 +466,6 @@ which parameters a profile expects.`,
 			return previewApply(cmd, profileID, versionFlag, parameters)
 		}
 
-		clusterID, clusterLabel, err := resolveApplyTargetCluster(clusterFlag)
-		if err != nil {
-			return err
-		}
-
 		request := client.InstantiateStackProfileRequest{
 			ProfileID:    profileID,
 			NewStackName: stackName,
@@ -484,46 +482,138 @@ which parameters a profile expects.`,
 			return err
 		}
 
+		if len(clusterFlags) > 1 {
+			return applyProfileToClusters(cmd, format, clusterFlags, request)
+		}
+		clusterFlag := ""
+		if len(clusterFlags) == 1 {
+			clusterFlag = clusterFlags[0]
+		}
+		clusterID, clusterLabel, err := resolveApplyTargetCluster(clusterFlag)
+		if err != nil {
+			return err
+		}
+
 		if format == outputDefault {
 			fmt.Printf("Applying stack profile to cluster '%s'...\n", clusterLabel)
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
-		defer cancel()
-
-		result, err := apiClient.InstantiateStackProfile(ctx, clusterID, request)
+		result, err := instantiateProfileOnCluster(clusterID, request)
 		if err != nil {
-			return fmt.Errorf("applying stack profile: %w", err)
+			return err
 		}
 
 		if format != outputDefault {
 			return encodeStructured(cmd.OutOrStdout(), format, result)
 		}
 
-		fmt.Printf("\nStack profile applied successfully!\n")
-		fmt.Printf("  Draft ID:    %s\n", result.DraftID)
-		fmt.Printf("  Stack Name:  %s\n", result.StackName)
-		fmt.Printf("  Version:     v%d\n", result.ProfileVersion)
-		fmt.Printf("  Addons:      %d\n", result.AddonsCount)
-		fmt.Printf("  Manifests:   %d\n", result.ManifestsCount)
-
-		if len(result.Warnings) > 0 {
-			fmt.Println("\nWarnings:")
-			for _, warning := range result.Warnings {
-				fmt.Printf("  - %s\n", warning)
-			}
-		}
-
-		if result.Deployed {
-			fmt.Printf("\nThe stack has been deployed. %d job(s) scheduled.\n", result.JobCount)
-			if result.OperationID != nil {
-				fmt.Printf("  Operation ID: %s\n", *result.OperationID)
-			}
-		} else {
-			fmt.Printf("\nThe stack was created as a draft. Review and deploy it in the Ankra dashboard, or re-run with --deploy.\n")
-		}
+		printApplyResult(result)
 		return nil
 	},
+}
+
+func instantiateProfileOnCluster(clusterID string, request client.InstantiateStackProfileRequest) (*client.InstantiateStackProfileResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+	result, err := apiClient.InstantiateStackProfile(ctx, clusterID, request)
+	if err != nil {
+		return nil, fmt.Errorf("applying stack profile: %w", err)
+	}
+	return result, nil
+}
+
+func printApplyResult(result *client.InstantiateStackProfileResult) {
+	fmt.Printf("\nStack profile applied successfully!\n")
+	fmt.Printf("  Draft ID:    %s\n", result.DraftID)
+	fmt.Printf("  Stack Name:  %s\n", result.StackName)
+	fmt.Printf("  Version:     v%d\n", result.ProfileVersion)
+	fmt.Printf("  Addons:      %d\n", result.AddonsCount)
+	fmt.Printf("  Manifests:   %d\n", result.ManifestsCount)
+
+	if len(result.Warnings) > 0 {
+		fmt.Println("\nWarnings:")
+		for _, warning := range result.Warnings {
+			fmt.Printf("  - %s\n", warning)
+		}
+	}
+
+	if result.Deployed {
+		fmt.Printf("\nThe stack has been deployed. %d job(s) scheduled.\n", result.JobCount)
+		if result.OperationID != nil {
+			fmt.Printf("  Operation ID: %s\n", *result.OperationID)
+		}
+	} else {
+		fmt.Printf("\nThe stack was created as a draft. Review and deploy it in the Ankra dashboard, or re-run with --deploy.\n")
+	}
+}
+
+// multiClusterApplyOutcome is one cluster's result when apply targets
+// several clusters at once.
+type multiClusterApplyOutcome struct {
+	Cluster string                                `json:"cluster"`
+	Status  string                                `json:"status"`
+	Error   string                                `json:"error,omitempty"`
+	Result  *client.InstantiateStackProfileResult `json:"result,omitempty"`
+}
+
+// applyProfileToClusters applies the same profile version and bindings to
+// every cluster named, one after the other, and keeps going past a failure
+// so one bad cluster does not stop the rest of the fleet. The exit status
+// reports any failure.
+func applyProfileToClusters(cmd *cobra.Command, format outputFormat, clusterFlags []string, request client.InstantiateStackProfileRequest) error {
+	outcomes := make([]multiClusterApplyOutcome, 0, len(clusterFlags))
+	failed := 0
+	for _, clusterFlag := range clusterFlags {
+		outcome := multiClusterApplyOutcome{Cluster: clusterFlag}
+		clusterID, _, resolveError := resolveApplyTargetCluster(clusterFlag)
+		if resolveError != nil {
+			outcome.Status, outcome.Error = "failed", resolveError.Error()
+		} else {
+			if format == outputDefault {
+				fmt.Printf("== %s\n", clusterFlag)
+			}
+			result, applyError := instantiateProfileOnCluster(clusterID, request)
+			switch {
+			case applyError != nil:
+				outcome.Status, outcome.Error = "failed", applyError.Error()
+			case result.Deployed:
+				outcome.Status, outcome.Result = "deployed", result
+			default:
+				outcome.Status, outcome.Result = "draft", result
+			}
+			if format == outputDefault && result != nil {
+				printApplyResult(result)
+				fmt.Println()
+			}
+		}
+		if outcome.Status == "failed" {
+			failed++
+			if format == outputDefault {
+				fmt.Printf("== %s\n  failed: %s\n\n", clusterFlag, outcome.Error)
+			}
+		}
+		outcomes = append(outcomes, outcome)
+	}
+	if format != outputDefault {
+		return encodeStructured(cmd.OutOrStdout(), format, outcomes)
+	}
+	summary := table.NewWriter()
+	summary.SetOutputMirror(os.Stdout)
+	summary.SetStyle(table.StyleRounded)
+	summary.AppendHeader(table.Row{"CLUSTER", "STACK", "VERSION", "STATUS"})
+	for _, outcome := range outcomes {
+		stackName, version := "-", "-"
+		if outcome.Result != nil {
+			stackName = outcome.Result.StackName
+			version = fmt.Sprintf("v%d", outcome.Result.ProfileVersion)
+		}
+		summary.AppendRow(table.Row{outcome.Cluster, stackName, version, outcome.Status})
+	}
+	summary.Render()
+	if failed > 0 {
+		return fmt.Errorf("%d of %d clusters failed", failed, len(clusterFlags))
+	}
+	return nil
 }
 
 // previewApply is `apply --dry-run`: it reads the profile version's inputs,
@@ -686,7 +776,7 @@ func init() {
 	stackProfilesGetCmd.Flags().String("version", "", "Profile version to describe, as 1 or v1 (defaults to the current version)")
 	registerStructuredOutputFlags(stackProfilesGetCmd)
 
-	stackProfilesApplyCmd.Flags().String("cluster", "", "Target cluster name or ID (defaults to the selected cluster)")
+	stackProfilesApplyCmd.Flags().StringArray("cluster", nil, "Target cluster name or ID (repeatable: apply the same profile to several clusters in one go; defaults to the selected cluster)")
 	stackProfilesApplyCmd.Flags().String("version", "", "Profile version to apply, as 1 or v1 (defaults to the profile's current version)")
 	stackProfilesApplyCmd.Flags().String("stack-name", "", "Name for the new stack (defaults to the profile's stack name)")
 	stackProfilesApplyCmd.Flags().StringArray("set", nil, "Bind a parameter: name=value (repeatable; not for secrets)")

--- a/cmd/stack_profiles_apply_test.go
+++ b/cmd/stack_profiles_apply_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -14,13 +15,19 @@ const testClusterUUID = "11111111-2222-3333-4444-555555555555"
 
 type stackProfileMock struct {
 	baseMock
-	instantiateRequest *client.InstantiateStackProfileRequest
-	instantiateResult  *client.InstantiateStackProfileResult
-	detail             *client.StackProfileDetail
+	instantiateRequest    *client.InstantiateStackProfileRequest
+	instantiateResult     *client.InstantiateStackProfileResult
+	instantiateClusterIDs []string
+	failClusterID         string
+	detail                *client.StackProfileDetail
 }
 
 func (m *stackProfileMock) InstantiateStackProfile(ctx context.Context, clusterID string, request client.InstantiateStackProfileRequest) (*client.InstantiateStackProfileResult, error) {
 	m.instantiateRequest = &request
+	m.instantiateClusterIDs = append(m.instantiateClusterIDs, clusterID)
+	if m.failClusterID != "" && clusterID == m.failClusterID {
+		return nil, errors.New("cluster is offline")
+	}
 	if m.instantiateResult != nil {
 		return m.instantiateResult, nil
 	}
@@ -41,7 +48,6 @@ func resetStackProfileApplyFlags(t *testing.T) {
 	t.Helper()
 	flags := stackProfilesApplyCmd.Flags()
 	for name, value := range map[string]string{
-		"cluster":    "",
 		"stack-name": "",
 		"version":    "0",
 		"deploy":     "false",
@@ -50,7 +56,7 @@ func resetStackProfileApplyFlags(t *testing.T) {
 	} {
 		_ = flags.Set(name, value)
 	}
-	for _, name := range []string{"set", "set-file", "set-env"} {
+	for _, name := range []string{"cluster", "set", "set-file", "set-env"} {
 		if sliceValue, ok := flags.Lookup(name).Value.(pflag.SliceValue); ok {
 			_ = sliceValue.Replace([]string{})
 		}
@@ -174,5 +180,52 @@ func TestStackProfilesApplyJSONOutput(t *testing.T) {
 	}
 	if !strings.Contains(output, "\"draft_id\"") {
 		t.Errorf("expected json with draft_id, got: %s", output)
+	}
+}
+
+func TestStackProfilesApplyToSeveralClusters(t *testing.T) {
+	resetStackProfileApplyFlags(t)
+	second := "22222222-2222-3333-4444-555555555555"
+	mock := &stackProfileMock{instantiateResult: &client.InstantiateStackProfileResult{
+		DraftID: "draft-1", StackName: "hello-fleet", ProfileVersion: 2, ManifestsCount: 4, Deployed: true, JobCount: 6,
+	}}
+	setMockClient(t, mock)
+
+	stdout := captureStdout(t, func() {
+		_, _ = executeCommand("stack-profiles", "apply", "profile-1", "--cluster", testClusterUUID, "--cluster", second, "--deploy")
+	})
+
+	if len(mock.instantiateClusterIDs) != 2 || mock.instantiateClusterIDs[0] != testClusterUUID || mock.instantiateClusterIDs[1] != second {
+		t.Fatalf("clusters applied = %v", mock.instantiateClusterIDs)
+	}
+	if !mock.instantiateRequest.Deploy {
+		t.Errorf("expected --deploy to carry through to every cluster")
+	}
+	for _, want := range []string{"== " + testClusterUUID, "== " + second, "CLUSTER", "hello-fleet", "v2", "deployed"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("stdout lacks %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestStackProfilesApplyToSeveralClustersKeepsGoingPastAFailure(t *testing.T) {
+	resetStackProfileApplyFlags(t)
+	second := "22222222-2222-3333-4444-555555555555"
+	mock := &stackProfileMock{failClusterID: testClusterUUID}
+	setMockClient(t, mock)
+
+	var executeError error
+	stdout := captureStdout(t, func() {
+		_, executeError = executeCommand("stack-profiles", "apply", "profile-1", "--cluster", testClusterUUID, "--cluster", second)
+	})
+
+	if executeError == nil {
+		t.Fatal("expected the command to report the failed cluster")
+	}
+	if len(mock.instantiateClusterIDs) != 2 {
+		t.Fatalf("the second cluster should still be applied after the first failed: %v", mock.instantiateClusterIDs)
+	}
+	if !strings.Contains(stdout, "failed") || !strings.Contains(stdout, "cluster is offline") || !strings.Contains(stdout, "draft") {
+		t.Errorf("stdout = %s", stdout)
 	}
 }

--- a/cmd/stack_profiles_apply_test.go
+++ b/cmd/stack_profiles_apply_test.go
@@ -191,9 +191,11 @@ func TestStackProfilesApplyToSeveralClusters(t *testing.T) {
 	}}
 	setMockClient(t, mock)
 
-	stdout := captureStdout(t, func() {
-		_, _ = executeCommand("stack-profiles", "apply", "profile-1", "--cluster", testClusterUUID, "--cluster", second, "--deploy")
+	var stdout string
+	captured := captureStdout(t, func() {
+		stdout, _ = executeCommand("stack-profiles", "apply", "profile-1", "--cluster", testClusterUUID, "--cluster", second, "--deploy")
 	})
+	stdout += captured
 
 	if len(mock.instantiateClusterIDs) != 2 || mock.instantiateClusterIDs[0] != testClusterUUID || mock.instantiateClusterIDs[1] != second {
 		t.Fatalf("clusters applied = %v", mock.instantiateClusterIDs)
@@ -215,9 +217,11 @@ func TestStackProfilesApplyToSeveralClustersKeepsGoingPastAFailure(t *testing.T)
 	setMockClient(t, mock)
 
 	var executeError error
-	stdout := captureStdout(t, func() {
-		_, executeError = executeCommand("stack-profiles", "apply", "profile-1", "--cluster", testClusterUUID, "--cluster", second)
+	var stdout string
+	captured := captureStdout(t, func() {
+		stdout, executeError = executeCommand("stack-profiles", "apply", "profile-1", "--cluster", testClusterUUID, "--cluster", second)
 	})
+	stdout += captured
 
 	if executeError == nil {
 		t.Fatal("expected the command to report the failed cluster")

--- a/cmd/stack_profiles_apply_test.go
+++ b/cmd/stack_profiles_apply_test.go
@@ -229,3 +229,22 @@ func TestStackProfilesApplyToSeveralClustersKeepsGoingPastAFailure(t *testing.T)
 		t.Errorf("stdout = %s", stdout)
 	}
 }
+
+func TestStackProfilesApplyToSeveralClustersStructuredOutputStillFails(t *testing.T) {
+	resetStackProfileApplyFlags(t)
+	second := "22222222-2222-3333-4444-555555555555"
+	mock := &stackProfileMock{failClusterID: testClusterUUID}
+	setMockClient(t, mock)
+
+	var executeError error
+	var output string
+	captured := captureStdout(t, func() {
+		output, executeError = executeCommand("stack-profiles", "apply", "profile-1", "--cluster", testClusterUUID, "--cluster", second, "-o", "json")
+	})
+	if executeError == nil {
+		t.Fatal("-o json must still exit non-zero when a cluster failed")
+	}
+	if !strings.Contains(output+captured, `"status": "failed"`) || !strings.Contains(output+captured, `"status": "draft"`) {
+		t.Errorf("the JSON payload should still be emitted before the error:\n%s%s", output, captured)
+	}
+}

--- a/cmd/unified_diff.go
+++ b/cmd/unified_diff.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+)
+
+// unifiedDiff renders a unified diff (three lines of context) between two
+// texts, the way `diff -u` prints it, so the CLI can show what changed inside
+// a profile's manifests without shelling out. Line-based, longest common
+// subsequence; the inputs are manifests and values files, never large.
+func unifiedDiff(fromLabel string, toLabel string, fromText string, toText string) string {
+	fromLines := splitDiffLines(fromText)
+	toLines := splitDiffLines(toText)
+	operations := diffOperations(fromLines, toLines)
+	hunks := groupDiffHunks(operations, 3)
+	if len(hunks) == 0 {
+		return ""
+	}
+	var builder strings.Builder
+	_, _ = fmt.Fprintf(&builder, "--- %s\n+++ %s\n", fromLabel, toLabel)
+	for _, hunk := range hunks {
+		fromStart, fromCount, toStart, toCount := hunkRanges(operations, hunk)
+		_, _ = fmt.Fprintf(&builder, "@@ -%s +%s @@\n", formatHunkRange(fromStart, fromCount), formatHunkRange(toStart, toCount))
+		for _, operation := range operations[hunk.start:hunk.end] {
+			builder.WriteString(operation.kind)
+			builder.WriteString(operation.text)
+			builder.WriteString("\n")
+		}
+	}
+	return builder.String()
+}
+
+type diffOperation struct {
+	kind string // " ", "-" or "+"
+	text string
+}
+
+type diffHunk struct {
+	start int
+	end   int
+}
+
+func splitDiffLines(text string) []string {
+	if text == "" {
+		return []string{}
+	}
+	return strings.Split(strings.TrimSuffix(text, "\n"), "\n")
+}
+
+// diffOperations walks the longest-common-subsequence table backwards and
+// emits the edit script in forward order.
+func diffOperations(fromLines []string, toLines []string) []diffOperation {
+	fromCount, toCount := len(fromLines), len(toLines)
+	table := make([][]int, fromCount+1)
+	for index := range table {
+		table[index] = make([]int, toCount+1)
+	}
+	for fromIndex := fromCount - 1; fromIndex >= 0; fromIndex-- {
+		for toIndex := toCount - 1; toIndex >= 0; toIndex-- {
+			if fromLines[fromIndex] == toLines[toIndex] {
+				table[fromIndex][toIndex] = table[fromIndex+1][toIndex+1] + 1
+			} else if table[fromIndex+1][toIndex] >= table[fromIndex][toIndex+1] {
+				table[fromIndex][toIndex] = table[fromIndex+1][toIndex]
+			} else {
+				table[fromIndex][toIndex] = table[fromIndex][toIndex+1]
+			}
+		}
+	}
+	operations := []diffOperation{}
+	fromIndex, toIndex := 0, 0
+	for fromIndex < fromCount && toIndex < toCount {
+		switch {
+		case fromLines[fromIndex] == toLines[toIndex]:
+			operations = append(operations, diffOperation{" ", fromLines[fromIndex]})
+			fromIndex++
+			toIndex++
+		case table[fromIndex+1][toIndex] >= table[fromIndex][toIndex+1]:
+			operations = append(operations, diffOperation{"-", fromLines[fromIndex]})
+			fromIndex++
+		default:
+			operations = append(operations, diffOperation{"+", toLines[toIndex]})
+			toIndex++
+		}
+	}
+	for ; fromIndex < fromCount; fromIndex++ {
+		operations = append(operations, diffOperation{"-", fromLines[fromIndex]})
+	}
+	for ; toIndex < toCount; toIndex++ {
+		operations = append(operations, diffOperation{"+", toLines[toIndex]})
+	}
+	return operations
+}
+
+// groupDiffHunks clusters the changed operations into hunks that carry
+// `context` unchanged lines on either side, merging hunks whose context
+// would overlap.
+func groupDiffHunks(operations []diffOperation, context int) []diffHunk {
+	hunks := []diffHunk{}
+	for index := 0; index < len(operations); index++ {
+		if operations[index].kind == " " {
+			continue
+		}
+		start := index - context
+		if start < 0 {
+			start = 0
+		}
+		end := index + 1
+		for end < len(operations) {
+			next := end
+			for next < len(operations) && operations[next].kind == " " {
+				next++
+			}
+			if next >= len(operations) || next-end > 2*context {
+				break
+			}
+			end = next + 1
+		}
+		end += context
+		if end > len(operations) {
+			end = len(operations)
+		}
+		hunks = append(hunks, diffHunk{start: start, end: end})
+		index = end - 1
+	}
+	return hunks
+}
+
+func hunkRanges(operations []diffOperation, hunk diffHunk) (int, int, int, int) {
+	fromLine, toLine := 1, 1
+	for _, operation := range operations[:hunk.start] {
+		switch operation.kind {
+		case " ":
+			fromLine++
+			toLine++
+		case "-":
+			fromLine++
+		case "+":
+			toLine++
+		}
+	}
+	fromCount, toCount := 0, 0
+	for _, operation := range operations[hunk.start:hunk.end] {
+		switch operation.kind {
+		case " ":
+			fromCount++
+			toCount++
+		case "-":
+			fromCount++
+		case "+":
+			toCount++
+		}
+	}
+	return fromLine, fromCount, toLine, toCount
+}
+
+func formatHunkRange(start int, count int) string {
+	if count == 0 {
+		return fmt.Sprintf("%d,0", start-1)
+	}
+	if count == 1 {
+		return fmt.Sprintf("%d", start)
+	}
+	return fmt.Sprintf("%d,%d", start, count)
+}

--- a/cmd/unified_diff.go
+++ b/cmd/unified_diff.go
@@ -13,22 +13,59 @@ func unifiedDiff(fromLabel string, toLabel string, fromText string, toText strin
 	fromLines := splitDiffLines(fromText)
 	toLines := splitDiffLines(toText)
 	operations := diffOperations(fromLines, toLines)
+	fromEndsWithNewline := fromText == "" || strings.HasSuffix(fromText, "\n")
+	toEndsWithNewline := toText == "" || strings.HasSuffix(toText, "\n")
+	if fromEndsWithNewline != toEndsWithNewline && fromText != "" && toText != "" {
+		operations = markTrailingNewlineChange(operations)
+	}
 	hunks := groupDiffHunks(operations, 3)
 	if len(hunks) == 0 {
 		return ""
 	}
 	var builder strings.Builder
 	_, _ = fmt.Fprintf(&builder, "--- %s\n+++ %s\n", fromLabel, toLabel)
+	lastFrom, lastTo := len(fromLines)-1, len(toLines)-1
+	fromIndex, toIndex := 0, 0
 	for _, hunk := range hunks {
 		fromStart, fromCount, toStart, toCount := hunkRanges(operations, hunk)
 		_, _ = fmt.Fprintf(&builder, "@@ -%s +%s @@\n", formatHunkRange(fromStart, fromCount), formatHunkRange(toStart, toCount))
+		fromIndex, toIndex = fromStart-1, toStart-1
 		for _, operation := range operations[hunk.start:hunk.end] {
 			builder.WriteString(operation.kind)
 			builder.WriteString(operation.text)
 			builder.WriteString("\n")
+			switch operation.kind {
+			case " ":
+				fromIndex++
+				toIndex++
+			case "-":
+				fromIndex++
+			case "+":
+				toIndex++
+			}
+			// `diff -u` flags a last line that has no newline, so a change that
+			// is only the trailing newline is visible instead of vanishing.
+			atFromEnd := operation.kind != "+" && !fromEndsWithNewline && fromIndex-1 == lastFrom
+			atToEnd := operation.kind != "-" && !toEndsWithNewline && toIndex-1 == lastTo
+			if atFromEnd || atToEnd {
+				builder.WriteString(noNewlineMarker)
+			}
 		}
 	}
 	return builder.String()
+}
+
+const noNewlineMarker = "\\ No newline at end of file\n"
+
+// markTrailingNewlineChange turns the final unchanged line into a removal
+// plus an addition, which is how a newline-only difference is shown.
+func markTrailingNewlineChange(operations []diffOperation) []diffOperation {
+	last := len(operations) - 1
+	if last < 0 || operations[last].kind != " " {
+		return operations
+	}
+	text := operations[last].text
+	return append(append(operations[:last:last], diffOperation{"-", text}), diffOperation{"+", text})
 }
 
 type diffOperation struct {


### PR DESCRIPTION
Bead: ankra-edvu9

## Why

The stack-profile fleet film (https://youtu.be/w2TYN40Gxb4) rolled one profile version across four clusters, and every step that was not a single `ankra` command was a shell loop, a `jq` pipeline over the deployments payload, a process-substitution `diff` of decoded manifests, or `export-iac` + `yq` + `cluster apply` per cluster. Those belong in the CLI.

## What

- **`stack-profiles apply --cluster` is repeatable.** The same version and bindings go to every cluster named; a failed cluster does not stop the rest; a summary table (or a JSON array with `-o json`) reports each one. Single-cluster behaviour and output are unchanged.
- **`stack-profiles deployments` prints a table by default**: cluster, stack, state, version, `up to date` / `update available (vN)`, deployed at, with a header line (`Current version v2 · 4 deployments across 4 clusters · 4 behind v2`). `--outdated` keeps only the ones behind. `-o json` still returns the platform records, so scripts keep working.
- **`stack-profiles diff` shows content.** Human output is a unified diff of every decoded manifest and add-on values file that differs between the versions (resources only one version has are printed whole); `-o json` keeps the platform's hash payload. The diff is a small in-house LCS unified diff, no new dependency.
- **New `stack-profiles rollout <profile> --cluster ...|--all [--outdated] [--version N] [--wait] [--dry-run] [-o json]`.** Exports the version as ClusterInfrastructureAsCode, addresses it to each target cluster and the stack name that deployment already uses, and applies it the way `cluster apply` does, so the same stack is updated in place (rolling update, nothing created twice). A cluster with no deployment of the profile is refused rather than silently given a first one.
- `buildImportRequest` is split into a from-bytes variant so an in-memory document can be applied.

## Verified

- Unit tests for the fleet table, `--outdated`, the content diff (modified, added, removed), multi-cluster apply (including one failing cluster), rollout (`--all --outdated`, per-cluster, stack-name carry-over, refusal without a deployment, dry run, partial failure, target validation) and the diff helper. Full `go test ./...` green, `go vet` and `golangci-lint` clean.
- Live against the dev org's `hello-fleet` profile on four clusters: `deployments`, `deployments --outdated`, `diff --from 1 --to 2`, `rollout --all --dry-run`, and a real `rollout --all --outdated` (four configuration writes accepted, `-o json` shape checked).

## Known gap (not this PR)

The platform's from-profile lane cannot update a deployment in place (it creates a renamed side-by-side draft), so `rollout` uses the `cluster apply` path. That path never touches the profile's provenance row, so `deployments` keeps reporting the previous version after a rollout until the backend records rollouts; that backend change is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
