### PR TITLE
release: cut v0.16.0 (ankra-sbzj4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Ankra CLI Changelog
 
-## Unreleased
+## v0.16.0 — 2026-09-12
+
+Promotes the v0.16.0 line to stable. The headline is that automation can wait
+on a pipeline run it did not start: `ankra pipeline get` gains `--wait`,
+`--watch` and `--exit-code`, and they work on the push and pull request runs a
+webhook creates, which no `--wait` reached before. A run can also be addressed
+by the commit a CI job knows rather than by a run id it cannot know in advance.
+Alongside it, everything rc0 through rc2 carried - stack profiles across a
+fleet (`apply --cluster`, a `deployments` table, a decoded `diff`, `rollout`),
+`cluster operations list --attention`, `cluster apply --cluster` targeting the
+cluster you name, `helm credentials` accepting the id its own listing prints -
+and, new in this release, every cluster-scoped command accepting a cluster's
+name where it previously accepted only its id.
 
 ### Added
 


### PR DESCRIPTION
CHANGELOG only — no source change. Promotes the v0.16.0 line to stable.

## What the tag would carry above `v0.16.0-rc2`

- **#292** `pipeline get --wait / --watch / --exit-code / --timeout`, run selection by `--head-sha` / `--branch` / `--trigger` with `--latest`, and three `pipeline logs` fixes (frames without `event_type` dropped, a live tail that never ended, an archiving step exiting 0 with no log). Linear PLA-843, Smartoptics ticket #1165, bead `ankra-w1i58`.
- **#275** every cluster-scoped command accepts the cluster's name, not only its id (`ankra-aprvp`).
- **#280** `cluster scaleway deprovision` asks before deleting (`ankra-e3pa7`).
- **#290** CI only — no entry, per convention.

rc0–rc2 keep their own sections; the stable section is a prose lead-in over the line plus the entries for the four commits above rc2, following the v0.13.0 / v0.14.0 precedent.

## Why stable and not another rc

Any tag containing `-` publishes as a prerelease and reaches only the beta channel. The PLA-843 reporter runs stable (they measured against v0.15.2), and waiting on a webhook-started run is the thing their automation does most — an rc3 would not reach them. This is the same trap that made v0.15.1 necessary after v0.16.0-rc0.

If you would rather cut `v0.16.0-rc3`, the only change needed is the heading on line 3; nothing else in the diff is version-specific.

## Checked

- Release-notes extractor dry-run matches the new heading and emits 91 lines starting at the lead-in — no silent fall back to `--generate-notes`:
  `awk -v version="0.16.0" '$0 ~ "^## v?"version"([[:space:]]|$)" {found=1; next} found && /^## / {exit} found {print}' CHANGELOG.md`
- No empty `## Unreleased` left behind.
- Every commit above rc2 has its entry in this section (placement-trap check).
- Open at the time of writing and therefore not included: #293 (AWS k3s, draft), #271 (application members in `stacks list`). Re-run the placement check before tagging if either lands first.

## Not done here

Merging and pushing the annotated tag, and the downloaded-binary verification that follows it. This PR was opened by a background job that is not permitted to merge. **Needs Mark to merge and tag.**

Bead: ankra-sbzj4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016j3rvmTk3vyLWWQvtSwbXx
