### PR TITLE
feat(pipeline): wait on a run you did not dispatch, and carry its outcome into the exit code (ankra-gxs9p)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,38 @@
 
 ## Unreleased
 
+### Added
+
+- **`ankra pipeline get --wait` waits for a run you did not dispatch.** `run
+  --wait` and `rerun --wait` can only block on a run they started themselves,
+  and every push and pull_request run is started by the webhook instead - so
+  the one run a CI script most wants to wait for was the one nothing could
+  wait for, and consumers were writing their own poll loops around `pipeline
+  list`. `get --wait` blocks until the run concludes, announces each status
+  change on stderr, prints the final detail, and reports the outcome through
+  the exit code. Available on `ankra application pipeline get` too.
+- **`--timeout` bounds any `--wait` on the pipeline lane** (`get`, `run`,
+  `rerun`). It defaults to no limit, which is the contract `run --wait`
+  already had - a caller who wants to give up presses Ctrl+C - and an expired
+  budget exits 5, the scripting contract's wait-timeout code, with a message
+  saying the run keeps going and how to follow it. A negative duration is
+  refused as a usage error rather than read as "no limit".
+- **`ankra pipeline get --exit-code` reports a concluded run's outcome as the
+  exit status** without waiting, for a script that already knows the run has
+  settled. A bare `get` is unchanged and still exits 0 whatever it finds, so
+  nothing that prints a run's detail today changes behaviour. A run that has
+  not concluded exits 0 under `--exit-code`: "still going" is not "did not
+  succeed", and `--wait` is how you ask for a verdict.
+
 ### Fixed
+
+- **`--wait -o json` no longer exits 0 on a failed run.** `pipeline run
+  --wait` and `pipeline rerun --wait` reported a non-success conclusion
+  through the exit code only when rendering the human table; the structured
+  branch returned as soon as it had encoded the payload and never reached the
+  verdict. That is precisely the invocation a CI script uses, so a failed
+  build could pass a pipeline step silently. The payload is still printed;
+  the exit code is now the same answer in both formats.
 
 - **Every cluster-scoped command now takes the cluster's name as well as its
   id.** The three `ankra cluster playground` verbs learned this in #239, but

--- a/cmd/application_pipeline.go
+++ b/cmd/application_pipeline.go
@@ -86,6 +86,7 @@ func newApplicationPipelineGetCommand() *cobra.Command {
 			return runPipelineGet(command, client.PipelineSelector{ApplicationID: applicationID}, arguments[1])
 		},
 	}
+	registerPipelineGetFlags(getCommand)
 	registerStructuredOutputFlags(getCommand)
 	return getCommand
 }
@@ -122,7 +123,7 @@ func newApplicationPipelineRerunCommand() *cobra.Command {
 		},
 	}
 	rerunCommand.Flags().Bool("failed-only", false, "Re-run only the steps that did not succeed, and whatever depends on them")
-	rerunCommand.Flags().Bool("wait", false, "Wait for the new run to conclude before returning")
+	registerPipelineWaitFlags(rerunCommand, "Wait for the new run to conclude before returning")
 	registerStructuredOutputFlags(rerunCommand)
 	return rerunCommand
 }

