### PR TITLE
fix(cluster): apply honours --cluster as the target instead of importing a cluster named after the file (ankra-k7rhn)

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -83,10 +83,20 @@ func runApply(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	targetNote, err := applyClusterOverride(cmd, &importRequest)
+	if err != nil {
+		return err
+	}
 
 	if dryRun {
 		fmt.Printf("Validation succeeded for %q; no changes applied (--dry-run).\n", filePath)
+		if targetNote != "" {
+			fmt.Println(targetNote)
+		}
 		return nil
+	}
+	if targetNote != "" {
+		fmt.Println(targetNote)
 	}
 
 	wait, err := asyncWriteWaitFlag(cmd)
@@ -161,6 +171,30 @@ func runApply(cmd *cobra.Command, _ []string) error {
 	fmt.Printf("\nView it in the UI:\n  %s/organisation/clusters/cluster/imported/%s/overview\n",
 		strings.TrimRight(baseURL, "/"), importResponse.ClusterId)
 	return nil
+}
+
+// applyClusterOverride makes --cluster the target of the apply. The document's
+// metadata.name is the cluster name the platform addresses, so a file written
+// for one cluster (or exported from a profile, where the name is the profile's)
+// used to import a NEW cluster under that name whenever --cluster was passed
+// alongside it - the flag was read by nothing. With the flag set, the cluster
+// is resolved (name or id) and its name replaces metadata.name; the note says
+// so when the two differ so the substitution is never silent.
+func applyClusterOverride(cmd *cobra.Command, importRequest *client.CreateImportClusterRequest) (string, error) {
+	override := clusterFlagOverride(cmd)
+	if override == "" {
+		return "", nil
+	}
+	cluster, lookupError := lookupClusterByNameOrID(override)
+	if lookupError != nil {
+		return "", lookupError
+	}
+	if cluster.Name == importRequest.Name {
+		return "", nil
+	}
+	note := fmt.Sprintf("Applying to cluster '%s' (--cluster), not '%s' (metadata.name in the file).", cluster.Name, importRequest.Name)
+	importRequest.Name = cluster.Name
+	return note, nil
 }
 
 // loadImportCluster reads and validates an ImportCluster file into the

--- a/cmd/apply_cluster_flag_test.go
+++ b/cmd/apply_cluster_flag_test.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ankra/internal/client"
+)
+
+const applyOverrideDocument = `apiVersion: v1
+kind: ImportCluster
+metadata:
+  name: hello-fleet
+spec:
+  stacks:
+  - name: hello-fleet
+    manifests:
+    - name: hello-namespace
+      manifest_base64: YXBpVmVyc2lvbjogdjEKa2luZDogTmFtZXNwYWNlCm1ldGFkYXRhOgogIG5hbWU6IGhlbGxvCg==
+      parents: []
+    addons: []
+`
+
+type applyOverrideMock struct {
+	baseMock
+	applied []client.CreateImportClusterRequest
+}
+
+func (mock *applyOverrideMock) GetCluster(name string) (client.ClusterListItem, error) {
+	if name == "prod-eu" {
+		return client.ClusterListItem{ID: "11111111-1111-1111-1111-111111111111", Name: "prod-eu"}, nil
+	}
+	return client.ClusterListItem{}, os.ErrNotExist
+}
+
+func (mock *applyOverrideMock) GetClusterByID(clusterID string) (client.ClusterListItem, error) {
+	if clusterID == "11111111-1111-1111-1111-111111111111" {
+		return client.ClusterListItem{ID: clusterID, Name: "prod-eu"}, nil
+	}
+	return client.ClusterListItem{}, os.ErrNotExist
+}
+
+func (mock *applyOverrideMock) ApplyCluster(ctx context.Context, request client.CreateImportClusterRequest, wait bool) (*client.ImportResponse, bool, error) {
+	mock.applied = append(mock.applied, request)
+	return &client.ImportResponse{Name: request.Name, ClusterId: "11111111-1111-1111-1111-111111111111"}, false, nil
+}
+
+func writeApplyOverrideDocument(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "hello-fleet.yaml")
+	if writeError := os.WriteFile(path, []byte(applyOverrideDocument), 0o600); writeError != nil {
+		t.Fatal(writeError)
+	}
+	return path
+}
+
+// resetClusterApplyFlags clears the apply flags and the persistent --cluster
+// override, now and again when the test ends: the override is a package
+// global, and a value left behind would redirect every later apply test.
+func resetClusterApplyFlags(t *testing.T) {
+	t.Helper()
+	clear := func() {
+		resetCommandFlags(t, clusterApplyCmd)
+		_ = clusterCmd.PersistentFlags().Set(activeClusterFlagName, "")
+		clusterCmd.PersistentFlags().Lookup(activeClusterFlagName).Changed = false
+	}
+	clear()
+	t.Cleanup(clear)
+}
+
+func TestClusterApplyClusterFlagOverridesMetadataName(t *testing.T) {
+	resetClusterApplyFlags(t)
+	mock := &applyOverrideMock{}
+	setMockClient(t, mock)
+	path := writeApplyOverrideDocument(t)
+
+	stdout := captureStdout(t, func() {
+		if _, executeError := executeCommand("cluster", "apply", "-f", path, "--cluster", "prod-eu"); executeError != nil {
+			t.Errorf("apply failed: %v", executeError)
+		}
+	})
+
+	if len(mock.applied) != 1 || mock.applied[0].Name != "prod-eu" {
+		t.Fatalf("applied = %+v, want the --cluster name as the target", mock.applied)
+	}
+	if !strings.Contains(stdout, "Applying to cluster 'prod-eu' (--cluster), not 'hello-fleet'") {
+		t.Errorf("the substitution must be announced:\n%s", stdout)
+	}
+}
+
+func TestClusterApplyClusterFlagAcceptsAnID(t *testing.T) {
+	resetClusterApplyFlags(t)
+	mock := &applyOverrideMock{}
+	setMockClient(t, mock)
+	path := writeApplyOverrideDocument(t)
+
+	captureStdout(t, func() {
+		if _, executeError := executeCommand("cluster", "apply", "-f", path, "--cluster", "11111111-1111-1111-1111-111111111111"); executeError != nil {
+			t.Errorf("apply failed: %v", executeError)
+		}
+	})
+	if len(mock.applied) != 1 || mock.applied[0].Name != "prod-eu" {
+		t.Fatalf("applied = %+v, want the cluster's name resolved from its id", mock.applied)
+	}
+}
+
+func TestClusterApplyWithoutClusterFlagKeepsMetadataName(t *testing.T) {
+	resetClusterApplyFlags(t)
+	mock := &applyOverrideMock{}
+	setMockClient(t, mock)
+	path := writeApplyOverrideDocument(t)
+
+	captureStdout(t, func() {
+		if _, executeError := executeCommand("cluster", "apply", "-f", path); executeError != nil {
+			t.Errorf("apply failed: %v", executeError)
+		}
+	})
+	if len(mock.applied) != 1 || mock.applied[0].Name != "hello-fleet" {
+		t.Fatalf("applied = %+v, want metadata.name untouched", mock.applied)
+	}
+}
+
+func TestClusterApplyUnknownClusterFlagFails(t *testing.T) {
+	resetClusterApplyFlags(t)
+	mock := &applyOverrideMock{}
+	setMockClient(t, mock)
+	path := writeApplyOverrideDocument(t)
+
+	var executeError error
+	captureStdout(t, func() {
+		_, executeError = executeCommand("cluster", "apply", "-f", path, "--cluster", "nowhere")
+	})
+	if executeError == nil || !strings.Contains(executeError.Error(), `cluster "nowhere" not found`) {
+		t.Fatalf("expected a not-found error, got %v", executeError)
+	}
+	if len(mock.applied) != 0 {
+		t.Errorf("nothing should be applied: %+v", mock.applied)
+	}
+}


### PR DESCRIPTION
Bead: ankra-k7rhn

## Why

`ankra cluster apply -f file --cluster X` read the flag for nothing: the target came only from `metadata.name`. A document written for another cluster, or exported from a stack profile (where `metadata.name` is the profile's name), therefore imported a **new** cluster under that name. Found building the stack-profile fleet film; `stack-profiles rollout` (#285) had to rewrite the name itself.

## What

With `--cluster` set, the cluster is resolved by name or id and its name becomes the request's target. When it differs from `metadata.name` the substitution is printed (`Applying to cluster 'prod-eu' (--cluster), not 'hello-fleet' (metadata.name in the file).`) so it is never silent, including under `--dry-run`. A flag naming an unknown cluster fails before anything is sent. Without the flag nothing changes.

## Verified

Unit tests: override by name, override by id, no flag keeps `metadata.name`, unknown cluster refused. The persistent flag is now cleared after each of these tests so no later apply test inherits it. Full suite, `go vet` and `golangci-lint` clean via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
