### PR TITLE
ci: replace the dead Depot fallback defaults (ankra-ai93r)

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   sync-docs:
     name: Generate and PR CLI reference
-    runs-on: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
+    runs-on: ${{ vars.CI_RUNNER_2 || 'ubuntu-latest' }}
     steps:
       - name: Checkout ankra-cli
         uses: actions/checkout@v6

--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -12,17 +12,17 @@ permissions:
   contents: read
 
 # Superseded runs used to keep their runner for the full race compile, so a
-# branch pushed three times held three Depot runners at once and later runs
-# queued for hours (run 34059805725 waited 3h17m for a runner).
+# branch pushed three times held three runners at once and later runs queued
+# for hours (run 34059805725 waited 3h17m for a runner).
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   lint-test-build:
-    runs-on: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
+    runs-on: ${{ vars.CI_RUNNER_2 || 'ubuntu-latest' }}
     # A starved runner stops reporting rather than failing, so the job holds
-    # its Depot slot until someone notices: run 34042422066 sat on master for
+    # its runner slot until someone notices: run 34042422066 sat on master for
     # ~6h before a human cancelled it. Fail fast and give the runner back.
     timeout-minutes: 45
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Create release
     permissions:
       contents: write
-    runs-on: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
+    runs-on: ${{ vars.CI_RUNNER_2 || 'ubuntu-latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -67,16 +67,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
+          - os: ${{ vars.CI_RUNNER_2 || 'ubuntu-latest' }}
             goos: linux
             goarch: amd64
-          - os: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
+          - os: ${{ vars.CI_RUNNER_2 || 'ubuntu-latest' }}
             goos: linux
             goarch: arm64
-          - os: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
+          - os: ${{ vars.CI_RUNNER_2 || 'ubuntu-latest' }}
             goos: windows
             goarch: amd64
-          - os: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
+          - os: ${{ vars.CI_RUNNER_2 || 'ubuntu-latest' }}
             goos: windows
             goarch: arm64
           - os: macos-latest
@@ -156,7 +156,7 @@ jobs:
     if: ${{ !contains(github.ref_name, '-') }}
     permissions:
       contents: read
-    runs-on: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
+    runs-on: ${{ vars.CI_RUNNER_2 || 'ubuntu-latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/systemtest.yml
+++ b/.github/workflows/systemtest.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   lifecycle-system-test:
     name: Cloud lifecycle system test
-    runs-on: ${{ vars.CI_RUNNER_2 || 'depot-ubuntu-24.04' }}
+    runs-on: ${{ vars.CI_RUNNER_2 || 'ubuntu-latest' }}
     timeout-minutes: 240
     env:
       ANKRA_SYSTEMTEST_CONFIRM: 'yes'


### PR DESCRIPTION
Bead: ankra-ai93r

Every `runs-on` in the org is `${{ vars.CI_RUNNER_* || 'depot-ubuntu-24.04' }}`. The ankraio Depot account is gone, so those defaults name a runner label nothing will ever claim.

They are unreachable today — the variables resolve — but they are a landmine, because **a job on a dead runner label queues forever instead of failing**. Unset a variable, or copy one of these workflows into a repo that has none, and the job hangs silently rather than erroring. This replaces the defaults with labels that exist.

**9 literals** replaced across `lint-build.yml`, `systemtest.yml`, `docs-sync.yml`, `release.yml` (4 of them are the cross-compile matrix's `os:` entries; the two `macos-latest` rows are untouched).

### Comments rewritten

Two comments in `lint-build.yml` justified the concurrency cancel and the 45-minute timeout in terms of held "Depot runners" / "its Depot slot". **The reasoning is kept verbatim** — a superseded run used to hold its runner for the whole race compile, and a starved runner stops reporting rather than failing, so the job must fail fast and give the runner back. Only the dead vendor's name is dropped; the run IDs and measurements stay.

## Why this mapping

This repo is **public**, so the fallback is `ubuntu-latest`, not ARC:

| Variable | Old default | New default |
| --- | --- | --- |
| `CI_RUNNER_2` | `depot-ubuntu-24.04` | `ubuntu-latest` |

Public repos cannot use the ARC scale sets at all — they are in neither runner group, and the privileged group forbids public repos by design so that a fork PR can never reach privileged dind on the cluster holding the Harbor and ArgoCD credentials. GitHub-hosted runners are free for public repositories.

## Risk

**Routing is unchanged.** The variables already resolve to exactly the values these defaults now name, and `runs-on` resolves at run creation from the variable, not the fallback. This only makes the branch of each expression that nobody currently takes name a runner that exists.

Validated: every edited workflow parses and enumerates its jobs via `ruby -ryaml`. `grep -rn depot .github/` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