--- a/cmd/pipeline_run.go
+++ b/cmd/pipeline_run.go
@@ -19,9 +19,39 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// pipelineRunWaitPollInterval is how often `run --wait` and `rerun --wait`
-// re-read the run while it is in flight.
-const pipelineRunWaitPollInterval = 3 * time.Second
+// pipelineRunWaitPollInterval is how often `--wait` re-reads the run while it
+// is in flight. It is a var only so the tests can shorten it; nothing else
+// writes it.
+var pipelineRunWaitPollInterval = 3 * time.Second
+
+// registerPipelineWaitFlags adds the --wait pair every command that can block
+// on a run shares. The timeout defaults to zero, which is "no bound": waiting
+// forever and giving up on Ctrl+C is the contract `run --wait` shipped with,
+// and a default that quietly abandoned a long build would change what an
+// existing invocation means. A caller who wants a bound names one.
+func registerPipelineWaitFlags(command *cobra.Command, waitUsage string) {
+	command.Flags().Bool("wait", false, waitUsage)
+	command.Flags().Duration("timeout", 0,
+		"How long --wait blocks before giving up (default: no limit; expiry exits 5)")
+}
+
+// pipelineWaitContext derives the context a --wait poll loop runs under,
+// bounding it by --timeout when one was named.
+func pipelineWaitContext(command *cobra.Command) (context.Context, context.CancelFunc, error) {
+	timeout, timeoutFlagError := command.Flags().GetDuration("timeout")
+	if timeoutFlagError != nil {
+		return nil, nil, fmt.Errorf("reading --timeout: %w", timeoutFlagError)
+	}
+	if timeout < 0 {
+		return nil, nil, withExitCode(exitUsage,
+			fmt.Errorf("--timeout must not be negative, got %s", timeout))
+	}
+	if timeout == 0 {
+		return command.Context(), func() {}, nil
+	}
+	waitContext, cancelWait := context.WithTimeout(command.Context(), timeout)
+	return waitContext, cancelWait, nil
+}
 
 func newPipelineRunCommand() *cobra.Command {
 	runCommand := &cobra.Command{
@@ -58,7 +88,7 @@ func registerPipelineRunDispatchFlags(command *cobra.Command) {
 	command.Flags().StringArray("input", nil, "Dispatch input as key=value (repeatable)")
 	command.Flags().String("reason", "", "Human note recorded on the run")
 	command.Flags().String("spec-file", "", "Run this pipeline definition instead of the stored one (requires pipelines.manage)")
-	command.Flags().Bool("wait", false, "Wait for the run to conclude before returning")
+	registerPipelineWaitFlags(command, "Wait for the run to conclude before returning")
 }
 
 // localHeadCommit answers the working directory's HEAD commit and the branch
@@ -160,40 +190,87 @@ func runPipelineDispatch(command *cobra.Command, selector client.PipelineSelecto
 		return nil
 	}
 
-	detail, waitError := waitForPipelineRunConclusion(command, selector, result.PipelineRunID)
+	return waitForAndReportPipelineRun(command, selector, result.PipelineRunID, format)
+}
+
+// waitForAndReportPipelineRun blocks until the run concludes, renders it in
+// whichever format was asked for, and then reports its conclusion through the
+// exit code.
+//
+// Rendering and the conclusion are two separate answers, and the structured
+// branch used to return before giving the second one: `--wait -o json` on a
+// failed run printed the failure and exited 0, which is precisely the
+// invocation a CI script uses and precisely the case pipelineRunConclusionError
+// exists for. The verdict is now reported the same way whatever the caller
+// asked stdout to look like.
+func waitForAndReportPipelineRun(command *cobra.Command, selector client.PipelineSelector,
+	runID string, format outputFormat) error {
+	detail, waitError := waitForPipelineRunConclusion(command, selector, runID)
 	if waitError != nil {
 		return waitError
 	}
 	if format != outputDefault {
-		return encodeStructured(command.OutOrStdout(), format, detail)
+		if encodeError := encodeStructured(command.OutOrStdout(), format, detail); encodeError != nil {
+			return encodeError
+		}
+	} else {
+		printPipelineRunDetail(command.OutOrStdout(), *detail)
 	}
-	printPipelineRunDetail(command.OutOrStdout(), *detail)
 	return pipelineRunConclusionError(detail.PipelineRun)
 }
 
 // waitForPipelineRunConclusion polls GetPipelineRun until the run's status is
-// "concluded". There is no --timeout: a person who wants to give up presses
-// Ctrl+C, the same contract 'cluster operations list --watch' already gives.
+// "concluded". Without --timeout it waits as long as the run takes and a
+// person who wants to give up presses Ctrl+C, the same contract
+// 'cluster operations list --watch' already gives; with one, an expired budget
+// is the scripting contract's wait-timeout exit rather than a bare context
+// error, so a caller can tell "still running" from "the platform said no".
 func waitForPipelineRunConclusion(command *cobra.Command, selector client.PipelineSelector,
 	runID string) (*client.PipelineRunDetail, error) {
+	waitContext, cancelWait, contextError := pipelineWaitContext(command)
+	if contextError != nil {
+		return nil, contextError
+	}
+	defer cancelWait()
+
 	progress := command.ErrOrStderr()
 	announced := ""
 	for {
-		detail, getError := apiClient.GetPipelineRun(command.Context(), selector, runID)
+		detail, getError := apiClient.GetPipelineRun(waitContext, selector, runID)
 		if getError != nil {
+			if expiryError := pipelineWaitExpired(command, waitContext, runID); expiryError != nil {
+				return nil, expiryError
+			}
 			return nil, getError
 		}
 		if detail.Status != announced {
 			_, _ = fmt.Fprintf(progress, "Run #%d is %s.\n", detail.RunNumber, detail.Status)
 			announced = detail.Status
 		}
-		if detail.Status == "concluded" {
+		if detail.Status == pipelineRunStatusConcluded {
 			return detail, nil
 		}
-		if sleepError := sleepInterrupted(command.Context(), pipelineRunWaitPollInterval); sleepError != nil {
+		if sleepError := sleepInterrupted(waitContext, pipelineRunWaitPollInterval); sleepError != nil {
+			if expiryError := pipelineWaitExpired(command, waitContext, runID); expiryError != nil {
+				return nil, expiryError
+			}
 			return nil, sleepError
 		}
 	}
+}
+
+// pipelineWaitExpired answers the wait-timeout error when --timeout is what
+// ended the wait, and nil when something else did. A Ctrl+C cancels the
+// command's own context and must not be reported as an expired budget, so the
+// distinction is drawn on which context is done: the outer one being live
+// while the derived one is not leaves only the timeout.
+func pipelineWaitExpired(command *cobra.Command, waitContext context.Context, runID string) error {
+	if command.Context().Err() != nil || waitContext.Err() == nil {
+		return nil
+	}
+	return withExitCode(exitWaitTimeout, fmt.Errorf(
+		"--timeout expired while waiting for run %s; it keeps running - follow it with 'ankra pipeline get %s'",
+		runID, runID))
 }
 
 // sleepInterrupted waits, or stops early when the command is interrupted. A
@@ -327,7 +404,21 @@ func newPipelineGetCommand() *cobra.Command {
 	getCommand := &cobra.Command{
 		Use:   "get <run>",
 		Short: "Show a pipeline run's detail",
-		Args:  cobra.ExactArgs(1),
+		Long: `Show a pipeline run's detail.
+
+--wait blocks until the run concludes and then prints it, which is what a
+webhook-started run needs: 'run --wait' and 'rerun --wait' can only wait on a
+run they dispatched themselves, and a push or pull_request run was dispatched
+by the trigger lane. Bound it with --timeout; without one it waits as long as
+the run takes.
+
+A run's outcome reaches the exit code only when you ask for it, because a bare
+'get' is a read and scripts already depend on it succeeding whatever it finds.
+--wait asks for it implicitly - waiting for a verdict and then discarding it
+is not a thing to make a caller write - and --exit-code asks for it without
+waiting, so a run that is still going exits 0 and a concluded one exits 1
+unless its outcome is success. Either way the detail is printed first.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(command *cobra.Command, arguments []string) error {
 			selector, selectorError := resolvePipelineSelector(command)
 			if selectorError != nil {
@@ -337,8 +428,17 @@ func newPipelineGetCommand() *cobra.Command {
 		},
 	}
 	registerPipelineSelectorFlags(getCommand)
+	registerPipelineGetFlags(getCommand)
 	registerStructuredOutputFlags(getCommand)
 	return getCommand
+}
+
+// registerPipelineGetFlags is shared by `pipeline get` and
+// `application pipeline get`.
+func registerPipelineGetFlags(command *cobra.Command) {
+	registerPipelineWaitFlags(command, "Wait for the run to conclude before printing it")
+	command.Flags().Bool("exit-code", false,
+		"Exit non-zero when the run has concluded with an outcome other than success (implied by --wait)")
 }
 
 func runPipelineGet(command *cobra.Command, selector client.PipelineSelector, runID string) error {
@@ -346,15 +446,32 @@ func runPipelineGet(command *cobra.Command, selector client.PipelineSelector, ru
 	if formatError != nil {
 		return formatError
 	}
-	detail, getError := apiClient.GetPipelineRun(command.Context(), selector, strings.TrimSpace(runID))
+	runID = strings.TrimSpace(runID)
+	wait, _ := command.Flags().GetBool("wait")
+	if wait {
+		return waitForAndReportPipelineRun(command, selector, runID, format)
+	}
+
+	detail, getError := apiClient.GetPipelineRun(command.Context(), selector, runID)
 	if getError != nil {
 		return getError
 	}
 	if format != outputDefault {
-		return encodeStructured(command.OutOrStdout(), format, detail)
+		if encodeError := encodeStructured(command.OutOrStdout(), format, detail); encodeError != nil {
+			return encodeError
+		}
+	} else {
+		printPipelineRunDetail(command.OutOrStdout(), *detail)
 	}
-	printPipelineRunDetail(command.OutOrStdout(), *detail)
-	return nil
+
+	exitOnOutcome, _ := command.Flags().GetBool("exit-code")
+	if !exitOnOutcome || detail.Status != pipelineRunStatusConcluded {
+		// A run that has not concluded has no outcome to report, and reporting
+		// "not success yet" as a failure would make --exit-code answer "did it
+		// fail" with "it has not finished". That is what --wait is for.
+		return nil
+	}
+	return pipelineRunConclusionError(detail.PipelineRun)
 }
 
 func printPipelineRunDetail(out io.Writer, detail client.PipelineRunDetail) {
@@ -486,7 +603,7 @@ whatever depended on them.`,
 	}
 	registerPipelineSelectorFlags(rerunCommand)
 	rerunCommand.Flags().Bool("failed-only", false, "Re-run only the steps that did not succeed, and whatever depends on them")
-	rerunCommand.Flags().Bool("wait", false, "Wait for the new run to conclude before returning")
+	registerPipelineWaitFlags(rerunCommand, "Wait for the new run to conclude before returning")
 	registerStructuredOutputFlags(rerunCommand)
 	return rerunCommand
 }
@@ -510,13 +627,5 @@ func runPipelineRerun(command *cobra.Command, selector client.PipelineSelector, 
 		_, _ = fmt.Fprintf(command.OutOrStdout(), "Run #%d queued: %s\n", result.RunNumber, result.PipelineRunID)
 		return nil
 	}
-	detail, waitError := waitForPipelineRunConclusion(command, selector, result.PipelineRunID)
-	if waitError != nil {
-		return waitError
-	}
-	if format != outputDefault {
-		return encodeStructured(command.OutOrStdout(), format, detail)
-	}
-	printPipelineRunDetail(command.OutOrStdout(), *detail)
-	return pipelineRunConclusionError(detail.PipelineRun)
+	return waitForAndReportPipelineRun(command, selector, result.PipelineRunID, format)
 }

--- a/cmd/pipeline_wait_test.go
+++ b/cmd/pipeline_wait_test.go
@@ -1,0 +1,251 @@
+package cmd
+
+// The waiting half of the run lifecycle: `get --wait`, `--timeout`,
+// `--exit-code`, and the rule every one of them rests on - a run's conclusion
+// is reported through the exit code whatever stdout was asked to look like.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"ankra/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// shortenPipelineRunWaitPolling makes the poll loops turn without the tests
+// waiting three seconds a lap.
+func shortenPipelineRunWaitPolling(t *testing.T) {
+	t.Helper()
+	previous := pipelineRunWaitPollInterval
+	pipelineRunWaitPollInterval = time.Millisecond
+	t.Cleanup(func() { pipelineRunWaitPollInterval = previous })
+}
+
+// concludedPipelineRun is a settled run detail with the given outcome.
+func concludedPipelineRun(runNumber int64, outcome string) client.PipelineRunDetail {
+	return client.PipelineRunDetail{PipelineRun: client.PipelineRun{
+		ID: "run-1", RunNumber: runNumber, Status: "concluded",
+		Outcome: &outcome, Trigger: "push", TriggerRef: "refs/heads/main",
+		HeadSHA: strings.Repeat("a", 40), QueuedAt: "2026-09-01T00:00:00Z",
+	}}
+}
+
+// runningPipelineRun is the same run before it settled.
+func runningPipelineRun(runNumber int64, status string) client.PipelineRunDetail {
+	return client.PipelineRunDetail{PipelineRun: client.PipelineRun{
+		ID: "run-1", RunNumber: runNumber, Status: status,
+		Trigger: "push", TriggerRef: "refs/heads/main",
+		HeadSHA: strings.Repeat("a", 40), QueuedAt: "2026-09-01T00:00:00Z",
+	}}
+}
+
+// TestPipelineGetWaitBlocksUntilTheRunConcludes is the ticket's first ask: a
+// run started by the push/pull_request webhook can only be addressed by
+// `get`, so `get` is where waiting has to live.
+func TestPipelineGetWaitBlocksUntilTheRunConcludes(t *testing.T) {
+	shortenPipelineRunWaitPolling(t)
+	mockClient := &pipelineLaneMock{getResults: []client.PipelineRunDetail{
+		runningPipelineRun(44, "queued"),
+		runningPipelineRun(44, "running"),
+		concludedPipelineRun(44, "success"),
+	}}
+	output, executeError := runPipelineCommand(t, mockClient,
+		"get", "run-1", "--application", testApplicationID, "--wait")
+	if executeError != nil {
+		t.Fatalf("get --wait error = %v", executeError)
+	}
+	if mockClient.getCalls != 3 {
+		t.Errorf("GetPipelineRun calls = %d, want 3 (polled until concluded)", mockClient.getCalls)
+	}
+	if !strings.Contains(output, "Run #44 is running.") {
+		t.Errorf("each new status is announced, got %q", output)
+	}
+	if !strings.Contains(output, "Run #44") || !strings.Contains(output, "success") {
+		t.Errorf("the final detail is printed, got %q", output)
+	}
+}
+
+// TestPipelineGetWaitExitsNonZeroOnAFailedRun is ask 3 under --wait: a script
+// that waited for a verdict must be able to branch on the exit status instead
+// of parsing the outcome field back out of the payload.
+func TestPipelineGetWaitExitsNonZeroOnAFailedRun(t *testing.T) {
+	shortenPipelineRunWaitPolling(t)
+	mockClient := &pipelineLaneMock{getResult: pipelineRunDetailPtr(concludedPipelineRun(44, "failure"))}
+	_, executeError := runPipelineCommand(t, mockClient,
+		"get", "run-1", "--application", testApplicationID, "--wait")
+	if executeError == nil {
+		t.Fatal("a run that concluded failure must not exit 0 under --wait")
+	}
+	if !strings.Contains(executeError.Error(), "concluded failure") {
+		t.Errorf("error = %v, want the outcome named", executeError)
+	}
+}
+
+// TestPipelineWaitReportsTheConclusionUnderStructuredOutput pins the bug this
+// change fixes on the waits that already existed: the structured branch
+// returned encodeStructured's nil and never reached the conclusion, so
+// `--wait -o json` - the one shape a CI script uses - printed a failed run and
+// exited 0.
+func TestPipelineWaitReportsTheConclusionUnderStructuredOutput(t *testing.T) {
+	shortenPipelineRunWaitPolling(t)
+	for _, invocation := range []struct {
+		name      string
+		arguments []string
+	}{
+		{"get", []string{"get", "run-1", "--application", testApplicationID, "--wait", "-o", "json"}},
+		{"run", []string{"run", "--application", testApplicationID, "--sha", strings.Repeat("a", 40), "--wait", "-o", "json"}},
+		{"rerun", []string{"rerun", "run-0", "--application", testApplicationID, "--wait", "-o", "json"}},
+	} {
+		t.Run(invocation.name, func(t *testing.T) {
+			queued := &client.CreatePipelineRunResult{PipelineRunID: "run-1", RunNumber: 44}
+			mockClient := &pipelineLaneMock{
+				getResult:    pipelineRunDetailPtr(concludedPipelineRun(44, "failure")),
+				createResult: queued,
+				rerunResult:  queued,
+			}
+			output, executeError := runPipelineCommand(t, mockClient, invocation.arguments...)
+			if executeError == nil {
+				t.Fatal("a failed run under --wait -o json must not exit 0")
+			}
+			if exitCodeFor(executeError) != exitError {
+				t.Errorf("exit code = %d, want %d", exitCodeFor(executeError), exitError)
+			}
+			// The payload is still emitted: the exit code is an extra answer,
+			// not a replacement for the one a script parses. The test harness
+			// points stdout and stderr at one buffer, so the payload is read
+			// as the first JSON value in it rather than as the whole buffer -
+			// the progress lines and cobra's own error trailer are stderr.
+			jsonStart := strings.Index(output, "{")
+			if jsonStart < 0 {
+				t.Fatalf("no JSON on stdout, got %q", output)
+			}
+			var decoded map[string]any
+			if decodeError := json.NewDecoder(
+				strings.NewReader(output[jsonStart:])).Decode(&decoded); decodeError != nil {
+				t.Fatalf("stdout is not the run payload: %v (%q)", decodeError, output)
+			}
+			if decoded["outcome"] != "failure" {
+				t.Errorf("payload outcome = %v, want failure", decoded["outcome"])
+			}
+		})
+	}
+}
+
+// TestPipelineGetWithoutWaitStillExitsZero pins the compatibility floor: a
+// bare `get` is a read, and every script that prints a run's detail today
+// keeps working. The outcome reaches the exit code only when it is asked for.
+func TestPipelineGetWithoutWaitStillExitsZero(t *testing.T) {
+	mockClient := &pipelineLaneMock{getResult: pipelineRunDetailPtr(concludedPipelineRun(44, "failure"))}
+	if _, executeError := runPipelineCommand(t, mockClient,
+		"get", "run-1", "--application", testApplicationID); executeError != nil {
+		t.Fatalf("a bare get must stay exit 0 whatever it finds, got %v", executeError)
+	}
+}
+
+// TestPipelineGetExitCodeReportsAConcludedOutcome is ask 3 without waiting:
+// the run has already settled and the caller only wants the verdict.
+func TestPipelineGetExitCodeReportsAConcludedOutcome(t *testing.T) {
+	mockClient := &pipelineLaneMock{getResult: pipelineRunDetailPtr(concludedPipelineRun(44, "failure"))}
+	_, executeError := runPipelineCommand(t, mockClient,
+		"get", "run-1", "--application", testApplicationID, "--exit-code")
+	if executeError == nil || !strings.Contains(executeError.Error(), "concluded failure") {
+		t.Fatalf("--exit-code must report a failed outcome, got %v", executeError)
+	}
+	if mockClient.getCalls != 1 {
+		t.Errorf("GetPipelineRun calls = %d, want 1 (--exit-code does not wait)", mockClient.getCalls)
+	}
+
+	succeeded := &pipelineLaneMock{getResult: pipelineRunDetailPtr(concludedPipelineRun(44, "success"))}
+	if _, executeError := runPipelineCommand(t, succeeded,
+		"get", "run-1", "--application", testApplicationID, "--exit-code"); executeError != nil {
+		t.Fatalf("a successful run exits 0 under --exit-code, got %v", executeError)
+	}
+}
+
+// TestPipelineGetExitCodeIsSilentOnARunStillGoing: "has not concluded" is not
+// "did not succeed". Answering an unfinished run with a failure exit would
+// make --exit-code a worse poll loop than the one it replaces.
+func TestPipelineGetExitCodeIsSilentOnARunStillGoing(t *testing.T) {
+	mockClient := &pipelineLaneMock{getResult: pipelineRunDetailPtr(runningPipelineRun(44, "running"))}
+	if _, executeError := runPipelineCommand(t, mockClient,
+		"get", "run-1", "--application", testApplicationID, "--exit-code"); executeError != nil {
+		t.Fatalf("a run still going is not a failure, got %v", executeError)
+	}
+}
+
+// TestPipelineWaitTimeoutExitsWithTheWaitCode gives the scripting contract's
+// retryable answer to a run that outlives its budget, rather than a bare
+// context error that reads like the platform refused.
+func TestPipelineWaitTimeoutExitsWithTheWaitCode(t *testing.T) {
+	shortenPipelineRunWaitPolling(t)
+	mockClient := &pipelineLaneMock{getResult: pipelineRunDetailPtr(runningPipelineRun(44, "running"))}
+	_, executeError := runPipelineCommand(t, mockClient,
+		"get", "run-1", "--application", testApplicationID, "--wait", "--timeout", "20ms")
+	if executeError == nil {
+		t.Fatal("an expired --timeout must not exit 0")
+	}
+	if exitCodeFor(executeError) != exitWaitTimeout {
+		t.Errorf("exit code = %d, want %d (wait timeout)", exitCodeFor(executeError), exitWaitTimeout)
+	}
+	if !strings.Contains(executeError.Error(), "keeps running") {
+		t.Errorf("error = %v, want it to say the run is still going", executeError)
+	}
+}
+
+// TestPipelineWaitRefusesANegativeTimeout: a negative budget is a typo, and
+// silently treating it as "no limit" would block a script that asked for the
+// opposite.
+func TestPipelineWaitRefusesANegativeTimeout(t *testing.T) {
+	mockClient := &pipelineLaneMock{getResult: pipelineRunDetailPtr(concludedPipelineRun(44, "success"))}
+	_, executeError := runPipelineCommand(t, mockClient,
+		"get", "run-1", "--application", testApplicationID, "--wait", "--timeout", "-1m")
+	if executeError == nil {
+		t.Fatal("a negative --timeout must be refused")
+	}
+	if exitCodeFor(executeError) != exitUsage {
+		t.Errorf("exit code = %d, want %d", exitCodeFor(executeError), exitUsage)
+	}
+}
+
+// TestPipelineWaitFlagsOnBothSurfaces: `ankra pipeline get` and
+// `ankra application pipeline get` call the same runPipelineGet, so a flag
+// registered on only one of them is a flag half the users cannot reach.
+func TestPipelineWaitFlagsOnBothSurfaces(t *testing.T) {
+	surfaces := map[string]map[string][]string{
+		"pipeline": {
+			"get":   {"wait", "timeout", "exit-code"},
+			"run":   {"wait", "timeout"},
+			"rerun": {"wait", "timeout"},
+		},
+		"application pipeline": {
+			"get":   {"wait", "timeout", "exit-code"},
+			"run":   {"wait", "timeout"},
+			"rerun": {"wait", "timeout"},
+		},
+	}
+	roots := map[string]func() *cobra.Command{
+		"pipeline":             newPipelineCommand,
+		"application pipeline": newApplicationPipelineCommand,
+	}
+	for surface, expected := range surfaces {
+		root := roots[surface]()
+		for _, subcommand := range root.Commands() {
+			flags, wanted := expected[subcommand.Name()]
+			if !wanted {
+				continue
+			}
+			for _, flagName := range flags {
+				if subcommand.Flags().Lookup(flagName) == nil {
+					t.Errorf("%s %s is missing --%s", surface, subcommand.Name(), flagName)
+				}
+			}
+		}
+	}
+}
+
+func pipelineRunDetailPtr(detail client.PipelineRunDetail) *client.PipelineRunDetail {
+	return &detail
+}

--- a/internal/skills/embedded/skills/ankra-cicd/SKILL.md
+++ b/internal/skills/embedded/skills/ankra-cicd/SKILL.md
@@ -116,6 +116,20 @@ ankra pipeline run --application <application> --sha <full-sha> --wait
 `ankra pipeline list --application <application>`, `ankra pipeline get <run>` and
 `ankra pipeline logs <run>`.
 
+**Waiting on a run somebody else started.** `run --wait` and `rerun --wait` only block on a run
+they dispatched; every push and pull_request run is dispatched by the webhook. Wait on one of
+those with `get`:
+
+```bash
+ankra pipeline get <run> --application <application> --wait --timeout 45m
+```
+
+`--wait` exits non-zero when the run concludes with an outcome other than success, so a script
+branches on `$?` instead of parsing `outcome`; `--timeout` expiry exits `5` and the run keeps
+going. A bare `get` is a read and always exits 0 — add `--exit-code` to get the outcome as the
+exit status without waiting. Find the run for a commit with
+`ankra pipeline list --head-sha <full-sha> --trigger pull_request -o json`.
+
 ### Do not route around this with a hand-rolled workflow
 
 For a repository registered with `ankra application add`, adding your own


### PR DESCRIPTION
<!-- ankra-tech-agent:pr -->
Linear: https://linear.app/ankra/issue/PLA-843/1165-cli-cannot-wait-on-or-watch-a-pipeline-run-you-did-not-dispatch
Bead: ankra-gxs9p

## What this is

Smartoptics moved two repositories fully onto Ankra Pipelines and deleted their GitHub
Actions workflows, so Ankra is now the only build and deploy signal for them. They then
found that the single most common thing their automation does — wait for a run and branch
on whether it passed — is the one thing the CLI could not do.

This ships asks 1 and 3 of the five in PLA-843. Asks 2, 4 and 5 are filed as beads
(below); none of them blocks this.

## The gap

`--wait` existed only on `pipeline run` and `pipeline rerun`, and both of those *dispatch*
the run they then wait on. Every push and pull_request run is dispatched by the webhook
instead, so for the majority of runs there was nothing to wait with: `pipeline get` had no
`--wait`, and nothing under `pipeline` had `--watch`. Consumers were writing a bash loop
around `pipeline list` that polls every 60 seconds and diffs the status string.

`runPipelineGet` also returned `nil` unconditionally, so a script could not branch on exit
status and had to parse `outcome` back out of the payload.

## The bug found on the way

`pipeline run --wait -o json` and `pipeline rerun --wait -o json` exited **0 on a failed
run**. `pipelineRunConclusionError` exists precisely to make a non-success conclusion a
non-zero exit, and the human-table branch reached it — but the structured branch returned
`encodeStructured`'s result and never got there:

```go
if format != outputDefault {
    return encodeStructured(command.OutOrStdout(), format, detail)   // <- returns nil
}
printPipelineRunDetail(command.OutOrStdout(), *detail)
return pipelineRunConclusionError(detail.PipelineRun)
```

`--wait -o json` is exactly the shape a CI script uses, so a failed build could pass a
pipeline step silently. This was not in the customer's report; it is the same defect class
as their ask 3 and is fixed here. Rendering and the verdict are now two separate steps in
one shared `waitForAndReportPipelineRun`, so the two output formats cannot drift again.

## What changed

- **`pipeline get --wait`** blocks until the run concludes, announces each status change on
  stderr, prints the final detail on stdout, and reports the outcome through the exit code.
  It reuses the existing `waitForPipelineRunConclusion` and `pipelineRunConclusionError`.
- **`--timeout` on `get`/`run`/`rerun`**, defaulting to **0 = no limit**. That default is
  deliberate: waiting indefinitely and giving up on Ctrl+C is the contract `run --wait`
  shipped with and its doc comment defends, so nothing an existing invocation means
  changes. An expired budget exits `5` (`exitWaitTimeout`) and says the run keeps going. A
  negative duration is a usage error, not a silent "no limit".
- **`pipeline get --exit-code`** reports a *concluded* run's outcome as the exit status
  without waiting. A run still going exits 0 under it — "has not concluded" is not "did not
  succeed", and `--wait` is how you ask for a verdict.
- **A bare `pipeline get` is unchanged** and still exits 0 whatever it finds. The customer
  explicitly offered this as the compatibility-safe option and it is the one taken: every
  script that prints a run's detail today keeps working.
- Every flag is registered on the `ankra application pipeline …` twin too, with a test that
  fails if the two surfaces drift.
- CHANGELOG, and the `ankra-cicd` embedded skill gains the waiting recipe.

## Verification

- `go build ./...`, `go vet ./cmd/...` clean; `gofmt -l` reports only two files this branch
  does not touch (`internal/client/baseurl.go`, `internal/client/helpers_test.go`, both
  unformatted on `master`).
- `go test -count=1 ./...` — see the checks on this PR. `golangci-lint` is not installed
  locally; the full linter runs in CI.
- New tests in `cmd/pipeline_wait_test.go` cover: `get --wait` polling to conclusion; a
  failed run exiting non-zero under `--wait`; the `-o json` regression on all three of
  `get`/`run`/`rerun` (asserting the payload is *still* printed); a bare `get` staying exit
  0; `--exit-code` on a concluded run and its silence on a running one; `--timeout` expiry
  exiting 5; a negative `--timeout` refused; and both command surfaces carrying the flags.

## Not in this PR

Filed as beads, each with the design question that needs a human:

- `ankra-0yxgz` — ask 2, addressing a run by `--head-sha`/`--trigger`/`--latest` instead of
  a run id. The listing filters already exist; what needs deciding is how `--latest`
  breaks ties and what "no run for this commit yet" exits as, since a webhook run lags the
  push by seconds.
- `ankra-57d0z` — ask 4, `--watch` emitting NDJSON per state transition. Nothing streams
  *run* state today (only step logs), so this is either a new platform stream or a
  documented client-side diff over the same poll, and that choice sets the latency promise.
  It should also agree on an envelope with `ankra-y638.7.2`.
- `ankra-g3ra5` — ask 5, `logs` on a concluded-but-archiving step. The reported symptom
  ("blocks, still open at a 120s timeout") **does not reproduce**: that branch prints to
  stderr and returns immediately, and `v0.15.2` is byte-identical to `master` there. The
  real defect is that it returns exit 0 with empty stdout, which is indistinguishable from
  a step that printed nothing — which is why a retry wrapper looked like a hang. Fixing it
  wants an exit-code decision: 8/9/10 are already reserved by `ankra-y638.7.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
